### PR TITLE
add flag to User entity to allow it to be marked as a service account

### DIFF
--- a/src/domain/community/user/dto/user.dto.update.ts
+++ b/src/domain/community/user/dto/user.dto.update.ts
@@ -45,6 +45,13 @@ export class UpdateUserInput extends UpdateNameableInput {
   @MaxLength(SMALL_TEXT_LENGTH)
   gender?: string;
 
+  @Field({
+    nullable: true,
+    description:
+      'Set this user profile as being used as a service account or not.',
+  })
+  serviceProfile?: boolean;
+
   @Field(() => UpdateProfileInput, { nullable: true })
   profileData?: UpdateProfileInput;
 }

--- a/src/domain/community/user/user.entity.ts
+++ b/src/domain/community/user/user.entity.ts
@@ -43,6 +43,9 @@ export class User extends NameableEntity implements IUser {
   @Column()
   communicationID: string = '';
 
+  @Column({ type: 'boolean' })
+  serviceProfile: boolean = false;
+
   @OneToMany(() => Application, application => application.id, {
     eager: false,
     cascade: false,

--- a/src/domain/community/user/user.interface.ts
+++ b/src/domain/community/user/user.interface.ts
@@ -39,6 +39,10 @@ export abstract class IUser extends INameable {
   // the internal communicationID (Matrix) for the user
   communicationID!: string;
 
+  // Indicates if this profile is a service profile that is only used for service account style access
+  // to the platform. Temporary measure, full service account support for later.
+  serviceProfile!: boolean;
+
   // Protected via field access for gdpr reasons
   email!: string;
   phone!: string;

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -296,7 +296,7 @@ export class UserService {
   }
 
   async getUsers(): Promise<IUser[]> {
-    return (await this.userRepository.find()) || [];
+    return (await this.userRepository.find({ serviceProfile: false })) || [];
   }
 
   async updateUser(userInput: UpdateUserInput): Promise<IUser> {
@@ -329,6 +329,10 @@ export class UserService {
     }
     if (userInput.gender !== undefined) {
       user.gender = userInput.gender;
+    }
+
+    if (userInput.serviceProfile !== undefined) {
+      user.serviceProfile = userInput.serviceProfile;
     }
 
     if (userInput.profileData) {
@@ -413,7 +417,7 @@ export class UserService {
   }
 
   async getUserCount(): Promise<number> {
-    return await this.userRepository.count();
+    return await this.userRepository.count({ serviceProfile: false });
   }
 
   async getUserIDByCommunicationsID(communicationID: string): Promise<string> {

--- a/src/migrations/1634103839440-service-account.ts
+++ b/src/migrations/1634103839440-service-account.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class serviceAccount1634103839440 implements MigrationInterface {
+  name = 'serviceAccount1634103839440';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`user\` ADD \`serviceProfile\` tinyint NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`user\` DROP COLUMN \`serviceProfile\``
+    );
+  }
+}


### PR DESCRIPTION
Extends the User profile entity to be able to mark a profile as being for a service account. Not ideal but enough for now.

Note: this bring a migration so it needs to be merged into the communications PR. 
