### PR TITLE
added cascading updates with checks for references and tagsets to Profile + Context

### DIFF
--- a/graphql-samples/mutations/update/update-challenge
+++ b/graphql-samples/mutations/update/update-challenge
@@ -13,14 +13,14 @@ variables:
       "name": "Balance the grid22",
       "context": {
         "ID": "2",
-        "updateReferences": [
+        "references": [
               {
-                "ID": 11,
+                "ID": 1,
         				"name": "videoxxxx",
                 "uri": "https://www.youtube.com/watch?v=v4qj6MRCdIo"
               },
               {
-                "ID": 12,
+                "ID": 2,
         				"name": "visualxxxx",
                 "uri": "https://sdgs.un.org/sites/default/files/2020-07/The-Sustainable-Development-Goals-Report-2020_Page_09.png"
               }

--- a/graphql-samples/mutations/update/update-reference
+++ b/graphql-samples/mutations/update/update-reference
@@ -1,0 +1,18 @@
+mutation updateReference($updateData: UpdateReferenceInput!) {
+  updateReference(updateData: $updateData) {
+    id
+    name
+    uri
+  }
+}
+
+
+query variables:
+{
+  "updateData": {
+    "ID": 4,
+  	"name": "testName",
+  	"uri": "testUri",
+  	"description": "testDescription"
+  }
+}

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -124,7 +124,7 @@ export class ChallengeService {
           `Challenge not initialised: ${challengeData.ID}`,
           LogContext.CHALLENGES
         );
-      await this.contextService.update(
+      challenge.context = await this.contextService.updateContext(
         challenge.context,
         challengeData.context
       );

--- a/src/domain/challenge/ecoverse/ecoverse.service.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.ts
@@ -248,7 +248,10 @@ export class EcoverseService {
       if (!ecoverse.context) {
         ecoverse.context = new Context();
       }
-      await this.contextService.update(ecoverse.context, ecoverseData.context);
+      ecoverse.context = await this.contextService.updateContext(
+        ecoverse.context,
+        ecoverseData.context
+      );
     }
 
     if (ecoverseData.tags) {

--- a/src/domain/challenge/opportunity/opportunity.service.ts
+++ b/src/domain/challenge/opportunity/opportunity.service.ts
@@ -223,7 +223,7 @@ export class OpportunityService {
     }
 
     if (opportunityData.context && opportunity.context) {
-      await this.contextService.update(
+      opportunity.context = await this.contextService.updateContext(
         opportunity.context,
         opportunityData.context
       );

--- a/src/domain/common/reference/reference.service.ts
+++ b/src/domain/common/reference/reference.service.ts
@@ -58,6 +58,32 @@ export class ReferenceService {
     return await this.referenceRepository.save(reference);
   }
 
+  updateReferences(
+    references: IReference[] | undefined,
+    referencesData: UpdateReferenceInput[]
+  ): IReference[] {
+    if (!references)
+      throw new EntityNotFoundException(
+        'Not able to locate refernces',
+        LogContext.CHALLENGES
+      );
+    if (referencesData) {
+      for (const referenceData of referencesData) {
+        // check the reference being update is part of the current entity
+        const reference = references.find(
+          reference => reference.id == referenceData.ID
+        );
+        if (!reference)
+          throw new EntityNotFoundException(
+            `Unable to update reference with supplied ID: ${referenceData.ID} - no reference in parent entity.`,
+            LogContext.CHALLENGES
+          );
+        this.updateReferenceValues(reference, referenceData);
+      }
+    }
+    return references;
+  }
+
   async getReferenceOrFail(referenceID: number): Promise<IReference> {
     const reference = await this.referenceRepository.findOne({
       id: referenceID,

--- a/src/domain/community/organisation/organisation.service.ts
+++ b/src/domain/community/organisation/organisation.service.ts
@@ -107,7 +107,7 @@ export class OrganisationService {
     const organisation = await this.getOrganisationByIdOrFail(orgID);
 
     if (organisation.profile) {
-      await this.profileService.removeProfile(organisation.profile.id);
+      await this.profileService.deleteProfile(organisation.profile.id);
     }
 
     if (organisation.groups) {

--- a/src/domain/community/profile/profile.dto.update.ts
+++ b/src/domain/community/profile/profile.dto.update.ts
@@ -1,6 +1,8 @@
 import { InputType, Field } from '@nestjs/graphql';
 import { IsOptional, MaxLength } from 'class-validator';
 import { MID_TEXT_LENGTH, LONG_TEXT_LENGTH } from '@src/common/constants';
+import { UpdateReferenceInput } from '@domain/common/reference';
+import { UpdateTagsetInput } from '@domain/common/tagset';
 @InputType()
 export class UpdateProfileInput {
   @Field({ nullable: false })
@@ -15,4 +17,12 @@ export class UpdateProfileInput {
   @IsOptional()
   @MaxLength(LONG_TEXT_LENGTH)
   description?: string;
+
+  @Field(() => [UpdateReferenceInput], { nullable: true })
+  @IsOptional()
+  references?: UpdateReferenceInput[];
+
+  @Field(() => [UpdateTagsetInput], { nullable: true })
+  @IsOptional()
+  tagsets?: UpdateTagsetInput[];
 }

--- a/src/domain/community/profile/profile.service.ts
+++ b/src/domain/community/profile/profile.service.ts
@@ -71,7 +71,34 @@ export class ProfileService {
     return profile;
   }
 
-  async removeProfile(profileID: number): Promise<IProfile> {
+  async updateProfile(profileData: UpdateProfileInput): Promise<IProfile> {
+    const profile = await this.getProfileOrFail(profileData.ID);
+
+    if (profileData.avatar) {
+      profile.avatar = profileData.avatar;
+    }
+    if (profileData.description) {
+      profile.description = profileData.description;
+    }
+
+    if (profileData.references) {
+      profile.references = this.referenceService.updateReferences(
+        profile.references,
+        profileData.references
+      );
+    }
+
+    if (profileData.tagsets) {
+      profile.tagsets = this.tagsetService.updateTagsets(
+        profile.tagsets,
+        profileData.tagsets
+      );
+    }
+
+    return await this.profileRepository.save(profile);
+  }
+
+  async deleteProfile(profileID: number): Promise<IProfile> {
     // Note need to load it in with all contained entities so can remove fully
     const profile = await this.getProfileByIdOrFail(profileID);
 
@@ -139,19 +166,6 @@ export class ProfileService {
     await this.profileRepository.save(profile);
 
     return newReference;
-  }
-
-  async updateProfile(profileData: UpdateProfileInput): Promise<IProfile> {
-    const profile = await this.getProfileOrFail(profileData.ID);
-
-    if (profileData.avatar) {
-      profile.avatar = profileData.avatar;
-    }
-    if (profileData.description) {
-      profile.description = profileData.description;
-    }
-
-    return await this.profileRepository.save(profile);
   }
 
   async getProfileOrFail(profileID: string): Promise<IProfile> {

--- a/src/domain/community/user-group/user-group.service.ts
+++ b/src/domain/community/user-group/user-group.service.ts
@@ -95,7 +95,7 @@ export class UserGroupService {
       );
 
     if (group.profile) {
-      await this.profileService.removeProfile(group.profile.id);
+      await this.profileService.deleteProfile(group.profile.id);
     }
 
     const { id } = group;

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -56,7 +56,7 @@ export class UserService {
     const { id } = user;
 
     if (user.profile) {
-      await this.profileService.removeProfile(user.profile.id);
+      await this.profileService.deleteProfile(user.profile.id);
     }
 
     const result = await this.userRepository.remove(user as User);

--- a/src/domain/context/context/context.dto.update.ts
+++ b/src/domain/context/context/context.dto.update.ts
@@ -1,6 +1,7 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { IsOptional, MaxLength } from 'class-validator';
 import { LONG_TEXT_LENGTH, MID_TEXT_LENGTH } from '@src/common/constants';
+import { UpdateReferenceInput } from '@domain/common/reference';
 
 @InputType()
 export class UpdateContextInput {
@@ -28,4 +29,11 @@ export class UpdateContextInput {
   @IsOptional()
   @MaxLength(LONG_TEXT_LENGTH)
   impact?: string;
+
+  @Field(() => [UpdateReferenceInput], {
+    nullable: true,
+    description: 'Update the set of References for the Context.',
+  })
+  @IsOptional()
+  references?: UpdateReferenceInput[];
 }

--- a/src/domain/context/context/context.service.ts
+++ b/src/domain/context/context/context.service.ts
@@ -40,7 +40,7 @@ export class ContextService {
     return context;
   }
 
-  async update(
+  async updateContext(
     context: IContext,
     contextInput: UpdateContextInput
   ): Promise<IContext> {
@@ -61,8 +61,14 @@ export class ContextService {
       context.who = contextInput.who;
     }
 
-    await this.contextRepository.save(context);
-    return context;
+    if (contextInput.references) {
+      context.references = await this.referenceService.updateReferences(
+        context.references,
+        contextInput.references
+      );
+    }
+
+    return await this.contextRepository.save(context);
   }
 
   async removeContext(contextID: number): Promise<IContext> {


### PR DESCRIPTION
Reworked how the updating of tagsets and references is cascaded so that they are not saved before the parent entity is saved. 
 
