### PR TITLE
authorization policy reset on orgs; tidy up

### DIFF
--- a/graphql-samples/mutations/authorization/reset-authorization-on-ecoverse
+++ b/graphql-samples/mutations/authorization/reset-authorization-on-ecoverse
@@ -1,5 +1,5 @@
-mutation authorizationDefinitionResetOnEcoverse($authorizationResetData: EcoverseAuthorizationResetInput!) {
-  authorizationDefinitionResetOnEcoverse(authorizationResetData: $authorizationResetData) {
+mutation authorizationPolicyResetOnEcoverse($authorizationResetData: EcoverseAuthorizationResetInput!) {
+  authorizationDPolicyResetOnEcoverse(authorizationResetData: $authorizationResetData) {
     nameID
   }
 }

--- a/graphql-samples/mutations/authorization/reset-authorization-on-ecoverse
+++ b/graphql-samples/mutations/authorization/reset-authorization-on-ecoverse
@@ -1,5 +1,5 @@
 mutation authorizationPolicyResetOnEcoverse($authorizationResetData: EcoverseAuthorizationResetInput!) {
-  authorizationDPolicyResetOnEcoverse(authorizationResetData: $authorizationResetData) {
+  authorizationPolicyResetOnEcoverse(authorizationResetData: $authorizationResetData) {
     nameID
   }
 }

--- a/graphql-samples/mutations/authorization/reset-authorization-on-organisation
+++ b/graphql-samples/mutations/authorization/reset-authorization-on-organisation
@@ -1,0 +1,11 @@
+mutation authorizationPolicyResetOnOrganisation($authorizationResetData: OrganisationAuthorizationResetInput!) {
+  authorizationPolicyResetOnOrganisation(authorizationResetData: $authorizationResetData) {
+    nameID
+  }
+}
+
+{
+  "authorizationResetData": {
+    "organisationID": "uuid_nameid"
+  }
+}

--- a/graphql-samples/mutations/authorization/reset-authorization-on-user
+++ b/graphql-samples/mutations/authorization/reset-authorization-on-user
@@ -1,5 +1,5 @@
-mutation authorizationDefinitionResetOnUser($authorizationResetData: UserAuthorizationResetInput!) {
-  authorizationDefinitionResetOnUser(authorizationResetData: $authorizationResetData) {
+mutation authorizationPolicyResetOnUser($authorizationResetData: UserAuthorizationResetInput!) {
+  authorizationPolicyResetOnUser(authorizationResetData: $authorizationResetData) {
     nameID
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Cherrytwist Foundation",
   "private": false,

--- a/src/core/bootstrap/bootstrap.service.ts
+++ b/src/core/bootstrap/bootstrap.service.ts
@@ -169,7 +169,7 @@ export class BootstrapService {
             });
           }
           user = await this.userAuthorizationService.grantCredentials(user);
-          user = await this.userAuthorizationService.applyAuthorizationRules(
+          user = await this.userAuthorizationService.applyAuthorizationPolicy(
             user
           );
         }
@@ -207,7 +207,7 @@ export class BootstrapService {
           nameID: DEFAULT_HOST_ORG_NAMEID,
           displayName: DEFAULT_HOST_ORG_DISPLAY_NAME,
         });
-        await this.organisationAuthorizationService.applyAuthorizationRules(
+        await this.organisationAuthorizationService.applyAuthorizationPolicy(
           hostOrg
         );
       }
@@ -220,7 +220,7 @@ export class BootstrapService {
           tagline: 'An empty ecoverse to be populated',
         },
       });
-      return await this.ecoverseAuthorizationService.applyAuthorizationRules(
+      return await this.ecoverseAuthorizationService.applyAuthorizationPolicy(
         ecoverse
       );
     }

--- a/src/domain/agent/agent/agent.service.ts
+++ b/src/domain/agent/agent/agent.service.ts
@@ -20,6 +20,7 @@ import { SsiAgentService } from '@src/services/platform/ssi/agent/ssi.agent.serv
 import { VerifiedCredential } from '@src/services/platform/ssi/agent';
 import { ConfigService } from '@nestjs/config';
 import { AuthorizationDefinitionService } from '@domain/common/authorization-definition/authorization.definition.service';
+import { AuthorizationDefinition } from '@domain/common/authorization-definition/authorization.definition.entity';
 
 @Injectable()
 export class AgentService {
@@ -35,7 +36,7 @@ export class AgentService {
   async createAgent(inputData: CreateAgentInput): Promise<IAgent> {
     const agent: IAgent = Agent.create(inputData);
     agent.credentials = [];
-    agent.authorization = await this.authorizationDefinitionService.createAuthorizationDefinition();
+    agent.authorization = new AuthorizationDefinition();
 
     const ssiEnabled = this.configService.get(ConfigurationTypes.Identity).ssi
       .enabled;

--- a/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
@@ -17,7 +17,7 @@ export class BaseChallengeAuthorizationService {
     private communityAuthorizationService: CommunityAuthorizationService
   ) {}
 
-  async applyAuthorizationRules(
+  async applyAuthorizationPolicy(
     baseChallenge: IBaseChallenge,
     repository: Repository<BaseChallenge>
   ): Promise<IBaseChallenge> {
@@ -28,7 +28,7 @@ export class BaseChallengeAuthorizationService {
     );
     // disable anonymous access for community
     if (community.authorization) {
-      baseChallenge.community = await this.communityAuthorizationService.applyAuthorizationRules(
+      baseChallenge.community = await this.communityAuthorizationService.applyAuthorizationPolicy(
         community,
         baseChallenge.authorization
       );
@@ -57,7 +57,7 @@ export class BaseChallengeAuthorizationService {
       context.authorization,
       baseChallenge.authorization
     );
-    baseChallenge.context = await this.contextAuthorizationService.applyAuthorizationRules(
+    baseChallenge.context = await this.contextAuthorizationService.applyAuthorizationPolicy(
       context
     );
 

--- a/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
@@ -36,10 +36,6 @@ export class BaseChallengeAuthorizationService {
 
     const tagset = baseChallenge.tagset;
     if (tagset) {
-      // Ensure always applying from a clean state
-      tagset.authorization = await this.authorizationDefinitionService.reset(
-        tagset.authorization
-      );
       tagset.authorization = this.authorizationDefinitionService.inheritParentAuthorization(
         tagset.authorization,
         baseChallenge.authorization
@@ -50,15 +46,21 @@ export class BaseChallengeAuthorizationService {
       baseChallenge.id,
       repository
     );
-    context.authorization = await this.authorizationDefinitionService.reset(
-      context.authorization
-    );
     context.authorization = this.authorizationDefinitionService.inheritParentAuthorization(
       context.authorization,
       baseChallenge.authorization
     );
     baseChallenge.context = await this.contextAuthorizationService.applyAuthorizationPolicy(
       context
+    );
+
+    baseChallenge.agent = await this.baseChallengeService.getAgent(
+      baseChallenge.id,
+      repository
+    );
+    baseChallenge.agent.authorization = this.authorizationDefinitionService.inheritParentAuthorization(
+      baseChallenge.agent.authorization,
+      baseChallenge.authorization
     );
 
     return await repository.save(baseChallenge);

--- a/src/domain/challenge/base-challenge/base.challenge.service.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.ts
@@ -60,7 +60,6 @@ export class BaseChallengeService {
         baseChallengeData.context
       );
     }
-    baseChallenge.authorization = new AuthorizationDefinition();
 
     baseChallenge.tagset = await this.tagsetService.createTagset({
       name: RestrictedTagsetNames.Default,

--- a/src/domain/challenge/challenge/challenge.resolver.mutations.ts
+++ b/src/domain/challenge/challenge/challenge.resolver.mutations.ts
@@ -57,7 +57,7 @@ export class ChallengeResolverMutations {
     const childChallenge = await this.challengeService.createChildChallenge(
       challengeData
     );
-    return await this.challengeAuthorizationService.applyAuthorizationRules(
+    return await this.challengeAuthorizationService.applyAuthorizationPolicy(
       childChallenge,
       challenge.authorization
     );
@@ -84,7 +84,7 @@ export class ChallengeResolverMutations {
     const opportunity = await this.challengeService.createOpportunity(
       opportunityData
     );
-    return await this.opportunityAuthorizationService.applyAuthorizationRules(
+    return await this.opportunityAuthorizationService.applyAuthorizationPolicy(
       opportunity,
       challenge.authorization
     );

--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -34,7 +34,7 @@ export class ChallengeAuthorizationService {
     private challengeRepository: Repository<Challenge>
   ) {}
 
-  async applyAuthorizationRules(
+  async applyAuthorizationPolicy(
     challenge: IChallenge,
     parentAuthorization: IAuthorizationDefinition | undefined
   ): Promise<IChallenge> {
@@ -52,13 +52,13 @@ export class ChallengeAuthorizationService {
     );
 
     // propagate authorization rules for child entities
-    await this.baseChallengeAuthorizationService.applyAuthorizationRules(
+    await this.baseChallengeAuthorizationService.applyAuthorizationPolicy(
       challenge,
       this.challengeRepository
     );
     if (challenge.childChallenges) {
       for (const childChallenge of challenge.childChallenges) {
-        await this.applyAuthorizationRules(
+        await this.applyAuthorizationPolicy(
           childChallenge,
           challenge.authorization
         );
@@ -66,7 +66,7 @@ export class ChallengeAuthorizationService {
     }
     if (challenge.opportunities) {
       for (const opportunity of challenge.opportunities) {
-        await this.opportunityAuthorizationService.applyAuthorizationRules(
+        await this.opportunityAuthorizationService.applyAuthorizationPolicy(
           opportunity,
           challenge.authorization
         );

--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -73,16 +73,6 @@ export class ChallengeAuthorizationService {
       }
     }
 
-    const agent = await this.challengeService.getAgent(challenge.id);
-    agent.authorization = await this.authorizationDefinitionService.reset(
-      agent.authorization
-    );
-
-    agent.authorization = this.authorizationDefinitionService.inheritParentAuthorization(
-      agent.authorization,
-      challenge.authorization
-    );
-
     return await this.challengeRepository.save(challenge);
   }
 

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -38,7 +38,6 @@ import { challengeLifecycleConfigExtended } from './challenge.lifecycle.config.e
 import { LifecycleService } from '@domain/common/lifecycle/lifecycle.service';
 import { INVP } from '@domain/common/nvp/nvp.interface';
 import { UUID_LENGTH } from '@common/constants';
-import { AuthorizationDefinition } from '@domain/common/authorization-definition';
 import { IAgent } from '@domain/agent/agent';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
 import { IChallenge } from './challenge.interface';
@@ -71,8 +70,6 @@ export class ChallengeService {
     ecoverseID: string
   ): Promise<IChallenge> {
     const challenge: IChallenge = Challenge.create(challengeData);
-    challenge.authorization = new AuthorizationDefinition();
-
     challenge.ecoverseID = ecoverseID;
     challenge.childChallenges = [];
 

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
@@ -51,7 +51,7 @@ export class EcoverseResolverMutations {
       `updateEcoverse: ${ecoverseData.nameID}`
     );
     const ecoverse = await this.ecoverseService.createEcoverse(ecoverseData);
-    return await this.ecoverseAuthorizationService.applyAuthorizationRules(
+    return await this.ecoverseAuthorizationService.applyAuthorizationPolicy(
       ecoverse
     );
   }
@@ -79,7 +79,7 @@ export class EcoverseResolverMutations {
     ecoverseData.ID = ecoverse.id;
 
     if (ecoverseData.authorizationDefinition) {
-      await this.ecoverseAuthorizationService.updateAuthorizationDefinition(
+      await this.ecoverseAuthorizationService.updateAuthorizationPolicy(
         ecoverse,
         ecoverseData.authorizationDefinition
       );
@@ -127,7 +127,7 @@ export class EcoverseResolverMutations {
       `challengeCreate: ${ecoverse.nameID}`
     );
     const challenge = await this.ecoverseService.createChallenge(challengeData);
-    return await this.challengeAuthorizationService.applyAuthorizationRules(
+    return await this.challengeAuthorizationService.applyAuthorizationPolicy(
       challenge,
       ecoverse.authorization
     );
@@ -135,10 +135,10 @@ export class EcoverseResolverMutations {
 
   @UseGuards(GraphqlGuard)
   @Mutation(() => IEcoverse, {
-    description: 'Reset the AuthorizationDefinition on the specified Ecoverse.',
+    description: 'Reset the Authorization Policy on the specified Ecoverse.',
   })
   @Profiling.api
-  async authorizationDefinitionResetOnEcoverse(
+  async authorizationPolicyResetOnEcoverse(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('authorizationResetData')
     authorizationResetData: EcoverseAuthorizationResetInput
@@ -152,7 +152,7 @@ export class EcoverseResolverMutations {
       AuthorizationPrivilege.UPDATE,
       `reset authorization definition: ${agentInfo.email}`
     );
-    return await this.ecoverseAuthorizationService.applyAuthorizationRules(
+    return await this.ecoverseAuthorizationService.applyAuthorizationPolicy(
       ecoverse
     );
   }

--- a/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
@@ -27,7 +27,7 @@ export class EcoverseAuthorizationService {
     private ecoverseRepository: Repository<Ecoverse>
   ) {}
 
-  async applyAuthorizationRules(ecoverse: IEcoverse): Promise<IEcoverse> {
+  async applyAuthorizationPolicy(ecoverse: IEcoverse): Promise<IEcoverse> {
     // Ensure always applying from a clean state
     ecoverse.authorization = await this.authorizationDefinitionService.reset(
       ecoverse.authorization
@@ -36,7 +36,7 @@ export class EcoverseAuthorizationService {
       ecoverse.authorization,
       ecoverse.id
     );
-    await this.baseChallengeAuthorizationService.applyAuthorizationRules(
+    await this.baseChallengeAuthorizationService.applyAuthorizationPolicy(
       ecoverse,
       this.ecoverseRepository
     );
@@ -44,7 +44,7 @@ export class EcoverseAuthorizationService {
     // propagate authorization rules for child entities
     const challenges = await this.ecoverseService.getChallenges(ecoverse);
     for (const challenge of challenges) {
-      await this.challengeAuthorizationService.applyAuthorizationRules(
+      await this.challengeAuthorizationService.applyAuthorizationPolicy(
         challenge,
         ecoverse.authorization
       );
@@ -61,7 +61,7 @@ export class EcoverseAuthorizationService {
     return await this.ecoverseRepository.save(ecoverse);
   }
 
-  async updateAuthorizationDefinition(
+  async updateAuthorizationPolicy(
     ecoverse: IEcoverse,
     authorizationUpdateData: UpdateAuthorizationDefinitionInput
   ): Promise<IEcoverse> {

--- a/src/domain/collaboration/opportunity/opportunity.service.authorization.ts
+++ b/src/domain/collaboration/opportunity/opportunity.service.authorization.ts
@@ -19,7 +19,7 @@ export class OpportunityAuthorizationService {
     private opportunityRepository: Repository<Opportunity>
   ) {}
 
-  async applyAuthorizationRules(
+  async applyAuthorizationPolicy(
     opportunity: IOpportunity,
     challengeAuthorization: IAuthorizationDefinition | undefined
   ): Promise<IOpportunity> {
@@ -29,7 +29,7 @@ export class OpportunityAuthorizationService {
     );
 
     // propagate authorization rules for child entities
-    await this.baseChallengeAuthorizationService.applyAuthorizationRules(
+    await this.baseChallengeAuthorizationService.applyAuthorizationPolicy(
       opportunity,
       this.opportunityRepository
     );

--- a/src/domain/common/authorization-definition/authorization.definition.service.ts
+++ b/src/domain/common/authorization-definition/authorization.definition.service.ts
@@ -27,11 +27,6 @@ export class AuthorizationDefinitionService {
     private readonly logger: LoggerService
   ) {}
 
-  async createAuthorizationDefinition(): Promise<IAuthorizationDefinition> {
-    const authorization = new AuthorizationDefinition();
-    return await this.authorizationDefinitionRepository.save(authorization);
-  }
-
   reset(
     authorizationDefinition: IAuthorizationDefinition | undefined
   ): IAuthorizationDefinition {

--- a/src/domain/community/community/community.resolver.mutations.ts
+++ b/src/domain/community/community/community.resolver.mutations.ts
@@ -26,6 +26,7 @@ import { UserService } from '@domain/community/user/user.service';
 import { UserGroupService } from '../user-group/user-group.service';
 import { AuthorizationDefinitionService } from '@domain/common/authorization-definition/authorization.definition.service';
 import { CommunitySendMessageInput } from './community.dto.send.msg';
+import { UserGroupAuthorizationService } from '../user-group/user-group.service.authorization';
 @Resolver()
 export class CommunityResolverMutations {
   constructor(
@@ -33,6 +34,7 @@ export class CommunityResolverMutations {
     private authorizationEngine: AuthorizationEngineService,
     private userService: UserService,
     private userGroupService: UserGroupService,
+    private userGroupAuthorizationService: UserGroupAuthorizationService,
     private communityService: CommunityService,
     @Inject(CommunityLifecycleOptionsProvider)
     private communityLifecycleOptionsProvider: CommunityLifecycleOptionsProvider,
@@ -62,7 +64,9 @@ export class CommunityResolverMutations {
       group.authorization,
       community.authorization
     );
-    return await this.userGroupService.saveUserGroup(group);
+    return await this.userGroupAuthorizationService.applyAuthorizationPolicy(
+      group
+    );
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -6,12 +6,14 @@ import { Community, ICommunity } from '@domain/community/community';
 import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
 import { AuthorizationDefinitionService } from '@domain/common/authorization-definition/authorization.definition.service';
 import { IAuthorizationDefinition } from '@domain/common/authorization-definition/authorization.definition.interface';
+import { UserGroupAuthorizationService } from '../user-group/user-group.service.authorization';
 
 @Injectable()
 export class CommunityAuthorizationService {
   constructor(
     private communityService: CommunityService,
     private authorizationDefinitionService: AuthorizationDefinitionService,
+    private userGroupAuthorizationService: UserGroupAuthorizationService,
     @InjectRepository(Community)
     private communityRepository: Repository<Community>
   ) {}
@@ -38,6 +40,7 @@ export class CommunityAuthorizationService {
         group.authorization,
         community.authorization
       );
+      await this.userGroupAuthorizationService.applyAuthorizationPolicy(group);
     }
 
     const applications = await this.communityService.getApplications(community);

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -16,7 +16,7 @@ export class CommunityAuthorizationService {
     private communityRepository: Repository<Community>
   ) {}
 
-  async applyAuthorizationRules(
+  async applyAuthorizationPolicy(
     community: ICommunity,
     parentAuthorization: IAuthorizationDefinition | undefined
   ): Promise<ICommunity> {

--- a/src/domain/community/organisation/organisation.dto.reset.authorization.ts
+++ b/src/domain/community/organisation/organisation.dto.reset.authorization.ts
@@ -1,0 +1,12 @@
+import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class OrganisationAuthorizationResetInput {
+  @Field(() => UUID_NAMEID_EMAIL, {
+    nullable: false,
+    description:
+      'The identifier of the Organisation whose AuthorizationDefinition should be reset.',
+  })
+  organisationID!: string;
+}

--- a/src/domain/community/organisation/organisation.resolver.fields.ts
+++ b/src/domain/community/organisation/organisation.resolver.fields.ts
@@ -3,10 +3,7 @@ import { Args, Resolver } from '@nestjs/graphql';
 import { Parent, ResolveField } from '@nestjs/graphql';
 import { Organisation } from './organisation.entity';
 import { OrganisationService } from './organisation.service';
-import {
-  ValidationException,
-  EntityNotInitializedException,
-} from '@common/exceptions';
+import { EntityNotInitializedException } from '@common/exceptions';
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { GraphqlGuard } from '@core/authorization';
 import { IOrganisation } from '@domain/community/organisation';
@@ -32,20 +29,7 @@ export class OrganisationResolverFields {
   })
   @Profiling.api
   async groups(@Parent() organisation: Organisation) {
-    // get the organisation with the groups loaded
-    const organisationGroups = await this.organisationService.getOrganisationOrFail(
-      organisation.id,
-      {
-        relations: ['groups'],
-      }
-    );
-    const groups = organisationGroups.groups;
-    if (!groups)
-      throw new ValidationException(
-        `No groups on organisation: ${organisation.displayName}`,
-        LogContext.COMMUNITY
-      );
-    return groups;
+    return await this.organisationService.getUserGroups(organisation);
   }
 
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)

--- a/src/domain/community/organisation/organisation.resolver.mutations.ts
+++ b/src/domain/community/organisation/organisation.resolver.mutations.ts
@@ -17,12 +17,14 @@ import { AgentInfo } from '@core/authentication/agent-info';
 import { UserGroupService } from '../user-group/user-group.service';
 import { AuthorizationDefinitionService } from '@domain/common/authorization-definition/authorization.definition.service';
 import { OrganisationAuthorizationResetInput } from './organisation.dto.reset.authorization';
+import { UserGroupAuthorizationService } from '../user-group/user-group.service.authorization';
 
 @Resolver(() => IOrganisation)
 export class OrganisationResolverMutations {
   constructor(
     private authorizationDefinitionService: AuthorizationDefinitionService,
     private userGroupService: UserGroupService,
+    private userGroupAuthorizationService: UserGroupAuthorizationService,
     private organisationAuthorizationService: OrganisationAuthorizationService,
     private organisationService: OrganisationService,
     private authorizationEngine: AuthorizationEngineService
@@ -80,7 +82,9 @@ export class OrganisationResolverMutations {
       group.authorization,
       organisation.authorization
     );
-    return await this.userGroupService.saveUserGroup(group);
+    return await this.userGroupAuthorizationService.applyAuthorizationPolicy(
+      group
+    );
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/domain/community/organisation/organisation.service.authorization.ts
+++ b/src/domain/community/organisation/organisation.service.authorization.ts
@@ -33,14 +33,13 @@ export class OrganisationAuthorizationService {
       organisation.id
     );
 
-    const profile = organisation.profile;
-    if (profile) {
-      profile.authorization = this.authorizationDefinition.inheritParentAuthorization(
-        profile.authorization,
+    if (organisation.profile) {
+      organisation.profile.authorization = this.authorizationDefinition.inheritParentAuthorization(
+        organisation.profile.authorization,
         organisation.authorization
       );
       organisation.profile = await this.profileAuthorizationService.applyAuthorizationPolicy(
-        profile
+        organisation.profile
       );
     }
 
@@ -49,6 +48,16 @@ export class OrganisationAuthorizationService {
       organisation.agent.authorization,
       organisation.authorization
     );
+
+    organisation.groups = await this.organisationService.getUserGroups(
+      organisation
+    );
+    for (const group of organisation.groups) {
+      group.authorization = this.authorizationDefinitionService.inheritParentAuthorization(
+        group.authorization,
+        organisation.authorization
+      );
+    }
 
     return await this.organisationRepository.save(organisation);
   }

--- a/src/domain/community/organisation/organisation.service.authorization.ts
+++ b/src/domain/community/organisation/organisation.service.authorization.ts
@@ -9,10 +9,12 @@ import { IAuthorizationDefinition } from '@domain/common/authorization-definitio
 import { AuthorizationDefinitionService } from '@domain/common/authorization-definition/authorization.definition.service';
 import { AuthorizationRuleCredential } from '@domain/common/authorization-definition/authorization.rule.credential';
 import { EntityNotInitializedException } from '@common/exceptions';
+import { OrganisationService } from './organisation.service';
 
 @Injectable()
 export class OrganisationAuthorizationService {
   constructor(
+    private organisationService: OrganisationService,
     private authorizationDefinition: AuthorizationDefinitionService,
     private authorizationDefinitionService: AuthorizationDefinitionService,
     private profileAuthorizationService: ProfileAuthorizationService,
@@ -41,6 +43,12 @@ export class OrganisationAuthorizationService {
         profile
       );
     }
+
+    organisation.agent = await this.organisationService.getAgent(organisation);
+    organisation.agent.authorization = this.authorizationDefinitionService.inheritParentAuthorization(
+      organisation.agent.authorization,
+      organisation.authorization
+    );
 
     return await this.organisationRepository.save(organisation);
   }

--- a/src/domain/community/organisation/organisation.service.authorization.ts
+++ b/src/domain/community/organisation/organisation.service.authorization.ts
@@ -10,6 +10,7 @@ import { AuthorizationDefinitionService } from '@domain/common/authorization-def
 import { AuthorizationRuleCredential } from '@domain/common/authorization-definition/authorization.rule.credential';
 import { EntityNotInitializedException } from '@common/exceptions';
 import { OrganisationService } from './organisation.service';
+import { UserGroupAuthorizationService } from '../user-group/user-group.service.authorization';
 
 @Injectable()
 export class OrganisationAuthorizationService {
@@ -17,6 +18,7 @@ export class OrganisationAuthorizationService {
     private organisationService: OrganisationService,
     private authorizationDefinition: AuthorizationDefinitionService,
     private authorizationDefinitionService: AuthorizationDefinitionService,
+    private userGroupAuthorizationService: UserGroupAuthorizationService,
     private profileAuthorizationService: ProfileAuthorizationService,
     @InjectRepository(Organisation)
     private organisationRepository: Repository<Organisation>
@@ -57,6 +59,7 @@ export class OrganisationAuthorizationService {
         group.authorization,
         organisation.authorization
       );
+      await this.userGroupAuthorizationService.applyAuthorizationPolicy(group);
     }
 
     return await this.organisationRepository.save(organisation);

--- a/src/domain/community/organisation/organisation.service.ts
+++ b/src/domain/community/organisation/organisation.service.ts
@@ -248,6 +248,22 @@ export class OrganisationService {
     return agent;
   }
 
+  async getUserGroups(organisation: IOrganisation): Promise<IUserGroup[]> {
+    const organisationGroups = await this.getOrganisationOrFail(
+      organisation.id,
+      {
+        relations: ['groups'],
+      }
+    );
+    const groups = organisationGroups.groups;
+    if (!groups)
+      throw new ValidationException(
+        `No groups on organisation: ${organisation.displayName}`,
+        LogContext.COMMUNITY
+      );
+    return groups;
+  }
+
   async getOrganisationCount(): Promise<number> {
     return await this.organisationRepository.count();
   }

--- a/src/domain/community/profile/profile.service.authorization.ts
+++ b/src/domain/community/profile/profile.service.authorization.ts
@@ -12,7 +12,7 @@ export class ProfileAuthorizationService {
     private profileRepository: Repository<Profile>
   ) {}
 
-  async applyAuthorizationRules(profile: IProfile): Promise<IProfile> {
+  async applyAuthorizationPolicy(profile: IProfile): Promise<IProfile> {
     if (profile.references) {
       for (const reference of profile.references) {
         reference.authorization = this.authorizationDefinitionService.inheritParentAuthorization(

--- a/src/domain/community/user-group/user-group.module.ts
+++ b/src/domain/community/user-group/user-group.module.ts
@@ -10,6 +10,7 @@ import { TagsetModule } from '@domain/common/tagset/tagset.module';
 import { AgentModule } from '@domain/agent/agent/agent.module';
 import { AuthorizationEngineModule } from '@src/services/platform/authorization-engine/authorization-engine.module';
 import { AuthorizationDefinitionModule } from '@domain/common/authorization-definition/authorization.definition.module';
+import { UserGroupAuthorizationService } from './user-group.service.authorization';
 
 @Module({
   imports: [
@@ -23,9 +24,10 @@ import { AuthorizationDefinitionModule } from '@domain/common/authorization-defi
   ],
   providers: [
     UserGroupService,
+    UserGroupAuthorizationService,
     UserGroupResolverMutations,
     UserGroupResolverFields,
   ],
-  exports: [UserGroupService],
+  exports: [UserGroupService, UserGroupAuthorizationService],
 })
 export class UserGroupModule {}

--- a/src/domain/community/user-group/user-group.service.authorization.ts
+++ b/src/domain/community/user-group/user-group.service.authorization.ts
@@ -26,8 +26,8 @@ export class UserGroupAuthorizationService {
     private userGroupRepository: Repository<UserGroup>
   ) {}
 
-  async applyAuthorizationRules(userGroup: IUserGroup): Promise<IUserGroup> {
-    userGroup.authorization = this.updateAuthorizationDefinition(
+  async applyAuthorizationPolicy(userGroup: IUserGroup): Promise<IUserGroup> {
+    userGroup.authorization = this.updateAuthorizationPolicy(
       userGroup.authorization,
       userGroup.id
     );
@@ -38,14 +38,14 @@ export class UserGroupAuthorizationService {
       profile.authorization,
       userGroup.authorization
     );
-    userGroup.profile = await this.profileAuthorizationService.applyAuthorizationRules(
+    userGroup.profile = await this.profileAuthorizationService.applyAuthorizationPolicy(
       profile
     );
 
     return await this.userGroupRepository.save(userGroup);
   }
 
-  private updateAuthorizationDefinition(
+  private updateAuthorizationPolicy(
     authorization: IAuthorizationDefinition | undefined,
     userGroupID: string
   ): IAuthorizationDefinition {

--- a/src/domain/community/user/user.resolver.mutations.ts
+++ b/src/domain/community/user/user.resolver.mutations.ts
@@ -35,9 +35,7 @@ export class UserResolverMutations {
     @CurrentUser() agentInfo: AgentInfo,
     @Args('userData') userData: CreateUserInput
   ): Promise<IUser> {
-    const authorization = this.userAuthorizationService.createUserAuthorizationDefinition(
-      agentInfo.email
-    );
+    const authorization = this.userAuthorizationService.createUserAuthorizationDefinition();
     await this.authorizationEngine.grantAccessOrFail(
       agentInfo,
       authorization,
@@ -46,7 +44,7 @@ export class UserResolverMutations {
     );
     let user = await this.userService.createUser(userData);
     user = await this.userAuthorizationService.grantCredentials(user);
-    return await this.userAuthorizationService.applyAuthorizationRules(user);
+    return await this.userAuthorizationService.applyAuthorizationPolicy(user);
   }
 
   @UseGuards(GraphqlGuard)
@@ -61,7 +59,7 @@ export class UserResolverMutations {
     // If a user has a valid session, and hence email / names etc set, then they can create a User profile
     let user = await this.userService.createUserFromAgentInfo(agentInfo);
     user = await this.userAuthorizationService.grantCredentials(user);
-    return await this.userAuthorizationService.applyAuthorizationRules(user);
+    return await this.userAuthorizationService.applyAuthorizationPolicy(user);
   }
 
   @UseGuards(GraphqlGuard)
@@ -131,10 +129,10 @@ export class UserResolverMutations {
 
   @UseGuards(GraphqlGuard)
   @Mutation(() => IUser, {
-    description: 'Reset the AuthorizationDefinition on the specified User.',
+    description: 'Reset the Authorization policy on the specified User.',
   })
   @Profiling.api
-  async authorizationDefinitionResetOnUser(
+  async authorizationPolicyResetOnUser(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('authorizationResetData')
     authorizationResetData: UserAuthorizationResetInput
@@ -146,8 +144,8 @@ export class UserResolverMutations {
       agentInfo,
       user.authorization,
       AuthorizationPrivilege.UPDATE,
-      `reset authorization definition on user: ${agentInfo.email}`
+      `reset authorization definition on user: ${authorizationResetData.userID}`
     );
-    return await this.userAuthorizationService.applyAuthorizationRules(user);
+    return await this.userAuthorizationService.applyAuthorizationPolicy(user);
   }
 }

--- a/src/domain/context/actor-group/actor-group.service.authorization.ts
+++ b/src/domain/context/actor-group/actor-group.service.authorization.ts
@@ -15,7 +15,7 @@ export class ActorGroupAuthorizationService {
     private actorGroupRepository: Repository<ActorGroup>
   ) {}
 
-  async applyAuthorizationRules(
+  async applyAuthorizationPolicy(
     actorGroup: IActorGroup,
     parentAuthorization: IAuthorizationDefinition | undefined
   ): Promise<IActorGroup> {

--- a/src/domain/context/context/context.service.authorization.ts
+++ b/src/domain/context/context/context.service.authorization.ts
@@ -19,14 +19,14 @@ export class ContextAuthorizationService {
     private contextRepository: Repository<Context>
   ) {}
 
-  async applyAuthorizationRules(context: IContext): Promise<IContext> {
+  async applyAuthorizationPolicy(context: IContext): Promise<IContext> {
     // cascade
     const ecosystemModel = await this.contextService.getEcosystemModel(context);
     ecosystemModel.authorization = await this.authorizationDefinitionService.inheritParentAuthorization(
       ecosystemModel.authorization,
       context.authorization
     );
-    context.ecosystemModel = await this.ecosysteModelAuthorizationService.applyAuthorizationRules(
+    context.ecosystemModel = await this.ecosysteModelAuthorizationService.applyAuthorizationPolicy(
       ecosystemModel
     );
 

--- a/src/domain/context/ecosystem-model/ecosystem-model.resolver.mutations.ts
+++ b/src/domain/context/ecosystem-model/ecosystem-model.resolver.mutations.ts
@@ -40,7 +40,7 @@ export class EcosystemModelResolverMutations {
     const actorGroup = await this.ecosystemModelService.createActorGroup(
       actorGroupData
     );
-    return await this.actorGroupAuthorizationService.applyAuthorizationRules(
+    return await this.actorGroupAuthorizationService.applyAuthorizationPolicy(
       actorGroup,
       ecosystemModel.authorization
     );

--- a/src/domain/context/ecosystem-model/ecosystem-model.service.authorization.ts
+++ b/src/domain/context/ecosystem-model/ecosystem-model.service.authorization.ts
@@ -19,7 +19,7 @@ export class EcosystemModelAuthorizationService {
     private ecosystemModelRepository: Repository<EcosystemModel>
   ) {}
 
-  async applyAuthorizationRules(
+  async applyAuthorizationPolicy(
     ecosystemModel: IEcosystemModel
   ): Promise<IEcosystemModel> {
     for (const actorGroup of this.ecosystemModelService.getActorGroups(
@@ -29,7 +29,7 @@ export class EcosystemModelAuthorizationService {
         actorGroup.authorization,
         ecosystemModel.authorization
       );
-      await this.actorGroupAuthorizationService.applyAuthorizationRules(
+      await this.actorGroupAuthorizationService.applyAuthorizationPolicy(
         actorGroup,
         ecosystemModel.authorization
       );


### PR DESCRIPTION
added mutation to reset authorization policy on Organizations; 
renamed to authorization policy in some places, more needed; 
fixed code duplication in User Auth Service; 
renamed methods to make clearer what they do

Notes:
- this fixes a number of bugs related to organisations that did not have their authoriztion policy properly set. It should be run via a script (to be added on lib) to demo / prod after trying out locally.