### PR TITLE
updated authorization on aspects so that creator cannot delete all comments

### DIFF
--- a/src/domain/communication/comments/comments.service.authorization.ts
+++ b/src/domain/communication/comments/comments.service.authorization.ts
@@ -1,16 +1,19 @@
 import { Injectable } from '@nestjs/common';
-import { AuthorizationPrivilege } from '@common/enums';
+import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { CommentsService } from './comments.service';
 import { IComments } from './comments.interface';
 import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
+import { AuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential';
+import { RoomService } from '../room/room.service';
 
 @Injectable()
 export class CommentsAuthorizationService {
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
-    private commentsService: CommentsService
+    private commentsService: CommentsService,
+    private roomService: RoomService
   ) {}
 
   async applyAuthorizationPolicy(
@@ -43,5 +46,34 @@ export class CommentsAuthorizationService {
       authorization,
       privilegeRules
     );
+  }
+
+  async extendAuthorizationPolicyForMessageSender(
+    comments: IComments,
+    messageID: string
+  ): Promise<IAuthorizationPolicy> {
+    const newRules: AuthorizationPolicyRuleCredential[] = [];
+
+    const senderUserID = await this.roomService.getUserIdForMessage(
+      comments,
+      messageID
+    );
+
+    if (senderUserID !== '') {
+      const messageSender = new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.UPDATE, AuthorizationPrivilege.DELETE],
+        AuthorizationCredential.USER_SELF_MANAGEMENT,
+        senderUserID
+      );
+      newRules.push(messageSender);
+    }
+
+    const updatedAuthorization =
+      this.authorizationPolicyService.appendCredentialAuthorizationRules(
+        comments.authorization,
+        newRules
+      );
+
+    return updatedAuthorization;
   }
 }

--- a/src/domain/context/aspect/aspect.service.authorization.ts
+++ b/src/domain/context/aspect/aspect.service.authorization.ts
@@ -35,6 +35,17 @@ export class AspectAuthorizationService {
         parentAuthorization
       );
 
+    // Inherit for comments before extending so that the creating user does not
+    // have rights to delete comments
+    if (aspect.comments) {
+      aspect.comments =
+        await this.commentsAuthorizationService.applyAuthorizationPolicy(
+          aspect.comments,
+          aspect.authorization
+        );
+    }
+
+    // Extend to give the user creating the aspect more rights
     aspect.authorization = this.appendCredentialRules(aspect);
 
     // cascade
@@ -49,14 +60,6 @@ export class AspectAuthorizationService {
       aspect.bannerNarrow.authorization =
         this.authorizationPolicyService.inheritParentAuthorization(
           aspect.bannerNarrow.authorization,
-          aspect.authorization
-        );
-    }
-
-    if (aspect.comments) {
-      aspect.comments =
-        await this.commentsAuthorizationService.applyAuthorizationPolicy(
-          aspect.comments,
           aspect.authorization
         );
     }


### PR DESCRIPTION
added option for message sender to be able to delete their own comment

NOTE: this PR covers the server side functionality; there is still an update needed on the client to allow non-admin users to see the trashcan to remove their own messages.