### PR TITLE
Enabled introspection in all cases so gql schema is visible

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -101,6 +101,7 @@ import { RequestLoggerMiddleware } from '@core/middleware/request.logger.middlew
         cors: false, // this is to avoid a duplicate cors origin header being created when behind the oathkeeper reverse proxy
         uploads: false,
         autoSchemaFile: true,
+        introspection: true,
         playground: {
           settings: {
             'request.credentials': 'include',


### PR DESCRIPTION
To test, set NODE_ENV=production. If graphql schema is visible, then the fix works.