### PR TITLE
fixed loading of tags by reloading of ecoverses after sorting

### DIFF
--- a/src/domain/challenge/ecoverse/ecoverse.service.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.ts
@@ -190,7 +190,14 @@ export class EcoverseService {
       return 0;
     });
 
-    return sortedEcoverses || [];
+    // Load the ecoverses through normal mechanisms
+    const ecoversesResult: IEcoverse[] = [];
+    for (const sortedEcoverse of sortedEcoverses) {
+      const ecoverse = await this.getEcoverseOrFail(sortedEcoverse.id);
+      ecoversesResult.push(ecoverse);
+    }
+
+    return ecoversesResult;
   }
 
   private getChallengeAndOpportunitiesCount(challenges: IChallenge[]): number {


### PR DESCRIPTION
Ideally would have used a .map implementation but that was not working out easily for me. 

Clearly this puts an extra load for each ecoverse, but this probably needs to be done in all cases where we directly query the db and not use the ORM layer to load. 