### PR TITLE
added activity field with count for members to organization

### DIFF
--- a/src/domain/community/organization/organization.resolver.fields.ts
+++ b/src/domain/community/organization/organization.resolver.fields.ts
@@ -15,6 +15,7 @@ import { IAgent } from '@domain/agent/agent';
 import { UUID } from '@domain/common/scalars';
 import { UserGroupService } from '@domain/community/user-group/user-group.service';
 import { IOrganizationVerification } from '../organization-verification/organization.verification.interface';
+import { INVP } from '@domain/common/nvp/nvp.interface';
 @Resolver(() => IOrganization)
 export class OrganizationResolverFields {
   constructor(
@@ -93,5 +94,14 @@ export class OrganizationResolverFields {
   @Profiling.api
   async agent(@Parent() organization: Organization): Promise<IAgent> {
     return await this.organizationService.getAgent(organization);
+  }
+
+  @ResolveField('activity', () => [INVP], {
+    nullable: true,
+    description: 'The activity within this Organization.',
+  })
+  @Profiling.api
+  async activity(@Parent() organization: Organization) {
+    return await this.organizationService.getActivity(organization);
   }
 }


### PR DESCRIPTION
This is to allow the client so show the users count on organizations where he is not a member. 

Also to reduce the load on the server for getting information about organizations; currently the client is loading up all orgs with all users to get the count, this is killing in terms of load. 