### PR TITLE
updating of authorization policy applies the auth policy throughout the tree, not a separate path

### DIFF
--- a/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.authorization.ts
@@ -1,4 +1,3 @@
-import { UpdateAuthorizationPolicyInput } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { CommunityAuthorizationService } from '@domain/community/community/community.service.authorization';
 import { ContextAuthorizationService } from '@domain/context/context/context.service.authorization';
@@ -67,30 +66,5 @@ export class BaseChallengeAuthorizationService {
       );
 
     return await repository.save(baseChallenge);
-  }
-
-  async updateAuthorization(
-    baseChallenge: IBaseChallenge,
-    repository: Repository<BaseChallenge>,
-    authorizationUpdateData: UpdateAuthorizationPolicyInput
-  ): Promise<IBaseChallenge> {
-    baseChallenge.authorization =
-      this.authorizationPolicyService.updateAuthorization(
-        baseChallenge.authorization,
-        authorizationUpdateData
-      );
-
-    // propagate authorization rules for child entities
-    baseChallenge.context = await this.baseChallengeService.getContext(
-      baseChallenge.id,
-      repository
-    );
-    baseChallenge.context.authorization =
-      this.authorizationPolicyService.updateAuthorization(
-        baseChallenge.context.authorization,
-        authorizationUpdateData
-      );
-
-    return baseChallenge;
   }
 }

--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -7,10 +7,7 @@ import {
   LogContext,
 } from '@common/enums';
 import { Repository } from 'typeorm';
-import {
-  IAuthorizationPolicy,
-  UpdateAuthorizationPolicyInput,
-} from '@domain/common/authorization-policy';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { EntityNotInitializedException } from '@common/exceptions';
 import { BaseChallengeAuthorizationService } from '@domain/challenge/base-challenge/base.challenge.service.authorization';
 import { OpportunityAuthorizationService } from '@domain/collaboration/opportunity/opportunity.service.authorization';
@@ -150,33 +147,5 @@ export class ChallengeAuthorizationService {
     rules.push(stateChange);
 
     return JSON.stringify(rules);
-  }
-
-  async updateAuthorization(
-    challenge: IChallenge,
-    authorizationUpdateData: UpdateAuthorizationPolicyInput
-  ): Promise<IChallenge> {
-    await this.baseChallengeAuthorizationService.updateAuthorization(
-      challenge,
-      this.challengeRepository,
-      authorizationUpdateData
-    );
-
-    // propagate authorization rules for child entities
-    if (challenge.opportunities) {
-      for (const opportunity of challenge.opportunities) {
-        opportunity.authorization =
-          this.authorizationPolicyService.updateAuthorization(
-            opportunity.authorization,
-            authorizationUpdateData
-          );
-        await this.opportunityAuthorizationService.updateAuthorization(
-          opportunity,
-          opportunity.authorization
-        );
-      }
-    }
-
-    return await this.challengeRepository.save(challenge);
   }
 }

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
@@ -83,7 +83,7 @@ export class EcoverseResolverMutations {
     ecoverseData.ID = ecoverse.id;
 
     if (ecoverseData.authorizationPolicy) {
-      await this.ecoverseAuthorizationService.updateAuthorizationPolicy(
+      await this.ecoverseAuthorizationService.applyAuthorizationPolicy(
         ecoverse,
         ecoverseData.authorizationPolicy
       );

--- a/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
@@ -30,7 +30,7 @@ export class EcoverseAuthorizationService {
   async applyAuthorizationPolicy(ecoverse: IEcoverse): Promise<IEcoverse> {
     // Store the current value of anonymousReadAccess
     const anonymousReadAccessCache =
-      ecoverse.authorization?.anonymousReadAccess || true;
+      ecoverse.authorization?.anonymousReadAccess;
     // Ensure always applying from a clean state
     ecoverse.authorization = await this.authorizationPolicyService.reset(
       ecoverse.authorization
@@ -39,7 +39,9 @@ export class EcoverseAuthorizationService {
       ecoverse.authorization,
       ecoverse.id
     );
-    ecoverse.authorization.anonymousReadAccess = anonymousReadAccessCache;
+    if (anonymousReadAccessCache === false) {
+      ecoverse.authorization.anonymousReadAccess = anonymousReadAccessCache;
+    }
 
     await this.baseChallengeAuthorizationService.applyAuthorizationPolicy(
       ecoverse,

--- a/src/domain/collaboration/opportunity/opportunity.service.authorization.ts
+++ b/src/domain/collaboration/opportunity/opportunity.service.authorization.ts
@@ -1,10 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import {
-  IAuthorizationPolicy,
-  UpdateAuthorizationPolicyInput,
-} from '@domain/common/authorization-policy';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { BaseChallengeAuthorizationService } from '@domain/challenge/base-challenge/base.challenge.service.authorization';
 import { Opportunity } from '@domain/collaboration/opportunity';
 import { IOpportunity } from '..';
@@ -49,39 +46,6 @@ export class OpportunityAuthorizationService {
           this.authorizationPolicyService.inheritParentAuthorization(
             relation.authorization,
             opportunity.authorization
-          );
-      }
-    }
-
-    return await this.opportunityRepository.save(opportunity);
-  }
-
-  async updateAuthorization(
-    opportunity: IOpportunity,
-    authorizationUpdateData: UpdateAuthorizationPolicyInput
-  ): Promise<IOpportunity> {
-    await this.baseChallengeAuthorizationService.updateAuthorization(
-      opportunity,
-      this.opportunityRepository,
-      authorizationUpdateData
-    );
-
-    // propagate authorization rules for child entities
-    if (opportunity.projects) {
-      for (const project of opportunity.projects) {
-        project.authorization =
-          this.authorizationPolicyService.updateAuthorization(
-            project.authorization,
-            authorizationUpdateData
-          );
-      }
-    }
-    if (opportunity.relations) {
-      for (const relation of opportunity.relations) {
-        relation.authorization =
-          this.authorizationPolicyService.updateAuthorization(
-            relation.authorization,
-            authorizationUpdateData
           );
       }
     }

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -12,7 +12,6 @@ import { IAuthorizationPolicy } from './authorization.policy.interface';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { CredentialsSearchInput } from '@domain/agent/credential/credentials.dto.search';
 import { AuthorizationRuleCredential } from './authorization.rule.credential';
-import { UpdateAuthorizationPolicyInput } from './authorization.policy.dto.update';
 import { AuthorizationRuleVerifiedCredential } from './authorization.rule.verified.credential';
 import { IAuthorizationRuleCredential } from './authorization.rule.credential.interface';
 
@@ -114,16 +113,6 @@ export class AuthorizationPolicyService {
     this.appendCredentialAuthorizationRules(child, newRules);
     child.anonymousReadAccess = parent.anonymousReadAccess;
     return child;
-  }
-
-  updateAuthorization(
-    origAuthorization: IAuthorizationPolicy | undefined,
-    authorizationUpdateData: UpdateAuthorizationPolicyInput
-  ): IAuthorizationPolicy {
-    const authorization = this.validateAuthorization(origAuthorization);
-    authorization.anonymousReadAccess =
-      authorizationUpdateData.anonymousReadAccess;
-    return authorization;
   }
 
   appendCredentialAuthorizationRules(


### PR DESCRIPTION
Previously there was a separate update path for authorization policy updates. This is removed: all authorization changes go through the same path now. 

Note: requires reseting the auth policy on ecoverse, or just toggling the auth policy via the admin screen on each ecoverse. 
