### PR TITLE
filter challenge search results by access; expose ecoverseID on returned data; updated email + phone fields to not be nullable on return type

### DIFF
--- a/graphql-samples/queries/search/simple-search-challenges
+++ b/graphql-samples/queries/search/simple-search-challenges
@@ -1,7 +1,8 @@
-query create($searchData: SearchInput!){
+query search($searchData: SearchInput!){
   search(searchData: $searchData) {
     score
     result {
+      id
       __typename
       ... on User {
         nameID
@@ -14,6 +15,7 @@ query create($searchData: SearchInput!){
       }
       ... on Challenge {
         nameID
+        ecoverseID
         context {
           tagline
         }
@@ -21,6 +23,8 @@ query create($searchData: SearchInput!){
     }
   }
 }
+
+
 
 {
   "searchData":

--- a/graphql-samples/queries/search/simple-search-filtered
+++ b/graphql-samples/queries/search/simple-search-filtered
@@ -1,4 +1,4 @@
-query create($searchData: SearchInput!){
+query search($searchData: SearchInput!){
   search(searchData: $searchData) {
     score
     result {

--- a/graphql-samples/queries/search/simple-search-scored
+++ b/graphql-samples/queries/search/simple-search-scored
@@ -1,4 +1,4 @@
-query create($searchData: SearchInput!){
+query search($searchData: SearchInput!){
   search(searchData: $searchData) {
     score
     terms

--- a/src/domain/challenge/challenge/challenge.interface.ts
+++ b/src/domain/challenge/challenge/challenge.interface.ts
@@ -1,5 +1,5 @@
 import { IOpportunity } from '@domain/collaboration/opportunity/opportunity.interface';
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { IBaseChallenge } from '@domain/challenge/base-challenge/base.challenge.interface';
 import { ISearchable } from '@domain/common/interfaces/searchable.interface';
 
@@ -10,5 +10,6 @@ export abstract class IChallenge extends IBaseChallenge implements ISearchable {
   childChallenges?: IChallenge[];
   opportunities?: IOpportunity[];
 
+  @Field(() => String)
   ecoverseID!: string;
 }

--- a/src/domain/community/user/user.resolver.fields.ts
+++ b/src/domain/community/user/user.resolver.fields.ts
@@ -62,7 +62,7 @@ export class UserResolverFields {
 
   @UseGuards(GraphqlGuard)
   @ResolveField('email', () => String, {
-    nullable: true,
+    nullable: false,
     description: 'The email address for this User.',
   })
   @Profiling.api
@@ -83,7 +83,7 @@ export class UserResolverFields {
 
   @UseGuards(GraphqlGuard)
   @ResolveField('phone', () => String, {
-    nullable: true,
+    nullable: false,
     description: 'The phone number for this User.',
   })
   @Profiling.api

--- a/src/services/domain/search/search.resolver.queries.ts
+++ b/src/services/domain/search/search.resolver.queries.ts
@@ -39,6 +39,6 @@ export class SearchResolverQueries {
       this.searchAuthorizationDefinition,
       `search query: ${agentInfo.email}`
     );
-    return await this.searchService.search(searchData);
+    return await this.searchService.search(searchData, agentInfo);
   }
 }

--- a/src/services/domain/search/search.service.ts
+++ b/src/services/domain/search/search.service.ts
@@ -221,7 +221,9 @@ export class SearchService {
       const challengeMatches = await this.challengeRepository
         .createQueryBuilder('challenge')
         .leftJoinAndSelect('challenge.tagset', 'tagset')
+        .leftJoinAndSelect('challenge.authorization', 'authorization')
         .leftJoinAndSelect('challenge.context', 'context')
+        .leftJoinAndSelect('context.visual', 'visual')
         .leftJoinAndSelect('challenge.opportunities', 'opportunity')
         .where('challenge.nameID like :term')
         .orWhere('challenge.displayName like :term')

--- a/src/services/domain/search/search.service.ts
+++ b/src/services/domain/search/search.service.ts
@@ -7,10 +7,12 @@ import { UserGroup } from '@domain/community/user-group/user-group.entity';
 import { User } from '@domain/community/user/user.entity';
 import { SearchResultEntry } from './search-result-entry.dto';
 import { ISearchResultEntry } from './search-result-entry.interface';
-import { LogContext } from '@common/enums';
+import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { ValidationException } from '@common/exceptions/validation.exception';
 import { Organisation } from '@domain/community/organisation/organisation.entity';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
+import { AgentInfo } from '@core/authentication/agent-info';
+import { AuthorizationEngineService } from '@services/platform/authorization-engine/authorization-engine.service';
 
 enum SearchEntityTypes {
   User = 'user',
@@ -47,10 +49,14 @@ export class SearchService {
     private organisationRepository: Repository<Organisation>,
     @InjectRepository(Challenge)
     private challengeRepository: Repository<Challenge>,
+    private authorizationEngine: AuthorizationEngineService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  async search(searchData: SearchInput): Promise<ISearchResultEntry[]> {
+  async search(
+    searchData: SearchInput,
+    agentInfo: AgentInfo
+  ): Promise<ISearchResultEntry[]> {
     this.validateSearchParameters(searchData);
 
     // Use maps to aggregate results as searching; data structure chosen for linear lookup o(1)
@@ -96,7 +102,11 @@ export class SearchService {
     if (searchOrganisations)
       await this.searchOrganisationsByTerms(filteredTerms, organisationResults);
     if (searchChallenges)
-      await this.searchChallengesByTerms(filteredTerms, challengeResults);
+      await this.searchChallengesByTerms(
+        filteredTerms,
+        challengeResults,
+        agentInfo
+      );
 
     this.logger.verbose?.(
       `Executed search query: ${userResults.size} users results; ${groupResults.size} group results; ${organisationResults.size} organisation results found; ${challengeResults.size} challenge results found`,
@@ -215,24 +225,41 @@ export class SearchService {
 
   async searchChallengesByTerms(
     terms: string[],
-    challengeResults: Map<number, Match>
+    challengeResults: Map<number, Match>,
+    agentInfo: AgentInfo
   ) {
     for (const term of terms) {
+      const readableChallengeMatches: Challenge[] = [];
       const challengeMatches = await this.challengeRepository
         .createQueryBuilder('challenge')
         .leftJoinAndSelect('challenge.tagset', 'tagset')
+        .leftJoinAndSelect('challenge.opportunities', 'opportunities')
         .leftJoinAndSelect('challenge.authorization', 'authorization')
         .leftJoinAndSelect('challenge.context', 'context')
-        .leftJoinAndSelect('context.visual', 'visual')
-        .leftJoinAndSelect('challenge.opportunities', 'opportunity')
         .where('challenge.nameID like :term')
         .orWhere('challenge.displayName like :term')
         .orWhere('tagset.tags like :term')
         .orWhere('context.tagline like :term')
         .setParameters({ term: `%${term}%` })
         .getMany();
+      // Only show challenges that the current user has read access to
+      for (const challenge of challengeMatches) {
+        if (
+          this.authorizationEngine.isAccessGranted(
+            agentInfo,
+            challenge.authorization,
+            AuthorizationPrivilege.READ
+          )
+        ) {
+          readableChallengeMatches.push(challenge);
+        }
+      }
       // Create results for each match
-      await this.buildMatchingResults(challengeMatches, challengeResults, term);
+      await this.buildMatchingResults(
+        readableChallengeMatches,
+        challengeResults,
+        term
+      );
     }
   }
 


### PR DESCRIPTION
Search results for challenges are now filtered based on whether the currently logged in user has read access.
Expose ecoverseID on search entity so it can be queries on search results so that the Challenge can then be looked up.
Updated field meta data for email, phone on user as otherwise was giving a problem for codegen on the client