### PR TITLE
ensure all entities have an authorization policy on reset to avoid issues with data

### DIFF
--- a/src/domain/challenge/base-challenge/base.challenge.service.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.ts
@@ -74,7 +74,7 @@ export class BaseChallengeService {
   async setMembershipCredential(
     baseChallenge: IBaseChallenge,
     membershipCredentialType: AuthorizationCredential
-  ) {
+  ): Promise<ICommunity> {
     const membershipCredential = await this.credentialService.createCredential({
       type: membershipCredentialType,
       resourceID: baseChallenge.id,

--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -22,11 +22,13 @@ import {
 import { AuthorizationDefinitionService } from '@domain/common/authorization-definition/authorization.definition.service';
 import { Challenge } from './challenge.entity';
 import { IChallenge } from './challenge.interface';
+import { BaseChallengeService } from '../base-challenge/base.challenge.service';
 
 @Injectable()
 export class ChallengeAuthorizationService {
   constructor(
     private authorizationDefinitionService: AuthorizationDefinitionService,
+    private baseChallengeService: BaseChallengeService,
     private baseChallengeAuthorizationService: BaseChallengeAuthorizationService,
     private challengeService: ChallengeService,
     private opportunityAuthorizationService: OpportunityAuthorizationService,
@@ -77,6 +79,13 @@ export class ChallengeAuthorizationService {
           challenge.authorization
         );
       }
+    }
+
+    if (!challenge.community?.credential) {
+      challenge.community = await this.baseChallengeService.setMembershipCredential(
+        challenge,
+        AuthorizationCredential.ChallengeMember
+      );
     }
 
     return await this.challengeRepository.save(challenge);

--- a/src/domain/common/authorization-definition/authorization.definition.service.ts
+++ b/src/domain/common/authorization-definition/authorization.definition.service.ts
@@ -105,7 +105,11 @@ export class AuthorizationDefinitionService {
     childAuthorization: IAuthorizationDefinition | undefined,
     parentAuthorization: IAuthorizationDefinition | undefined
   ): IAuthorizationDefinition {
-    const child = this.validateAuthorization(childAuthorization);
+    // create a new child definition if one is not provided, a temporary fix
+    let child = childAuthorization;
+    if (!child) {
+      child = new AuthorizationDefinition();
+    }
     const parent = this.validateAuthorization(parentAuthorization);
     // Reset the child to a base state for authorization definition
     this.reset(child);


### PR DESCRIPTION
 + ensure all communities have a credential for membership
