### PR TITLE
Authorization policy fixes

### DIFF
--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -122,6 +122,8 @@ export class ChallengeAuthorizationService {
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
+        AuthorizationPrivilege.GRANT,
+        AuthorizationPrivilege.DELETE,
       ],
     };
     rules.push(challengeAdmin);

--- a/src/domain/community/community/community.resolver.mutations.ts
+++ b/src/domain/community/community/community.resolver.mutations.ts
@@ -159,7 +159,7 @@ export class CommunityResolverMutations {
         application.authorization,
         {
           type: AuthorizationCredential.UserSelfManagement,
-          resourceID: applicationData.userID,
+          resourceID: user.id,
         },
         [
           AuthorizationPrivilege.READ,

--- a/src/domain/community/community/community.resolver.mutations.ts
+++ b/src/domain/community/community/community.resolver.mutations.ts
@@ -85,7 +85,7 @@ export class CommunityResolverMutations {
     await this.authorizationEngine.grantAccessOrFail(
       agentInfo,
       community.authorization,
-      AuthorizationPrivilege.UPDATE,
+      AuthorizationPrivilege.GRANT,
       `assign user community: ${community.displayName}`
     );
     return await this.communityService.assignMember(membershipData);
@@ -106,7 +106,7 @@ export class CommunityResolverMutations {
     await this.authorizationEngine.grantAccessOrFail(
       agentInfo,
       community.authorization,
-      AuthorizationPrivilege.UPDATE,
+      AuthorizationPrivilege.GRANT,
       `remove user community: ${community.displayName}`
     );
     return await this.communityService.removeMember(membershipData);
@@ -158,8 +158,8 @@ export class CommunityResolverMutations {
       await this.authorizationPolicyService.appendCredentialAuthorizationRule(
         application.authorization,
         {
-          type: AuthorizationCredential.GlobalRegistered,
-          resourceID: '',
+          type: AuthorizationCredential.UserSelfManagement,
+          resourceID: applicationData.userID,
         },
         [
           AuthorizationPrivilege.READ,


### PR DESCRIPTION
fixed community user membership to use grant privilege; 
fixed auth policy assigned to new applications;
fixed auth policy on challenges for ChallengeAdmins

Note: requires reseting the authorization policies on ecoverses + users. 

It would be useful to re-run the authorization test harness applying this patch + resetting auth policies. 