### PR TITLE
added removal of membership credential for community, group + org when removing those entities

### DIFF
--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -133,6 +133,12 @@ export class CommunityService {
       }
     }
 
+    // Remove all issued membership credentials
+    const members = await this.getMembers(community);
+    for (const member of members) {
+      await this.removeMember({ userID: member.id, communityID: community.id });
+    }
+
     if (community.authorization)
       await this.authorizationPolicyService.delete(community.authorization);
 

--- a/src/domain/community/organisation/organisation.service.ts
+++ b/src/domain/community/organisation/organisation.service.ts
@@ -136,6 +136,15 @@ export class OrganisationService {
       }
     }
 
+    // Remove all issued membership credentials
+    const members = await this.getMembers(organisation);
+    for (const member of members) {
+      await this.removeMember({
+        userID: member.id,
+        organisationID: organisation.id,
+      });
+    }
+
     if (organisation.authorization) {
       await this.authorizationPolicyService.delete(organisation.authorization);
     }
@@ -196,12 +205,12 @@ export class OrganisationService {
     return organisation;
   }
 
-  async getOrganisations(): Promise<Organisation[]> {
+  async getOrganisations(): Promise<IOrganisation[]> {
     const organisations = await this.organisationRepository.find();
     return organisations || [];
   }
 
-  async getMembers(organisation: Organisation): Promise<IUser[]> {
+  async getMembers(organisation: IOrganisation): Promise<IUser[]> {
     return await this.userService.usersWithCredentials({
       type: AuthorizationCredential.OrganisationMember,
       resourceID: organisation.id,

--- a/src/domain/community/user-group/user-group.service.ts
+++ b/src/domain/community/user-group/user-group.service.ts
@@ -82,6 +82,12 @@ export class UserGroupService {
     if (group.authorization)
       await this.authorizationPolicyService.delete(group.authorization);
 
+    // Remove all issued membership credentials
+    const members = await this.getMembers(group.id);
+    for (const member of members) {
+      await this.removeUser({ userID: member.id, groupID: group.id });
+    }
+
     const { id } = group;
     const result = await this.userGroupRepository.remove(group);
     return {


### PR DESCRIPTION
Note: this fixes any future removals but does not address updating existing credentials.

There is a separate card raised to purge orphaned credentials: https://github.com/alkem-io/server/issues/1274
