### PR TITLE
IPFS Fix

### DIFF
--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -122,10 +122,10 @@ http:
         - 'web'
 
     ipfs:
-      rule: 'PathPrefix(`/ipfs`)'
+      rule: 'PathPrefix(`/ipfs`) || HostRegexp(`{^[a-zA-Z0-9_.-]*$}.ipfs.localhost`)'
       service: 'ipfs-http-adapter'
       entryPoints:
-        - 'ipfs-http-adapter'
+        - 'web'
 
     ipfs-api:
       rule: 'PathPrefix(`/`)'

--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -1,5 +1,15 @@
 http:
   services:
+    ipfs-http-adapter:
+      loadBalancer:
+        servers:
+          - url: 'http://ipfs:8080'
+
+    ipfs-api:
+      loadBalancer:
+        servers:
+          - url: 'http://ipfs:5001'
+
     alkemio-server:
       loadBalancer:
         servers:
@@ -29,11 +39,6 @@ http:
       loadBalancer:
         servers:
           - url: 'http://oathkeeper:4456/'
-
-    ipfs-http-adapter:
-      loadBalancer:
-        servers:
-          - url: 'http://ipfs:8080/'
 
     synapse:
       loadBalancer:
@@ -96,12 +101,6 @@ http:
       entryPoints:
         - 'web'
 
-    ipfs:
-      rule: 'PathPrefix(`/ipfs`)'
-      service: 'ipfs-http-adapter'
-      entryPoints:
-        - 'web'
-
     synapse:
       rule: 'PathPrefix(`/`)'
       service: 'synapse'
@@ -121,6 +120,19 @@ http:
         - strip-jwks-prefix
       entryPoints:
         - 'web'
+
+    ipfs:
+      rule: 'PathPrefix(`/ipfs`)'
+      service: 'ipfs-http-adapter'
+      entryPoints:
+        - 'ipfs-http-adapter'
+
+    ipfs-api:
+      rule: 'PathPrefix(`/`)'
+      service: 'ipfs-api'
+      entryPoints:
+        - 'ipfs-api'
+
 tcp:
   services:
     mysql:

--- a/.build/traefik/traefik.yml
+++ b/.build/traefik/traefik.yml
@@ -15,8 +15,6 @@ entryPoints:
     address: ':8008'
   ipfs-api:
     address: ':5001'
-  ipfs-http-adapter:
-    address: ':8079'
 
 providers:
   file:

--- a/.build/traefik/traefik.yml
+++ b/.build/traefik/traefik.yml
@@ -13,6 +13,10 @@ entryPoints:
     address: ':3306'
   synapse:
     address: ':8008'
+  ipfs-api:
+    address: ':5001'
+  ipfs-http-adapter:
+    address: ':8079'
 
 providers:
   file:

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -293,10 +293,10 @@ storage:
   # IPFS (https://ipfs.io/) configuration.
   ipfs:
     # IPFS API endpoint. The name that the server uses for access IPFS for uploads.
-    endpoint: ${IPFS_ENDPOINT}:http://ipfs:5001
+    endpoint: ${IPFS_ENDPOINT}:http://localhost:5001
 
     # IPFS http proxy endpoint. Exposed through traefik (or any ingress / reverse proxy of choice).
-    clientEndpoint: ${IPFS_CLIENT_ENDPOINT}:http://localhost:3000/ipfs
+    clientEndpoint: ${IPFS_CLIENT_ENDPOINT}:http://localhost:8080/ipfs
 
     # Max file size of files that will be uploaded to IPFS (in bytes).
     maxFileSize: 1048576

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -296,7 +296,7 @@ storage:
     endpoint: ${IPFS_ENDPOINT}:http://localhost:5001
 
     # IPFS http proxy endpoint. Exposed through traefik (or any ingress / reverse proxy of choice).
-    clientEndpoint: ${IPFS_CLIENT_ENDPOINT}:http://localhost:8080/ipfs
+    clientEndpoint: ${IPFS_CLIENT_ENDPOINT}:http://localhost:3000/ipfs
 
     # Max file size of files that will be uploaded to IPFS (in bytes).
     maxFileSize: 1048576

--- a/docs/Running.md
+++ b/docs/Running.md
@@ -33,7 +33,7 @@ E.g. on Linux you can grant permissions the following way:
 - Navigate to the directory, e.g. .build/synapse
 - Change the permissions with `chmod o+w .`
 
-2. Validate that the server is running by visiting the [graphql endpoint](http://localhost:4455/graphql).
+2. Validate that the server is running by visiting the [graphql endpoint](http://localhost:3000/graphql).
 
 ## Notes
 

--- a/quickstart-server.yml
+++ b/quickstart-server.yml
@@ -26,7 +26,7 @@ services:
       - WAIT_HOST_CONNECT_TIMEOUT=30
       - GRAPHQL_ENDPOINT_PORT=4000
       - IPFS_ENDPOINT=http://ipfs:5001
-      - IPFS_CLIENT_ENDPOINT=http://localhost:8080/ipfs
+      - IPFS_CLIENT_ENDPOINT=http://localhost:3000/ipfs
       - AUTH_ORY_KRATOS_JWKS_URI=http://oathkeeper:4456/.well-known/jwks.json
       - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/identity/ory/kratos/public
       - AUTH_ORY_KRATOS_PUBLIC_BASE_URL_SERVER=http://kratos:4433/

--- a/quickstart-server.yml
+++ b/quickstart-server.yml
@@ -26,7 +26,7 @@ services:
       - WAIT_HOST_CONNECT_TIMEOUT=30
       - GRAPHQL_ENDPOINT_PORT=4000
       - IPFS_ENDPOINT=http://ipfs:5001
-      - IPFS_CLIENT_ENDPOINT=http://localhost:3000/ipfs
+      - IPFS_CLIENT_ENDPOINT=http://localhost:8080/ipfs
       - AUTH_ORY_KRATOS_JWKS_URI=http://oathkeeper:4456/.well-known/jwks.json
       - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/identity/ory/kratos/public
       - AUTH_ORY_KRATOS_PUBLIC_BASE_URL_SERVER=http://kratos:4433/

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -19,7 +19,6 @@ services:
       - 3306:3306
       - 8008:8008
       - 5001:5001
-      - 8080:8079
     networks:
       - alkemio_dev_net
     environment:

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -18,6 +18,8 @@ services:
       - 3000:80
       - 3306:3306
       - 8008:8008
+      - 5001:5001
+      - 8080:8079
     networks:
       - alkemio_dev_net
     environment:


### PR DESCRIPTION
When working on the 'web port' (3000), having an image uploaded to ipfs should resolve it via traefik route through http://localhost:3000/ipfs/[CID].

However, routing to that endpoint has a redirect to XXX.ipfs.localhost:3000 that is not managed by the same IPFS route and ends up trying to be routed to the web client. The redirect to .ipfs.domain is not observed on any prod environment.

I have fixed it by changing the IPFS route to match port 8080 and not 3000. This will imply changes on demo and client as well. Alternative approach would be to try match and redirect .ipfs.localhost as well to the correct endpoint and port.