### PR TITLE
updated defaults for new user creation preferences for notifications +

### DIFF
--- a/src/common/enums/user.preference.type.ts
+++ b/src/common/enums/user.preference.type.ts
@@ -11,6 +11,10 @@ export enum UserPreferenceType {
   NOTIFICATION_USER_SIGN_UP = 'NotificationUserSignUp',
   NOTIFICATION_COMMUNITY_REVIEW_SUBMITTED = 'NotificationCommunityReviewSubmitted',
   NOTIFICATION_COMMUNITY_REVIEW_SUBMITTED_ADMIN = 'NotificationCommunityReviewSubmittedAdmin',
+  NOTIFICATION_ASPECT_CREATED = 'NotificationAspectCreated',
+  NOTIFICATION_ASPECT_CREATED_ADMIN = 'NotificationAspectCreatedAdmin',
+  NOTIFICATION_ASPECT_COMMENT_CREATED_BY = 'NotificationAspectCommentCreatedBy',
+  NOTIFICATION_ASPECT_COMMENT_ADMIN = 'NotificationAspectCommentAdmin',
 }
 
 registerEnumType(UserPreferenceType, {

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -1,5 +1,5 @@
 import { UUID_LENGTH } from '@common/constants';
-import { LogContext } from '@common/enums';
+import { LogContext, UserPreferenceType } from '@common/enums';
 import {
   AuthenticationException,
   EntityNotFoundException,
@@ -184,12 +184,31 @@ export class UserService {
 
   createPreferenceDefaults(): Map<PreferenceType, string> {
     const defaults: Map<PreferenceType, string> = new Map();
-    defaults.set(PreferenceType.NOTIFICATION_COMMUNICATION_UPDATES, 'true');
+    defaults.set(UserPreferenceType.NOTIFICATION_COMMUNICATION_UPDATES, 'true');
     defaults.set(
-      PreferenceType.NOTIFICATION_COMMUNICATION_DISCUSSION_CREATED,
+      UserPreferenceType.NOTIFICATION_COMMUNICATION_UPDATE_SENT_ADMIN,
       'true'
     );
-    defaults.set(PreferenceType.NOTIFICATION_APPLICATION_RECEIVED, 'true');
+
+    defaults.set(
+      UserPreferenceType.NOTIFICATION_COMMUNICATION_DISCUSSION_CREATED,
+      'true'
+    );
+    defaults.set(
+      UserPreferenceType.NOTIFICATION_COMMUNICATION_DISCUSSION_CREATED_ADMIN,
+      'true'
+    );
+
+    defaults.set(UserPreferenceType.NOTIFICATION_APPLICATION_RECEIVED, 'true');
+    defaults.set(UserPreferenceType.NOTIFICATION_APPLICATION_SUBMITTED, 'true');
+
+    defaults.set(UserPreferenceType.NOTIFICATION_ASPECT_CREATED, 'true');
+    defaults.set(UserPreferenceType.NOTIFICATION_ASPECT_CREATED_ADMIN, 'true');
+    defaults.set(
+      UserPreferenceType.NOTIFICATION_ASPECT_COMMENT_CREATED_BY,
+      'true'
+    );
+    defaults.set(UserPreferenceType.NOTIFICATION_ASPECT_COMMENT_ADMIN, 'true');
 
     return defaults;
   }


### PR DESCRIPTION
added user preference types + defaults for pending preferences

Note: I thought it useful to already add the UserPreference type + defaults for notifications related to aspects + comments.
