### PR TITLE
Authorization refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/axios": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -183,7 +183,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_notifications
     hostname: notifications
-    image: alkemio/notifications:v0.4.2
+    image: alkemio/notifications:v0.4.5
     environment:
       - RABBITMQ_HOST
       - LOGGING_CONSOLE_ENABLED

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -6,6 +6,7 @@ export enum AuthorizationPrivilege {
   UPDATE = 'update',
   DELETE = 'delete',
   GRANT = 'grant', // allow the issuing / revoking of credentials of the same type within a given scope
+  CREATE_CANVAS = 'createCanvas',
 }
 
 registerEnumType(AuthorizationPrivilege, {

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -9,7 +9,7 @@ export enum AuthorizationPrivilege {
   CREATE_CANVAS = 'create-canvas',
   CREATE_HUB = 'ceate-hub',
   CREATE_ORGANIZATION = 'create-organization',
-  READ_USERS = 'read-search',
+  READ_USERS = 'read-users',
 }
 
 registerEnumType(AuthorizationPrivilege, {

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -9,10 +9,7 @@ export enum AuthorizationPrivilege {
   CREATE_CANVAS = 'create-canvas',
   CREATE_HUB = 'ceate-hub',
   CREATE_ORGANIZATION = 'create-organization',
-  READ_MEMBERSHIP = 'read-membership',
-  READ_SEACRH = 'read-search',
   READ_USERS = 'read-search',
-  READ_USERS_MATCHING_CREDENTIALS = 'read-users-matching-credentials',
 }
 
 registerEnumType(AuthorizationPrivilege, {

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -7,7 +7,7 @@ export enum AuthorizationPrivilege {
   DELETE = 'delete',
   GRANT = 'grant', // allow the issuing / revoking of credentials of the same type within a given scope
   CREATE_CANVAS = 'create-canvas',
-  CREATE_HUB = 'ceate-hub',
+  CREATE_HUB = 'create-hub',
   CREATE_ORGANIZATION = 'create-organization',
   READ_USERS = 'read-users',
 }

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -6,7 +6,13 @@ export enum AuthorizationPrivilege {
   UPDATE = 'update',
   DELETE = 'delete',
   GRANT = 'grant', // allow the issuing / revoking of credentials of the same type within a given scope
-  CREATE_CANVAS = 'createCanvas',
+  CREATE_CANVAS = 'create-canvas',
+  CREATE_HUB = 'ceate-hub',
+  CREATE_ORGANIZATION = 'create-organization',
+  READ_MEMBERSHIP = 'read-membership',
+  READ_SEACRH = 'read-search',
+  READ_USERS = 'read-search',
+  READ_USERS_MATCHING_CREDENTIALS = 'read-users-matching-credentials',
 }
 
 registerEnumType(AuthorizationPrivilege, {

--- a/src/common/enums/logging.context.ts
+++ b/src/common/enums/logging.context.ts
@@ -19,4 +19,5 @@ export enum LogContext {
   SUBSCRIPTIONS = 'subscriptions',
   SSI = 'ssi',
   REQUESTS = 'requests',
+  PLATFORM = 'platform',
 }

--- a/src/core/authorization/authorization.policy.rule.credential.ts
+++ b/src/core/authorization/authorization.policy.rule.credential.ts
@@ -9,16 +9,11 @@ export class AuthorizationPolicyRuleCredential {
   constructor(
     grantedPrivileges: AuthorizationPrivilege[],
     type: string,
-    resourceID?: string,
-    inheritable?: boolean
+    resourceID?: string
   ) {
     this.type = type;
     this.resourceID = resourceID || '';
     this.grantedPrivileges = grantedPrivileges;
-    if (inheritable === undefined) {
-      this.inheritable = true;
-    } else {
-      this.inheritable = inheritable;
-    }
+    this.inheritable = true;
   }
 }

--- a/src/core/authorization/authorization.policy.rule.credential.ts
+++ b/src/core/authorization/authorization.policy.rule.credential.ts
@@ -4,12 +4,21 @@ export class AuthorizationPolicyRuleCredential {
   type: string;
   resourceID: string;
   grantedPrivileges: AuthorizationPrivilege[];
-  inheritable?: boolean = true;
+  inheritable: boolean;
 
-  constructor() {
-    this.type = '';
-    this.resourceID = '';
-    this.grantedPrivileges = [];
-    this.inheritable = true;
+  constructor(
+    grantedPrivileges: AuthorizationPrivilege[],
+    type: string,
+    resourceID?: string,
+    inheritable?: boolean
+  ) {
+    this.type = type;
+    this.resourceID = resourceID || '';
+    this.grantedPrivileges = grantedPrivileges;
+    this.inheritable = inheritable || true;
+  }
+
+  isInheritable(): boolean {
+    return this.inheritable;
   }
 }

--- a/src/core/authorization/authorization.policy.rule.credential.ts
+++ b/src/core/authorization/authorization.policy.rule.credential.ts
@@ -15,10 +15,10 @@ export class AuthorizationPolicyRuleCredential {
     this.type = type;
     this.resourceID = resourceID || '';
     this.grantedPrivileges = grantedPrivileges;
-    this.inheritable = inheritable || true;
-  }
-
-  isInheritable(): boolean {
-    return this.inheritable;
+    if (inheritable === undefined) {
+      this.inheritable = true;
+    } else {
+      this.inheritable = inheritable;
+    }
   }
 }

--- a/src/core/authorization/authorization.policy.rule.credential.ts
+++ b/src/core/authorization/authorization.policy.rule.credential.ts
@@ -1,7 +1,15 @@
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 
-export type AuthorizationPolicyRuleCredential = {
+export class AuthorizationPolicyRuleCredential {
   type: string;
   resourceID: string;
   grantedPrivileges: AuthorizationPrivilege[];
-};
+  inheritable?: boolean = true;
+
+  constructor() {
+    this.type = '';
+    this.resourceID = '';
+    this.grantedPrivileges = [];
+    this.inheritable = true;
+  }
+}

--- a/src/core/authorization/authorization.policy.rule.privilege.ts
+++ b/src/core/authorization/authorization.policy.rule.privilege.ts
@@ -1,0 +1,14 @@
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+
+export class AuthorizationPolicyRulePrivilege {
+  sourcePrivilege: AuthorizationPrivilege;
+  grantedPrivileges: AuthorizationPrivilege[];
+
+  constructor(
+    grantedPrivileges: AuthorizationPrivilege[],
+    sourcePrivilege: AuthorizationPrivilege
+  ) {
+    this.sourcePrivilege = sourcePrivilege;
+    this.grantedPrivileges = grantedPrivileges;
+  }
+}

--- a/src/core/authorization/authorization.service.ts
+++ b/src/core/authorization/authorization.service.ts
@@ -101,10 +101,7 @@ export class AuthorizationService {
       this.convertCredentialRulesStr(authorization.credentialRules);
     for (const rule of credentialRules) {
       for (const credential of agentInfo.credentials) {
-        if (
-          credential.type === rule.type &&
-          credential.resourceID === rule.resourceID
-        ) {
+        if (this.isCredentialMatch(credential, rule)) {
           for (const privilege of rule.grantedPrivileges) {
             if (privilege === privilegeRequired) return true;
             grantedPrivileges.push(privilege);
@@ -160,10 +157,7 @@ export class AuthorizationService {
       this.convertCredentialRulesStr(authorization.credentialRules);
     for (const rule of credentialRules) {
       for (const credential of credentials) {
-        if (
-          credential.type === rule.type &&
-          credential.resourceID === rule.resourceID
-        ) {
+        if (this.isCredentialMatch(credential, rule)) {
           for (const privilege of rule.grantedPrivileges) {
             grantedPrivileges.push(privilege);
           }
@@ -184,6 +178,21 @@ export class AuthorizationService {
     );
 
     return uniquePrivileges;
+  }
+
+  private isCredentialMatch(
+    credential: ICredential,
+    credentialRule: AuthorizationPolicyRuleCredential
+  ): boolean {
+    if (credential.type === credentialRule.type) {
+      if (
+        credentialRule.resourceID === '' ||
+        credential.resourceID === credentialRule.resourceID
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   convertCredentialRulesStr(

--- a/src/core/authorization/authorization.service.ts
+++ b/src/core/authorization/authorization.service.ts
@@ -9,6 +9,7 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy/author
 import { AuthorizationPolicyRuleCredential } from './authorization.policy.rule.credential';
 import { AuthorizationPolicyRuleVerifiedCredential } from './authorization.policy.rule.verified.credential';
 import { LogContext } from '@common/enums';
+import { AuthorizationPolicyRulePrivilege } from './authorization.policy.rule.privilege';
 
 @Injectable()
 export class AuthorizationService {
@@ -32,19 +33,6 @@ export class AuthorizationService {
 
     // If get to here then no match was found
     throw new ForbiddenException(errorMsg, LogContext.AUTH);
-  }
-
-  grantReadAccessOrFail(
-    agentInfo: AgentInfo,
-    authorization: IAuthorizationPolicy | undefined,
-    msg: string
-  ) {
-    this.grantAccessOrFail(
-      agentInfo,
-      authorization,
-      AuthorizationPrivilege.READ,
-      msg
-    );
   }
 
   logCredentialCheckFailDetails(
@@ -106,6 +94,9 @@ export class AuthorizationService {
       return true;
     }
 
+    // Keep track of all the granted privileges via Credential rules so can use with Privilege rules
+    const grantedPrivileges: AuthorizationPrivilege[] = [];
+
     const credentialRules: AuthorizationPolicyRuleCredential[] =
       this.convertCredentialRulesStr(authorization.credentialRules);
     for (const rule of credentialRules) {
@@ -116,6 +107,7 @@ export class AuthorizationService {
         ) {
           for (const privilege of rule.grantedPrivileges) {
             if (privilege === privilegeRequired) return true;
+            grantedPrivileges.push(privilege);
           }
         }
       }
@@ -137,9 +129,18 @@ export class AuthorizationService {
                 LogContext.AUTH
               );
               return true;
+              grantedPrivileges.push(privilege);
             }
           }
         }
+      }
+    }
+
+    const privilegeRules: AuthorizationPolicyRulePrivilege[] =
+      this.convertPrivilegeRulesStr(authorization.privilegeRules);
+    for (const rule of privilegeRules) {
+      if (grantedPrivileges.includes(rule.sourcePrivilege)) {
+        if (rule.grantedPrivileges.includes(privilegeRequired)) return true;
       }
     }
     return false;
@@ -167,6 +168,14 @@ export class AuthorizationService {
             grantedPrivileges.push(privilege);
           }
         }
+      }
+    }
+
+    const privilegeRules: AuthorizationPolicyRulePrivilege[] =
+      this.convertPrivilegeRulesStr(authorization.privilegeRules);
+    for (const rule of privilegeRules) {
+      if (grantedPrivileges.includes(rule.sourcePrivilege)) {
+        grantedPrivileges.push(...rule.grantedPrivileges);
       }
     }
 
@@ -201,6 +210,20 @@ export class AuthorizationService {
       return rules;
     } catch (error) {
       const msg = `Unable to convert rules to json: ${error}`;
+      this.logger.error(msg);
+      throw new ForbiddenException(msg, LogContext.AUTH);
+    }
+  }
+
+  convertPrivilegeRulesStr(
+    rulesStr: string
+  ): AuthorizationPolicyRulePrivilege[] {
+    if (!rulesStr || rulesStr.length == 0) return [];
+    try {
+      const rules: AuthorizationPolicyRulePrivilege[] = JSON.parse(rulesStr);
+      return rules;
+    } catch (error) {
+      const msg = `Unable to convert privilege rules to json: ${error}`;
       this.logger.error(msg);
       throw new ForbiddenException(msg, LogContext.AUTH);
     }

--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -111,24 +111,24 @@ export class ChallengeAuthorizationService {
   ): AuthorizationPolicyRuleCredential[] {
     const rules: AuthorizationPolicyRuleCredential[] = [];
 
-    const challengeAdmin = {
-      type: AuthorizationCredential.CHALLENGE_ADMIN,
-      resourceID: challengeID,
-      grantedPrivileges: [
+    const challengeAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.CHALLENGE_ADMIN,
+      challengeID
+    );
     rules.push(challengeAdmin);
 
-    const challengeMember = {
-      type: AuthorizationCredential.CHALLENGE_MEMBER,
-      resourceID: challengeID,
-      grantedPrivileges: [AuthorizationPrivilege.READ],
-    };
+    const challengeMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ],
+      AuthorizationCredential.CHALLENGE_MEMBER,
+      challengeID
+    );
     rules.push(challengeMember);
 
     return rules;

--- a/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.resolver.mutations.ts
@@ -9,14 +9,12 @@ import {
   UpdateEcoverseInput,
 } from '@domain/challenge/ecoverse';
 import { GraphqlGuard } from '@core/authorization';
-import { AuthorizationRoleGlobal } from '@common/enums';
 import { AgentInfo } from '@core/authentication';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { EcoverseAuthorizationService } from './ecoverse.service.authorization';
 import { ChallengeAuthorizationService } from '@domain/challenge/challenge/challenge.service.authorization';
 import { IEcoverse } from './ecoverse.interface';
-import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { IUser } from '@domain/community/user/user.interface';
 import { AssignEcoverseAdminInput } from './dto/ecoverse.dto.assign.admin';
 import { RemoveEcoverseAdminInput } from './dto/ecoverse.dto.remove.admin';
@@ -25,21 +23,13 @@ import { CreateChallengeOnEcoverseInput } from '../challenge/dto/challenge.dto.c
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 @Resolver()
 export class EcoverseResolverMutations {
-  private globalAdminAuthorization: IAuthorizationPolicy;
-
   constructor(
     private authorizationService: AuthorizationService,
     private authorizationPolicyService: AuthorizationPolicyService,
     private ecoverseService: EcoverseService,
     private ecoverseAuthorizationService: EcoverseAuthorizationService,
     private challengeAuthorizationService: ChallengeAuthorizationService
-  ) {
-    this.globalAdminAuthorization =
-      this.authorizationPolicyService.createGlobalRolesAuthorizationPolicy(
-        [AuthorizationRoleGlobal.ADMIN],
-        [AuthorizationPrivilege.CREATE, AuthorizationPrivilege.UPDATE]
-      );
-  }
+  ) {}
 
   @UseGuards(GraphqlGuard)
   @Mutation(() => IEcoverse, {
@@ -50,10 +40,12 @@ export class EcoverseResolverMutations {
     @CurrentUser() agentInfo: AgentInfo,
     @Args('ecoverseData') ecoverseData: CreateEcoverseInput
   ): Promise<IEcoverse> {
+    const authorizatinoPolicy =
+      this.authorizationPolicyService.getPlatformAuthorizationPolicy();
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.globalAdminAuthorization,
-      AuthorizationPrivilege.CREATE,
+      authorizatinoPolicy,
+      AuthorizationPrivilege.CREATE_HUB,
       `updateEcoverse: ${ecoverseData.nameID}`
     );
     const ecoverse = await this.ecoverseService.createEcoverse(ecoverseData);

--- a/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
@@ -88,44 +88,42 @@ export class EcoverseAuthorizationService {
     // By default it is world visible
     authorization.anonymousReadAccess = true;
 
-    const globalAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN,
-      resourceID: '',
-      grantedPrivileges: [
+    const globalAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
         AuthorizationPrivilege.GRANT,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN
+    );
     newRules.push(globalAdmin);
 
-    const communityAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
-      resourceID: '',
-      grantedPrivileges: [AuthorizationPrivilege.READ],
-    };
+    const communityAdmin = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ],
+      AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
+    );
     newRules.push(communityAdmin);
 
-    const ecoverseAdmin = {
-      type: AuthorizationCredential.ECOVERSE_ADMIN,
-      resourceID: ecoverseID,
-      grantedPrivileges: [
+    const ecoverseAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
         AuthorizationPrivilege.GRANT,
       ],
-    };
+      AuthorizationCredential.ECOVERSE_ADMIN,
+      ecoverseID
+    );
     newRules.push(ecoverseAdmin);
 
-    const ecoverseMember = {
-      type: AuthorizationCredential.ECOVERSE_MEMBER,
-      resourceID: ecoverseID,
-      grantedPrivileges: [AuthorizationPrivilege.READ],
-    };
+    const ecoverseMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ],
+      AuthorizationCredential.ECOVERSE_MEMBER,
+      ecoverseID
+    );
     newRules.push(ecoverseMember);
 
     this.authorizationPolicyService.appendCredentialAuthorizationRules(

--- a/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.authorization.ts
@@ -38,6 +38,10 @@ export class EcoverseAuthorizationService {
     ecoverse.authorization = await this.authorizationPolicyService.reset(
       ecoverse.authorization
     );
+    ecoverse.authorization =
+      this.authorizationPolicyService.inheritPlatformAuthorization(
+        ecoverse.authorization
+      );
     ecoverse.authorization = this.extendAuthorizationPolicy(
       ecoverse.authorization,
       ecoverse.id
@@ -87,18 +91,6 @@ export class EcoverseAuthorizationService {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
     // By default it is world visible
     authorization.anonymousReadAccess = true;
-
-    const globalAdmin = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE,
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-        AuthorizationPrivilege.DELETE,
-        AuthorizationPrivilege.GRANT,
-      ],
-      AuthorizationCredential.GLOBAL_ADMIN
-    );
-    newRules.push(globalAdmin);
 
     const communityAdmin = new AuthorizationPolicyRuleCredential(
       [AuthorizationPrivilege.READ],

--- a/src/domain/collaboration/opportunity/opportunity.service.authorization.ts
+++ b/src/domain/collaboration/opportunity/opportunity.service.authorization.ts
@@ -87,24 +87,24 @@ export class OpportunityAuthorizationService {
   ): AuthorizationPolicyRuleCredential[] {
     const rules: AuthorizationPolicyRuleCredential[] = [];
 
-    const opportunityAdmin = {
-      type: AuthorizationCredential.OPPORTUNITY_ADMIN,
-      resourceID: opportunityID,
-      grantedPrivileges: [
+    const opportunityAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.OPPORTUNITY_ADMIN,
+      opportunityID
+    );
     rules.push(opportunityAdmin);
 
-    const opportunityMember = {
-      type: AuthorizationCredential.OPPORTUNITY_MEMBER,
-      resourceID: opportunityID,
-      grantedPrivileges: [AuthorizationPrivilege.READ],
-    };
+    const opportunityMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ],
+      AuthorizationCredential.OPPORTUNITY_MEMBER,
+      opportunityID
+    );
     rules.push(opportunityMember);
 
     return rules;

--- a/src/domain/collaboration/relation/relation.service.authorization.ts
+++ b/src/domain/collaboration/relation/relation.service.authorization.ts
@@ -35,15 +35,15 @@ export class RelationAuthorizationService {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
     // Allow users to update their own created relation
-    const selfCreatedRelation = {
-      type: AuthorizationCredential.USER_SELF_MANAGEMENT,
-      resourceID: userID,
-      grantedPrivileges: [
+    const selfCreatedRelation = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.USER_SELF_MANAGEMENT,
+      userID
+    );
     newRules.push(selfCreatedRelation);
 
     this.authorizationPolicyService.appendCredentialAuthorizationRules(
@@ -64,11 +64,11 @@ export class RelationAuthorizationService {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
     // Allow global registered users to create
-    const globalRegisteredCreateRelation = {
-      type: AuthorizationCredential.GLOBAL_REGISTERED,
-      resourceID: '',
-      grantedPrivileges: [AuthorizationPrivilege.CREATE],
-    };
+    const globalRegisteredCreateRelation =
+      new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.CREATE],
+        AuthorizationCredential.GLOBAL_REGISTERED
+      );
     newRules.push(globalRegisteredCreateRelation);
 
     this.authorizationPolicyService.appendCredentialAuthorizationRules(

--- a/src/domain/common/authorization-policy/authorization.policy.entity.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.entity.ts
@@ -11,6 +11,9 @@ export class AuthorizationPolicy
   credentialRules: string;
 
   @Column('text')
+  privilegeRules: string;
+
+  @Column('text')
   verifiedCredentialRules: string;
 
   @Column()
@@ -21,5 +24,6 @@ export class AuthorizationPolicy
     this.anonymousReadAccess = false;
     this.credentialRules = '';
     this.verifiedCredentialRules = '';
+    this.privilegeRules = '';
   }
 }

--- a/src/domain/common/authorization-policy/authorization.policy.interface.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.interface.ts
@@ -9,4 +9,5 @@ export abstract class IAuthorizationPolicy extends IBaseAlkemio {
   // exposed via field resolver
   credentialRules!: string;
   verifiedCredentialRules!: string;
+  privilegeRules!: string;
 }

--- a/src/domain/common/authorization-policy/authorization.policy.module.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthorizationPolicy } from './authorization.policy.entity';
 import { AuthorizationPolicyResolverFields } from './authorization.policy.resolver.fields';
+import { AuthorizationPolicyResolverQueries } from './authorization.policy.resolver.queries';
 import { AuthorizationPolicyService } from './authorization.policy.service';
 
 @Module({
@@ -10,7 +11,11 @@ import { AuthorizationPolicyService } from './authorization.policy.service';
     AuthorizationModule,
     TypeOrmModule.forFeature([AuthorizationPolicy]),
   ],
-  providers: [AuthorizationPolicyService, AuthorizationPolicyResolverFields],
+  providers: [
+    AuthorizationPolicyService,
+    AuthorizationPolicyResolverFields,
+    AuthorizationPolicyResolverQueries,
+  ],
   exports: [AuthorizationPolicyService],
 })
 export class AuthorizationPolicyModule {}

--- a/src/domain/common/authorization-policy/authorization.policy.resolver.queries.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.resolver.queries.ts
@@ -1,0 +1,18 @@
+import { Resolver, Query } from '@nestjs/graphql';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
+import { Profiling } from '@common/decorators/profiling.decorator';
+import { AuthorizationPolicyService } from './authorization.policy.service';
+
+@Resolver()
+export class AuthorizationPolicyResolverQueries {
+  constructor(private authorizationPolicyService: AuthorizationPolicyService) {}
+
+  @Query(() => IAuthorizationPolicy, {
+    nullable: false,
+    description: 'The authorization policy for the platform',
+  })
+  @Profiling.api
+  authorization(): IAuthorizationPolicy {
+    return this.authorizationPolicyService.getPlatformAuthorizationPolicy();
+  }
+}

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -123,7 +123,7 @@ export class AuthorizationPolicyService {
     );
     const newRules: AuthorizationPolicyRuleCredential[] = [];
     for (const inheritedRule of inheritedRules) {
-      if (inheritedRule.isInheritable()) {
+      if (inheritedRule.inheritable) {
         newRules.push(inheritedRule);
       }
     }

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -202,8 +202,6 @@ export class AuthorizationPolicyService {
         credType = AuthorizationCredential.GLOBAL_ADMIN;
       } else if (globalRole === AuthorizationRoleGlobal.COMMUNITY_ADMIN) {
         credType = AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY;
-      } else if (globalRole === AuthorizationRoleGlobal.REGISTERED) {
-        credType = AuthorizationCredential.GLOBAL_REGISTERED;
       } else {
         throw new ForbiddenException(
           `Authorization: invalid global role encountered: ${globalRole}`,

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -136,7 +136,9 @@ export class AuthorizationPolicyService {
       auth.credentialRules
     );
     for (const additionalRule of additionalRules) {
-      existingRules.push(additionalRule);
+      if (additionalRule.inheritable) {
+        existingRules.push(additionalRule);
+      }
     }
 
     auth.credentialRules = JSON.stringify(existingRules);

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -249,13 +249,9 @@ export class AuthorizationPolicyService {
     globalAdminNotInherited.inheritable = false;
     rules.push(globalAdminNotInherited);
 
+    // Allow all registered users to query non-protected user information
     const userNotInherited = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.READ_MEMBERSHIP,
-        AuthorizationPrivilege.READ_SEACRH,
-        AuthorizationPrivilege.READ_USERS,
-        AuthorizationPrivilege.READ_USERS_MATCHING_CREDENTIALS,
-      ],
+      [AuthorizationPrivilege.READ_USERS],
       AuthorizationCredential.GLOBAL_REGISTERED
     );
     userNotInherited.inheritable = false;

--- a/src/domain/common/canvas-checkout/canvas.checkout.service.authorization.ts
+++ b/src/domain/common/canvas-checkout/canvas.checkout.service.authorization.ts
@@ -36,11 +36,12 @@ export class CanvasCheckoutAuthorizationService {
 
     // Allow any member of this community to create messages on the discussion
     if (checkout.lockedBy && checkout.lockedBy.length > 0) {
-      const lockedBy = {
-        type: AuthorizationCredential.USER_SELF_MANAGEMENT,
-        resourceID: checkout.lockedBy,
-        grantedPrivileges: [AuthorizationPrivilege.UPDATE],
-      };
+      const lockedBy = new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.UPDATE],
+        AuthorizationCredential.USER_SELF_MANAGEMENT,
+        checkout.lockedBy
+      );
+
       newRules.push(lockedBy);
     }
 

--- a/src/domain/common/canvas/canvas.service.authorization.ts
+++ b/src/domain/common/canvas/canvas.service.authorization.ts
@@ -43,11 +43,12 @@ export class CanvasAuthorizationService {
 
     // Allow any member of this community to create messages on the discussion
     if (checkout.lockedBy && checkout.lockedBy.length > 0) {
-      const lockedBy = {
-        type: AuthorizationCredential.USER_SELF_MANAGEMENT,
-        resourceID: checkout.lockedBy,
-        grantedPrivileges: [AuthorizationPrivilege.UPDATE],
-      };
+      const lockedBy = new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.UPDATE],
+        AuthorizationCredential.USER_SELF_MANAGEMENT,
+        checkout.lockedBy
+      );
+
       newRules.push(lockedBy);
     }
 

--- a/src/domain/common/canvas/canvas.service.authorization.ts
+++ b/src/domain/common/canvas/canvas.service.authorization.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { AuthorizationCredential } from '@common/enums';
+import { AuthorizationCredential, LogContext } from '@common/enums';
 import { AuthorizationPrivilege } from '@common/enums';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -8,6 +8,8 @@ import { CanvasService } from './canvas.service';
 import { ICanvas } from './canvas.interface';
 import { CanvasCheckoutAuthorizationService } from '../canvas-checkout/canvas.checkout.service.authorization';
 import { ICanvasCheckout } from '../canvas-checkout/canvas.checkout.interface';
+import { ICredential } from '@domain/agent';
+import { EntityNotInitializedException } from '@common/exceptions/entity.not.initialized.exception';
 
 @Injectable()
 export class CanvasAuthorizationService {
@@ -19,13 +21,20 @@ export class CanvasAuthorizationService {
 
   async applyAuthorizationPolicy(
     canvas: ICanvas,
-    parentAuthorization: IAuthorizationPolicy | undefined
+    parentAuthorization: IAuthorizationPolicy | undefined,
+    communityCredential?: ICredential
   ): Promise<ICanvas> {
     canvas.authorization =
       this.authorizationPolicyService.inheritParentAuthorization(
         canvas.authorization,
         parentAuthorization
       );
+    if (communityCredential) {
+      canvas.authorization = this.appendCredentialRules(
+        canvas.authorization,
+        communityCredential
+      );
+    }
     if (canvas.checkout) {
       canvas.checkout =
         await this.canvasCheckoutAuthorizationService.applyAuthorizationPolicy(
@@ -41,7 +50,6 @@ export class CanvasAuthorizationService {
   ): IAuthorizationPolicy {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    // Allow any member of this community to create messages on the discussion
     if (checkout.lockedBy && checkout.lockedBy.length > 0) {
       const lockedBy = new AuthorizationPolicyRuleCredential(
         [AuthorizationPrivilege.UPDATE],
@@ -55,6 +63,35 @@ export class CanvasAuthorizationService {
     const updatedAuthorization =
       this.authorizationPolicyService.appendCredentialAuthorizationRules(
         checkout.authorization,
+        newRules
+      );
+
+    return updatedAuthorization;
+  }
+
+  private appendCredentialRules(
+    authorization: IAuthorizationPolicy | undefined,
+    communityCredential: ICredential
+  ): IAuthorizationPolicy {
+    if (!authorization)
+      throw new EntityNotInitializedException(
+        'Authorization definition not found for Canvas',
+        LogContext.CONTEXT
+      );
+
+    const newRules: AuthorizationPolicyRuleCredential[] = [];
+
+    const communityMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.UPDATE],
+      communityCredential.type,
+      communityCredential.resourceID
+    );
+    communityMember.inheritable = false;
+    newRules.push(communityMember);
+
+    const updatedAuthorization =
+      this.authorizationPolicyService.appendCredentialAuthorizationRules(
+        authorization,
         newRules
       );
 

--- a/src/domain/communication/communication/communication.service.authorization.ts
+++ b/src/domain/communication/communication/communication.service.authorization.ts
@@ -59,14 +59,11 @@ export class CommunicationAuthorizationService {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
     // Allow any member of this community to create discussions, and to send messages to the discussion
-    const communityMember = {
-      type: communityCredential.type,
-      resourceID: communityCredential.resourceID,
-      grantedPrivileges: [
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.CREATE,
-      ],
-    };
+    const communityMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ, AuthorizationPrivilege.CREATE],
+      communityCredential.type,
+      communityCredential.resourceID
+    );
     newRules.push(communityMember);
 
     //

--- a/src/domain/communication/discussion/discussion.service.authorization.ts
+++ b/src/domain/communication/discussion/discussion.service.authorization.ts
@@ -68,14 +68,11 @@ export class DiscussionAuthorizationService {
 
     // Allow any member of this community to create messages on the discussion
     if (senderUserID !== '') {
-      const messageSender = {
-        type: AuthorizationCredential.USER_SELF_MANAGEMENT,
-        resourceID: senderUserID,
-        grantedPrivileges: [
-          AuthorizationPrivilege.UPDATE,
-          AuthorizationPrivilege.DELETE,
-        ],
-      };
+      const messageSender = new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.UPDATE, AuthorizationPrivilege.DELETE],
+        AuthorizationCredential.USER_SELF_MANAGEMENT,
+        senderUserID
+      );
       newRules.push(messageSender);
     }
 

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -78,25 +78,23 @@ export class CommunityAuthorizationService {
   ): IAuthorizationPolicy {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const globalCommunityAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
-      resourceID: '',
-      grantedPrivileges: [
+    const globalCommunityAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
+    );
     newRules.push(globalCommunityAdmin);
 
     if (allowGlobalRegisteredReadAccess) {
-      const globalRegistered = {
-        type: AuthorizationCredential.GLOBAL_REGISTERED,
-        resourceID: '',
-        grantedPrivileges: [AuthorizationPrivilege.READ],
-      };
+      const globalRegistered = new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.READ],
+        AuthorizationCredential.GLOBAL_REGISTERED
+      );
       newRules.push(globalRegistered);
     }
 

--- a/src/domain/community/organization-verification/organization.verification.service.authorization.ts
+++ b/src/domain/community/organization-verification/organization.verification.service.authorization.ts
@@ -51,50 +51,42 @@ export class OrganizationVerificationAuthorizationService {
 
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const globalAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN,
-      resourceID: '',
-      grantedPrivileges: [
+    const globalAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN
+    );
     newRules.push(globalAdmin);
 
-    const communityAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
-      resourceID: '',
-      grantedPrivileges: [
+    const communityAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
+    );
     newRules.push(communityAdmin);
 
-    const orgAdmin = {
-      type: AuthorizationCredential.ORGANIZATION_ADMIN,
-      resourceID: organizationID,
-      grantedPrivileges: [
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-      ],
-    };
+    const orgAdmin = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ, AuthorizationPrivilege.UPDATE],
+      AuthorizationCredential.ORGANIZATION_ADMIN,
+      organizationID
+    );
     newRules.push(orgAdmin);
 
-    const orgOwner = {
-      type: AuthorizationCredential.ORGANIZATION_OWNER,
-      resourceID: organizationID,
-      grantedPrivileges: [
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-      ],
-    };
+    const orgOwner = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ, AuthorizationPrivilege.UPDATE],
+      AuthorizationCredential.ORGANIZATION_OWNER,
+      organizationID
+    );
     newRules.push(orgOwner);
 
     const updatedAuthorization =

--- a/src/domain/community/organization/organization.resolver.mutations.ts
+++ b/src/domain/community/organization/organization.resolver.mutations.ts
@@ -10,7 +10,7 @@ import {
 } from '@domain/community/organization';
 import { CreateUserGroupInput, IUserGroup } from '@domain/community/user-group';
 import { GraphqlGuard } from '@core/authorization';
-import { AuthorizationPrivilege, AuthorizationRoleGlobal } from '@common/enums';
+import { AuthorizationPrivilege } from '@common/enums';
 import { OrganizationAuthorizationService } from './organization.service.authorization';
 import { AgentInfo } from '@core/authentication/agent-info';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -45,17 +45,12 @@ export class OrganizationResolverMutations {
     @Args('organizationData') organizationData: CreateOrganizationInput
   ): Promise<IOrganization> {
     const authorizationPolicy =
-      this.authorizationPolicyService.createGlobalRolesAuthorizationPolicy(
-        [
-          AuthorizationRoleGlobal.COMMUNITY_ADMIN,
-          AuthorizationRoleGlobal.ADMIN,
-        ],
-        [AuthorizationPrivilege.CREATE]
-      );
+      this.authorizationPolicyService.getPlatformAuthorizationPolicy();
+
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
       authorizationPolicy,
-      AuthorizationPrivilege.CREATE,
+      AuthorizationPrivilege.CREATE_ORGANIZATION,
       `create Organization: ${organizationData.nameID}`
     );
     const organization = await this.organizationService.createOrganization(

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -92,70 +92,69 @@ export class OrganizationAuthorizationService {
 
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const globalAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN,
-      resourceID: '',
-      grantedPrivileges: [
+    const globalAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN
+    );
     newRules.push(globalAdmin);
 
-    const communityAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
-      resourceID: '',
-      grantedPrivileges: [
+    const communityAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
+    );
     newRules.push(communityAdmin);
 
-    const organizationAdmin = {
-      type: AuthorizationCredential.ORGANIZATION_ADMIN,
-      resourceID: organizationID,
-      grantedPrivileges: [
+    const organizationAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.ORGANIZATION_ADMIN,
+      organizationID
+    );
+
     newRules.push(organizationAdmin);
 
-    const organizationOwner = {
-      type: AuthorizationCredential.ORGANIZATION_OWNER,
-      resourceID: organizationID,
-      grantedPrivileges: [
+    const organizationOwner = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.GRANT,
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
       ],
-    };
+      AuthorizationCredential.ORGANIZATION_OWNER,
+      organizationID
+    );
     newRules.push(organizationOwner);
 
-    const organizationMember = {
-      type: AuthorizationCredential.ORGANIZATION_MEMBER,
-      resourceID: organizationID,
-      grantedPrivileges: [AuthorizationPrivilege.READ],
-    };
+    const organizationMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ],
+      AuthorizationCredential.ORGANIZATION_MEMBER,
+      organizationID
+    );
     newRules.push(organizationMember);
 
-    const registeredUser = {
-      type: AuthorizationCredential.GLOBAL_REGISTERED,
-      resourceID: '',
-      grantedPrivileges: [AuthorizationPrivilege.READ],
-    };
+    const registeredUser = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ],
+      AuthorizationCredential.GLOBAL_REGISTERED
+    );
+
     newRules.push(registeredUser);
 
     const updatedAuthorization =

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -32,6 +32,10 @@ export class OrganizationAuthorizationService {
     organization.authorization = await this.authorizationPolicyService.reset(
       organization.authorization
     );
+    organization.authorization =
+      this.authorizationPolicyService.inheritPlatformAuthorization(
+        organization.authorization
+      );
     organization.authorization = this.appendCredentialRules(
       organization.authorization,
       organization.id
@@ -91,18 +95,6 @@ export class OrganizationAuthorizationService {
       );
 
     const newRules: AuthorizationPolicyRuleCredential[] = [];
-
-    const globalAdmin = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE,
-        AuthorizationPrivilege.GRANT,
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-        AuthorizationPrivilege.DELETE,
-      ],
-      AuthorizationCredential.GLOBAL_ADMIN
-    );
-    newRules.push(globalAdmin);
 
     const communityAdmin = new AuthorizationPolicyRuleCredential(
       [

--- a/src/domain/community/user-group/user-group.service.authorization.ts
+++ b/src/domain/community/user-group/user-group.service.authorization.ts
@@ -59,11 +59,12 @@ export class UserGroupAuthorizationService {
       );
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const userGroupMember = {
-      type: AuthorizationCredential.USER_GROUP_MEMBER,
-      resourceID: userGroupID,
-      grantedPrivileges: [AuthorizationPrivilege.READ],
-    };
+    const userGroupMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ],
+      AuthorizationCredential.USER_GROUP_MEMBER,
+      userGroupID
+    );
+
     newRules.push(userGroupMember);
 
     this.authorizationPolicy.appendCredentialAuthorizationRules(

--- a/src/domain/community/user/user.resolver.queries.ts
+++ b/src/domain/community/user/user.resolver.queries.ts
@@ -11,6 +11,7 @@ import { GraphqlGuard } from '@core/authorization';
 import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { AuthorizationPrivilege } from '@common/enums';
 
 @Resolver(() => IUser)
 export class UserResolverQueries {
@@ -27,9 +28,10 @@ export class UserResolverQueries {
   })
   @Profiling.api
   async users(@CurrentUser() agentInfo: AgentInfo): Promise<IUser[]> {
-    await this.authorizationService.grantReadAccessOrFail(
+    await this.authorizationService.grantAccessOrFail(
       agentInfo,
       this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.READ_USERS,
       `users query: ${agentInfo.email}`
     );
     return await this.userService.getUsers();
@@ -45,9 +47,10 @@ export class UserResolverQueries {
     @CurrentUser() agentInfo: AgentInfo,
     @Args('ID', { type: () => UUID_NAMEID_EMAIL }) id: string
   ): Promise<IUser> {
-    await this.authorizationService.grantReadAccessOrFail(
+    await this.authorizationService.grantAccessOrFail(
       agentInfo,
       this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.READ_USERS,
       `user query: ${agentInfo.email}`
     );
     return await this.userService.getUserOrFail(id);
@@ -63,9 +66,10 @@ export class UserResolverQueries {
     @CurrentUser() agentInfo: AgentInfo,
     @Args({ name: 'IDs', type: () => [UUID_NAMEID_EMAIL] }) ids: string[]
   ): Promise<IUser[]> {
-    await this.authorizationService.grantReadAccessOrFail(
+    await this.authorizationService.grantAccessOrFail(
       agentInfo,
       this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.READ_USERS,
       `users query: ${agentInfo.email}`
     );
     const users = await this.userService.getUsers();

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -107,30 +107,29 @@ export class UserAuthorizationService {
   ): IAuthorizationPolicy {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const globalAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN,
-      resourceID: '',
-      grantedPrivileges: [
+    const globalAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
         AuthorizationPrivilege.GRANT,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN
+    );
     newRules.push(globalAdmin);
 
-    const communityAdmin = {
-      type: AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
-      resourceID: '',
-      grantedPrivileges: [
+    const communityAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
         AuthorizationPrivilege.DELETE,
         AuthorizationPrivilege.GRANT,
       ],
-    };
+      AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
+    );
+
     newRules.push(communityAdmin);
 
     this.authorizationPolicyService.appendCredentialAuthorizationRules(
@@ -157,15 +156,15 @@ export class UserAuthorizationService {
     // add the rules dependent on the user
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const userSelfAdmin = {
-      type: AuthorizationCredential.USER_SELF_MANAGEMENT,
-      resourceID: user.id,
-      grantedPrivileges: [
+    const userSelfAdmin = new AuthorizationPolicyRuleCredential(
+      [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
         AuthorizationPrivilege.UPDATE,
       ],
-    };
+      AuthorizationCredential.USER_SELF_MANAGEMENT,
+      user.id
+    );
     newRules.push(userSelfAdmin);
 
     // Get the agent + credentials + grant access for ecoverse / challenge admins read only
@@ -175,27 +174,29 @@ export class UserAuthorizationService {
     for (const credential of credentials) {
       // Grant read access to Ecoverse Admins for ecoverses the user is a member of
       if (credential.type === AuthorizationCredential.ECOVERSE_MEMBER) {
-        const ecoverseAdmin = {
-          type: AuthorizationCredential.ECOVERSE_ADMIN,
-          resourceID: credential.resourceID,
-          grantedPrivileges: [AuthorizationPrivilege.READ],
-        };
+        const ecoverseAdmin = new AuthorizationPolicyRuleCredential(
+          [AuthorizationPrivilege.READ],
+          AuthorizationCredential.ECOVERSE_ADMIN,
+          credential.resourceID
+        );
         newRules.push(ecoverseAdmin);
       } else if (credential.type === AuthorizationCredential.CHALLENGE_MEMBER) {
-        const challengeAdmin = {
-          type: AuthorizationCredential.CHALLENGE_ADMIN,
-          resourceID: credential.resourceID,
-          grantedPrivileges: [AuthorizationPrivilege.READ],
-        };
+        const challengeAdmin = new AuthorizationPolicyRuleCredential(
+          [AuthorizationPrivilege.READ],
+          AuthorizationCredential.CHALLENGE_ADMIN,
+          credential.resourceID
+        );
+
         newRules.push(challengeAdmin);
       } else if (
         credential.type === AuthorizationCredential.ORGANIZATION_MEMBER
       ) {
-        const challengeAdmin = {
-          type: AuthorizationCredential.ORGANIZATION_ADMIN,
-          resourceID: credential.resourceID,
-          grantedPrivileges: [AuthorizationPrivilege.READ],
-        };
+        const challengeAdmin = new AuthorizationPolicyRuleCredential(
+          [AuthorizationPrivilege.READ],
+          AuthorizationCredential.ORGANIZATION_ADMIN,
+          credential.resourceID
+        );
+
         newRules.push(challengeAdmin);
       }
     }

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -27,9 +27,13 @@ export class UserAuthorizationService {
 
   async applyAuthorizationPolicy(user: IUser): Promise<IUser> {
     // Ensure always applying from a clean state
-    user.authorization = await this.authorizationPolicyService.reset(
+    user.authorization = this.authorizationPolicyService.reset(
       user.authorization
     );
+    user.authorization =
+      this.authorizationPolicyService.inheritPlatformAuthorization(
+        user.authorization
+      );
 
     user.authorization = await this.appendCredentialRules(
       user.authorization,
@@ -106,18 +110,6 @@ export class UserAuthorizationService {
     authorization: IAuthorizationPolicy
   ): IAuthorizationPolicy {
     const newRules: AuthorizationPolicyRuleCredential[] = [];
-
-    const globalAdmin = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE,
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-        AuthorizationPrivilege.DELETE,
-        AuthorizationPrivilege.GRANT,
-      ],
-      AuthorizationCredential.GLOBAL_ADMIN
-    );
-    newRules.push(globalAdmin);
 
     const communityAdmin = new AuthorizationPolicyRuleCredential(
       [

--- a/src/domain/context/context/context.resolver.mutations.ts
+++ b/src/domain/context/context/context.resolver.mutations.ts
@@ -96,7 +96,7 @@ export class ContextResolverMutations {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
       context.authorization,
-      AuthorizationPrivilege.CREATE,
+      AuthorizationPrivilege.CREATE_CANVAS,
       `create canvas on context: ${context.id}`
     );
     const canvas = await this.contextService.createCanvas(canvasData);

--- a/src/domain/context/context/context.service.authorization.ts
+++ b/src/domain/context/context/context.service.authorization.ts
@@ -16,6 +16,7 @@ import { EntityNotInitializedException } from '@common/exceptions/entity.not.ini
 import { LogContext } from '@common/enums/logging.context';
 import { AuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential';
 import { ICredential } from '@domain/agent/credential/credential.interface';
+import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
 
 @Injectable()
 export class ContextAuthorizationService {
@@ -44,6 +45,7 @@ export class ContextAuthorizationService {
       context.id,
       communityCredential
     );
+    context.authorization = this.appendPrivilegeRules(context.authorization);
     // cascade
     const ecosystemModel = await this.contextService.getEcosystemModel(context);
     ecosystemModel.authorization =
@@ -120,5 +122,22 @@ export class ContextAuthorizationService {
       );
 
     return updatedAuthorization;
+  }
+
+  private appendPrivilegeRules(
+    authorization: IAuthorizationPolicy
+  ): IAuthorizationPolicy {
+    const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
+
+    const createPrivilege = new AuthorizationPolicyRulePrivilege(
+      [AuthorizationPrivilege.CREATE_CANVAS],
+      AuthorizationPrivilege.CREATE
+    );
+    privilegeRules.push(createPrivilege);
+
+    return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
+      authorization,
+      privilegeRules
+    );
   }
 }

--- a/src/domain/context/context/context.service.authorization.ts
+++ b/src/domain/context/context/context.service.authorization.ts
@@ -73,7 +73,8 @@ export class ContextAuthorizationService {
       const updatedCanvas =
         await this.canvasAuthorizationService.applyAuthorizationPolicy(
           canvas,
-          context.authorization
+          context.authorization,
+          communityCredential
         );
       updatedCanvases.push(updatedCanvas);
     }
@@ -102,7 +103,7 @@ export class ContextAuthorizationService {
     if (!authorization)
       throw new EntityNotInitializedException(
         `Authorization definition not found for Context: ${contextID}`,
-        LogContext.COMMUNITY
+        LogContext.CONTEXT
       );
 
     const newRules: AuthorizationPolicyRuleCredential[] = [];

--- a/src/domain/context/context/context.service.authorization.ts
+++ b/src/domain/context/context/context.service.authorization.ts
@@ -108,9 +108,9 @@ export class ContextAuthorizationService {
     const communityMember = new AuthorizationPolicyRuleCredential(
       [AuthorizationPrivilege.CREATE_CANVAS],
       communityCredential.type,
-      communityCredential.resourceID,
-      false
+      communityCredential.resourceID
     );
+    communityMember.inheritable = false;
     newRules.push(communityMember);
 
     const updatedAuthorization =

--- a/src/domain/context/context/context.service.authorization.ts
+++ b/src/domain/context/context/context.service.authorization.ts
@@ -15,6 +15,7 @@ import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { EntityNotInitializedException } from '@common/exceptions/entity.not.initialized.exception';
 import { LogContext } from '@common/enums/logging.context';
 import { AuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential';
+import { ICredential } from '@domain/agent/credential/credential.interface';
 
 @Injectable()
 export class ContextAuthorizationService {
@@ -30,7 +31,7 @@ export class ContextAuthorizationService {
   async applyAuthorizationPolicy(
     context: IContext,
     parentAuthorization: IAuthorizationPolicy | undefined,
-    communityCredential: Credential
+    communityCredential: ICredential
   ): Promise<IContext> {
     context.authorization =
       this.authorizationPolicyService.inheritParentAuthorization(
@@ -94,7 +95,7 @@ export class ContextAuthorizationService {
   private appendCredentialRules(
     authorization: IAuthorizationPolicy | undefined,
     contextID: string,
-    communityCredential: Credential
+    communityCredential: ICredential
   ): IAuthorizationPolicy {
     if (!authorization)
       throw new EntityNotInitializedException(
@@ -104,12 +105,12 @@ export class ContextAuthorizationService {
 
     const newRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const communityMember: AuthorizationPolicyRuleCredential = {
-      type: communityCredential.type,
-      resourceID: communityCredential.id,
-      grantedPrivileges: [AuthorizationPrivilege.CREATE_CANVAS],
-      inheritable: false,
-    };
+    const communityMember = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.CREATE_CANVAS],
+      communityCredential.type,
+      communityCredential.resourceID,
+      false
+    );
     newRules.push(communityMember);
 
     const updatedAuthorization =

--- a/src/migrations/1640945390921-auth-policy-privilege-rule.ts
+++ b/src/migrations/1640945390921-auth-policy-privilege-rule.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class authPolicyPrivilegeRule1640945390921
+  implements MigrationInterface
+{
+  name = 'authPolicyPrivilegeRule1640945390921';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`authorization_policy\` ADD \`privilegeRules\` text NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`authorization_policy\` DROP COLUMN \`privilegeRules\``
+    );
+  }
+}

--- a/src/services/admin/authorization/admin.authorization.resolver.queries.ts
+++ b/src/services/admin/authorization/admin.authorization.resolver.queries.ts
@@ -2,10 +2,9 @@ import { CurrentUser, Profiling } from '@src/common/decorators';
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { GraphqlGuard } from '@core/authorization';
 import { IUser } from '@domain/community/user';
-import { AuthorizationPrivilege, AuthorizationRoleGlobal } from '@common/enums';
+import { AuthorizationPrivilege } from '@common/enums';
 import { UserAuthorizationPrivilegesInput } from './dto/authorization.dto.user.authorization.privileges';
 import { UseGuards } from '@nestjs/common/decorators/core/use-guards.decorator';
-import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AgentInfo } from '@core/authentication/agent-info';
 import { AdminAuthorizationService } from './admin.authorization.service';
@@ -14,19 +13,11 @@ import { AuthorizationPolicyService } from '@domain/common/authorization-policy/
 
 @Resolver()
 export class AdminAuthorizationResolverQueries {
-  private authorizationQueriesPolicy: IAuthorizationPolicy;
-
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
     private authorizationService: AuthorizationService,
     private adminAuthorizationService: AdminAuthorizationService
-  ) {
-    this.authorizationQueriesPolicy =
-      this.authorizationPolicyService.createGlobalRolesAuthorizationPolicy(
-        [AuthorizationRoleGlobal.REGISTERED],
-        [AuthorizationPrivilege.READ]
-      );
-  }
+  ) {}
 
   @Query(() => [IUser], {
     nullable: false,
@@ -42,8 +33,8 @@ export class AdminAuthorizationResolverQueries {
   ): Promise<IUser[]> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationQueriesPolicy,
-      AuthorizationPrivilege.READ,
+      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.READ_USERS,
       `authorization query: ${agentInfo.email}`
     );
     return await this.adminAuthorizationService.usersWithCredentials(
@@ -65,8 +56,8 @@ export class AdminAuthorizationResolverQueries {
   ): Promise<AuthorizationPrivilege[]> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationQueriesPolicy,
-      AuthorizationPrivilege.READ,
+      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.READ_USERS,
       `authorization query: ${agentInfo.email}`
     );
     return await this.adminAuthorizationService.userAuthorizationPrivileges(

--- a/src/services/domain/membership/membership.resolver.queries.ts
+++ b/src/services/domain/membership/membership.resolver.queries.ts
@@ -9,6 +9,7 @@ import { AgentInfo } from '@core/authentication';
 import { OrganizationMembership } from './membership.dto.organization.result';
 import { MembershipOrganizationInput } from './membership.dto.organization.input';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 
 @Resolver()
 export class MembershipResolverQueries {
@@ -28,9 +29,10 @@ export class MembershipResolverQueries {
     @CurrentUser() agentInfo: AgentInfo,
     @Args('membershipData') membershipData: MembershipUserInput
   ): Promise<UserMembership> {
-    await this.authorizationService.grantReadAccessOrFail(
+    await this.authorizationService.grantAccessOrFail(
       agentInfo,
       this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.READ_USERS,
       `membership query: ${agentInfo.email}`
     );
     return await this.membershipService.getUserMemberships(membershipData);

--- a/src/services/domain/membership/membership.resolver.queries.ts
+++ b/src/services/domain/membership/membership.resolver.queries.ts
@@ -4,9 +4,7 @@ import { MembershipService } from './membership.service';
 import { CurrentUser, Profiling } from '@src/common/decorators';
 import { GraphqlGuard } from '@core/authorization';
 import { MembershipUserInput, UserMembership } from './index';
-import { AuthorizationPrivilege, AuthorizationRoleGlobal } from '@common/enums';
 import { AuthorizationService } from '@core/authorization/authorization.service';
-import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AgentInfo } from '@core/authentication';
 import { OrganizationMembership } from './membership.dto.organization.result';
 import { MembershipOrganizationInput } from './membership.dto.organization.input';
@@ -14,19 +12,11 @@ import { AuthorizationPolicyService } from '@domain/common/authorization-policy/
 
 @Resolver()
 export class MembershipResolverQueries {
-  private membershipAuthorizationPolicy: IAuthorizationPolicy;
-
   constructor(
     private authorizationService: AuthorizationService,
     private authorizationPolicyService: AuthorizationPolicyService,
     private membershipService: MembershipService
-  ) {
-    this.membershipAuthorizationPolicy =
-      this.authorizationPolicyService.createGlobalRolesAuthorizationPolicy(
-        [AuthorizationRoleGlobal.REGISTERED],
-        [AuthorizationPrivilege.READ]
-      );
-  }
+  ) {}
 
   @UseGuards(GraphqlGuard)
   @Query(() => UserMembership, {
@@ -40,7 +30,7 @@ export class MembershipResolverQueries {
   ): Promise<UserMembership> {
     await this.authorizationService.grantReadAccessOrFail(
       agentInfo,
-      this.membershipAuthorizationPolicy,
+      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
       `membership query: ${agentInfo.email}`
     );
     return await this.membershipService.getUserMemberships(membershipData);


### PR DESCRIPTION
Framework extensions
* Added another rule type: privilegeRule, which allows granting of a set of privileges based on holding another privilege. This is primarily for roles that are admin, as if they hold the generic CREATE then local create such as CREATE_CANVAS should also apply to them.
* Add notion of authorization policy rules that are not inheritable
* Extended the set of authorization privileges to include: CREATE_CANVAS, CREATE_HUB, CREATE_ORGANIZATION, READ_USERS

Platform level Authorization:
* Created platform level authorization policy
* Exposed platform level authorization policy as a top level query

Usage
* Added ability for hub admins and challenge admins to create organizations
* Allow members of a community to create canvases as well as the admins (requires client update to use)
* Made all user related top level queries depend on the READ_USERS privilege, instead of creating multiple local authorization policies

There is also a related client branch: server-1618 that is updated to use the new CREATE_CANVAS privilege to allow members to create / edit canvases.

NOTE: to use this branch you need to both run migrations and reset the authorization policy on Hubs