### PR TITLE
Remove eager loading

### DIFF
--- a/src/domain/challenge/challenge/challenge.entity.ts
+++ b/src/domain/challenge/challenge/challenge.entity.ts
@@ -7,32 +7,30 @@ import { BaseChallenge } from '@domain/challenge/base-challenge/base.challenge.e
 
 @Entity()
 export class Challenge extends BaseChallenge implements IChallenge {
-  @OneToMany(
-    () => Opportunity,
-    opportunity => opportunity.challenge,
-    { eager: false, cascade: true }
-  )
+  @OneToMany(() => Opportunity, opportunity => opportunity.challenge, {
+    eager: false,
+    cascade: true,
+  })
   opportunities?: Opportunity[];
 
-  @OneToMany(
-    () => Challenge,
-    challenge => challenge.parentChallenge,
-    { eager: false, cascade: true }
-  )
+  @OneToMany(() => Challenge, challenge => challenge.parentChallenge, {
+    eager: false,
+    cascade: true,
+  })
   childChallenges?: Challenge[];
 
-  @ManyToOne(
-    () => Challenge,
-    challenge => challenge.childChallenges,
-    { eager: false, cascade: false, onDelete: 'CASCADE' }
-  )
+  @ManyToOne(() => Challenge, challenge => challenge.childChallenges, {
+    eager: false,
+    cascade: false,
+    onDelete: 'CASCADE',
+  })
   parentChallenge?: Challenge;
 
-  @ManyToOne(
-    () => Ecoverse,
-    ecoverse => ecoverse.challenges,
-    { eager: false, cascade: false, onDelete: 'CASCADE' }
-  )
+  @ManyToOne(() => Ecoverse, ecoverse => ecoverse.challenges, {
+    eager: false,
+    cascade: false,
+    onDelete: 'CASCADE',
+  })
   parentEcoverse?: Ecoverse;
 
   @Column()

--- a/src/domain/challenge/ecoverse/ecoverse.entity.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.entity.ts
@@ -4,11 +4,10 @@ import { BaseChallenge } from '@domain/challenge/base-challenge/base.challenge.e
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
 @Entity()
 export class Ecoverse extends BaseChallenge implements IEcoverse {
-  @OneToMany(
-    () => Challenge,
-    challenge => challenge.parentEcoverse,
-    { eager: false, cascade: true }
-  )
+  @OneToMany(() => Challenge, challenge => challenge.parentEcoverse, {
+    eager: false,
+    cascade: true,
+  })
   challenges?: Challenge[];
 
   constructor() {

--- a/src/domain/challenge/ecoverse/ecoverse.service.ts
+++ b/src/domain/challenge/ecoverse/ecoverse.service.ts
@@ -347,7 +347,7 @@ export class EcoverseService {
 
   async getGroups(ecoverse: IEcoverse): Promise<IUserGroup[]> {
     const community = await this.getCommunity(ecoverse);
-    return community.groups || [];
+    return await this.communityService.getUserGroups(community);
   }
 
   async getOpportunitiesInNameableScope(

--- a/src/domain/collaboration/opportunity/opportunity.entity.ts
+++ b/src/domain/collaboration/opportunity/opportunity.entity.ts
@@ -7,25 +7,23 @@ import { BaseChallenge } from '@domain/challenge/base-challenge/base.challenge.e
 
 @Entity()
 export class Opportunity extends BaseChallenge implements IOpportunity {
-  @ManyToOne(
-    () => Challenge,
-    challenge => challenge.opportunities,
-    { eager: false, cascade: false, onDelete: 'CASCADE' }
-  )
+  @ManyToOne(() => Challenge, challenge => challenge.opportunities, {
+    eager: false,
+    cascade: false,
+    onDelete: 'CASCADE',
+  })
   challenge?: Challenge;
 
-  @OneToMany(
-    () => Project,
-    project => project.opportunity,
-    { eager: true, cascade: true }
-  )
+  @OneToMany(() => Project, project => project.opportunity, {
+    eager: true,
+    cascade: true,
+  })
   projects?: Project[];
 
-  @OneToMany(
-    () => Relation,
-    relation => relation.opportunity,
-    { eager: false, cascade: true }
-  )
+  @OneToMany(() => Relation, relation => relation.opportunity, {
+    eager: false,
+    cascade: true,
+  })
   relations?: Relation[];
 
   @Column()

--- a/src/domain/collaboration/project/project.entity.ts
+++ b/src/domain/collaboration/project/project.entity.ts
@@ -33,18 +33,17 @@ export class Project extends NameableEntity implements IProject {
   @JoinColumn()
   tagset?: Tagset;
 
-  @OneToMany(
-    () => Agreement,
-    agreement => agreement.project,
-    { eager: true, cascade: true }
-  )
+  @OneToMany(() => Agreement, agreement => agreement.project, {
+    eager: true,
+    cascade: true,
+  })
   agreements?: Agreement[];
 
-  @ManyToOne(
-    () => Opportunity,
-    opportunity => opportunity.projects,
-    { eager: false, cascade: false, onDelete: 'CASCADE' }
-  )
+  @ManyToOne(() => Opportunity, opportunity => opportunity.projects, {
+    eager: false,
+    cascade: false,
+    onDelete: 'CASCADE',
+  })
   opportunity?: Opportunity;
 
   constructor(name: string, nameID: string) {

--- a/src/domain/common/visual/visual.service.ts
+++ b/src/domain/common/visual/visual.service.ts
@@ -19,6 +19,9 @@ import { IpfsService } from '@src/services/platform/ipfs/ipfs.service';
 
 @Injectable()
 export class VisualService {
+  private readonly avatarMinImageSize = 190;
+  private readonly avatarMaxImageSize = 410;
+
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
     @InjectRepository(Visual)
@@ -161,10 +164,10 @@ export class VisualService {
   async createVisualAvatar(): Promise<IVisual> {
     return await this.createVisual({
       name: 'avatar',
-      minWidth: 190,
-      maxWidth: 400,
-      minHeight: 190,
-      maxHeight: 400,
+      minWidth: this.avatarMinImageSize,
+      maxWidth: this.avatarMaxImageSize,
+      minHeight: this.avatarMinImageSize,
+      maxHeight: this.avatarMaxImageSize,
       aspectRatio: 1,
     });
   }

--- a/src/domain/community/community/community.entity.ts
+++ b/src/domain/community/community/community.entity.ts
@@ -40,7 +40,7 @@ export class Community
   communication?: Communication;
 
   @OneToMany(() => UserGroup, userGroup => userGroup.community, {
-    eager: true,
+    eager: false,
     cascade: true,
   })
   groups?: UserGroup[];

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -90,14 +90,17 @@ export class CommunityService {
   }
 
   // Loads the group into the Community entity if not already present
-  getUserGroups(community: ICommunity): IUserGroup[] {
-    if (!community.groups) {
+  async getUserGroups(community: ICommunity): Promise<IUserGroup[]> {
+    const communityWithGroups = await this.getCommunityOrFail(community.id, {
+      relations: ['groups'],
+    });
+    if (!communityWithGroups.groups) {
       throw new EntityNotInitializedException(
         `Community not initialized: ${community.displayName}`,
         LogContext.COMMUNITY
       );
     }
-    return community.groups;
+    return communityWithGroups.groups;
   }
 
   async getCommunityOrFail(

--- a/src/domain/community/profile/profile.entity.ts
+++ b/src/domain/community/profile/profile.entity.ts
@@ -11,19 +11,19 @@ import { Visual } from '@domain/common/visual/visual.entity';
 @Entity()
 export class Profile extends AuthorizableEntity implements IProfile {
   @OneToMany(() => Reference, reference => reference.profile, {
-    eager: true,
+    eager: false,
     cascade: true,
   })
   references?: Reference[];
 
   @OneToMany(() => Tagset, tagset => tagset.profile, {
-    eager: true,
+    eager: false,
     cascade: true,
   })
   tagsets?: Tagset[];
 
   @OneToOne(() => Visual, {
-    eager: true,
+    eager: false,
     cascade: true,
     onDelete: 'SET NULL',
   })

--- a/src/domain/community/profile/profile.interface.ts
+++ b/src/domain/community/profile/profile.interface.ts
@@ -5,16 +5,8 @@ import { IVisual } from '@domain/common/visual';
 import { Field, ObjectType } from '@nestjs/graphql';
 @ObjectType('Profile')
 export abstract class IProfile extends IAuthorizable {
-  @Field(() => [IReference], {
-    nullable: true,
-    description: 'A list of URLs to relevant information.',
-  })
   references?: IReference[];
 
-  @Field(() => [ITagset], {
-    nullable: true,
-    description: 'A list of named tagsets, each of which has a list of tags.',
-  })
   tagsets?: ITagset[];
 
   avatar?: IVisual;

--- a/src/domain/community/profile/profile.service.authorization.ts
+++ b/src/domain/community/profile/profile.service.authorization.ts
@@ -3,16 +3,25 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { IProfile, Profile } from '@domain/community/profile';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { ProfileService } from './profile.service';
 
 @Injectable()
 export class ProfileAuthorizationService {
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
+    private profileService: ProfileService,
     @InjectRepository(Profile)
     private profileRepository: Repository<Profile>
   ) {}
 
-  async applyAuthorizationPolicy(profile: IProfile): Promise<IProfile> {
+  async applyAuthorizationPolicy(profileInput: IProfile): Promise<IProfile> {
+    const profile = await this.profileService.getProfileOrFail(
+      profileInput.id,
+      {
+        relations: ['references', 'avatar', 'tagsets', 'authorization'],
+      }
+    );
+
     if (profile.references) {
       for (const reference of profile.references) {
         reference.authorization =


### PR DESCRIPTION
Removes eager loading from the following relationships:
- community.groups
- profile.references
- profile.tagsets
- profile.avatar

Also fixes a bug related to removing avatar when removing a profile.

Moved to use the avatar definition on the visual service also on the profile. 