### PR TITLE
Discussions stabilisation

### DIFF
--- a/graphql-samples/admin/communication/communication-remove-orphaned-room
+++ b/graphql-samples/admin/communication/communication-remove-orphaned-room
@@ -1,0 +1,10 @@
+mutation adminCommunicationRemoveOrphanedRoom($orphanedRoomData: CommunicationAdminRemoveOrphanedRoomInput!) {
+  adminCommunicationRemoveOrphanedRoom(orphanedRoomData: $orphanedRoomData)
+}
+
+Variables:
+{
+  "orphanedRoomData": {
+      "roomID": "!RqdYgEpGfmOLZpwgnY:alkemio.matrix.host"
+  }
+}

--- a/graphql-samples/mutations/communication/create-discussion-on-communication
+++ b/graphql-samples/mutations/communication/create-discussion-on-communication
@@ -11,7 +11,6 @@ Variables:
       "title": "uuid",
       "description": "text",
       "category": "GENERAL",
-      "message": "something",
       "communicationID": "uuid"
   }
 }

--- a/graphql-samples/mutations/communication/create-discussion-on-communication
+++ b/graphql-samples/mutations/communication/create-discussion-on-communication
@@ -9,6 +9,7 @@ Variables:
 {
   "createData": {
       "title": "uuid",
+      "description": "text",
       "category": "GENERAL",
       "message": "something",
       "communicationID": "uuid"

--- a/graphql-samples/mutations/communication/update-discussion
+++ b/graphql-samples/mutations/communication/update-discussion
@@ -10,6 +10,7 @@ Variables:
   "updateData": {
       "ID": "uuid",
       "category": "IDEAS",
-      "title": "something new"
+      "title": "something new",
+      "description": "something new"
   }
 }

--- a/src/domain/communication/communication/communication.resolver.fields.ts
+++ b/src/domain/communication/communication/communication.resolver.fields.ts
@@ -1,6 +1,6 @@
 import { GraphqlGuard } from '@core/authorization';
 import { UseGuards } from '@nestjs/common';
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { AuthorizationAgentPrivilege, Profiling } from '@src/common/decorators';
 import { CommunicationService } from './communication.service';
 import { AuthorizationPrivilege } from '@common/enums';
@@ -34,5 +34,22 @@ export class CommunicationResolverFields {
     @Parent() communication: ICommunication
   ): Promise<IDiscussion[]> {
     return await this.communicationService.getDiscussions(communication);
+  }
+
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
+  @ResolveField('discussions', () => IDiscussion, {
+    nullable: true,
+    description: 'A particular Discussions active in this Communication.',
+  })
+  @Profiling.api
+  async discussion(
+    @Parent() communication: ICommunication,
+    @Args('ID') discussionID: string
+  ): Promise<IDiscussion> {
+    return await this.communicationService.getDiscussionOrFail(
+      communication,
+      discussionID
+    );
   }
 }

--- a/src/domain/communication/communication/communication.resolver.fields.ts
+++ b/src/domain/communication/communication/communication.resolver.fields.ts
@@ -38,7 +38,7 @@ export class CommunicationResolverFields {
 
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @UseGuards(GraphqlGuard)
-  @ResolveField('discussions', () => IDiscussion, {
+  @ResolveField('discussion', () => IDiscussion, {
     nullable: true,
     description: 'A particular Discussions active in this Communication.',
   })

--- a/src/domain/communication/communication/communication.resolver.mutations.ts
+++ b/src/domain/communication/communication/communication.resolver.mutations.ts
@@ -45,7 +45,7 @@ export class CommunicationResolverMutations {
 
     const discussion = await this.communicationService.createDiscussion(
       createData,
-      agentInfo.communicationID
+      agentInfo.userID
     );
     await this.discussionAuthorizationService.applyAuthorizationPolicy(
       discussion,

--- a/src/domain/communication/communication/communication.service.ts
+++ b/src/domain/communication/communication/communication.service.ts
@@ -94,7 +94,7 @@ export class CommunicationService {
 
   async createDiscussion(
     discussionData: CommunicationCreateDiscussionInput,
-    communicationUserID: string
+    userID: string
   ): Promise<IDiscussion> {
     const title = discussionData.title;
     const communicationID = discussionData.communicationID;
@@ -110,45 +110,23 @@ export class CommunicationService {
     const discussion = await this.discussionService.createDiscussion(
       discussionData,
       communication.communicationGroupID,
-      communicationUserID,
+      userID,
       `${communication.displayName}-discussion-${discussionData.title}`
     );
-
-    const updates = this.getUpdates(communication);
-
-    await this.communicationAdapter.replicateRoomMembership(
-      discussion.communicationRoomID,
-      updates.communicationRoomID,
-      communicationUserID
-    );
-
     this.logger.verbose?.(
       `[Discussion] Room created (${title}) and membership replicated from Updates (${communicationID})`,
       LogContext.COMMUNICATION
     );
 
-    // Send before saving to give the event some bit of time to be received by reading admin account.
-    try {
-      await this.discussionService.sendMessageToDiscussion(
-        discussion,
-        communicationUserID,
-        {
-          message: discussionData.message,
-        }
-      );
-      this.logger.verbose?.(
-        `[Discussion] Initial message sent: ${discussionData.message}`,
-        LogContext.COMMUNICATION
-      );
-    } catch (error) {
-      this.logger.warn(
-        `Unable to send message to newly created discussion (${discussion.displayName}): ${error}`,
-        LogContext.COMMUNICATION
-      );
-    }
-
     communication.discussions?.push(discussion);
     await this.communicationRepository.save(communication);
+
+    // Set the Matrix membership for notifications
+    const updates = this.getUpdates(communication);
+    await this.communicationAdapter.replicateRoomMembership(
+      discussion.communicationRoomID,
+      updates.communicationRoomID
+    );
 
     return discussion;
   }

--- a/src/domain/communication/communication/communication.service.ts
+++ b/src/domain/communication/communication/communication.service.ts
@@ -141,6 +141,22 @@ export class CommunicationService {
     return communication.discussions;
   }
 
+  getDiscussionOrFail(
+    communication: ICommunication,
+    discussionID: string
+  ): IDiscussion {
+    const discussions = this.getDiscussions(communication);
+    const discussion = discussions.find(
+      discussion => discussion.id === discussionID
+    );
+    if (!discussion) {
+      throw new EntityNotFoundException(
+        `Unable to find Discussion with ID: ${discussionID}`,
+        LogContext.COMMUNICATION
+      );
+    }
+    return discussion;
+  }
   getUpdates(communication: ICommunication): IUpdates {
     if (!communication.updates) {
       throw new EntityNotInitializedException(

--- a/src/domain/communication/communication/dto/communication.dto.create.discussion.ts
+++ b/src/domain/communication/communication/dto/communication.dto.create.discussion.ts
@@ -29,10 +29,9 @@ export class CommunicationCreateDiscussionInput {
   category!: string;
 
   @Field(() => String, {
-    nullable: false,
-    description: 'The starting message in the discussion',
+    nullable: true,
+    description: 'The description for the Discussion',
   })
-  @IsOptional()
   @MaxLength(MID_TEXT_LENGTH)
-  message!: string;
+  description?: string;
 }

--- a/src/domain/communication/discussion/discussion.entity.ts
+++ b/src/domain/communication/discussion/discussion.entity.ts
@@ -9,11 +9,14 @@ export class Discussion extends RoomableEntity implements IDiscussion {
     communicationGroupID: string,
     displayName: string,
     title?: string,
+    description?: string,
     category?: string
   ) {
     super(communicationGroupID, displayName);
     this.title = title || '';
     this.category = category || '';
+    this.description = description || '';
+    this.commentsCount = 0;
   }
 
   @Column('text', { nullable: false })
@@ -21,6 +24,15 @@ export class Discussion extends RoomableEntity implements IDiscussion {
 
   @Column('text', { nullable: false })
   category!: string;
+
+  @Column('text', { nullable: false })
+  description!: string;
+
+  @Column('int', { nullable: false })
+  commentsCount!: number;
+
+  @Column('varchar', { length: 36, nullable: false })
+  createdBy!: string;
 
   @ManyToOne(() => Communication, communication => communication.discussions, {
     eager: false,

--- a/src/domain/communication/discussion/discussion.interface.ts
+++ b/src/domain/communication/discussion/discussion.interface.ts
@@ -1,4 +1,5 @@
 import { DiscussionCategory } from '@common/enums/communication.discussion.category';
+import { UUID } from '@domain/common/scalars';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { IRoomable } from '../room/roomable.interface';
 
@@ -9,8 +10,28 @@ export abstract class IDiscussion extends IRoomable {
   })
   title!: string;
 
+  @Field(() => String, {
+    description: 'The description of this Discussion.',
+  })
+  description!: string;
+
   @Field(() => DiscussionCategory, {
     description: 'The category assigned to this Discussion.',
   })
-  category?: string;
+  category!: string;
+
+  @Field(() => UUID, {
+    description: 'The id of the user that created this discussion.',
+  })
+  createdBy!: string;
+
+  @Field(() => Date, {
+    description: 'The date this discussion was created.',
+  })
+  createdDate!: Date;
+
+  @Field(() => Number, {
+    description: 'The number of comments.',
+  })
+  commentsCount!: number;
 }

--- a/src/domain/communication/discussion/discussion.interface.ts
+++ b/src/domain/communication/discussion/discussion.interface.ts
@@ -25,11 +25,6 @@ export abstract class IDiscussion extends IRoomable {
   })
   createdBy!: string;
 
-  @Field(() => Date, {
-    description: 'The date this discussion was created.',
-  })
-  createdDate!: Date;
-
   @Field(() => Number, {
     description: 'The number of comments.',
   })

--- a/src/domain/communication/discussion/discussion.resolver.fields.ts
+++ b/src/domain/communication/discussion/discussion.resolver.fields.ts
@@ -6,6 +6,7 @@ import { AuthorizationPrivilege } from '@common/enums';
 import { DiscussionService } from './discussion.service';
 import { IDiscussion } from './discussion.interface';
 import { CommunicationMessageResult } from '../message/communication.dto.message.result';
+import { Discussion } from './discussion.entity';
 
 @Resolver(() => IDiscussion)
 export class DiscussionResolverFields {
@@ -25,5 +26,15 @@ export class DiscussionResolverFields {
       discussion
     );
     return discussionRoom.messages;
+  }
+
+  @ResolveField('timestamp', () => Number, {
+    nullable: true,
+    description: 'The timestamp for the creation of this Discussion.',
+  })
+  async timestamp(@Parent() discussion: IDiscussion): Promise<number> {
+    const createdDate = (discussion as Discussion).createdDate;
+    const date = new Date(createdDate);
+    return date.getTime();
   }
 }

--- a/src/domain/communication/discussion/discussion.service.ts
+++ b/src/domain/communication/discussion/discussion.service.ts
@@ -30,13 +30,15 @@ export class DiscussionService {
   async createDiscussion(
     discussionData: CommunicationCreateDiscussionInput,
     communicationGroupID: string,
-    communicationUserID: string,
+    userID: string,
     displayName: string
   ): Promise<IDiscussion> {
     const discussion = Discussion.create(discussionData);
     discussion.authorization = new AuthorizationPolicy();
     discussion.communicationGroupID = communicationGroupID;
     discussion.displayName = displayName;
+    discussion.createdBy = userID;
+    discussion.commentsCount = 0;
     await this.save(discussion);
     discussion.communicationRoomID = await this.initializeDiscussionRoom(
       discussion
@@ -106,6 +108,8 @@ export class DiscussionService {
       discussion.title = updateDiscussionData.title;
     if (updateDiscussionData.category)
       discussion.category = updateDiscussionData.category;
+    if (updateDiscussionData.description)
+      discussion.description = updateDiscussionData.description;
     return await this.save(discussion);
   }
 
@@ -124,11 +128,14 @@ export class DiscussionService {
     communicationUserID: string,
     messageData: RoomSendMessageInput
   ): Promise<CommunicationMessageResult> {
-    return await this.roomService.sendMessage(
+    const message = await this.roomService.sendMessage(
       discussion,
       communicationUserID,
       messageData
     );
+    discussion.commentsCount = discussion.commentsCount + 1;
+    await this.save(discussion);
+    return message;
   }
 
   async removeMessageFromDiscussion(
@@ -141,6 +148,9 @@ export class DiscussionService {
       communicationUserID,
       messageData
     );
+    discussion.commentsCount = discussion.commentsCount - 1;
+    await this.save(discussion);
+
     return messageData.messageID;
   }
 }

--- a/src/domain/communication/discussion/dto/discussion.dto.update.ts
+++ b/src/domain/communication/discussion/dto/discussion.dto.update.ts
@@ -1,7 +1,7 @@
 import { DiscussionCategory } from '@common/enums/communication.discussion.category';
 import { UpdateBaseAlkemioInput } from '@domain/common/entity/base-entity/base.alkemio.dto.update';
 import { InputType, Field } from '@nestjs/graphql';
-import { SMALL_TEXT_LENGTH } from '@src/common/constants';
+import { MID_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@src/common/constants';
 import { MaxLength } from 'class-validator';
 
 @InputType()
@@ -15,4 +15,11 @@ export class UpdateDiscussionInput extends UpdateBaseAlkemioInput {
     description: 'The category for the Discussion',
   })
   category?: string;
+
+  @Field(() => String, {
+    nullable: true,
+    description: 'The description for the Discussion',
+  })
+  @MaxLength(MID_TEXT_LENGTH)
+  description?: string;
 }

--- a/src/domain/communication/room/room.service.ts
+++ b/src/domain/communication/room/room.service.ts
@@ -76,9 +76,9 @@ export class RoomService {
     messageData: RoomSendMessageInput
   ): Promise<CommunicationMessageResult> {
     // Ensure the user is a member of room and group so can send
-    await this.communicationAdapter.grantUserAccesToRooms(
+    await this.communicationAdapter.addUserToRoomSync(
       roomable.communicationGroupID,
-      [roomable.communicationRoomID],
+      roomable.communicationRoomID,
       communicationUserID
     );
     // Todo: call this first to allow room access to complete

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -254,7 +254,7 @@ export class UserService {
 
       if (!communicationID) {
         this.logger.warn(
-          `User could not be registered for communication ${user.id}`,
+          `Unable to register user for communication: ${user.email}`,
           LogContext.COMMUNICATION
         );
         return user;

--- a/src/migrations/1637759764246-discussions2.ts
+++ b/src/migrations/1637759764246-discussions2.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class discussions21637759764246 implements MigrationInterface {
+  name = 'discussions21637759764246';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`discussion\` ADD \`description\` text NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`discussion\` ADD \`commentsCount\` int NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`discussion\` ADD \`createdBy\` char(36) NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`discussion\` DROP COLUMN \`createdBy\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`discussion\` DROP COLUMN \`commentsCount\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`discussion\` DROP COLUMN \`description\``
+    );
+  }
+}

--- a/src/services/admin/communication/admin.communication.resolver.mutations.ts
+++ b/src/services/admin/communication/admin.communication.resolver.mutations.ts
@@ -49,11 +49,11 @@ export class AdminCommunicationResolverMutations {
     );
   }
 
-  @UseGuards(GraphqlGuard)
-  @Mutation(() => Boolean, {
-    description: 'Remove an orphaned room from messaging platform.',
-  })
-  @Profiling.api
+  // @UseGuards(GraphqlGuard)
+  // @Mutation(() => Boolean, {
+  //   description: 'Remove an orphaned room from messaging platform.',
+  // })
+  // @Profiling.api
   async adminCommunicationRemoveOrphanedRoom(
     @Args('orphanedRoomData')
     orphanedRoomData: CommunicationAdminRemoveOrphanedRoomInput,

--- a/src/services/admin/communication/admin.communication.resolver.mutations.ts
+++ b/src/services/admin/communication/admin.communication.resolver.mutations.ts
@@ -9,6 +9,7 @@ import { AgentInfo } from '@core/authentication';
 import { CommunicationAdminEnsureAccessInput } from './dto/admin.communication.dto.ensure.access.input';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AdminCommunicationService } from './admin.communication.service';
+import { CommunicationAdminRemoveOrphanedRoomInput } from './dto/admin.communication.dto.remove.orphaned.room';
 
 @Resolver()
 export class AdminCommunicationResolverMutations {
@@ -34,7 +35,7 @@ export class AdminCommunicationResolverMutations {
   @Profiling.api
   async adminCommunicationEnsureAccessToCommunications(
     @Args('communicationData')
-    grantCredentialData: CommunicationAdminEnsureAccessInput,
+    ensureAccessData: CommunicationAdminEnsureAccessInput,
     @CurrentUser() agentInfo: AgentInfo
   ): Promise<boolean> {
     await this.authorizationService.grantAccessOrFail(
@@ -44,7 +45,28 @@ export class AdminCommunicationResolverMutations {
       `grant community members access to communications: ${agentInfo.email}`
     );
     return await this.adminCommunicationService.ensureCommunityAccessToCommunications(
-      grantCredentialData
+      ensureAccessData
+    );
+  }
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => Boolean, {
+    description: 'Remove an orphaned room from messaging platform.',
+  })
+  @Profiling.api
+  async adminCommunicationRemoveOrphanedRoom(
+    @Args('orphanedRoomData')
+    orphanedRoomData: CommunicationAdminRemoveOrphanedRoomInput,
+    @CurrentUser() agentInfo: AgentInfo
+  ): Promise<boolean> {
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      this.communicationGlobalAdminPolicy,
+      AuthorizationPrivilege.GRANT,
+      `communications admin remove orphaned room: ${agentInfo.email}`
+    );
+    return await this.adminCommunicationService.removeOrphanedRoom(
+      orphanedRoomData
     );
   }
 }

--- a/src/services/admin/communication/dto/admin.communication.dto.remove.orphaned.room.ts
+++ b/src/services/admin/communication/dto/admin.communication.dto.remove.orphaned.room.ts
@@ -1,0 +1,7 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class CommunicationAdminRemoveOrphanedRoomInput {
+  @Field(() => String, { nullable: false })
+  roomID!: string;
+}

--- a/src/services/platform/communication-adapter/communication.adapter.ts
+++ b/src/services/platform/communication-adapter/communication.adapter.ts
@@ -625,10 +625,18 @@ export class CommunicationAdapter {
 
   async removeRoom(matrixRoomID: string) {
     try {
-      //const elevatedAgent = await this.getMatrixManagementAgentElevated();
+      const elevatedAgent = await this.getMatrixManagementAgentElevated();
       //todo: remove the room
       this.logger.verbose?.(
         `Removing matrix room: ${matrixRoomID}`,
+        LogContext.COMMUNICATION
+      );
+      const room = await this.matrixRoomAdapter.getMatrixRoom(
+        elevatedAgent.matrixClient,
+        matrixRoomID
+      );
+      this.logger.verbose?.(
+        `Located matrix room to remove: ${room.name}`,
         LogContext.COMMUNICATION
       );
     } catch (error) {

--- a/src/services/platform/matrix/adapter-room/matrix.room.adapter.ts
+++ b/src/services/platform/matrix/adapter-room/matrix.room.adapter.ts
@@ -149,15 +149,28 @@ export class MatrixRoomAdapter {
     );
   }
 
-  async removeUserFromRoom(roomID: string, matrixClient: MatrixClient) {
+  async removeUserFromRoom(
+    adminMatrixClient: MatrixClient,
+    roomID: string,
+    matrixClient: MatrixClient
+  ) {
     const matrixUserID = matrixClient.getUserId();
     try {
-      await this.getMatrixRoom(matrixClient, roomID);
       // todo: not yet working...
-      await matrixClient.leave(roomID);
+      // await matrixClient.leave(roomID, (err, data) =>
+      //   this.logger.verbose?.(`${err?.toString()}, ${data?.toString()}`)
+      // );
+
+      // force the user to leave
+      await adminMatrixClient.kick(roomID, matrixUserID);
+
+      // https://github.com/matrix-org/matrix-js-sdk/blob/b2d83c1f80b53ae3ca396ac102edf27bfbbd7015/src/client.ts#L4354
+
+      const room = await this.getMatrixRoom(matrixClient, roomID);
+      const membership = room.getMyMembership();
 
       this.logger.verbose?.(
-        `removed user from room: ${matrixUserID} - ${roomID}`,
+        `Membership state updated to ${membership} for user and room: ${matrixUserID} - ${roomID}`,
         LogContext.COMMUNICATION
       );
     } catch (error) {

--- a/src/services/platform/matrix/adapter-user/matrix.user.adapter.ts
+++ b/src/services/platform/matrix/adapter-user/matrix.user.adapter.ts
@@ -23,6 +23,14 @@ export class MatrixUserAdapter {
     return response.joined_rooms;
   }
 
+  async getJoinedGroups(matrixClient: MatrixClient): Promise<string[]> {
+    const groupsResponse = await matrixClient.getJoinedGroups();
+    const response = groupsResponse as any as {
+      groups: string[];
+    };
+    return response.groups;
+  }
+
   async verifyRoomMembershipOrFail(
     matrixClient: MatrixClient,
     roomID: string

--- a/src/services/platform/matrix/agent/matrix.agent.ts
+++ b/src/services/platform/matrix/agent/matrix.agent.ts
@@ -6,6 +6,8 @@ import { Inject, LoggerService } from '@nestjs/common';
 import {
   autoAcceptRoomGuardFactory,
   AutoAcceptSpecificRoomMembershipMonitorFactory,
+  ForgetRoomMembershipMonitorFactory,
+  roomMembershipLeaveGuardFactory,
   RoomMonitorFactory,
   RoomTimelineMonitorFactory,
 } from '@services/platform/matrix/events/matrix.event.adapter.room';
@@ -108,7 +110,7 @@ export class MatrixAgent implements IMatrixAgent, Disposable {
     this.attach(eventHandler);
   }
 
-  resolveSpecificRoomMembershipMonitor(
+  resolveAutoAcceptRoomMembershipMonitor(
     roomId: string,
     onRoomJoined: () => void,
     onComplete?: () => void,
@@ -125,7 +127,21 @@ export class MatrixAgent implements IMatrixAgent, Disposable {
     );
   }
 
-  resolveSpecificRoomMembershipOneTimeMonitor(
+  resolveAutoForgetRoomMembershipMonitor(
+    onRoomJoined: () => void,
+    onComplete?: () => void,
+    onError?: (message: string) => void
+  ) {
+    return ForgetRoomMembershipMonitorFactory.create(
+      this.matrixClient,
+      this.logger,
+      onRoomJoined,
+      onComplete,
+      onError
+    );
+  }
+
+  resolveAutoAcceptRoomMembershipOneTimeMonitor(
     roomId: string,
     userId: string,
     onRoomJoined: () => void,
@@ -133,13 +149,30 @@ export class MatrixAgent implements IMatrixAgent, Disposable {
     onError?: (message: string) => void
   ) {
     return {
-      observer: this.resolveSpecificRoomMembershipMonitor(
+      observer: this.resolveAutoAcceptRoomMembershipMonitor(
         roomId,
         onRoomJoined,
         onComplete,
         onError
       ),
       condition: autoAcceptRoomGuardFactory(userId, roomId),
+    };
+  }
+
+  resolveForgetRoomMembershipOneTimeMonitor(
+    roomId: string,
+    userId: string,
+    onRoomJoined: () => void,
+    onComplete?: () => void,
+    onError?: (message: string) => void
+  ) {
+    return {
+      observer: this.resolveAutoForgetRoomMembershipMonitor(
+        onRoomJoined,
+        onComplete,
+        onError
+      ),
+      condition: roomMembershipLeaveGuardFactory(userId, roomId),
     };
   }
 


### PR DESCRIPTION
When creating discussions only await the user that triggered the new discussion 
Only add user to group if not a member
added query to get a particular discussion
Reworked dicussion api to have fields for timestamp, createdBy, description instead of using the first message
Updated logic related to sending / creating of Discussions

Added logic related to removing users from rooms
Separate logic path for adding users synchronously to a single room.

Note: requires client updates, for which there is a draft PR (not fully functional) on the client-web repo.