### PR TITLE
extended ecoverse update to allow turning anonymous visibility on / off

### DIFF
--- a/graphql-samples/mutations/authorization/update-ecoverse-visibility
+++ b/graphql-samples/mutations/authorization/update-ecoverse-visibility
@@ -1,0 +1,29 @@
+mutation UpdateEcoverse($ecoverseData: UpdateEcoverseInput!) {
+  updateEcoverse(ecoverseData: $ecoverseData) {
+    id
+    authorization {
+      anonymousReadAccess
+    }
+    community {
+      authorization {
+        anonymousReadAccess
+      }
+    }
+    context {
+      authorization {
+        anonymousReadAccess
+      }
+    }
+  }
+}
+
+
+{
+  "ecoverseData":
+		{
+      "ID": "uuid",
+      "authorizationDefinition": {
+        "anonymousReadAccess": false
+      }
+		}
+}

--- a/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
@@ -1,3 +1,4 @@
+import { UpdateAuthorizationDefinitionInput } from '@domain/common/authorization-definition';
 import { CommunityAuthorizationService } from '@domain/community/community/community.service.authorization';
 import { ContextAuthorizationService } from '@domain/context/context/context.service.authorization';
 import { Injectable } from '@nestjs/common';
@@ -48,6 +49,29 @@ export class BaseChallengeAuthorizationService {
     );
     baseChallenge.context = await this.contextAuthorizationService.applyAuthorizationRules(
       context
+    );
+
+    return baseChallenge;
+  }
+
+  async updateAuthorization(
+    baseChallenge: IBaseChallenge,
+    repository: Repository<BaseChallenge>,
+    authorizationUpdateData: UpdateAuthorizationDefinitionInput
+  ): Promise<IBaseChallenge> {
+    baseChallenge.authorization = this.authorizationEngine.updateAuthorization(
+      baseChallenge.authorization,
+      authorizationUpdateData
+    );
+
+    // propagate authorization rules for child entities
+    baseChallenge.context = await this.baseChallengeService.getContext(
+      baseChallenge.id,
+      repository
+    );
+    baseChallenge.context.authorization = this.authorizationEngine.updateAuthorization(
+      baseChallenge.context.authorization,
+      authorizationUpdateData
     );
 
     return baseChallenge;

--- a/src/domain/challenge/ecoverse/ecoverse.dto.update.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.dto.update.ts
@@ -2,6 +2,7 @@ import { Field, InputType } from '@nestjs/graphql';
 import { IsOptional } from 'class-validator';
 import { UpdateBaseChallengeInput } from '@domain/challenge/base-challenge';
 import { UUID_NAMEID } from '@domain/common/scalars';
+import { UpdateAuthorizationDefinitionInput } from '@domain/common/authorization-definition';
 
 @InputType()
 export class UpdateEcoverseInput extends UpdateBaseChallengeInput {
@@ -11,4 +12,11 @@ export class UpdateEcoverseInput extends UpdateBaseChallengeInput {
   })
   @IsOptional()
   hostID?: string;
+
+  @Field(() => UpdateAuthorizationDefinitionInput, {
+    nullable: true,
+    description: 'Update anonymous visibility for the Ecoverse.',
+  })
+  @IsOptional()
+  authorizationDefinition?: UpdateAuthorizationDefinitionInput;
 }

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.fields.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.fields.ts
@@ -41,12 +41,10 @@ export class EcoverseResolverFields {
     return await this.ecoverseService.getCommunity(ecoverse);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @ResolveField('context', () => IContext, {
     nullable: true,
     description: 'The context for the ecoverse.',
   })
-  @UseGuards(GraphqlGuard)
   @Profiling.api
   async context(@Parent() ecoverse: Ecoverse) {
     return await this.ecoverseService.getContext(ecoverse);

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
@@ -70,6 +70,13 @@ export class EcoverseResolverMutations {
       `updateEcoverse: ${ecoverse.nameID}`
     );
 
+    if (ecoverseData.authorizationDefinition) {
+      await this.ecoverseAuthorizationService.updateAuthorizationDefinition(
+        ecoverse,
+        ecoverseData.authorizationDefinition
+      );
+    }
+
     return await this.ecoverseService.update(ecoverseData);
   }
 

--- a/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
@@ -7,7 +7,10 @@ import { AuthorizationEngineService } from '@src/services/platform/authorization
 import { EcoverseService } from './ecoverse.service';
 import { IEcoverse, Ecoverse } from '@domain/challenge/ecoverse';
 import { ChallengeAuthorizationService } from '../challenge/challenge.service.authorization';
-import { IAuthorizationDefinition } from '@domain/common/authorization-definition';
+import {
+  IAuthorizationDefinition,
+  UpdateAuthorizationDefinitionInput,
+} from '@domain/common/authorization-definition';
 import { AuthorizationCredentialRule } from '@src/services/platform/authorization-engine/authorization.credential.rule';
 import { EntityNotInitializedException } from '@common/exceptions';
 import { BaseChallengeAuthorizationService } from '../base-challenge/base.challenge.service.authorization';
@@ -24,7 +27,7 @@ export class EcoverseAuthorizationService {
   ) {}
 
   async applyAuthorizationRules(ecoverse: IEcoverse): Promise<IEcoverse> {
-    ecoverse.authorization = this.updateAuthorizationDefinition(
+    ecoverse.authorization = this.extendAuthorizationDefinition(
       ecoverse.authorization,
       ecoverse.id
     );
@@ -53,7 +56,33 @@ export class EcoverseAuthorizationService {
     return await this.ecoverseRepository.save(ecoverse);
   }
 
-  private updateAuthorizationDefinition(
+  async updateAuthorizationDefinition(
+    ecoverse: IEcoverse,
+    authorizationUpdateData: UpdateAuthorizationDefinitionInput
+  ): Promise<IEcoverse> {
+    await this.baseChallengeAuthorizationService.updateAuthorization(
+      ecoverse,
+      this.ecoverseRepository,
+      authorizationUpdateData
+    );
+
+    // propagate authorization rules for child entities
+    const challenges = await this.ecoverseService.getChallenges(ecoverse);
+    for (const challenge of challenges) {
+      await this.challengeAuthorizationService.updateAuthorization(
+        challenge,
+        authorizationUpdateData
+      );
+      challenge.authorization = this.authorizationEngine.updateAuthorization(
+        challenge.authorization,
+        authorizationUpdateData
+      );
+    }
+
+    return await this.ecoverseRepository.save(ecoverse);
+  }
+
+  private extendAuthorizationDefinition(
     authorization: IAuthorizationDefinition | undefined,
     ecoverseID: string
   ): IAuthorizationDefinition {

--- a/src/domain/common/authorization-definition/authorization.definition.dto.update.ts
+++ b/src/domain/common/authorization-definition/authorization.definition.dto.update.ts
@@ -1,0 +1,7 @@
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateAuthorizationDefinitionInput {
+  @Field({ nullable: false })
+  anonymousReadAccess!: boolean;
+}

--- a/src/domain/common/authorization-definition/index.ts
+++ b/src/domain/common/authorization-definition/index.ts
@@ -1,2 +1,3 @@
 export * from './authorization.definition.entity';
 export * from './authorization.definition.interface';
+export * from './authorization.definition.dto.update';

--- a/src/services/platform/authorization-engine/authorization-engine.service.ts
+++ b/src/services/platform/authorization-engine/authorization-engine.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   AuthorizationDefinition,
   IAuthorizationDefinition,
+  UpdateAuthorizationDefinitionInput,
 } from '@domain/common/authorization-definition';
 import { AgentInfo } from '@core/authentication';
 import { ConfigService } from '@nestjs/config';
@@ -191,6 +192,16 @@ export class AuthorizationEngineService {
     this.appendCredentialAuthorizationRules(child, newRules);
     child.anonymousReadAccess = parent.anonymousReadAccess;
     return child;
+  }
+
+  updateAuthorization(
+    origAuthorization: IAuthorizationDefinition | undefined,
+    authorizationUpdateData: UpdateAuthorizationDefinitionInput
+  ): IAuthorizationDefinition {
+    const authorization = this.validateAuthorization(origAuthorization);
+    authorization.anonymousReadAccess =
+      authorizationUpdateData.anonymousReadAccess;
+    return authorization;
   }
 
   appendCredentialAuthorizationRules(


### PR DESCRIPTION
Extends the update ecoverse DTO to take a sub entry for updating the Authorization. For now this has a single flag. 

Ecoverse hierarchy cascades this flag through the hierarchy.

New graphql-sample for turning this flag on / off
