### PR TITLE
Patch: user login + applications fixes

### DIFF
--- a/.build/ory/kratos/email-password/kratos.yml
+++ b/.build/ory/kratos/email-password/kratos.yml
@@ -60,6 +60,8 @@ selfservice:
     login:
       ui_url: http://localhost:3000/auth/login
       lifespan: 10m
+      after:
+        default_browser_return_url: http://localhost:3000/auth/login/success
 
     registration:
       lifespan: 10m

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -154,10 +154,10 @@ identity:
         # NB: The default kratos.yml config defines the selfservice endpoints with base address http://localhost:3000/auth.
         # That is used as there is a reverse proxy in front of the CT Web Client that forwards the calls to the Kratos Public URL.
         # You can check the currently logged in user at http://localhost:4433/sessions/whoami.
-        kratos_public_base_url: ${AUTH_ORY_KRATOS_PUBLIC_BASE_URL}:http://localhost:4433/
+        kratos_public_base_url: ${AUTH_ORY_KRATOS_PUBLIC_BASE_URL}:http://localhost:4433
 
         # Ory Kratos URL for usage by the CT server when inside a cluster.
-        kratos_public_base_url_server: ${AUTH_ORY_KRATOS_PUBLIC_BASE_URL_SERVER}:http://localhost:4433/
+        kratos_public_base_url_server: ${AUTH_ORY_KRATOS_PUBLIC_BASE_URL_SERVER}:http://localhost:4433
 
   ssi:
     # Jolocom SDK is used for providing SSI capabilities on the platform.

--- a/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
@@ -28,7 +28,6 @@ export class BaseChallengeAuthorizationService {
     );
     // disable anonymous access for community
     if (community.authorization) {
-      community.authorization.anonymousReadAccess = false;
       baseChallenge.community = await this.communityAuthorizationService.applyAuthorizationRules(
         community,
         baseChallenge.authorization

--- a/src/domain/challenge/challenge/challenge.resolver.fields.ts
+++ b/src/domain/challenge/challenge/challenge.resolver.fields.ts
@@ -18,8 +18,6 @@ import { IOrganisation } from '@domain/community/organisation/organisation.inter
 export class ChallengeResolverFields {
   constructor(private challengeService: ChallengeService) {}
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('community', () => ICommunity, {
     nullable: true,
     description: 'The community for the challenge.',

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.fields.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.fields.ts
@@ -31,12 +31,10 @@ export class EcoverseResolverFields {
     private ecoverseService: EcoverseService
   ) {}
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @ResolveField('community', () => ICommunity, {
     nullable: true,
     description: 'The community for the ecoverse.',
   })
-  @UseGuards(GraphqlGuard)
   @Profiling.api
   async community(@Parent() ecoverse: Ecoverse) {
     return await this.ecoverseService.getCommunity(ecoverse);

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -24,6 +24,9 @@ export class CommunityAuthorizationService {
       community.authorization,
       parentAuthorization
     );
+    // always false
+    community.authorization.anonymousReadAccess = false;
+
     community.authorization = this.extendAuthorizationDefinition(
       community.authorization
     );


### PR DESCRIPTION
- made community.id available on ecoverse so that users can actually apply to join an ecoverse
- fixed bug in the definition of authorization access for Community entities
- added login success return URL for kratos