### PR TITLE
User mgmt on Organisations; stabilisation

### DIFF
--- a/.github/workflows/build-deploy-k8s-test-azure.yml
+++ b/.github/workflows/build-deploy-k8s-test-azure.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: Azure/k8s-deploy@v1
         with:
           manifests: |
-            manifests/25-server-deployment-test.yaml
+            manifests/26-server-deployment-test.yaml
             manifests/30-server-service.yaml
           images: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:${{ github.sha }}

--- a/.github/workflows/build-deploy-k8s-test-azure.yml
+++ b/.github/workflows/build-deploy-k8s-test-azure.yml
@@ -4,46 +4,46 @@ on:
   workflow_dispatch:
 
 jobs:
-    build-and-deploy:
-        runs-on: ubuntu-latest
-        steps:
-        # checkout the repo
-        - name: 'Checkout GitHub Action'
-          uses: actions/checkout@master
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout the repo
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@master
 
-        - name: 'Login via Azure CLI'
-          uses: azure/login@v1
-          with:
-            creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-        - name: 'Build and push image'
-          uses: azure/docker-login@v1
-          with:
-            login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-            username: ${{ secrets.REGISTRY_USERNAME }}
-            password: ${{ secrets.REGISTRY_PASSWORD }}
-        - run: |
-            docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:latest
-            docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:${{ github.sha }}
-        - uses: Azure/aks-set-context@v1
-          with:
-            creds: ${{ secrets.AZURE_CRED_K8S }}
-            cluster-name: k8s-test
-            resource-group: res-grp-k8s-test
+      - name: 'Build and push image'
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - run: |
+          docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:latest
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:${{ github.sha }}
+      - uses: Azure/aks-set-context@v1
+        with:
+          creds: ${{ secrets.AZURE_CRED_K8S }}
+          cluster-name: k8s-test
+          resource-group: res-grp-k8s-test
 
-        - uses: Azure/k8s-create-secret@v1
-          with:
-            container-registry-url: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-            container-registry-username: ${{ secrets.REGISTRY_USERNAME }}
-            container-registry-password: ${{ secrets.REGISTRY_PASSWORD }}
-            secret-name: ct-server-secret
+      - uses: Azure/k8s-create-secret@v1
+        with:
+          container-registry-url: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          container-registry-username: ${{ secrets.REGISTRY_USERNAME }}
+          container-registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+          secret-name: ct-server-secret
 
-        - uses: Azure/k8s-deploy@v1
-          with:
-            manifests: |
-              manifests/25-server-deployment.yaml
-              manifests/30-server-service.yaml
-            images: |
-              ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:${{ github.sha }}
-            imagepullsecrets: |
-              ct-server-secret
+      - uses: Azure/k8s-deploy@v1
+        with:
+          manifests: |
+            manifests/25-server-deployment-test.yaml
+            manifests/30-server-service.yaml
+          images: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/ct-server:${{ github.sha }}
+          imagepullsecrets: |
+            ct-server-secret

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - v12.18.3
+  - v14.17.3
 env:
   matrix:
   - DATABASE_HOST=localhost MYSQL_DATABASE=alkemio MYSQL_ROOT_PASSWORD=toor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14.17.3-alpine
 
 
 #install CLI mariadb/mysql client

--- a/graphql-samples/mutations/update/assign-user-to-organisation
+++ b/graphql-samples/mutations/update/assign-user-to-organisation
@@ -1,4 +1,4 @@
-mutation assignUserToOrganisation($membershipData: AssignCOrganisationMemberInput!) {
+mutation assignUserToOrganisation($membershipData: AssignOrganisationMemberInput!) {
   assignUserToOrganisation(membershipData: $membershipData) {
     id,
   }

--- a/graphql-samples/mutations/update/assign-user-to-organisation
+++ b/graphql-samples/mutations/update/assign-user-to-organisation
@@ -1,0 +1,13 @@
+mutation assignUserToOrganisation($membershipData: AssignCOrganisationMemberInput!) {
+  assignUserToOrganisation(membershipData: $membershipData) {
+    id,
+  }
+}
+
+Variables:
+{
+  "membershipData": {
+    "userID": "uuid_nameid_email",
+    "organisationID": "uuid_nameid"
+  }
+}

--- a/manifests/26-server-deployment-test.yaml
+++ b/manifests/26-server-deployment-test.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: ct-server
-          image: ct-server
+          image: ctdev.azurecr.io/ct-server:latest
           envFrom:
             - secretRef:
                 name: ct-secrets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.11.6",
+  "version": "0.11.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Cherrytwist Foundation",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -129,5 +129,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "engines": {
+    "node": ">=14.17.3"
   }
 }

--- a/src/domain/challenge/base-challenge/base.challenge.service.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.ts
@@ -74,7 +74,7 @@ export class BaseChallengeService {
   async setMembershipCredential(
     baseChallenge: IBaseChallenge,
     membershipCredentialType: AuthorizationCredential
-  ) {
+  ): Promise<ICommunity> {
     const membershipCredential = await this.credentialService.createCredential({
       type: membershipCredentialType,
       resourceID: baseChallenge.id,

--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -22,11 +22,13 @@ import {
 import { AuthorizationDefinitionService } from '@domain/common/authorization-definition/authorization.definition.service';
 import { Challenge } from './challenge.entity';
 import { IChallenge } from './challenge.interface';
+import { BaseChallengeService } from '../base-challenge/base.challenge.service';
 
 @Injectable()
 export class ChallengeAuthorizationService {
   constructor(
     private authorizationDefinitionService: AuthorizationDefinitionService,
+    private baseChallengeService: BaseChallengeService,
     private baseChallengeAuthorizationService: BaseChallengeAuthorizationService,
     private challengeService: ChallengeService,
     private opportunityAuthorizationService: OpportunityAuthorizationService,
@@ -77,6 +79,13 @@ export class ChallengeAuthorizationService {
           challenge.authorization
         );
       }
+    }
+
+    if (!challenge.community?.credential) {
+      challenge.community = await this.baseChallengeService.setMembershipCredential(
+        challenge,
+        AuthorizationCredential.ChallengeMember
+      );
     }
 
     return await this.challengeRepository.save(challenge);

--- a/src/domain/common/authorization-definition/authorization.definition.service.ts
+++ b/src/domain/common/authorization-definition/authorization.definition.service.ts
@@ -105,7 +105,11 @@ export class AuthorizationDefinitionService {
     childAuthorization: IAuthorizationDefinition | undefined,
     parentAuthorization: IAuthorizationDefinition | undefined
   ): IAuthorizationDefinition {
-    const child = this.validateAuthorization(childAuthorization);
+    // create a new child definition if one is not provided, a temporary fix
+    let child = childAuthorization;
+    if (!child) {
+      child = new AuthorizationDefinition();
+    }
     const parent = this.validateAuthorization(parentAuthorization);
     // Reset the child to a base state for authorization definition
     this.reset(child);

--- a/src/domain/community/organisation/organisation.dto.assign.member.ts
+++ b/src/domain/community/organisation/organisation.dto.assign.member.ts
@@ -1,0 +1,11 @@
+import { UUID_NAMEID, UUID_NAMEID_EMAIL } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class AssignOrganisationMemberInput {
+  @Field(() => UUID_NAMEID, { nullable: false })
+  organisationID!: string;
+
+  @Field(() => UUID_NAMEID_EMAIL, { nullable: false })
+  userID!: string;
+}

--- a/src/domain/community/organisation/organisation.dto.remove.member.ts
+++ b/src/domain/community/organisation/organisation.dto.remove.member.ts
@@ -1,0 +1,11 @@
+import { UUID_NAMEID, UUID_NAMEID_EMAIL } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class RemoveOrganisationMemberInput {
+  @Field(() => UUID_NAMEID, { nullable: false })
+  organisationID!: string;
+
+  @Field(() => UUID_NAMEID_EMAIL, { nullable: false })
+  userID!: string;
+}


### PR DESCRIPTION
API
- new mutations for adding / removing users as members of organisations

Dev
- Migrated to Node 14, and made this version the minimum supported version

Authorization
- Extended reset authorization policy framework to deal with missing policies
- Ensure communities have a reference credential for checking membership