### PR TITLE
allow members to create comments

### DIFF
--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -8,6 +8,7 @@ export enum AuthorizationPrivilege {
   GRANT = 'grant', // allow the issuing / revoking of credentials of the same type within a given scope
   CREATE_CANVAS = 'create-canvas',
   CREATE_ASPECT = 'create-aspect',
+  CREATE_COMMENT = 'create-comment',
   CREATE_HUB = 'create-hub',
   CREATE_ORGANIZATION = 'create-organization',
   READ_USERS = 'read-users',

--- a/src/domain/communication/comments/comments.resolver.mutations.ts
+++ b/src/domain/communication/comments/comments.resolver.mutations.ts
@@ -41,7 +41,7 @@ export class CommentsResolverMutations {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
       comments.authorization,
-      AuthorizationPrivilege.UPDATE,
+      AuthorizationPrivilege.CREATE_COMMENT,
       `comments send message: ${comments.displayName}`
     );
 

--- a/src/domain/context/aspect/aspect.resolver.mutations.ts
+++ b/src/domain/context/aspect/aspect.resolver.mutations.ts
@@ -56,7 +56,7 @@ export class AspectResolverMutations {
       agentInfo,
       aspect.authorization,
       AuthorizationPrivilege.UPDATE,
-      `update aspect: ${aspect.displayName}`
+      `update aspect: ${aspect.nameID}`
     );
     return await this.aspectService.updateAspect(aspectData);
   }

--- a/src/domain/context/aspect/aspect.service.authorization.ts
+++ b/src/domain/context/aspect/aspect.service.authorization.ts
@@ -61,7 +61,7 @@ export class AspectAuthorizationService {
     aspect.references = await this.aspectService.getReferences(aspect);
     for (const reference of aspect.references) {
       reference.authorization =
-        await this.authorizationPolicyService.inheritParentAuthorization(
+        this.authorizationPolicyService.inheritParentAuthorization(
           reference.authorization,
           aspect.authorization
         );


### PR DESCRIPTION
added a new privilege: CREATE_COMMENT

Updated authorization policy definition for context + aspects to use this.

Note: had talked to Svetlo re client checking for CREATE on the Comments entity, but this should now become CREATE_COMMENT. Alternative was just way too messy as deep into context there would need to be knowledge of the Community.Credential.