### PR TITLE
separate out DTOs used for creating challenges in ecoverse + challenge

### DIFF
--- a/graphql-samples/mutations/create/create-challenge
+++ b/graphql-samples/mutations/create/create-challenge
@@ -1,4 +1,4 @@
-mutation CreateChallenge($challengeData: CreateChallengeInEcoverseInput!) {
+mutation CreateChallenge($challengeData: CreateChallengeOnEcoverseInput!) {
   createChallenge(challengeData: $challengeData) {
     displayName,
     id

--- a/graphql-samples/mutations/create/create-challenge
+++ b/graphql-samples/mutations/create/create-challenge
@@ -1,4 +1,4 @@
-mutation CreateChallenge($challengeData: CreateChallengeInput!) {
+mutation CreateChallenge($challengeData: CreateChallengeInEcoverseInput!) {
   createChallenge(challengeData: $challengeData) {
     displayName,
     id
@@ -9,7 +9,7 @@ query variables:
 {
   "challengeData":
   {
-    "parentID": "1",
+    "ecoverseID": "1",
     "displayName": "Balance the grid",
     "nameID": "balance-grid",
     "lifecycleTemplate": "EXTENDED",

--- a/graphql-samples/mutations/create/create-child-challenge
+++ b/graphql-samples/mutations/create/create-child-challenge
@@ -1,4 +1,4 @@
-mutation createChildChallenge($childChallengeData: CreateChallengeInChallengeInput!) {
+mutation createChildChallenge($childChallengeData: CreateChallengeOnChallengeInput!) {
   createChildChallenge(challengeData: $childChallengeData) {
     displayName,
     id

--- a/graphql-samples/mutations/create/create-child-challenge
+++ b/graphql-samples/mutations/create/create-child-challenge
@@ -1,5 +1,5 @@
-mutation createChildChallenge($childChallengeData: CreateChallengeInput!) {
-  createChildChallenge(childChallengeData: $childChallengeData) {
+mutation createChildChallenge($childChallengeData: CreateChallengeInChallengeInput!) {
+  createChildChallenge(challengeData: $childChallengeData) {
     displayName,
     id
   }
@@ -9,7 +9,7 @@ query variables:
 {
   "childChallengeData":
   {
-    "challengeID": "1",
+    "challengeID": "uuid",
     "displayName": "Balance the grid",
     "nameID": "balance-grid",
     "lifecycleTemplate": "EXTENDED",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Cherrytwist Foundation",
   "private": false,

--- a/src/domain/challenge/challenge/challenge.resolver.mutations.ts
+++ b/src/domain/challenge/challenge/challenge.resolver.mutations.ts
@@ -26,7 +26,7 @@ import { IChallenge } from './challenge.interface';
 import { IUser } from '@domain/community/user/user.interface';
 import { AssignChallengeAdminInput } from './dto/challenge.dto.assign.admin';
 import { RemoveChallengeAdminInput } from './dto/challenge.dto.remove.admin';
-import { CreateChallengeInChallengeInput } from './dto/challenge.dto.create.in.challenge';
+import { CreateChallengeOnChallengeInput } from './dto/challenge.dto.create.in.challenge';
 
 @Resolver()
 export class ChallengeResolverMutations {
@@ -45,7 +45,7 @@ export class ChallengeResolverMutations {
   @Profiling.api
   async createChildChallenge(
     @CurrentUser() agentInfo: AgentInfo,
-    @Args('challengeData') challengeData: CreateChallengeInChallengeInput
+    @Args('challengeData') challengeData: CreateChallengeOnChallengeInput
   ): Promise<IChallenge> {
     const challenge = await this.challengeService.getChallengeOrFail(
       challengeData.challengeID

--- a/src/domain/challenge/challenge/challenge.resolver.mutations.ts
+++ b/src/domain/challenge/challenge/challenge.resolver.mutations.ts
@@ -6,7 +6,6 @@ import { CurrentUser, Profiling } from '@src/common/decorators';
 import {
   ChallengeEventInput,
   DeleteChallengeInput,
-  CreateChallengeInput,
   UpdateChallengeInput,
 } from '@domain/challenge/challenge';
 import {
@@ -27,6 +26,7 @@ import { IChallenge } from './challenge.interface';
 import { IUser } from '@domain/community/user/user.interface';
 import { AssignChallengeAdminInput } from './dto/challenge.dto.assign.admin';
 import { RemoveChallengeAdminInput } from './dto/challenge.dto.remove.admin';
+import { CreateChallengeInChallengeInput } from './dto/challenge.dto.create.in.challenge';
 
 @Resolver()
 export class ChallengeResolverMutations {
@@ -45,10 +45,10 @@ export class ChallengeResolverMutations {
   @Profiling.api
   async createChildChallenge(
     @CurrentUser() agentInfo: AgentInfo,
-    @Args('challengeData') challengeData: CreateChallengeInput
+    @Args('challengeData') challengeData: CreateChallengeInChallengeInput
   ): Promise<IChallenge> {
     const challenge = await this.challengeService.getChallengeOrFail(
-      challengeData.parentID
+      challengeData.challengeID
     );
     await this.authorizationEngine.grantAccessOrFail(
       agentInfo,

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -49,6 +49,7 @@ import { UserService } from '@domain/community/user/user.service';
 import { IUser } from '@domain/community/user/user.interface';
 import { AssignChallengeAdminInput } from './dto/challenge.dto.assign.admin';
 import { RemoveChallengeAdminInput } from './dto/challenge.dto.remove.admin';
+import { CreateChallengeInChallengeInput } from './dto/challenge.dto.create.in.challenge';
 
 @Injectable()
 export class ChallengeService {
@@ -359,14 +360,14 @@ export class ChallengeService {
   }
 
   async createChildChallenge(
-    challengeData: CreateChallengeInput
+    challengeData: CreateChallengeInChallengeInput
   ): Promise<IChallenge> {
     this.logger.verbose?.(
-      `Adding child Challenge to Challenge (${challengeData.parentID})`,
+      `Adding child Challenge to Challenge (${challengeData.challengeID})`,
       LogContext.CHALLENGES
     );
 
-    const challenge = await this.getChallengeOrFail(challengeData.parentID, {
+    const challenge = await this.getChallengeOrFail(challengeData.challengeID, {
       relations: ['childChallenges', 'community'],
     });
 

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -49,7 +49,7 @@ import { UserService } from '@domain/community/user/user.service';
 import { IUser } from '@domain/community/user/user.interface';
 import { AssignChallengeAdminInput } from './dto/challenge.dto.assign.admin';
 import { RemoveChallengeAdminInput } from './dto/challenge.dto.remove.admin';
-import { CreateChallengeInChallengeInput } from './dto/challenge.dto.create.in.challenge';
+import { CreateChallengeOnChallengeInput } from './dto/challenge.dto.create.in.challenge';
 
 @Injectable()
 export class ChallengeService {
@@ -360,7 +360,7 @@ export class ChallengeService {
   }
 
   async createChildChallenge(
-    challengeData: CreateChallengeInChallengeInput
+    challengeData: CreateChallengeOnChallengeInput
   ): Promise<IChallenge> {
     this.logger.verbose?.(
       `Adding child Challenge to Challenge (${challengeData.challengeID})`,

--- a/src/domain/challenge/challenge/dto/challenge.dto.create.in.challenge.ts
+++ b/src/domain/challenge/challenge/dto/challenge.dto.create.in.challenge.ts
@@ -1,0 +1,9 @@
+import { UUID } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+import { CreateChallengeInput } from './challenge.dto.create';
+
+@InputType()
+export class CreateChallengeInChallengeInput extends CreateChallengeInput {
+  @Field(() => UUID, { nullable: false })
+  challengeID!: string;
+}

--- a/src/domain/challenge/challenge/dto/challenge.dto.create.in.challenge.ts
+++ b/src/domain/challenge/challenge/dto/challenge.dto.create.in.challenge.ts
@@ -3,7 +3,7 @@ import { Field, InputType } from '@nestjs/graphql';
 import { CreateChallengeInput } from './challenge.dto.create';
 
 @InputType()
-export class CreateChallengeInChallengeInput extends CreateChallengeInput {
+export class CreateChallengeOnChallengeInput extends CreateChallengeInput {
   @Field(() => UUID, { nullable: false })
   challengeID!: string;
 }

--- a/src/domain/challenge/challenge/dto/challenge.dto.create.in.ecoverse.ts
+++ b/src/domain/challenge/challenge/dto/challenge.dto.create.in.ecoverse.ts
@@ -1,0 +1,9 @@
+import { UUID_NAMEID } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+import { CreateChallengeInput } from './challenge.dto.create';
+
+@InputType()
+export class CreateChallengeInEcoverseInput extends CreateChallengeInput {
+  @Field(() => UUID_NAMEID, { nullable: false })
+  ecoverseID!: string;
+}

--- a/src/domain/challenge/challenge/dto/challenge.dto.create.in.ecoverse.ts
+++ b/src/domain/challenge/challenge/dto/challenge.dto.create.in.ecoverse.ts
@@ -3,7 +3,7 @@ import { Field, InputType } from '@nestjs/graphql';
 import { CreateChallengeInput } from './challenge.dto.create';
 
 @InputType()
-export class CreateChallengeInEcoverseInput extends CreateChallengeInput {
+export class CreateChallengeOnEcoverseInput extends CreateChallengeInput {
   @Field(() => UUID_NAMEID, { nullable: false })
   ecoverseID!: string;
 }

--- a/src/domain/challenge/challenge/dto/challenge.dto.create.ts
+++ b/src/domain/challenge/challenge/dto/challenge.dto.create.ts
@@ -5,9 +5,6 @@ import { IsOptional } from 'class-validator';
 
 @InputType()
 export class CreateChallengeInput extends CreateBaseChallengeInput {
-  @Field(() => UUID_NAMEID, { nullable: false })
-  parentID!: string;
-
   @Field(() => [UUID_NAMEID], {
     nullable: true,
     description: 'Set lead Organisations for the Challenge.',

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
@@ -1,4 +1,3 @@
-import { CreateChallengeInput } from '@domain/challenge/challenge/dto/challenge.dto.create';
 import { IChallenge } from '@domain/challenge/challenge/challenge.interface';
 import { UseGuards } from '@nestjs/common';
 import { Resolver, Args, Mutation } from '@nestjs/graphql';
@@ -22,6 +21,7 @@ import { IUser } from '@domain/community/user/user.interface';
 import { AssignEcoverseAdminInput } from './dto/ecoverse.dto.assign.admin';
 import { RemoveEcoverseAdminInput } from './dto/ecoverse.dto.remove.admin';
 import { EcoverseAuthorizationResetInput } from './dto/ecoverse.dto.reset.authorization';
+import { CreateChallengeInEcoverseInput } from '../challenge/dto/challenge.dto.create.in.ecoverse';
 @Resolver()
 export class EcoverseResolverMutations {
   private globalAdminAuthorization: IAuthorizationPolicy;
@@ -119,10 +119,10 @@ export class EcoverseResolverMutations {
   @Profiling.api
   async createChallenge(
     @CurrentUser() agentInfo: AgentInfo,
-    @Args('challengeData') challengeData: CreateChallengeInput
+    @Args('challengeData') challengeData: CreateChallengeInEcoverseInput
   ): Promise<IChallenge> {
     const ecoverse = await this.ecoverseService.getEcoverseOrFail(
-      challengeData.parentID
+      challengeData.ecoverseID
     );
     await this.authorizationEngine.grantAccessOrFail(
       agentInfo,
@@ -130,7 +130,9 @@ export class EcoverseResolverMutations {
       AuthorizationPrivilege.CREATE,
       `challengeCreate: ${ecoverse.nameID}`
     );
-    const challenge = await this.ecoverseService.createChallenge(challengeData);
+    const challenge = await this.ecoverseService.createChallengeInEcoverse(
+      challengeData
+    );
     return await this.challengeAuthorizationService.applyAuthorizationPolicy(
       challenge,
       ecoverse.authorization

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
@@ -21,7 +21,7 @@ import { IUser } from '@domain/community/user/user.interface';
 import { AssignEcoverseAdminInput } from './dto/ecoverse.dto.assign.admin';
 import { RemoveEcoverseAdminInput } from './dto/ecoverse.dto.remove.admin';
 import { EcoverseAuthorizationResetInput } from './dto/ecoverse.dto.reset.authorization';
-import { CreateChallengeInEcoverseInput } from '../challenge/dto/challenge.dto.create.in.ecoverse';
+import { CreateChallengeOnEcoverseInput } from '../challenge/dto/challenge.dto.create.in.ecoverse';
 @Resolver()
 export class EcoverseResolverMutations {
   private globalAdminAuthorization: IAuthorizationPolicy;
@@ -119,7 +119,7 @@ export class EcoverseResolverMutations {
   @Profiling.api
   async createChallenge(
     @CurrentUser() agentInfo: AgentInfo,
-    @Args('challengeData') challengeData: CreateChallengeInEcoverseInput
+    @Args('challengeData') challengeData: CreateChallengeOnEcoverseInput
   ): Promise<IChallenge> {
     const ecoverse = await this.ecoverseService.getEcoverseOrFail(
       challengeData.ecoverseID

--- a/src/domain/challenge/ecoverse/ecoverse.service.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.ts
@@ -39,7 +39,7 @@ import { IUser } from '@domain/community/user/user.interface';
 import { RemoveEcoverseAdminInput } from './dto/ecoverse.dto.remove.admin';
 import { UserService } from '@domain/community/user/user.service';
 import { UpdateEcoverseInput } from './dto/ecoverse.dto.update';
-import { CreateChallengeInEcoverseInput } from '../challenge/dto/challenge.dto.create.in.ecoverse';
+import { CreateChallengeOnEcoverseInput } from '../challenge/dto/challenge.dto.create.in.ecoverse';
 
 @Injectable()
 export class EcoverseService {
@@ -296,7 +296,7 @@ export class EcoverseService {
   }
 
   async createChallengeInEcoverse(
-    challengeData: CreateChallengeInEcoverseInput
+    challengeData: CreateChallengeOnEcoverseInput
   ): Promise<IChallenge> {
     const ecoverse = await this.getEcoverseOrFail(challengeData.ecoverseID, {
       relations: ['challenges'],

--- a/src/domain/challenge/ecoverse/ecoverse.service.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.ts
@@ -6,7 +6,6 @@ import {
   ValidationException,
 } from '@common/exceptions';
 import { IAgent } from '@domain/agent/agent';
-import { CreateChallengeInput } from '@domain/challenge/challenge';
 import { ChallengeService } from '@domain/challenge/challenge/challenge.service';
 import {
   CreateEcoverseInput,
@@ -40,6 +39,7 @@ import { IUser } from '@domain/community/user/user.interface';
 import { RemoveEcoverseAdminInput } from './dto/ecoverse.dto.remove.admin';
 import { UserService } from '@domain/community/user/user.service';
 import { UpdateEcoverseInput } from './dto/ecoverse.dto.update';
+import { CreateChallengeInEcoverseInput } from '../challenge/dto/challenge.dto.create.in.ecoverse';
 
 @Injectable()
 export class EcoverseService {
@@ -295,10 +295,10 @@ export class EcoverseService {
     );
   }
 
-  async createChallenge(
-    challengeData: CreateChallengeInput
+  async createChallengeInEcoverse(
+    challengeData: CreateChallengeInEcoverseInput
   ): Promise<IChallenge> {
-    const ecoverse = await this.getEcoverseOrFail(challengeData.parentID, {
+    const ecoverse = await this.getEcoverseOrFail(challengeData.ecoverseID, {
       relations: ['challenges'],
     });
     const nameAvailable = await this.namingService.isNameIdAvailableInEcoverse(
@@ -318,7 +318,7 @@ export class EcoverseService {
     );
     if (!ecoverse.challenges)
       throw new ValidationException(
-        `Unable to create Challenge: challenges not initialized: ${challengeData.parentID}`,
+        `Unable to create Challenge: challenges not initialized: ${challengeData.ecoverseID}`,
         LogContext.CHALLENGES
       );
 


### PR DESCRIPTION
Separate DTOs for the creation of a challenge in an ecvoerse and in a challenge. 

Update DTO field names to make it clearer.

Updated graphql samples.