### PR TITLE
Room removal support; comms admin extension to support

### DIFF
--- a/src/domain/communication/room/dto/communication.dto.room.result.ts
+++ b/src/domain/communication/room/dto/communication.dto.room.result.ts
@@ -21,6 +21,9 @@ export class CommunicationRoomResult {
   })
   displayName!: string;
 
+  // The communication IDs of the room members
+  members!: string[];
+
   constructor() {
     this.displayName = '';
   }

--- a/src/services/admin/communication/admin.communication.resolver.mutations.ts
+++ b/src/services/admin/communication/admin.communication.resolver.mutations.ts
@@ -49,11 +49,11 @@ export class AdminCommunicationResolverMutations {
     );
   }
 
-  // @UseGuards(GraphqlGuard)
-  // @Mutation(() => Boolean, {
-  //   description: 'Remove an orphaned room from messaging platform.',
-  // })
-  // @Profiling.api
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => Boolean, {
+    description: 'Remove an orphaned room from messaging platform.',
+  })
+  @Profiling.api
   async adminCommunicationRemoveOrphanedRoom(
     @Args('orphanedRoomData')
     orphanedRoomData: CommunicationAdminRemoveOrphanedRoomInput,

--- a/src/services/admin/communication/admin.communication.service.ts
+++ b/src/services/admin/communication/admin.communication.service.ts
@@ -154,6 +154,7 @@ export class AdminCommunicationService {
           roomNotUsed.id,
           roomNotUsed.displayName
         );
+        roomResult.members = matrixRoom.members;
         result.rooms.push(roomResult);
       }
     }


### PR DESCRIPTION
Updates the logic for a matrix room being present to ignore rooms with no members.
Added mutation to remove a particular orphaned matrix room.