### PR TITLE
added code to bring the messages count back in sync; 

### DIFF
--- a/src/domain/communication/communication/communication.resolver.mutations.ts
+++ b/src/domain/communication/communication/communication.resolver.mutations.ts
@@ -3,14 +3,12 @@ import { Resolver } from '@nestjs/graphql';
 import { Args, Mutation } from '@nestjs/graphql';
 import { CommunicationService } from './communication.service';
 import { CurrentUser } from '@src/common/decorators';
-
 import { GraphqlGuard } from '@core/authorization';
 import { AgentInfo } from '@core/authentication';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPrivilege } from '@common/enums';
 import { IDiscussion } from '../discussion/discussion.interface';
 import { CommunicationCreateDiscussionInput } from './dto/communication.dto.create.discussion';
-import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { DiscussionService } from '../discussion/discussion.service';
 import { DiscussionAuthorizationService } from '../discussion/discussion.service.authorization';
 
@@ -19,7 +17,6 @@ export class CommunicationResolverMutations {
   constructor(
     private authorizationService: AuthorizationService,
     private communicationService: CommunicationService,
-    private authorizationPolicyService: AuthorizationPolicyService,
     private discussionAuthorizationService: DiscussionAuthorizationService,
     private discussionService: DiscussionService
   ) {}
@@ -45,7 +42,8 @@ export class CommunicationResolverMutations {
 
     const discussion = await this.communicationService.createDiscussion(
       createData,
-      agentInfo.userID
+      agentInfo.userID,
+      agentInfo.communicationID
     );
     await this.discussionAuthorizationService.applyAuthorizationPolicy(
       discussion,

--- a/src/domain/communication/communication/communication.service.ts
+++ b/src/domain/communication/communication/communication.service.ts
@@ -94,7 +94,8 @@ export class CommunicationService {
 
   async createDiscussion(
     discussionData: CommunicationCreateDiscussionInput,
-    userID: string
+    userID: string,
+    userCommunicationID: string
   ): Promise<IDiscussion> {
     const title = discussionData.title;
     const communicationID = discussionData.communicationID;
@@ -126,7 +127,8 @@ export class CommunicationService {
     // Do not await as the memberhip will be updated in the background
     this.communicationAdapter.replicateRoomMembership(
       discussion.communicationRoomID,
-      updates.communicationRoomID
+      updates.communicationRoomID,
+      userCommunicationID
     );
 
     return discussion;

--- a/src/domain/communication/discussion/discussion.service.ts
+++ b/src/domain/communication/discussion/discussion.service.ts
@@ -120,7 +120,19 @@ export class DiscussionService {
   async getDiscussionRoom(
     discussion: IDiscussion
   ): Promise<CommunicationRoomResult> {
-    return await this.roomService.getCommunicationRoom(discussion);
+    const communicationRoom = await this.roomService.getCommunicationRoom(
+      discussion
+    );
+    const messagesCount = communicationRoom.messages.length;
+    if (messagesCount != discussion.commentsCount) {
+      this.logger.warn(
+        `Discussion (${discussion.displayName}) had a comment count of ${discussion.commentsCount} that is not syncd with the messages count of ${messagesCount}`,
+        LogContext.COMMUNICATION
+      );
+      discussion.commentsCount = messagesCount;
+      await this.save(discussion);
+    }
+    return communicationRoom;
   }
 
   async sendMessageToDiscussion(

--- a/src/services/platform/communication-adapter/communication.adapter.ts
+++ b/src/services/platform/communication-adapter/communication.adapter.ts
@@ -496,7 +496,8 @@ export class CommunicationAdapter {
 
   async replicateRoomMembership(
     targetRoomID: string,
-    sourceRoomID: string
+    sourceRoomID: string,
+    userToPrioritize: string
   ): Promise<boolean> {
     try {
       this.logger.verbose?.(
@@ -510,6 +511,15 @@ export class CommunicationAdapter {
           elevatedAgent.matrixClient,
           sourceRoomID
         );
+
+      // Ensure the user to be prioritized is first
+      const userIndex = sourceMatrixUserIDs.findIndex(
+        userID => userID === userToPrioritize
+      );
+      if (userIndex !== -1) {
+        sourceMatrixUserIDs.splice(0, 0, userToPrioritize);
+        sourceMatrixUserIDs.splice(userIndex + 1, 1);
+      }
 
       for (const matrixUserID of sourceMatrixUserIDs) {
         // skip the matrix elevated agent


### PR DESCRIPTION
ordered the addition of room replication to ensure user triggering the discussion creation goes first

Note: this ordering **reduces** the chances of the first message sending failing but does not guarantee it. If it does not help then still merge through.