### PR TITLE
Extend membership entities so they can look normalized for the apollo  cache

### DIFF
--- a/src/services/domain/membership/membership.dto.organisation.result.ts
+++ b/src/services/domain/membership/membership.dto.organisation.result.ts
@@ -1,8 +1,14 @@
+import { UUID } from '@domain/common/scalars';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { MembershipResultEntry } from './membership.dto.result.entry';
 
 @ObjectType()
 export class OrganisationMembership {
+  @Field(() => UUID, {
+    nullable: false,
+  })
+  id!: string;
+
   @Field(() => [MembershipResultEntry], {
     description: 'Details of Ecoverses the Organisation is hosting.',
   })

--- a/src/services/domain/membership/membership.dto.user.result.entry.ecoverse.ts
+++ b/src/services/domain/membership/membership.dto.user.result.entry.ecoverse.ts
@@ -8,11 +8,6 @@ export class MembershipUserResultEntryEcoverse extends MembershipResultEntry {
   })
   ecoverseID: string;
 
-  @Field(() => String, {
-    description: 'The Parent User ID',
-  })
-  userID: string;
-
   @Field(() => [MembershipResultEntry], {
     description: 'Details of the Challenges the user is a member of',
   })
@@ -35,6 +30,5 @@ export class MembershipUserResultEntryEcoverse extends MembershipResultEntry {
   ) {
     super(nameID, `${userID}/${ecoverseID}`, displayName);
     this.ecoverseID = ecoverseID;
-    this.userID = userID;
   }
 }

--- a/src/services/domain/membership/membership.dto.user.result.entry.ecoverse.ts
+++ b/src/services/domain/membership/membership.dto.user.result.entry.ecoverse.ts
@@ -4,9 +4,14 @@ import { MembershipResultEntry } from './membership.dto.result.entry';
 @ObjectType()
 export class MembershipUserResultEntryEcoverse extends MembershipResultEntry {
   @Field(() => String, {
-    description: 'Parent ID (User ID)',
+    description: 'The Ecoverse ID',
   })
-  parentID: string;
+  ecoverseID: string;
+
+  @Field(() => String, {
+    description: 'The Parent User ID',
+  })
+  userID: string;
 
   @Field(() => [MembershipResultEntry], {
     description: 'Details of the Challenges the user is a member of',
@@ -24,11 +29,12 @@ export class MembershipUserResultEntryEcoverse extends MembershipResultEntry {
   userGroups: MembershipResultEntry[] = [];
   constructor(
     nameID: string,
-    id: string,
+    ecoverseID: string,
     displayName: string,
-    parentID: string
+    userID: string
   ) {
-    super(nameID, id, displayName);
-    this.parentID = parentID;
+    super(nameID, `${userID}/${ecoverseID}`, displayName);
+    this.ecoverseID = ecoverseID;
+    this.userID = userID;
   }
 }

--- a/src/services/domain/membership/membership.dto.user.result.entry.ecoverse.ts
+++ b/src/services/domain/membership/membership.dto.user.result.entry.ecoverse.ts
@@ -3,6 +3,11 @@ import { MembershipResultEntry } from './membership.dto.result.entry';
 
 @ObjectType()
 export class MembershipUserResultEntryEcoverse extends MembershipResultEntry {
+  @Field(() => String, {
+    description: 'Parent ID (User ID)',
+  })
+  parentID: string;
+
   @Field(() => [MembershipResultEntry], {
     description: 'Details of the Challenges the user is a member of',
   })
@@ -17,4 +22,13 @@ export class MembershipUserResultEntryEcoverse extends MembershipResultEntry {
     description: 'Details of the UserGroups the user is a member of',
   })
   userGroups: MembershipResultEntry[] = [];
+  constructor(
+    nameID: string,
+    id: string,
+    displayName: string,
+    parentID: string
+  ) {
+    super(nameID, id, displayName);
+    this.parentID = parentID;
+  }
 }

--- a/src/services/domain/membership/membership.dto.user.result.entry.organisation.ts
+++ b/src/services/domain/membership/membership.dto.user.result.entry.organisation.ts
@@ -3,8 +3,23 @@ import { MembershipResultEntry } from './membership.dto.result.entry';
 
 @ObjectType()
 export class MembershipUserResultEntryOrganisation extends MembershipResultEntry {
+  @Field(() => String, {
+    description: 'The Organisation ID.',
+  })
+  organisationID: string;
+
   @Field(() => [MembershipResultEntry], {
     description: 'Details of the Organisations the user is a member of',
   })
   userGroups: MembershipResultEntry[] = [];
+
+  constructor(
+    nameID: string,
+    organisationID: string,
+    displayName: string,
+    userID: string
+  ) {
+    super(nameID, `${userID}/${organisationID}`, displayName);
+    this.organisationID = organisationID;
+  }
 }

--- a/src/services/domain/membership/membership.dto.user.result.ts
+++ b/src/services/domain/membership/membership.dto.user.result.ts
@@ -1,4 +1,4 @@
-import { NameID, UUID } from '@domain/common/scalars';
+import { UUID } from '@domain/common/scalars';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { ApplicationResultEntry } from './membership.dto.application.result.entry';
 import { MembershipUserResultEntryEcoverse } from './membership.dto.user.result.entry.ecoverse';
@@ -10,19 +10,6 @@ export class UserMembership {
     nullable: false,
   })
   id!: string;
-
-  @Field(() => String, {
-    nullable: false,
-    description: 'The display name.',
-  })
-  displayName!: string;
-
-  @Field(() => NameID, {
-    nullable: false,
-    description:
-      'A name identifier of the entity, unique within a given scope.',
-  })
-  nameID!: string;
 
   @Field(() => [MembershipUserResultEntryEcoverse], {
     description:

--- a/src/services/domain/membership/membership.dto.user.result.ts
+++ b/src/services/domain/membership/membership.dto.user.result.ts
@@ -1,3 +1,4 @@
+import { NameID, UUID } from '@domain/common/scalars';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { ApplicationResultEntry } from './membership.dto.application.result.entry';
 import { MembershipUserResultEntryEcoverse } from './membership.dto.user.result.entry.ecoverse';
@@ -5,6 +6,24 @@ import { MembershipUserResultEntryOrganisation } from './membership.dto.user.res
 
 @ObjectType()
 export class UserMembership {
+  @Field(() => UUID, {
+    nullable: false,
+  })
+  id!: string;
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'The display name.',
+  })
+  displayName!: string;
+
+  @Field(() => NameID, {
+    nullable: false,
+    description:
+      'A name identifier of the entity, unique within a given scope.',
+  })
+  nameID!: string;
+
   @Field(() => [MembershipUserResultEntryEcoverse], {
     description:
       'Details of Ecoverses the user is a member of, with child memberships',

--- a/src/services/domain/membership/membership.service.ts
+++ b/src/services/domain/membership/membership.service.ts
@@ -53,7 +53,7 @@ export class MembershipService {
     for (const credential of credentials) {
       if (credential.type === AuthorizationCredential.OrganisationMember) {
         membership.organisations.push(
-          await this.createOrganisationResult(credential.resourceID)
+          await this.createOrganisationResult(credential.resourceID, user.id)
         );
       } else if (credential.type === AuthorizationCredential.EcoverseMember) {
         membership.ecoverses.push(
@@ -126,7 +126,9 @@ export class MembershipService {
     for (const organisationResult of membership.organisations) {
       for (const group of storedOrgUserGroups) {
         const parent = await this.userGroupService.getParent(group);
-        if ((parent as IOrganisation).id === organisationResult.id) {
+        if (
+          (parent as IOrganisation).id === organisationResult.organisationID
+        ) {
           const groupResult = new MembershipResultEntry(
             group.name,
             group.id,
@@ -143,7 +145,8 @@ export class MembershipService {
   }
 
   async createOrganisationResult(
-    organisationID: string
+    organisationID: string,
+    userID: string
   ): Promise<MembershipUserResultEntryOrganisation> {
     const organisation = await this.organisationService.getOrganisationOrFail(
       organisationID
@@ -151,7 +154,8 @@ export class MembershipService {
     return new MembershipUserResultEntryOrganisation(
       organisation.nameID,
       organisation.id,
-      organisation.displayName
+      organisation.displayName,
+      userID
     );
   }
 

--- a/src/services/domain/membership/membership.service.ts
+++ b/src/services/domain/membership/membership.service.ts
@@ -45,6 +45,9 @@ export class MembershipService {
     if (!credentials) {
       return membership;
     }
+    membership.id = user.id;
+    membership.nameID = user.nameID;
+    membership.displayName = user.displayName;
     const storedChallenges: IChallenge[] = [];
     const storedOpportunities: IOpportunity[] = [];
     const storedCommunityUserGroups: IUserGroup[] = [];
@@ -56,7 +59,10 @@ export class MembershipService {
         );
       } else if (credential.type === AuthorizationCredential.EcoverseMember) {
         membership.ecoverses.push(
-          await this.createEcoverseMembershipResult(credential.resourceID)
+          await this.createEcoverseMembershipResult(
+            credential.resourceID,
+            user.id
+          )
         );
       } else if (credential.type === AuthorizationCredential.ChallengeMember) {
         const challenge = await this.challengeService.getChallengeOrFail(
@@ -152,13 +158,15 @@ export class MembershipService {
   }
 
   async createEcoverseMembershipResult(
-    ecoverseID: string
+    ecoverseID: string,
+    parentID: string
   ): Promise<MembershipUserResultEntryEcoverse> {
     const ecoverse = await this.ecoverseService.getEcoverseOrFail(ecoverseID);
     return new MembershipUserResultEntryEcoverse(
       ecoverse.nameID,
       ecoverse.id,
-      ecoverse.displayName
+      ecoverse.displayName,
+      parentID
     );
   }
 

--- a/src/services/domain/membership/membership.service.ts
+++ b/src/services/domain/membership/membership.service.ts
@@ -46,8 +46,6 @@ export class MembershipService {
       return membership;
     }
     membership.id = user.id;
-    membership.nameID = user.nameID;
-    membership.displayName = user.displayName;
     const storedChallenges: IChallenge[] = [];
     const storedOpportunities: IOpportunity[] = [];
     const storedCommunityUserGroups: IUserGroup[] = [];
@@ -92,7 +90,7 @@ export class MembershipService {
     // Assign to the right ecoverse
     for (const ecoverseResult of membership.ecoverses) {
       for (const challenge of storedChallenges) {
-        if (challenge.ecoverseID === ecoverseResult.id) {
+        if (challenge.ecoverseID === ecoverseResult.ecoverseID) {
           const challengeResult = new MembershipResultEntry(
             challenge.nameID,
             challenge.id,
@@ -102,7 +100,7 @@ export class MembershipService {
         }
       }
       for (const opportunity of storedOpportunities) {
-        if (opportunity.ecoverseID === ecoverseResult.id) {
+        if (opportunity.ecoverseID === ecoverseResult.ecoverseID) {
           const opportunityResult = new MembershipResultEntry(
             opportunity.nameID,
             opportunity.id,
@@ -113,7 +111,7 @@ export class MembershipService {
       }
       for (const group of storedCommunityUserGroups) {
         const parent = await this.userGroupService.getParent(group);
-        if ((parent as ICommunity).ecoverseID === ecoverseResult.id) {
+        if ((parent as ICommunity).ecoverseID === ecoverseResult.ecoverseID) {
           const groupResult = new MembershipResultEntry(
             group.name,
             group.id,
@@ -159,14 +157,14 @@ export class MembershipService {
 
   async createEcoverseMembershipResult(
     ecoverseID: string,
-    parentID: string
+    userID: string
   ): Promise<MembershipUserResultEntryEcoverse> {
     const ecoverse = await this.ecoverseService.getEcoverseOrFail(ecoverseID);
     return new MembershipUserResultEntryEcoverse(
       ecoverse.nameID,
       ecoverse.id,
       ecoverse.displayName,
-      parentID
+      userID
     );
   }
 
@@ -180,6 +178,8 @@ export class MembershipService {
         relations: ['agent'],
       }
     );
+    membership.id = organisation.id;
+
     const agent = organisation?.agent;
     if (agent?.credentials) {
       for (const credential of agent.credentials) {


### PR DESCRIPTION
The apollo client's cache stores entites normalized.
In the case of UserMembership our hierarchy structure can't be stored as normalized structure using only the ID as a key.

Lets say we have next two results for two different users:
```json
{
   "membershipUser":{
      "ecoverses":[
         {
            "id":"e02c0498-4116-4ac4-8b5a-aa992c0fc824",
            "challenges":[
               {
                  "id":"76fd5c6e-bf4c-458b-a1a6-6e7e63999b5b"
               },
               {
                  "id":"17bb5476-6cff-41e5-bdb6-cdaab2fbaf2e"
               }
            ]
         }
      ]
   }
}
```

```json
{
   "membershipUser":{
      "ecoverses":[
         {
            "id":"e02c0498-4116-4ac4-8b5a-aa992c0fc824",
            "challenges":[
               {
                  "id":"76fd5c6e-bf4c-458b-a1a6-6e7e63999b5b"
               }
            ]
         }
      ]
   }
}
```
The Ecoverse in both results have same ID so in the cache single Record will be created.
When the first data is stored in the cache the two records for the Ecoverse.Challenges will be stored in the case with respective IDs. After the second data is received the first Ecoverse record will be overwritten with the new challenges, so one challenge is lost. And because same ecoverse is return as result from 2 different queries they will have same results.

The other problem here is that the membershipUser does not have ID and cache can't merge it easily.

### First Solution - implemented

First we need the membershipUser to have ID. Best candidate is the UserId.
Second we need a way to distinguish the ecoverses result (MembershipUserResultEntryEcoverse) between two users. So complex cache key can be used. UserID+EcoverseID. Unfortunately the cache can't use value from the parent to create a complex key, but can work with child object keys. The easiest way was to add the parentID to the Ecoverse result. Now we have a complex key: Id+ parentID.

### Second solution
the result can be normalized.

membershipUser can be flatten to:
```
{
  ecoverses: MembershipResultEntry;
  challenges: MembershipResultEntry;
  opportunities: MembershipResultEntry;
}

```
and MembershipResultEntry will need a `parentId` or `ecoverseId` so we know which entity to which ecoverse  belongs to.

NB! We may have issue with nested challenges and fallowing the parent-child chain.