### PR TITLE
Release: New user preferences, preference updates, sorting of aspects & opportunities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/apollo": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/common/enums/event.type.ts
+++ b/src/common/enums/event.type.ts
@@ -1,5 +1,6 @@
 export enum EventType {
   COMMUNITY_APPLICATION_CREATED = 'communityApplicationCreated',
+  COMMUNITY_NEW_MEMBER = 'communityNewMember',
   USER_REGISTERED = 'userRegistered',
   COMMUNICATION_COMMENT_SENT = 'communicationCommentSent',
   COMMUNICATION_UPDATE_SENT = 'communicationUpdateSent',

--- a/src/common/enums/user.preference.type.ts
+++ b/src/common/enums/user.preference.type.ts
@@ -11,6 +11,10 @@ export enum UserPreferenceType {
   NOTIFICATION_USER_SIGN_UP = 'NotificationUserSignUp',
   NOTIFICATION_COMMUNITY_REVIEW_SUBMITTED = 'NotificationCommunityReviewSubmitted',
   NOTIFICATION_COMMUNITY_REVIEW_SUBMITTED_ADMIN = 'NotificationCommunityReviewSubmittedAdmin',
+  NOTIFICATION_ASPECT_CREATED = 'NotificationAspectCreated',
+  NOTIFICATION_ASPECT_CREATED_ADMIN = 'NotificationAspectCreatedAdmin',
+  NOTIFICATION_ASPECT_COMMENT_CREATED_BY = 'NotificationAspectCommentCreatedBy',
+  NOTIFICATION_ASPECT_COMMENT_ADMIN = 'NotificationAspectCommentAdmin',
 }
 
 registerEnumType(UserPreferenceType, {

--- a/src/common/enums/user.preference.type.ts
+++ b/src/common/enums/user.preference.type.ts
@@ -11,6 +11,8 @@ export enum UserPreferenceType {
   NOTIFICATION_USER_SIGN_UP = 'NotificationUserSignUp',
   NOTIFICATION_COMMUNITY_REVIEW_SUBMITTED = 'NotificationCommunityReviewSubmitted',
   NOTIFICATION_COMMUNITY_REVIEW_SUBMITTED_ADMIN = 'NotificationCommunityReviewSubmittedAdmin',
+  NOTIFICATION_COMMUNITY_NEW_MEMBER = 'NotificationCommunityNewMember',
+  NOTIFICATION_COMMUNITY_NEW_MEMBER_ADMIN = 'NotificationCommunityNewMemberAdmin',
 }
 
 registerEnumType(UserPreferenceType, {

--- a/src/core/microservices/notifications.payload.builder.ts
+++ b/src/core/microservices/notifications.payload.builder.ts
@@ -57,6 +57,24 @@ export class NotificationsPayloadBuilder {
     return payload;
   }
 
+  async buildCommunityNewMemberPayload(userID: string, community: ICommunity) {
+    const payload = {
+      userID,
+      community: {
+        name: community.displayName,
+        type: community.type,
+      },
+      hub: {
+        nameID: await this.getHubNameID(community.hubID),
+        id: community.hubID,
+      },
+    };
+
+    await this.buildHubPayload(payload, community);
+
+    return payload;
+  }
+
   async buildCommunicationUpdateSentNotificationPayload(
     updateCreatorId: string,
     updates: IUpdates

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -391,7 +391,7 @@ export class ChallengeService {
 
     // Sort the opportunities base on their display name
     const sortedOpportunities = limitAndShuffled.sort((a, b) =>
-      a.displayName > b.displayName ? 1 : -1
+      a.displayName.toLowerCase() > b.displayName.toLowerCase() ? 1 : -1
     );
     return sortedOpportunities;
   }

--- a/src/domain/community/community/community.resolver.mutations.ts
+++ b/src/domain/community/community/community.resolver.mutations.ts
@@ -195,18 +195,12 @@ export class CommunityResolverMutations {
       `join community: ${community.displayName}`
     );
 
-    // Todo: notification for new community membership
-    // const payload =
-    //   await this.notificationsPayloadBuilder.buildApplicationCreatedNotificationPayload(
-    //     agentInfo.userID,
-    //     joiningData.userID,
-    //     community
-    //   );
-
-    // this.notificationsClient.emit<number>(
-    //   EventType.COMMUNITY_APPLICATION_CREATED,
-    //   payload
-    // );
+    const payload =
+      await this.notificationsPayloadBuilder.buildCommunityNewMemberPayload(
+        agentInfo.userID,
+        community
+      );
+    this.notificationsClient.emit(EventType.COMMUNITY_NEW_MEMBER, payload);
 
     return await this.communityService.assignMember({
       userID: agentInfo.userID,

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -1,5 +1,5 @@
 import { UUID_LENGTH } from '@common/constants';
-import { LogContext } from '@common/enums';
+import { LogContext, UserPreferenceType } from '@common/enums';
 import {
   AuthenticationException,
   EntityNotFoundException,
@@ -184,12 +184,31 @@ export class UserService {
 
   createPreferenceDefaults(): Map<PreferenceType, string> {
     const defaults: Map<PreferenceType, string> = new Map();
-    defaults.set(PreferenceType.NOTIFICATION_COMMUNICATION_UPDATES, 'true');
+    defaults.set(UserPreferenceType.NOTIFICATION_COMMUNICATION_UPDATES, 'true');
     defaults.set(
-      PreferenceType.NOTIFICATION_COMMUNICATION_DISCUSSION_CREATED,
+      UserPreferenceType.NOTIFICATION_COMMUNICATION_UPDATE_SENT_ADMIN,
       'true'
     );
-    defaults.set(PreferenceType.NOTIFICATION_APPLICATION_RECEIVED, 'true');
+
+    defaults.set(
+      UserPreferenceType.NOTIFICATION_COMMUNICATION_DISCUSSION_CREATED,
+      'true'
+    );
+    defaults.set(
+      UserPreferenceType.NOTIFICATION_COMMUNICATION_DISCUSSION_CREATED_ADMIN,
+      'true'
+    );
+
+    defaults.set(UserPreferenceType.NOTIFICATION_APPLICATION_RECEIVED, 'true');
+    defaults.set(UserPreferenceType.NOTIFICATION_APPLICATION_SUBMITTED, 'true');
+
+    defaults.set(UserPreferenceType.NOTIFICATION_ASPECT_CREATED, 'true');
+    defaults.set(UserPreferenceType.NOTIFICATION_ASPECT_CREATED_ADMIN, 'true');
+    defaults.set(
+      UserPreferenceType.NOTIFICATION_ASPECT_COMMENT_CREATED_BY,
+      'true'
+    );
+    defaults.set(UserPreferenceType.NOTIFICATION_ASPECT_COMMENT_ADMIN, 'true');
 
     return defaults;
   }

--- a/src/domain/context/context/context.service.ts
+++ b/src/domain/context/context/context.service.ts
@@ -343,7 +343,7 @@ export class ContextService {
         shuffle
       );
       const sortedAspects = limitAndShuffled.sort((a, b) =>
-        a.displayName > b.displayName ? 1 : -1
+        a.displayName.toLowerCase() > b.displayName.toLowerCase() ? 1 : -1
       );
       return sortedAspects;
     }

--- a/src/migrations/1650373194222-newCommunityMemberPreferences.ts
+++ b/src/migrations/1650373194222-newCommunityMemberPreferences.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { UserPreferenceType } from '@src/common';
+import { PreferenceType } from '@common/enums/preference.type';
+import {
+  addPreferenceDefinitions,
+  addPreferencesToUsers,
+  DefinitionInsertType,
+  PreferenceInsertType,
+  removePreferences,
+} from './utils/preferences';
+
+export class newCommunityMemberPreferences1650373194222
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const definitions: DefinitionInsertType[] = [
+      {
+        definitionSet: 'user',
+        group: 'Notification',
+        displayName: 'Community new member',
+        description:
+          'Receiver notification when a new user joins a community I am member of',
+        valueType: 'boolean',
+        type: UserPreferenceType.NOTIFICATION_COMMUNITY_NEW_MEMBER,
+      },
+      {
+        definitionSet: 'user',
+        group: 'NotificationCommunityAdmin',
+        displayName: '[Admin] Community new member',
+        description:
+          'Receiver notification when a new user joins a community for which I am an administrator',
+        valueType: 'boolean',
+        type: UserPreferenceType.NOTIFICATION_COMMUNITY_NEW_MEMBER_ADMIN,
+      },
+    ];
+    const defIds = await addPreferenceDefinitions(queryRunner, definitions);
+    // new preferences on existing users
+    const preferences: PreferenceInsertType[] = [
+      { value: 'true', definitionId: defIds[0] },
+      { value: 'true', definitionId: defIds[1] },
+    ];
+    await addPreferencesToUsers(queryRunner, preferences);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await removePreferences(queryRunner, [
+      PreferenceType.NOTIFICATION_COMMUNITY_NEW_MEMBER,
+      PreferenceType.NOTIFICATION_COMMUNITY_NEW_MEMBER_ADMIN,
+    ]);
+  }
+}

--- a/src/migrations/1650373194222-newCommunityMemberPreferences.ts
+++ b/src/migrations/1650373194222-newCommunityMemberPreferences.ts
@@ -18,8 +18,7 @@ export class newCommunityMemberPreferences1650373194222
         definitionSet: 'user',
         group: 'Notification',
         displayName: 'Community new member',
-        description:
-          'Receiver notification when a new user joins a community I am member of',
+        description: 'Receiver notification when I join a community',
         valueType: 'boolean',
         type: UserPreferenceType.NOTIFICATION_COMMUNITY_NEW_MEMBER,
       },

--- a/src/migrations/utils/preferences/add-preference-definitions.ts
+++ b/src/migrations/utils/preferences/add-preference-definitions.ts
@@ -1,0 +1,32 @@
+import { PreferenceType } from '@common/enums/preference.type';
+import { QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+export type DefinitionInsertType = {
+  definitionSet: string;
+  group: string;
+  displayName: string;
+  description: string;
+  valueType: string;
+  type: PreferenceType;
+};
+
+export const addPreferenceDefinitions = async (
+  queryRunner: QueryRunner,
+  definitions: DefinitionInsertType[]
+): Promise<string[]> => {
+  const defUUIDs = definitions.map(() => randomUUID());
+  const values = definitions.map(
+    (x, i) =>
+      `('${defUUIDs[i]}', 1, '${x.definitionSet}', '${x.group}', '${x.displayName}', '${x.description}', '${x.valueType}', '${x.type}')`
+  );
+  const value = values.join(',\n');
+  // new definitions
+  await queryRunner.query(
+    `INSERT INTO preference_definition (id, version, definitionSet, groupName, displayName, description, valueType, type)
+    VALUES
+      ${value}`
+  );
+
+  return defUUIDs;
+};

--- a/src/migrations/utils/preferences/add-preference-set.ts
+++ b/src/migrations/utils/preferences/add-preference-set.ts
@@ -1,0 +1,17 @@
+import { QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+export const addPreferenceSet = async (
+  queryRunner: QueryRunner
+): Promise<string> => {
+  const prefSetAuthId = randomUUID();
+  await queryRunner.query(`
+    INSERT INTO authorization_policy (id, createdDate, updatedDate, version, credentialRules, verifiedCredentialRules, anonymousReadAccess, privilegeRules)
+    VALUES ('${prefSetAuthId}', NOW(), NOW(), 1, '', '', 0, '')
+  `);
+  const prefSetId = randomUUID();
+  await queryRunner.query(
+    `INSERT INTO preference_set VALUES ('${prefSetId}', NOW(), NOW(), 1, '${prefSetAuthId}')`
+  );
+  return prefSetId;
+};

--- a/src/migrations/utils/preferences/add-preferences.ts
+++ b/src/migrations/utils/preferences/add-preferences.ts
@@ -1,0 +1,37 @@
+import { QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+export type PreferenceInsertType = {
+  value: string;
+  definitionId: string;
+};
+
+export const addPreferencesToUsers = async (
+  queryRunner: QueryRunner,
+  preferences: PreferenceInsertType[]
+) => {
+  const users: { id: string; preferenceSetId: string }[] =
+    await queryRunner.query('SELECT id, preferenceSetId FROM user');
+
+  const prefValues: string[] = [];
+  for (const user of users) {
+    const defAuthUUIDs = preferences.map(() => randomUUID());
+    const authValues = preferences.map(
+      (x, i) => `('${defAuthUUIDs[i]}', NOW(), NOW(), 1, '', '', 0, '')`
+    );
+    const authValue = authValues.join(',\n');
+    await queryRunner.query(
+      `INSERT INTO authorization_policy VALUES ${authValue}`
+    );
+
+    prefValues.push(
+      ...preferences.map(
+        (x, i) =>
+          `(UUID(), NOW(), NOW(), 1, 'true', '${defAuthUUIDs[i]}', '${x.definitionId}', '${user.preferenceSetId}')`
+      )
+    );
+  }
+
+  const prefValue = prefValues.join(',\n');
+  await queryRunner.query(`INSERT INTO preference VALUES ${prefValue}`);
+};

--- a/src/migrations/utils/preferences/add-preferences.ts
+++ b/src/migrations/utils/preferences/add-preferences.ts
@@ -32,6 +32,8 @@ export const addPreferencesToUsers = async (
     );
   }
 
-  const prefValue = prefValues.join(',\n');
-  await queryRunner.query(`INSERT INTO preference VALUES ${prefValue}`);
+  if (prefValues.length) {
+    const prefValue = prefValues.join(',\n');
+    await queryRunner.query(`INSERT INTO preference VALUES ${prefValue}`);
+  }
 };

--- a/src/migrations/utils/preferences/index.ts
+++ b/src/migrations/utils/preferences/index.ts
@@ -1,0 +1,4 @@
+export * from './add-preferences';
+export * from './add-preference-definitions';
+export * from './add-preference-set';
+export * from './remove-preferences';

--- a/src/migrations/utils/preferences/remove-preferences.ts
+++ b/src/migrations/utils/preferences/remove-preferences.ts
@@ -1,0 +1,31 @@
+import { QueryRunner } from 'typeorm';
+import { PreferenceType } from '@common/enums/preference.type';
+
+/***
+ * Removes the definition and each preference and authorization per definition
+ */
+export const removePreferences = async (
+  queryRunner: QueryRunner,
+  definitionType: PreferenceType[]
+) => {
+  const types = definitionType.map(x => `'${x}'`).join(',');
+  const prefDefs: { id: string }[] = await queryRunner.query(
+    `SELECT id FROM preference_definition WHERE type in (${types})`
+  );
+  const prefDefIds = prefDefs.map(x => `'${x.id}'`).join(',');
+
+  const prefAuths: { authorizationId: string }[] = await queryRunner.query(
+    `SELECT authorizationId FROM preference WHERE preferenceDefinitionId in (${prefDefIds})`
+  );
+  const prefAuthIds = prefAuths.map(x => `'${x.authorizationId}'`).join(',');
+
+  await queryRunner.query(
+    `DELETE FROM preference WHERE preferenceDefinitionId in (${prefDefIds})`
+  );
+  await queryRunner.query(
+    `DELETE FROM preference_definition WHERE id in (${prefDefIds})`
+  );
+  await queryRunner.query(
+    `DELETE FROM authorization_policy WHERE id in (${prefAuthIds})`
+  );
+};


### PR DESCRIPTION
Preferences
- User preference for notification when they join a new community
- Admin user preference for admin notification when a user joins a new community
- Some user preferences are set to 'true' by default when a new user is registered

API
- Aspects and Opportunities are sorted alphanumerically case insensitive
