### PR TITLE
Fix setting of parentCommunity for new Challenges; migration to repair needed

### DIFF
--- a/src/domain/challenge/base-challenge/base.challenge.entity.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.entity.ts
@@ -8,8 +8,10 @@ import { NameableEntity } from '@domain/common/entity/nameable-entity';
 import { IBaseChallenge } from './base.challenge.interface';
 import { Agent } from '@domain/agent/agent/agent.entity';
 
-export abstract class BaseChallenge extends NameableEntity
-  implements IBaseChallenge {
+export abstract class BaseChallenge
+  extends NameableEntity
+  implements IBaseChallenge
+{
   @OneToOne(() => Context, {
     eager: false,
     cascade: true,

--- a/src/domain/challenge/ecoverse/ecoverse.service.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.ts
@@ -40,6 +40,7 @@ import { RemoveEcoverseAdminInput } from './dto/ecoverse.dto.remove.admin';
 import { UserService } from '@domain/community/user/user.service';
 import { UpdateEcoverseInput } from './dto/ecoverse.dto.update';
 import { CreateChallengeOnEcoverseInput } from '../challenge/dto/challenge.dto.create.in.ecoverse';
+import { CommunityService } from '@domain/community/community/community.service';
 
 @Injectable()
 export class EcoverseService {
@@ -52,6 +53,7 @@ export class EcoverseService {
     private baseChallengeService: BaseChallengeService,
     private namingService: NamingService,
     private userService: UserService,
+    private communityService: CommunityService,
     private challengeService: ChallengeService,
     @InjectRepository(Ecoverse)
     private ecoverseRepository: Repository<Ecoverse>,
@@ -379,7 +381,7 @@ export class EcoverseService {
     challengeData: CreateChallengeOnEcoverseInput
   ): Promise<IChallenge> {
     const ecoverse = await this.getEcoverseOrFail(challengeData.ecoverseID, {
-      relations: ['challenges'],
+      relations: ['challenges', 'community'],
     });
     const nameAvailable = await this.namingService.isNameIdAvailableInEcoverse(
       challengeData.nameID,
@@ -403,6 +405,12 @@ export class EcoverseService {
       );
 
     ecoverse.challenges.push(newChallenge);
+    // Finally set the community relationship
+    await this.communityService.setParentCommunity(
+      newChallenge.community,
+      ecoverse.community
+    );
+
     await this.ecoverseRepository.save(ecoverse);
     return newChallenge;
   }

--- a/src/domain/community/community/community.entity.ts
+++ b/src/domain/community/community/community.entity.ts
@@ -15,26 +15,26 @@ import { Credential } from '@domain/agent/credential/credential.entity';
 import { Application } from '@domain/community/application/application.entity';
 
 @Entity()
-export class Community extends AuthorizableEntity
-  implements ICommunity, IGroupable {
+export class Community
+  extends AuthorizableEntity
+  implements ICommunity, IGroupable
+{
   @Column()
   displayName: string;
 
   @Column()
   ecoverseID: string;
 
-  @OneToMany(
-    () => UserGroup,
-    userGroup => userGroup.community,
-    { eager: true, cascade: true }
-  )
+  @OneToMany(() => UserGroup, userGroup => userGroup.community, {
+    eager: true,
+    cascade: true,
+  })
   groups?: UserGroup[];
 
-  @OneToMany(
-    () => Application,
-    application => application.community,
-    { eager: true, cascade: true }
-  )
+  @OneToMany(() => Application, application => application.community, {
+    eager: true,
+    cascade: true,
+  })
   applications?: IApplication[];
 
   // The credential profile  that is used for determining membership of this community

--- a/src/domain/community/community/community.resolver.fields.ts
+++ b/src/domain/community/community/community.resolver.fields.ts
@@ -54,6 +54,26 @@ export class CommunityResolverFields {
 
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @UseGuards(GraphqlGuard)
+  @ResolveField('parent', () => ICommunity, {
+    nullable: true,
+    description: 'Parent community for this community.',
+  })
+  @Profiling.api
+  async parent(@Parent() community: Community) {
+    const communityWithParent = await this.communityService.getCommunityOrFail(
+      community.id,
+      {
+        relations: ['parentCommunity'],
+      }
+    );
+    if (!communityWithParent.parentCommunity) return null;
+    return await this.communityService.getCommunityOrFail(
+      communityWithParent.parentCommunity.id
+    );
+  }
+
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
   @ResolveField('updatesRoom', () => CommunityRoom, {
     nullable: true,
     description: 'Room with messages for this community.',

--- a/src/domain/community/community/community.resolver.fields.ts
+++ b/src/domain/community/community/community.resolver.fields.ts
@@ -54,17 +54,6 @@ export class CommunityResolverFields {
 
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @UseGuards(GraphqlGuard)
-  @ResolveField('parent', () => ICommunity, {
-    nullable: true,
-    description: 'Parent community for this community.',
-  })
-  @Profiling.api
-  async parent(@Parent() community: Community) {
-    return await this.communityService.getParentCommunity(community);
-  }
-
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('updatesRoom', () => CommunityRoom, {
     nullable: true,
     description: 'Room with messages for this community.',

--- a/src/domain/community/community/community.resolver.fields.ts
+++ b/src/domain/community/community/community.resolver.fields.ts
@@ -60,16 +60,7 @@ export class CommunityResolverFields {
   })
   @Profiling.api
   async parent(@Parent() community: Community) {
-    const communityWithParent = await this.communityService.getCommunityOrFail(
-      community.id,
-      {
-        relations: ['parentCommunity'],
-      }
-    );
-    if (!communityWithParent.parentCommunity) return null;
-    return await this.communityService.getCommunityOrFail(
-      communityWithParent.parentCommunity.id
-    );
+    return await this.communityService.getParentCommunity(community);
   }
 
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -177,6 +177,28 @@ export class CommunityService {
     });
   }
 
+  async getParentCommunity(
+    community: ICommunity
+  ): Promise<ICommunity | undefined> {
+    // const communityWithParent = await this.getCommunityOrFail(community.id, {
+    //   relations: ['parentCommunity'],
+    // });
+
+    const communityWithParent = await this.communityRepository
+      .createQueryBuilder('community')
+      .leftJoinAndSelect('community.parentCommunity', 'parentCommunity')
+      .where('community.id = :communityID')
+      .setParameters({
+        communityID: `${community.id}`,
+      })
+      .getOne();
+    const parentCommunity = communityWithParent?.parentCommunity;
+    if (parentCommunity) {
+      return await this.getCommunityOrFail(parentCommunity.id);
+    }
+    return undefined;
+  }
+
   async assignMember(
     membershipData: AssignCommunityMemberInput
   ): Promise<ICommunity> {

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -155,6 +155,20 @@ export class CommunityService {
     return true;
   }
 
+  async getParentCommunity(
+    community: ICommunity
+  ): Promise<ICommunity | undefined> {
+    const communityWithParent = await this.getCommunityOrFail(community.id, {
+      relations: ['parentCommunity'],
+    });
+
+    const parentCommunity = communityWithParent?.parentCommunity;
+    if (parentCommunity) {
+      return await this.getCommunityOrFail(parentCommunity.id);
+    }
+    return undefined;
+  }
+
   async setParentCommunity(
     community?: ICommunity,
     parentCommunity?: ICommunity
@@ -175,28 +189,6 @@ export class CommunityService {
       type: membershipCredential.type,
       resourceID: membershipCredential.resourceID,
     });
-  }
-
-  async getParentCommunity(
-    community: ICommunity
-  ): Promise<ICommunity | undefined> {
-    // const communityWithParent = await this.getCommunityOrFail(community.id, {
-    //   relations: ['parentCommunity'],
-    // });
-
-    const communityWithParent = await this.communityRepository
-      .createQueryBuilder('community')
-      .leftJoinAndSelect('community.parentCommunity', 'parentCommunity')
-      .where('community.id = :communityID')
-      .setParameters({
-        communityID: `${community.id}`,
-      })
-      .getOne();
-    const parentCommunity = communityWithParent?.parentCommunity;
-    if (parentCommunity) {
-      return await this.getCommunityOrFail(parentCommunity.id);
-    }
-    return undefined;
   }
 
   async assignMember(

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -106,16 +106,16 @@ export class CommunityService {
     communityID: string,
     options?: FindOneOptions<Community>
   ): Promise<ICommunity> {
-    const Community = await this.communityRepository.findOne(
+    const community = await this.communityRepository.findOne(
       { id: communityID },
       options
     );
-    if (!Community)
+    if (!community)
       throw new EntityNotFoundException(
         `Unable to find Community with ID: ${communityID}`,
         LogContext.COMMUNITY
       );
-    return Community;
+    return community;
   }
 
   async removeCommunity(communityID: string): Promise<boolean> {


### PR DESCRIPTION
When creating challenges on an ecoverse the parent community was not being set. This meant the check for parent community for adding member was not being verified. 

Note: a seprate migration is needed that sets the parent community id field properly for all challenges. Raised as a separate item: https://github.com/alkem-io/server/issues/1409