### PR TITLE
matrix stabilisation

### DIFF
--- a/.build/synapse/homeserver.yaml
+++ b/.build/synapse/homeserver.yaml
@@ -836,48 +836,48 @@ log_config: "/data/alkemio.matrix.host.log.config"
 #
 # The defaults are as shown below.
 #
-#rc_message:
-#  per_second: 0.2
-#  burst_count: 10
+rc_message:
+  per_second: 2
+  burst_count: 10
 #
-#rc_registration:
-#  per_second: 0.17
-#  burst_count: 3
+rc_registration:
+  per_second: 2
+  burst_count: 3
 #
-#rc_login:
-#  address:
-#    per_second: 0.17
-#    burst_count: 3
-#  account:
-#    per_second: 0.17
-#    burst_count: 3
-#  failed_attempts:
-#    per_second: 0.17
-#    burst_count: 3
+rc_login:
+  address:
+    per_second: 2
+    burst_count: 3
+  account:
+    per_second: 2
+    burst_count: 3
+  failed_attempts:
+    per_second: 2
+    burst_count: 3
 #
-#rc_admin_redaction:
-#  per_second: 1
-#  burst_count: 50
+rc_admin_redaction:
+  per_second: 1
+  burst_count: 50
 #
-#rc_joins:
-#  local:
-#    per_second: 0.1
-#    burst_count: 10
-#  remote:
-#    per_second: 0.01
-#    burst_count: 10
+rc_joins:
+  local:
+    per_second: 1
+    burst_count: 10
+  remote:
+    per_second: 1
+    burst_count: 10
 #
-#rc_3pid_validation:
-#  per_second: 0.003
-#  burst_count: 5
+rc_3pid_validation:
+  per_second: 1
+  burst_count: 5
 #
-#rc_invites:
-#  per_room:
-#    per_second: 0.3
-#    burst_count: 10
-#  per_user:
-#    per_second: 0.003
-#    burst_count: 5
+rc_invites:
+  per_room:
+    per_second: 1
+    burst_count: 10
+  per_user:
+    per_second: 1
+    burst_count: 5
 
 # Ratelimiting settings for incoming federation
 #

--- a/graphql-samples/mutations/update/remove-user-from-community
+++ b/graphql-samples/mutations/update/remove-user-from-community
@@ -3,7 +3,7 @@ mutation removeUserFromCommunity($membershipData: RemoveCommunityMemberInput!) {
     id,
     members {
       id,
-      name
+      nameID
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Cherrytwist Foundation",
   "private": false,

--- a/src/services/platform/matrix/adapter-room/matrix.room.adapter.service.ts
+++ b/src/services/platform/matrix/adapter-room/matrix.room.adapter.service.ts
@@ -1,4 +1,5 @@
 import { LogContext } from '@common/enums';
+import { MatrixEntityNotFoundException } from '@common/exceptions';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { IContent } from 'matrix-js-sdk';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
@@ -88,6 +89,12 @@ export class MatrixRoomAdapterService {
   ) {
     // need to cache those
     const room = await adminMatrixClient.getRoom(roomID);
+    if (!room) {
+      throw new MatrixEntityNotFoundException(
+        `Unable to locate room: ${roomID}`,
+        LogContext.COMMUNICATION
+      );
+    }
 
     for (const matrixClient of matrixClients) {
       // not very well documented but we can validate whether the user has membership like this

--- a/src/services/platform/matrix/adapter-user/matrix.user.adapter.service.ts
+++ b/src/services/platform/matrix/adapter-user/matrix.user.adapter.service.ts
@@ -60,6 +60,7 @@ export class MatrixUserAdapterService {
   }
 
   convertMatrixUsernameToEmail(username: string) {
+    // Todo: this is problematic...
     return username.replace(/[=]/g, '@');
   }
 

--- a/src/services/platform/matrix/adapter-user/matrix.user.adapter.service.ts
+++ b/src/services/platform/matrix/adapter-user/matrix.user.adapter.service.ts
@@ -6,7 +6,7 @@ import { IMatrixUser } from './matrix.user.interface';
 
 @Injectable()
 export class MatrixUserAdapterService {
-  private mailRegex = /[@]/g;
+  private emailUsernameSpecialCharactersRegex = /[^a-zA-Z0-9_/-/=.]/g;
 
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
@@ -26,8 +26,22 @@ export class MatrixUserAdapterService {
   }
 
   convertEmailToMatrixUsername(email: string) {
-    // TODO: "User ID can only contain characters a-z, 0-9, or '=_-./'"
-    const username = email.replace(this.mailRegex, '=');
+    // Note: the incoming email has the form "username@domain". This is then used to create a matrix ID.
+    // Matrix: A user ID can only contain characters a-z, 0-9, or '=_-./'
+    // Email username: Uppercase and lowercase letters in English (A-Z, a-z), Digits from 0 to 9, Special characters such as ! # $ % & ' * + - / = ? ^ _ ` { |
+    // Email domain: Uppercase and lowercase letters in English (A-Z, a-z), digits from 0 to 9, A hyphen (-), A period (.)
+
+    const emailParts = email.split('@');
+    const emailUsername = emailParts[0];
+
+    // All characters from email domain are valid in Matrix usernames
+    const emailDomain = emailParts[1];
+    // Email usernames need to have the not allowed characters removed
+    const emailUsernameAdjusted = emailUsername.replace(
+      this.emailUsernameSpecialCharactersRegex,
+      ''
+    );
+    const username = `${emailUsernameAdjusted}=${emailDomain}`;
     return username.toLowerCase();
   }
 

--- a/src/services/platform/matrix/adapter-user/matrix.user.adapter.service.ts
+++ b/src/services/platform/matrix/adapter-user/matrix.user.adapter.service.ts
@@ -26,7 +26,9 @@ export class MatrixUserAdapterService {
   }
 
   convertEmailToMatrixUsername(email: string) {
-    return email.replace(this.mailRegex, '=');
+    // TODO: "User ID can only contain characters a-z, 0-9, or '=_-./'"
+    const username = email.replace(this.mailRegex, '=');
+    return username.toLowerCase();
   }
 
   convertMatrixUsernameToMatrixId(username: string) {

--- a/src/services/platform/matrix/management/matrix.user.management.service.ts
+++ b/src/services/platform/matrix/management/matrix.user.management.service.ts
@@ -154,8 +154,14 @@ export class MatrixUserManagementService {
     try {
       await this._matrixClient.isUsernameAvailable(username);
       return false;
-    } catch (error) {
-      return true;
+    } catch (error: any) {
+      const errcode = error.errcode;
+      if (errcode === 'M_USER_IN_USE') return true;
+      this.logger.error(
+        `Unable to check if username is available: ${error}`,
+        LogContext.COMMUNICATION
+      );
+      throw error;
     }
   }
 }


### PR DESCRIPTION
usernames to adhere to matrix policy
only filter out explicit expected error when checking if a user exists
explicit check to defend against invalid room id

Updated rate limits in synapse configuration to avoid "too many requests" errors