### PR TITLE
remove check for a user being part of the parent community to create an application; that check is applied when the applicaiton is approved

### DIFF
--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -332,20 +332,6 @@ export class CommunityService {
         LogContext.COMMUNITY
       );
 
-    // Check if there is a parent community, and that the user is a member there
-    const parentCommunity = community.parentCommunity;
-    if (parentCommunity) {
-      const isMember = await this.isMember(
-        applicationData.userID,
-        parentCommunity.id
-      );
-      if (!isMember)
-        throw new InvalidStateTransitionException(
-          `User ${applicationData.userID} is not a member of the parent Community: ${parentCommunity.displayName}.`,
-          LogContext.COMMUNITY
-        );
-    }
-
     const ecoverseID = community.ecoverseID;
     if (!ecoverseID)
       throw new EntityNotInitializedException(


### PR DESCRIPTION
This fixes the bug you encountered when creating an application on a Challenge when the user was not a member of the parent Hub