### PR TITLE
updated challenge community authorization to only grant apply privilege to users that are members of the containing hub or challenge

### DIFF
--- a/src/core/authorization/authorization.policy.rule.privilege.interface.ts
+++ b/src/core/authorization/authorization.policy.rule.privilege.interface.ts
@@ -1,0 +1,10 @@
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('AuthorizationPolicyRulePrivilege')
+export abstract class IAuthorizationPolicyRulePrivilege {
+  @Field(() => String)
+  sourcePrivilege!: string;
+  @Field(() => [AuthorizationPrivilege])
+  grantedPrivileges!: AuthorizationPrivilege[];
+}

--- a/src/core/authorization/authorization.policy.rule.privilege.ts
+++ b/src/core/authorization/authorization.policy.rule.privilege.ts
@@ -1,6 +1,9 @@
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { IAuthorizationPolicyRulePrivilege } from './authorization.policy.rule.privilege.interface';
 
-export class AuthorizationPolicyRulePrivilege {
+export class AuthorizationPolicyRulePrivilege
+  implements IAuthorizationPolicyRulePrivilege
+{
   sourcePrivilege: AuthorizationPrivilege;
   grantedPrivileges: AuthorizationPrivilege[];
 

--- a/src/domain/challenge/base-challenge/base.challenge.service.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.ts
@@ -27,6 +27,7 @@ import { AgentService } from '@domain/agent/agent/agent.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { RestrictedTagsetNames } from '@domain/common/tagset/tagset.entity';
 import { CommunityType } from '@common/enums/community.type';
+import { ICredential } from '@domain/agent';
 
 @Injectable()
 export class BaseChallengeService {
@@ -217,6 +218,20 @@ export class BaseChallengeService {
         LogContext.COMMUNITY
       );
     return community;
+  }
+
+  async getCommunityCredential(
+    baseChallengeId: string,
+    repository: Repository<BaseChallenge>
+  ): Promise<ICredential> {
+    const community = await this.getCommunity(baseChallengeId, repository);
+    const credential = community.credential;
+    if (!credential)
+      throw new RelationshipNotFoundException(
+        `Unable to load credential for community on challenge/hub: ${baseChallengeId} `,
+        LogContext.COMMUNITY
+      );
+    return credential;
   }
 
   async getContext(

--- a/src/domain/challenge/challenge/challenge.resolver.mutations.ts
+++ b/src/domain/challenge/challenge/challenge.resolver.mutations.ts
@@ -57,9 +57,12 @@ export class ChallengeResolverMutations {
       challengeData,
       agentInfo
     );
+    const communityCredential =
+      await this.challengeService.getCommunityCredential(challenge.id);
     return await this.challengeAuthorizationService.applyAuthorizationPolicy(
       childChallenge,
-      challenge.authorization
+      challenge.authorization,
+      communityCredential
     );
   }
 

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -37,7 +37,7 @@ import { challengeLifecycleConfigDefault } from './challenge.lifecycle.config.de
 import { challengeLifecycleConfigExtended } from './challenge.lifecycle.config.extended';
 import { LifecycleService } from '@domain/common/lifecycle/lifecycle.service';
 import { INVP } from '@domain/common/nvp/nvp.interface';
-import { UUID_LENGTH, WALLET_MANAGEMENT_SERVICE } from '@common/constants';
+import { UUID_LENGTH } from '@common/constants';
 import { IAgent } from '@domain/agent/agent';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
 import { IChallenge } from './challenge.interface';
@@ -49,9 +49,9 @@ import { AssignChallengeAdminInput } from './dto/challenge.dto.assign.admin';
 import { RemoveChallengeAdminInput } from './dto/challenge.dto.remove.admin';
 import { CreateChallengeOnChallengeInput } from './dto/challenge.dto.create.in.challenge';
 import { CommunityType } from '@common/enums/community.type';
-import { ClientProxy } from '@nestjs/microservices';
 import { AgentInfo } from '@src/core';
 import { limitAndShuffle } from '@common/utils/limitAndShuffle';
+import { ICredential } from '@domain/agent/credential/credential.interface';
 
 @Injectable()
 export class ChallengeService {
@@ -63,8 +63,6 @@ export class ChallengeService {
     private baseChallengeService: BaseChallengeService,
     private lifecycleService: LifecycleService,
     private organizationService: OrganizationService,
-    @Inject(WALLET_MANAGEMENT_SERVICE)
-    private walletManagementClient: ClientProxy,
     private userService: UserService,
     @InjectRepository(Challenge)
     private challengeRepository: Repository<Challenge>,
@@ -318,6 +316,13 @@ export class ChallengeService {
 
   async getCommunity(challengeId: string): Promise<ICommunity> {
     return await this.baseChallengeService.getCommunity(
+      challengeId,
+      this.challengeRepository
+    );
+  }
+
+  async getCommunityCredential(challengeId: string): Promise<ICredential> {
+    return await this.baseChallengeService.getCommunityCredential(
       challengeId,
       this.challengeRepository
     );

--- a/src/domain/challenge/hub/hub.resolver.mutations.ts
+++ b/src/domain/challenge/hub/hub.resolver.mutations.ts
@@ -152,9 +152,13 @@ export class HubResolverMutations {
       challengeData,
       agentInfo
     );
+    const hubCommunityCredential = await this.hubService.getCommunityCredential(
+      hub
+    );
     return await this.challengeAuthorizationService.applyAuthorizationPolicy(
       challenge,
-      hub.authorization
+      hub.authorization,
+      hubCommunityCredential
     );
   }
 

--- a/src/domain/challenge/hub/hub.service.authorization.ts
+++ b/src/domain/challenge/hub/hub.service.authorization.ts
@@ -69,11 +69,15 @@ export class HubAuthorizationService {
       );
 
     // propagate authorization rules for child entities
+    const hubCommunityCredential = await this.hubService.getCommunityCredential(
+      hub
+    );
     hub.challenges = await this.hubService.getChallenges(hub);
     for (const challenge of hub.challenges) {
       await this.challengeAuthorizationService.applyAuthorizationPolicy(
         challenge,
-        hub.authorization
+        hub.authorization,
+        hubCommunityCredential
       );
       challenge.authorization =
         await this.authorizationPolicyService.appendCredentialAuthorizationRule(

--- a/src/domain/challenge/hub/hub.service.ts
+++ b/src/domain/challenge/hub/hub.service.ts
@@ -47,6 +47,7 @@ import { PreferenceService } from '@domain/common/preference/preference.service'
 import { IPreference } from '@domain/common/preference/preference.interface';
 import { PreferenceDefinitionSet } from '@common/enums/preference.definition.set';
 import { HubPreferenceType } from '@common/enums/hub.preference.type';
+import { ICredential } from '@domain/agent/credential/credential.interface';
 
 @Injectable()
 export class HubService {
@@ -468,6 +469,13 @@ export class HubService {
 
   async getCommunity(hub: IHub): Promise<ICommunity> {
     return await this.baseChallengeService.getCommunity(
+      hub.id,
+      this.hubRepository
+    );
+  }
+
+  async getCommunityCredential(hub: IHub): Promise<ICredential> {
+    return await this.baseChallengeService.getCommunityCredential(
       hub.id,
       this.hubRepository
     );

--- a/src/domain/common/authorization-policy/authorization.policy.resolver.fields.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.resolver.fields.ts
@@ -8,6 +8,7 @@ import { AuthorizationPrivilege } from '@common/enums';
 import { UseGuards } from '@nestjs/common';
 import { GraphqlGuard } from '@core/authorization/graphql.guard';
 import { IAuthorizationPolicyRuleVerifiedCredentialClaim } from '@core/authorization/authorization.policy.rule.verified.credential.claim.interface';
+import { IAuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege.interface';
 
 @Resolver(() => IAuthorizationPolicy)
 export class AuthorizationPolicyResolverFields {
@@ -41,6 +42,18 @@ export class AuthorizationPolicyResolverFields {
     return this.authorizationPolicyService.getVerifiedCredentialClaimRules(
       authorization
     );
+  }
+
+  @ResolveField('privilegeRules', () => [IAuthorizationPolicyRulePrivilege], {
+    nullable: true,
+    description:
+      'The set of privilege rules that are contained by this Authorization Policy.',
+  })
+  @Profiling.api
+  privilegeRules(
+    @Parent() authorization: IAuthorizationPolicy
+  ): IAuthorizationPolicyRulePrivilege[] {
+    return this.authorizationPolicyService.getPrivilegeRules(authorization);
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -50,6 +50,7 @@ export class AuthorizationPolicyService {
     }
     authorizationPolicy.credentialRules = '';
     authorizationPolicy.verifiedCredentialRules = '';
+    authorizationPolicy.privilegeRules = '';
     return authorizationPolicy;
   }
 
@@ -221,7 +222,7 @@ export class AuthorizationPolicyService {
     authorization: IAuthorizationPolicy
   ): IAuthorizationPolicyRulePrivilege[] {
     const result = this.authorizationService.convertPrivilegeRulesStr(
-      authorization.verifiedCredentialRules
+      authorization.privilegeRules
     );
     return result;
   }

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -23,6 +23,7 @@ import { AgentInfo } from '@core/authentication/agent-info';
 import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
 import { AuthorizationPolicyRuleVerifiedCredentialClaim } from '@core/authorization/authorization.policy.rule.verified.credential.claim';
 import { IAuthorizationPolicyRuleVerifiedCredentialClaim } from '@core/authorization/authorization.policy.rule.verified.credential.claim.interface';
+import { IAuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege.interface';
 
 @Injectable()
 export class AuthorizationPolicyService {
@@ -198,6 +199,7 @@ export class AuthorizationPolicyService {
     resetAuthPolicy.credentialRules = JSON.stringify(newRules);
     return resetAuthPolicy;
   }
+
   getCredentialRules(
     authorization: IAuthorizationPolicy
   ): IAuthorizationPolicyRuleCredential[] {
@@ -214,6 +216,16 @@ export class AuthorizationPolicyService {
     );
     return result;
   }
+
+  getPrivilegeRules(
+    authorization: IAuthorizationPolicy
+  ): IAuthorizationPolicyRulePrivilege[] {
+    const result = this.authorizationService.convertPrivilegeRulesStr(
+      authorization.verifiedCredentialRules
+    );
+    return result;
+  }
+
   getAgentPrivileges(
     agentInfo: AgentInfo,
     authorizationPolicy: IAuthorizationPolicy

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -126,11 +126,11 @@ export class CommunityAuthorizationService {
   ): IAuthorizationPolicy {
     const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
 
-    const communityJoinPrivilege = new AuthorizationPolicyRulePrivilege(
-      [AuthorizationPrivilege.COMMUNITY_JOIN],
-      AuthorizationPrivilege.GRANT
-    );
-    privilegeRules.push(communityJoinPrivilege);
+    // const communityJoinPrivilege = new AuthorizationPolicyRulePrivilege(
+    //   [AuthorizationPrivilege.COMMUNITY_JOIN],
+    //   AuthorizationPrivilege.GRANT
+    // );
+    // privilegeRules.push(communityJoinPrivilege);
 
     return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
       authorization,


### PR DESCRIPTION
Updated challenge community authorization to only grant apply privilege to users that are members of the containing hub or challenge
The COMMUNITY_APPLY privilege is only granted to members of the parent Hub (or Challenge).

The COMMUNITY_JOIN privilege is no longer granted based on the user holding the COMMUNITY_JOIN privilege. So admins will see the same behavior. They can still adjust membership directly via the back end admin but the normal flows also now apply to them. 

Extended the authorization policy api to allow retrieval of the privilegeRules; it was somehow not available but should have been.