### PR TITLE
Ory Api Token Strategy

### DIFF
--- a/.build/ory/oathkeeper/access-rules.yml
+++ b/.build/ory/oathkeeper/access-rules.yml
@@ -37,3 +37,23 @@
     - handler: redirect
       config:
         to: https://localhost:4455/auth/login
+
+- id: 'cherrytwist:graphql:api:protected'
+  upstream:
+    preserve_host: true
+    url: 'http://192.168.10.1:4000'
+    strip_path: /admin
+  match:
+    url: 'http://localhost:4455/admin/graphql'
+    methods:
+      - POST
+  authenticators:
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+  errors:
+    - handler: redirect
+      config:
+        to: https://localhost:4455/auth/login

--- a/.build/ory/oathkeeper/oathkeeper.yml
+++ b/.build/ory/oathkeeper/oathkeeper.yml
@@ -66,6 +66,14 @@ authenticators:
       only:
         - ory_kratos_session
 
+  bearer_token:
+    enabled: true
+    config:
+      extra_from: '@this'
+      subject_from: 'identity.id'
+      check_session_url: http://kratos:4433/sessions/whoami
+      preserve_path: true
+
   noop:
     enabled: true
 
@@ -82,6 +90,7 @@ mutators:
     config:
       issuer_url: http://localhost:4455/
       jwks_url: file:///etc/config/oathkeeper/id_token.jwks.json
+      ttl: 1h
       claims: |
         {
           "session": {{ .Extra | toJson }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5132,6 +5132,14 @@
         }
       }
     },
+    "@ory/kratos-client": {
+      "version": "0.6.3-alpha.1",
+      "resolved": "https://registry.npmjs.org/@ory/kratos-client/-/kratos-client-0.6.3-alpha.1.tgz",
+      "integrity": "sha512-3ckStC6Zc/MQjg8bA113gBJylIzmbtvAmMwXq4348I/3QQNPXPHqzLor92XQ+/Eo7yAe8HMI5pbgLf0gjzXdFg==",
+      "requires": {
+        "axios": "^0.21.1"
+      }
+    },
     "@panva/asn1.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
@@ -17859,6 +17867,14 @@
             "pause": "0.0.1"
           }
         }
+      }
+    },
+    "passport-custom": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/passport-custom/-/passport-custom-1.1.1.tgz",
+      "integrity": "sha512-/2m7jUGxmCYvoqenLB9UrmkCgPt64h8ZtV+UtuQklZ/Tn1NpKBeOorCYkB/8lMRoiZ5hUrCoMmDtxCS/d38mlg==",
+      "requires": {
+        "passport-strategy": "1.x.x"
       }
     },
     "passport-jwt": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cherrytwist-server",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Cherrytwist server, responsible for managing the shared representation of the ecoverse",
   "author": "Cherrytwist Foundation",
   "private": false,
@@ -49,6 +49,7 @@
     "@nestjs/passport": "^7.1.5",
     "@nestjs/platform-express": "^7.6.15",
     "@nestjs/typeorm": "^7.1.5",
+    "@ory/kratos-client": "^0.6.3-alpha.1",
     "@types/express-session": "^1.17.3",
     "apollo-server-express": "^2.22.2",
     "axios": "^0.21.1",
@@ -73,6 +74,7 @@
     "normalizer": "^1.2.7",
     "passport": "^0.4.1",
     "passport-azure-ad": "^4.3.0",
+    "passport-custom": "^1.1.1",
     "passport-jwt": "^4.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/core/authentication/authentication.module.ts
+++ b/src/core/authentication/authentication.module.ts
@@ -7,6 +7,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AadBearerStrategy } from './aad.bearer.strategy';
 import { OryStrategy } from './ory.strategy';
 import { CredentialModule } from '@domain/agent/credential/credential.module';
+import { OryApiStrategy } from './ory.api.strategy';
 @Module({
   imports: [
     PassportModule.register({ session: false, defaultStrategy: 'azure-ad' }),
@@ -20,7 +21,12 @@ import { CredentialModule } from '@domain/agent/credential/credential.module';
       }),
     }),
   ],
-  providers: [AadBearerStrategy, AuthenticationService, OryStrategy],
+  providers: [
+    AadBearerStrategy,
+    AuthenticationService,
+    OryStrategy,
+    OryApiStrategy,
+  ],
   exports: [AuthenticationService],
 })
 export class AuthenticationModule {}

--- a/src/core/authentication/ory.api.strategy.ts
+++ b/src/core/authentication/ory.api.strategy.ts
@@ -1,0 +1,46 @@
+import { Injectable, Inject, LoggerService } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { Strategy } from 'passport-custom';
+import { AuthenticationService } from './authentication.service';
+import { Configuration, PublicApi } from '@ory/kratos-client';
+import { ConfigurationTypes, LogContext } from '@common/enums';
+
+@Injectable()
+export class OryApiStrategy extends PassportStrategy(
+  Strategy,
+  'oathkeeper-api-token'
+) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly authService: AuthenticationService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {
+    super();
+  }
+
+  async validate(payload: any) {
+    const kratosPublicBaseUrl = this.configService.get(
+      ConfigurationTypes.Identity
+    ).authentication.providers.ory.kratos_public_base_url;
+
+    const kratos = new PublicApi(
+      new Configuration({
+        basePath: kratosPublicBaseUrl,
+      })
+    );
+
+    const bearerToken = payload.headers.authorization.split(' ')[1];
+    const user = await kratos.toSession(bearerToken);
+
+    this.logger.verbose?.('Whoami', LogContext.AUTH);
+    this.logger.verbose?.(user.data.identity, LogContext.AUTH);
+
+    let identifier = '';
+    if (user) {
+      identifier = user.data.identity.traits.email;
+    }
+    return await this.authService.createAgentInfo(identifier);
+  }
+}

--- a/src/core/authentication/ory.strategy.ts
+++ b/src/core/authentication/ory.strategy.ts
@@ -35,7 +35,8 @@ export class OryStrategy extends PassportStrategy(Strategy, 'oathkeeper-jwt') {
   }
 
   async validate(payload: any) {
-    this.logger.verbose?.(`Ory Kratos payload: ${payload}`, LogContext.AUTH);
+    this.logger.verbose?.('Ory Kratos payload', LogContext.AUTH);
+    this.logger.verbose?.(payload, LogContext.AUTH);
 
     if (this.checkIfTokenHasExpired(payload.exp))
       throw new TokenException(

--- a/src/core/authorization/graphql.guard.ts
+++ b/src/core/authorization/graphql.guard.ts
@@ -14,7 +14,11 @@ import { AuthorizationEngineService } from '@src/services/authorization-engine/a
 import { AgentInfo } from '@core/authentication';
 import { AuthorizationRuleAgentPrivilege } from './authorization.rule.agent.privilege';
 @Injectable()
-export class GraphqlGuard extends AuthGuard(['azure-ad', 'oathkeeper-jwt']) {
+export class GraphqlGuard extends AuthGuard([
+  'azure-ad',
+  'oathkeeper-jwt',
+  'oathkeeper-api-token',
+]) {
   agentInfo?: AgentInfo;
 
   constructor(


### PR DESCRIPTION
To test it from cURL:

kratosPublicApiBaseURL=http://localhost:4433 \
graphqlEndpoint=http://localhost:4455/admin/graphql 

actionUrl=$(\
    curl -s -X GET -H "Accept: application/json" \
    "$kratosPublicApiBaseURL/self-service/login/api" \
    | jq -r '.ui.action'\
    )

sessionToken=$(\
curl -s -X POST -H  "Accept: application/json" -H "Content-Type: application/json" \
    -d '{"password_identifier": "admin@cherrytwist.org", "password": "[YOUR_PASSWORD_GOES_HERE]", "method": "password"}' \
    "$actionUrl" | jq -r '.session_token' \
    )

curl -i -H 'Content-Type: application/json' \
    -H "Authorization: Bearer $sessionToken" \
    -d '{"query": "query { users { displayName } }"}' \
    -X POST $graphqlEndpoint
