### PR TITLE
Workaround for membership Result entries not having uniq ids.

### DIFF
--- a/src/services/membership/membership.service.ts
+++ b/src/services/membership/membership.service.ts
@@ -41,7 +41,7 @@ export class MembershipService {
         );
         const orgResult = new MembershipResultEntry(
           organisation.name,
-          organisation.id.toString()
+          `organisation:${organisation.id.toString()}`
         );
         membership.organisations.push(orgResult);
       } else if (credential.type === AuthorizationCredential.CommunityMember) {
@@ -76,14 +76,14 @@ export class MembershipService {
       for (const challenge of storedChallenges) {
         const challengeResult = new MembershipResultEntry(
           challenge.name,
-          challenge.id.toString()
+          `challenge:${challenge.id.toString()}`
         );
         ecoverseResult.challenges.push(challengeResult);
       }
       for (const group of storedUserGroups) {
         const groupResult = new MembershipResultEntry(
           group.name,
-          group.id.toString()
+          `group:${group.id.toString()}`
         );
         ecoverseResult.userGroups.push(groupResult);
       }
@@ -103,7 +103,7 @@ export class MembershipService {
     );
     const ecoverseResult = new MembershipEcoverseResultEntry();
     ecoverseResult.name = ecoverse.name;
-    ecoverseResult.id = ecoverse.id.toString();
+    ecoverseResult.id = `ecoverse:${ecoverse.id.toString()}`;
     return ecoverseResult;
   }
 }


### PR DESCRIPTION
The Apollo cache relays on Type and ID. And this tuple should be uniq. With the current implementation the `MembershipEcoverseResultEntry` returns result for different entities which are not unique. This PR resolve that issue by implementing a workaround. Further design is required.