### PR TITLE
Applications questions, and membership to show applications; polishing

### DIFF
--- a/src/domain/challenge/challenge/challenge.resolver.fields.ts
+++ b/src/domain/challenge/challenge/challenge.resolver.fields.ts
@@ -73,7 +73,6 @@ export class ChallengeResolverFields {
     return await this.challengeService.getChildChallenges(challenge);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @ResolveField('agent', () => IAgent, {
     nullable: true,
     description: 'The Agent representing this Challenge.',

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -99,6 +99,16 @@ export class ChallengeService {
       machineConfig
     );
 
+    // set the credential type in use by the community
+    await this.baseChallengeService.setMembershipCredential(
+      challenge,
+      AuthorizationCredential.ChallengeMember
+    );
+
+    // save the challenge, just in case the lead orgs assignment fails. Note that
+    // assigning lead orgs does not update the challenge entity
+    const savedChallenge = await this.challengeRepository.save(challenge);
+
     if (challengeData.leadOrganisations) {
       await this.setChallengeLeads(
         challenge.id,
@@ -106,13 +116,7 @@ export class ChallengeService {
       );
     }
 
-    // set the credential type in use by the community
-    await this.baseChallengeService.setMembershipCredential(
-      challenge,
-      AuthorizationCredential.ChallengeMember
-    );
-
-    return await this.challengeRepository.save(challenge);
+    return savedChallenge;
   }
 
   async updateChallenge(

--- a/src/domain/challenge/ecoverse/ecoverse.service.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.ts
@@ -71,8 +71,6 @@ export class EcoverseService {
       AuthorizationCredential.EcoverseMember
     );
 
-    await this.setEcoverseHost(ecoverse.id, ecoverseData.hostID);
-
     // Lifecycle
     const machineConfig: any = challengeLifecycleConfigDefault;
     ecoverse.lifecycle = await this.lifecycleService.createLifecycle(
@@ -80,7 +78,12 @@ export class EcoverseService {
       machineConfig
     );
 
-    return await this.ecoverseRepository.save(ecoverse);
+    // save before assigning host in case that fails
+    const savedEcoverse = await this.ecoverseRepository.save(ecoverse);
+
+    await this.setEcoverseHost(ecoverse.id, ecoverseData.hostID);
+
+    return savedEcoverse;
   }
 
   async validateEcoverseData(ecoverseData: CreateEcoverseInput) {

--- a/src/domain/community/application/application.service.ts
+++ b/src/domain/community/application/application.service.ts
@@ -115,6 +115,15 @@ export class ApplicationService {
     return user;
   }
 
+  async getApplicationState(applicationID: string): Promise<string> {
+    const application = await this.getApplicationOrFail(applicationID);
+    const lifecycle = application.lifecycle;
+    if (lifecycle) {
+      return await this.lifecycleService.getState(lifecycle);
+    }
+    return '';
+  }
+
   async findExistingApplication(
     userID: string,
     communityID: string
@@ -132,5 +141,19 @@ export class ApplicationService {
       .getMany();
     if (existingApplication.length > 0) return existingApplication[0];
     return undefined;
+  }
+
+  async findApplicationsForUser(userID: string): Promise<IApplication[]> {
+    const existingApplications = await this.applicationRepository
+      .createQueryBuilder('application')
+      .leftJoinAndSelect('application.user', 'user')
+      .leftJoinAndSelect('application.community', 'community')
+      .where('user.id = :userID')
+      .setParameters({
+        userID: `${userID}`,
+      })
+      .getMany();
+    if (existingApplications.length > 0) return existingApplications;
+    return [];
   }
 }

--- a/src/domain/community/organisation/organisation.resolver.fields.ts
+++ b/src/domain/community/organisation/organisation.resolver.fields.ts
@@ -14,14 +14,12 @@ import { IUserGroup } from '@domain/community/user-group';
 import { IUser } from '@domain/community/user';
 import { IProfile } from '@domain/community/profile';
 import { AuthorizationAgentPrivilege, Profiling } from '@common/decorators';
-import { AuthorizationEngineService } from '@src/services/platform/authorization-engine/authorization-engine.service';
 import { IAgent } from '@domain/agent/agent';
 import { UUID } from '@domain/common/scalars';
 import { UserGroupService } from '@domain/community/user-group/user-group.service';
 @Resolver(() => IOrganisation)
 export class OrganisationResolverFields {
   constructor(
-    private authorizationEngine: AuthorizationEngineService,
     private organisationService: OrganisationService,
     private groupService: UserGroupService
   ) {}
@@ -94,7 +92,6 @@ export class OrganisationResolverFields {
     return organisation.profile;
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @ResolveField('agent', () => IAgent, {
     nullable: true,
     description: 'The Agent representing this User.',

--- a/src/domain/community/user/user.resolver.fields.ts
+++ b/src/domain/community/user/user.resolver.fields.ts
@@ -3,11 +3,7 @@ import { Resolver, Parent, ResolveField } from '@nestjs/graphql';
 import { User, IUser } from '@domain/community/user';
 import { UserService } from './user.service';
 import { IAgent } from '@domain/agent/agent';
-import {
-  AuthorizationAgentPrivilege,
-  CurrentUser,
-  Profiling,
-} from '@common/decorators';
+import { CurrentUser, Profiling } from '@common/decorators';
 import { AuthorizationPrivilege } from '@common/enums';
 import { GraphqlGuard } from '@core/authorization';
 import { CommunicationService } from '@src/services/platform/communication/communication.service';
@@ -23,8 +19,6 @@ export class UserResolverFields {
     private communicationService: CommunicationService
   ) {}
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('agent', () => IAgent, {
     nullable: true,
     description: 'The Agent representing this User.',
@@ -34,7 +28,6 @@ export class UserResolverFields {
     return await this.userService.getAgent(user.id);
   }
 
-  @UseGuards(GraphqlGuard)
   @ResolveField('communityRooms', () => [CommunityRoom], {
     nullable: true,
     description: 'The Community rooms this user is a member of',
@@ -44,7 +37,6 @@ export class UserResolverFields {
     return await this.communicationService.getCommunityRooms(user.email);
   }
 
-  @UseGuards(GraphqlGuard)
   @ResolveField('directRooms', () => [DirectRoom], {
     nullable: true,
     description: 'The direct rooms this user is a member of',
@@ -64,6 +56,7 @@ export class UserResolverFields {
     @Parent() user: User,
     @CurrentUser() agentInfo: AgentInfo
   ): Promise<string> {
+    // Need to do inside rather than as decorator so can return a replacement string
     const accessGranted = await this.authorizationEngine.isAccessGranted(
       agentInfo,
       user.authorization,

--- a/src/services/domain/membership/membership.dto.application.result.entry.ts
+++ b/src/services/domain/membership/membership.dto.application.result.entry.ts
@@ -1,0 +1,37 @@
+import { UUID } from '@domain/common/scalars';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class ApplicationResultEntry {
+  @Field(() => UUID, {
+    description: 'ID for the application',
+  })
+  id: string;
+
+  @Field(() => UUID, {
+    description: 'ID for the community',
+  })
+  communityID: string;
+
+  @Field(() => String, {
+    description: 'Display name of the community',
+  })
+  displayName: string;
+
+  @Field(() => String, {
+    description: 'The current state of the application.',
+  })
+  state: string;
+
+  constructor(
+    communityID: string,
+    displayName: string,
+    state: string,
+    id: string
+  ) {
+    this.displayName = displayName;
+    this.communityID = communityID;
+    this.state = state;
+    this.id = id;
+  }
+}

--- a/src/services/domain/membership/membership.dto.user.result.ts
+++ b/src/services/domain/membership/membership.dto.user.result.ts
@@ -1,4 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql';
+import { ApplicationResultEntry } from './membership.dto.application.result.entry';
 import { MembershipUserResultEntryEcoverse } from './membership.dto.user.result.entry.ecoverse';
 import { MembershipUserResultEntryOrganisation } from './membership.dto.user.result.entry.organisation';
 
@@ -15,4 +16,9 @@ export class UserMembership {
       'Details of the Organisations the user is a member of, with child memberships.',
   })
   organisations: MembershipUserResultEntryOrganisation[] = [];
+
+  @Field(() => [ApplicationResultEntry], {
+    description: 'Open applications for this user.',
+  })
+  applications: ApplicationResultEntry[] = [];
 }

--- a/src/services/domain/membership/membership.module.ts
+++ b/src/services/domain/membership/membership.module.ts
@@ -9,10 +9,12 @@ import { CommunityModule } from '@domain/community/community/community.module';
 import { ChallengeModule } from '@domain/challenge/challenge/challenge.module';
 import { OpportunityModule } from '@domain/collaboration/opportunity/opportunity.module';
 import { AuthorizationEngineModule } from '@src/services/platform/authorization-engine/authorization-engine.module';
+import { ApplicationModule } from '@domain/community/application/application.module';
 
 @Module({
   imports: [
     AuthorizationEngineModule,
+    ApplicationModule,
     UserModule,
     UserGroupModule,
     ChallengeModule,

--- a/src/services/platform/communication/communication.dto.message.result.ts
+++ b/src/services/platform/communication/communication.dto.message.result.ts
@@ -19,4 +19,10 @@ export class CommunicationMessageResult {
     description: 'The server timestamp in UTC',
   })
   timestamp!: number;
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'The id for the message event (Matrix)',
+  })
+  id!: string;
 }

--- a/src/services/platform/communication/communication.service.ts
+++ b/src/services/platform/communication/communication.service.ts
@@ -367,6 +367,7 @@ export class CommunicationService {
         message: ev.content.body,
         sender: user ? `${user}` : 'unknown',
         timestamp: ev.origin_server_ts,
+        id: ev.event_id,
       };
 
       messages.push(roomMessage);

--- a/src/services/platform/configuration/templates/ux-template.json
+++ b/src/services/platform/configuration/templates/ux-template.json
@@ -53,8 +53,20 @@
           "name": "default",
           "questions": [
             {
-              "question": "Why do you want to join?",
+              "question": "What makes you want to join?",
               "required": true
+            },
+            {
+              "question": "Anything role / contribution that you have in mind?",
+              "required": false
+            },
+            {
+              "question": "Are you already in contact with anyone in this community?",
+              "required": false
+            },
+            {
+              "question": "Anything fun you want to tell us about yourself?!",
+              "required": false
             }
           ]
         }


### PR DESCRIPTION
Remove protection on agent fields for users, orgs so roles can be determined
Added an id to messages for communications
Expanded user membership query to also return applications for users
Expanded the set of questions that are provided to users when applying

Bug fixes
- avoid leaving challenges / ecoverses in partial state if setting associated orgs fails
