### PR TITLE
Search service fixes after naming changes

### DIFF
--- a/graphql-samples/queries/search/simple-search-tagsets
+++ b/graphql-samples/queries/search/simple-search-tagsets
@@ -4,14 +4,14 @@ query search($searchData: SearchInput!){
     result {
       __typename
       ... on User {
-        name
+        nameID
         email
       }
       ... on UserGroup {
         name
       }
       ... on Organisation {
-        name
+        nameID
       }
     }
   }

--- a/src/domain/common/interfaces/searchable.interface.ts
+++ b/src/domain/common/interfaces/searchable.interface.ts
@@ -9,7 +9,7 @@ import { UUID } from '../scalars';
     if (searchable.groups) {
       return IOrganisation;
     }
-    if (searchable.name) {
+    if (searchable.email) {
       return IUser;
     }
     return IUserGroup;

--- a/src/services/search/search.service.ts
+++ b/src/services/search/search.service.ts
@@ -146,6 +146,7 @@ export class SearchService {
         .createQueryBuilder('user')
         .leftJoinAndSelect('user.profile', 'profile')
         .where('user.firstName like :term')
+        .orWhere('user.nameID like :term')
         .orWhere('user.lastName like :term')
         .orWhere('user.email like :term')
         .orWhere('user.country like :term')
@@ -182,7 +183,8 @@ export class SearchService {
         .createQueryBuilder('organisation')
         .leftJoinAndSelect('organisation.profile', 'profile')
         .leftJoinAndSelect('organisation.groups', 'groups')
-        .where('organisation.name like :term')
+        .where('organisation.nameID like :term')
+        .where('organisation.displayName like :term')
         .orWhere('profile.description like :term')
         .setParameters({ term: `%${term}%` })
         .getMany();

--- a/test/functional/integration/challenge/challenge.request.params.ts
+++ b/test/functional/integration/challenge/challenge.request.params.ts
@@ -6,11 +6,11 @@ import { getEcoverseId } from '../ecoverse/ecoverse.request.params';
 
 const uniqueId = (Date.now() + Math.random()).toString();
 
-let ecoverseId = async (): Promise<any> => {
-  const responseQuery = await getEcoverseId();
-  let response = responseQuery.body.data.ecoverse.id;
-  return response;
-};
+// let ecoverseId = async (): Promise<any> => {
+//   const responseQuery = await getEcoverseId();
+//   let response = responseQuery.body.data.ecoverse.id;
+//   return response;
+// };
 
 export const challengeVariablesData = async (
   challengeName: string,
@@ -18,7 +18,7 @@ export const challengeVariablesData = async (
 ) => {
   const variables = {
     challengeData: {
-      parentID: await ecoverseId(),
+      parentID: 'Eco1',//await ecoverseId(),
       displayName: challengeName,
       nameID: uniqueTextId,
       tags: 'testTags',

--- a/test/functional/integration/search/search.it-spec.ts
+++ b/test/functional/integration/search/search.it-spec.ts
@@ -9,13 +9,8 @@ let data: TestDataServiceInitResult;
 
 const userName = 'Qa User';
 let userId: string;
-let groupName = '';
-
 let organisationName = '';
 let organisationId = '';
-
-let challengeName = '';
-let challengeCommunityId = '';
 let uniqueTextId = '';
 const typeFilterAll = ['user', 'organisation'];
 const filterOnlyUser = ['user'];
@@ -52,9 +47,7 @@ beforeEach(async () => {
   uniqueTextId = Math.random()
     .toString(36)
     .slice(-6);
-  groupName = `QA groupName ${uniqueTextId}`;
   organisationName = `QA organisationName ${uniqueTextId}`;
-  challengeName = `testChallenge ${uniqueTextId}`;
 
   // Create organisation
   const responseCreateOrganisation = await createOrganisationMutation(
@@ -62,15 +55,6 @@ beforeEach(async () => {
     'org' + uniqueTextId
   );
   organisationId = responseCreateOrganisation.body.data.createOrganisation.id;
-
-  // Create Challenge
-  const responseCreateChallenge = await createChallangeMutation(
-    challengeName,
-    uniqueTextId
-  );
-  const challengeId = responseCreateChallenge.body.data.createChallenge.id;
-  challengeCommunityId =
-    responseCreateChallenge.body.data.createChallenge.community.id;
 });
 
 describe('Query Challenge data', () => {

--- a/test/functional/integration/search/search.it-spec.ts
+++ b/test/functional/integration/search/search.it-spec.ts
@@ -1,33 +1,19 @@
 import '@test/utils/array.matcher';
 import { appSingleton } from '@test/utils/app.singleton';
-import {
-  createChallangeMutation,
-  removeChallangeMutation,
-} from '@test/functional/integration/challenge/challenge.request.params';
+import { createChallangeMutation } from '@test/functional/integration/challenge/challenge.request.params';
 import { createOrganisationMutation } from '../organisation/organisation.request.params';
-import {
-  createGroupMutation,
-  removeUserGroupMutation,
-} from '../group/group.request.params';
 import { searchMutation } from '../search/search.request.params';
-import {
-  createUserMutation,
-  removeUserMutation,
-} from '@test/functional/e2e/user-management/user.request.params';
 import { TestDataServiceInitResult } from '@src/services/data-management/test-data.service';
-import { createGroupOnCommunityMutation } from '../community/community.request.params';
-import { connectableObservableDescriptor } from 'rxjs/internal/observable/ConnectableObservable';
 
 let data: TestDataServiceInitResult;
-//let userId: null
 
 const userName = 'Qa User';
 let userId: string;
 let groupName = '';
-let ecoverseGroupId = '';
+
 let organisationName = '';
 let organisationId = '';
-let communityGroupId = '';
+
 let challengeName = '';
 let challengeCommunityId = '';
 let uniqueTextId = '';
@@ -75,7 +61,6 @@ beforeEach(async () => {
     organisationName,
     'org' + uniqueTextId
   );
-  console.log(responseCreateOrganisation.body)
   organisationId = responseCreateOrganisation.body.data.createOrganisation.id;
 
   // Create Challenge
@@ -86,31 +71,21 @@ beforeEach(async () => {
   const challengeId = responseCreateChallenge.body.data.createChallenge.id;
   challengeCommunityId =
     responseCreateChallenge.body.data.createChallenge.community.id;
-
-  // // Create challenge community group
-  // const responseCreateGroupOnCommunnity = await createGroupOnCommunityMutation(
-  //   challengeCommunityId,
-  //   groupName
-  // );
-  // console.log(responseCreateOrganisation.body)
-  // communityGroupId =
-  //   responseCreateGroupOnCommunnity.body.data.createGroupOnCommunity.id;
 });
 
-describe.skip('Query Challenge data', () => {
-  // afterEach(async () => {
-  //   //await removeUserMutation(userId);
-  //   await removeUserGroupMutation(communityGroupId);
-  // });
+describe('Query Challenge data', () => {
   test('should search with all filters applied', async () => {
     // Act
     const responseSearchData = await searchMutation(termAll, typeFilterAll);
-    console.log(responseSearchData.body)
     // Assert
     expect(responseSearchData.body.data.search).toContainObject({
       terms: termAll,
       score: 10,
-      result: { __typename: 'User', nameID: `${userName}`, id: `${userId}` },
+      result: {
+        __typename: 'User',
+        id: `${userId}`,
+        displayName: `${userName}`,
+      },
     });
 
     expect(responseSearchData.body.data.search).toContainObject({
@@ -118,8 +93,8 @@ describe.skip('Query Challenge data', () => {
       score: 10,
       result: {
         __typename: 'Organisation',
-        nameID: `${organisationName}`,
         id: `${organisationId}`,
+        displayName: `${organisationName}`,
       },
     });
   });
@@ -141,7 +116,11 @@ describe.skip('Query Challenge data', () => {
     expect(responseSearchData.body.data.search).toContainObject({
       terms: termAll,
       score: 10,
-      result: { __typename: 'User', name: `${userName}`, id: `${userId}` },
+      result: {
+        __typename: 'User',
+        id: `${userId}`,
+        displayName: `${userName}`,
+      },
     });
 
     expect(responseSearchData.body.data.search).not.toContainObject({
@@ -149,8 +128,8 @@ describe.skip('Query Challenge data', () => {
       score: 10,
       result: {
         __typename: 'Organisation',
-        name: `${organisationName}`,
         id: `${organisationId}`,
+        displayName: `${organisationName}`,
       },
     });
   });
@@ -166,7 +145,11 @@ describe.skip('Query Challenge data', () => {
     expect(responseSearchData.body.data.search).toContainObject({
       terms: ['QA', 'user'],
       score: 30,
-      result: { __typename: 'User', name: `${userName}`, id: `${userId}` },
+      result: {
+        __typename: 'User',
+        id: `${userId}`,
+        displayName: `${userName}`,
+      },
     });
 
     expect(responseSearchData.body.data.search).toContainObject({
@@ -174,8 +157,8 @@ describe.skip('Query Challenge data', () => {
       score: 20,
       result: {
         __typename: 'Organisation',
-        name: `${organisationName}`,
         id: `${organisationId}`,
+        displayName: `${organisationName}`,
       },
     });
   });
@@ -191,7 +174,11 @@ describe.skip('Query Challenge data', () => {
     expect(responseSearchData.body.data.search).toContainObject({
       terms: termUserOnly,
       score: 10,
-      result: { __typename: 'User', name: `${userName}`, id: `${userId}` },
+      result: {
+        __typename: 'User',
+        id: `${userId}`,
+        displayName: `${userName}`,
+      },
     });
 
     expect(responseSearchData.body.data.search).not.toContainObject({
@@ -199,8 +186,8 @@ describe.skip('Query Challenge data', () => {
       score: 10,
       result: {
         __typename: 'Organisation',
-        name: `${organisationName}`,
         id: `${organisationId}`,
+        displayName: `${organisationName}`,
       },
     });
   });

--- a/test/functional/integration/search/search.request.params.ts
+++ b/test/functional/integration/search/search.request.params.ts
@@ -11,16 +11,12 @@ export const searchMutation = async (terms: any, filter: any) => {
         result {
           __typename
           ... on User {
-            nameID
             id
-          }
-          ... on UserGroup {
-            name
-            id
+            displayName
           }
           ... on Organisation {
-            nameID
             id
+            displayName
           }
         }
       }


### PR DESCRIPTION
Two bugs:

user entries were being returned by interface as usergroup, leading to errors
usage of old search field on organisation