### PR TITLE
allow RegisteredUsers to have READ access to Organisation members / groups, and also to communities on non-private ecoverse/challenge/opportunites

### DIFF
--- a/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
@@ -26,7 +26,7 @@ export class BaseChallengeAuthorizationService {
       baseChallenge.id,
       repository
     );
-    // disable anonymous access for community
+
     if (community.authorization) {
       baseChallenge.community =
         await this.communityAuthorizationService.applyAuthorizationPolicy(

--- a/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
@@ -28,6 +28,9 @@ export class EcoverseAuthorizationService {
   ) {}
 
   async applyAuthorizationPolicy(ecoverse: IEcoverse): Promise<IEcoverse> {
+    // Store the current value of anonymousReadAccess
+    const anonymousReadAccessCache =
+      ecoverse.authorization?.anonymousReadAccess || true;
     // Ensure always applying from a clean state
     ecoverse.authorization = await this.authorizationPolicyService.reset(
       ecoverse.authorization
@@ -36,6 +39,8 @@ export class EcoverseAuthorizationService {
       ecoverse.authorization,
       ecoverse.id
     );
+    ecoverse.authorization.anonymousReadAccess = anonymousReadAccessCache;
+
     await this.baseChallengeAuthorizationService.applyAuthorizationPolicy(
       ecoverse,
       this.ecoverseRepository

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -7,6 +7,7 @@ import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { UserGroupAuthorizationService } from '../user-group/user-group.service.authorization';
+import { AuthorizationRuleCredential } from '@domain/common/authorization-policy/authorization.rule.credential';
 
 @Injectable()
 export class CommunityAuthorizationService {
@@ -27,12 +28,14 @@ export class CommunityAuthorizationService {
         community.authorization,
         parentAuthorization
       );
-    // always false
-    community.authorization.anonymousReadAccess = false;
 
     community.authorization = this.extendAuthorizationPolicy(
-      community.authorization
+      community.authorization,
+      parentAuthorization?.anonymousReadAccess
     );
+
+    // always false
+    community.authorization.anonymousReadAccess = false;
 
     // cascade
     const groups = await this.communityService.getUserGroups(community);
@@ -58,21 +61,40 @@ export class CommunityAuthorizationService {
   }
 
   private extendAuthorizationPolicy(
-    authorization: IAuthorizationPolicy | undefined
+    authorization: IAuthorizationPolicy | undefined,
+    allowGlobalRegisteredReadAccess: boolean | undefined
   ): IAuthorizationPolicy {
-    return this.authorizationPolicyService.appendCredentialAuthorizationRule(
-      authorization,
-      {
-        type: AuthorizationCredential.GlobalAdminCommunity,
-        resourceID: '',
-      },
-      [
+    const newRules: AuthorizationRuleCredential[] = [];
+
+    const globalCommunityAdmin = {
+      type: AuthorizationCredential.GlobalAdminCommunity,
+      resourceID: '',
+      grantedPrivileges: [
         AuthorizationPrivilege.CREATE,
+        AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
-        AuthorizationPrivilege.GRANT,
-      ]
-    );
+      ],
+    };
+    newRules.push(globalCommunityAdmin);
+
+    if (allowGlobalRegisteredReadAccess) {
+      const globalRegistered = {
+        type: AuthorizationCredential.GlobalRegistered,
+        resourceID: '',
+        grantedPrivileges: [AuthorizationPrivilege.READ],
+      };
+      newRules.push(globalRegistered);
+    }
+
+    //
+    const updatedAuthorization =
+      this.authorizationPolicyService.appendCredentialAuthorizationRules(
+        authorization,
+        newRules
+      );
+
+    return updatedAuthorization;
   }
 }

--- a/src/domain/community/organisation/organisation.service.authorization.ts
+++ b/src/domain/community/organisation/organisation.service.authorization.ts
@@ -127,6 +127,13 @@ export class OrganisationAuthorizationService {
     };
     newRules.push(organisationMember);
 
+    const registeredUser = {
+      type: AuthorizationCredential.GlobalRegistered,
+      resourceID: '',
+      grantedPrivileges: [AuthorizationPrivilege.READ],
+    };
+    newRules.push(registeredUser);
+
     const updatedAuthorization =
       this.authorizationPolicy.appendCredentialAuthorizationRules(
         authorization,


### PR DESCRIPTION
The authorization policy does need to be reset on Organizations and on Ecoverses after deploying this update.