### PR TITLE
fixed manual verify being a final state

### DIFF
--- a/src/domain/community/organization-verification/organization.verification.lifecycle.config.ts
+++ b/src/domain/community/organization-verification/organization.verification.lifecycle.config.ts
@@ -23,7 +23,6 @@ export const organizationVerificationLifecycleConfig = {
       },
     },
     manuallyVerified: {
-      type: 'final',
       entry: ['organizationManuallyVerified'],
       data: {
         organizationID: (context: any, _event: any) => context.parentID,

--- a/src/domain/community/organization-verification/organization.verification.service.authorization.ts
+++ b/src/domain/community/organization-verification/organization.verification.service.authorization.ts
@@ -87,6 +87,16 @@ export class OrganizationVerificationAuthorizationService {
     };
     newRules.push(orgAdmin);
 
+    const orgOwner = {
+      type: AuthorizationCredential.ORGANIZATION_OWNER,
+      resourceID: organizationID,
+      grantedPrivileges: [
+        AuthorizationPrivilege.READ,
+        AuthorizationPrivilege.UPDATE,
+      ],
+    };
+    newRules.push(orgOwner);
+
     const updatedAuthorization =
       this.authorizationPolicy.appendCredentialAuthorizationRules(
         authorization,


### PR DESCRIPTION
Two fixes:
- make manualVerified a non-final state. Will be picked up by new orgs.
- allow org owners to request the verification. Requires auth policy reset on orgs. 

To discuss: migration / updates to lifecycle definitions...out of scope of this fix.