### PR TITLE
Bug fix: user deleting of references

### DIFF
--- a/graphql-samples/mutations/authorization/reset-authorization-on-user
+++ b/graphql-samples/mutations/authorization/reset-authorization-on-user
@@ -1,0 +1,11 @@
+mutation authorizationDefinitionResetOnUser($authorizationResetData: UserAuthorizationResetInput!) {
+  authorizationDefinitionResetOnUser(authorizationResetData: $authorizationResetData) {
+    nameID
+  }
+}
+
+{
+  "authorizationResetData": {
+    "userID": "uuid_nameid_email"
+  }
+}

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
@@ -146,9 +146,10 @@ export class EcoverseResolverMutations {
     const ecoverse = await this.ecoverseService.getEcoverseOrFail(
       authorizationResetData.ecoverseID
     );
-    await this.authorizationEngine.grantReadAccessOrFail(
+    await this.authorizationEngine.grantAccessOrFail(
       agentInfo,
       ecoverse.authorization,
+      AuthorizationPrivilege.UPDATE,
       `reset authorization definition: ${agentInfo.email}`
     );
     return await this.ecoverseAuthorizationService.applyAuthorizationRules(

--- a/src/domain/community/user/user.dto.reset.authorization.ts
+++ b/src/domain/community/user/user.dto.reset.authorization.ts
@@ -1,0 +1,12 @@
+import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class UserAuthorizationResetInput {
+  @Field(() => UUID_NAMEID_EMAIL, {
+    nullable: false,
+    description:
+      'The identifier of the User whose AuthorizationDefinition should be reset.',
+  })
+  userID!: string;
+}

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -42,12 +42,12 @@ export class UserAuthorizationService {
       user.authorization
     );
 
+    // Allow users to also delete entities within the profile
     profile.authorization = await this.authorizationDefinitionService.appendCredentialAuthorizationRule(
       profile.authorization,
-
       {
-        type: AuthorizationCredential.GlobalAdminCommunity,
-        resourceID: '',
+        type: AuthorizationCredential.UserSelfManagement,
+        resourceID: user.id,
       },
       [AuthorizationPrivilege.DELETE]
     );


### PR DESCRIPTION
updated user auth policy to grant holders of user self mgmt for that user the right to delete; 
added mutation to reset the auth definition on a user (to fix existing user auth definitions)

To discuss: script for applying the user auth def resets after deployment of this fix into production. (or demo)
