### PR TITLE
Fixed saving large canvases

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -31,6 +31,7 @@ hosting:
   subscriptions:
     enabled: ${SUBSCRIPTIONS_ENABLED}:false
 
+  max_json_payload_size: ${HOSTING_MAX_JSON_PAYLOAD_SIZE}:64mb
 ## bootstrap ##
 # Used to determine the the information that is used to to initialize a functional Alkemio instance.
 bootstrap:

--- a/src/domain/common/canvas/canvas.entity.ts
+++ b/src/domain/common/canvas/canvas.entity.ts
@@ -16,7 +16,7 @@ export class Canvas extends AuthorizableEntity implements ICanvas {
   @Column('text', { nullable: false })
   name!: string;
 
-  @Column('text', { nullable: false })
+  @Column('longtext', { nullable: false })
   value!: string;
 
   @Column('boolean', { nullable: false })

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { faviconMiddleware } from './core/middleware/favicon.middleware';
 import { useContainer } from 'class-validator';
 import { graphqlUploadExpress } from 'graphql-upload';
 import { ConfigurationTypes } from '@common/enums';
+import { json } from 'body-parser';
 
 const bootstrap = async () => {
   const app = await NestFactory.create(AppModule);
@@ -44,6 +45,13 @@ const bootstrap = async () => {
     graphqlUploadExpress({
       maxFileSize: configService.get(ConfigurationTypes.STORAGE)?.ipfs
         ?.max_file_size,
+    })
+  );
+
+  app.use(
+    json({
+      limit: configService.get(ConfigurationTypes.HOSTING)
+        ?.max_json_payload_size,
     })
   );
 

--- a/src/migrations/1639665207723-increase-canvas-value-size.ts
+++ b/src/migrations/1639665207723-increase-canvas-value-size.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class increaseCanvasValueSize1639665207723
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE canvas
+      CHANGE COLUMN value value LONGTEXT NOT NULL ;`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE canvas
+      CHANGE COLUMN value value TEXT NOT NULL ;`
+    );
+  }
+}


### PR DESCRIPTION
- Switched canvas value from TEXT (max 65,535 bytes) to LONGTEXT(max 4,294,967,295 bytes).
- Increased max json payload size in express to accommodate larger values (check https://stackoverflow.com/questions/50988891/payloadtoolargeerror-with-limit-set and https://github.com/nestjs/nest/issues/529)