### PR TITLE
Convert challenge to Hub, opportunity to Challenge

### DIFF
--- a/graphql-samples/mutations/convert/convert-challenge-to-hub
+++ b/graphql-samples/mutations/convert/convert-challenge-to-hub
@@ -1,0 +1,14 @@
+mutation ConvertChallengeToHub($convertData: ConvertChallengeToHubInput!) {
+  convertChallengeToHub(convertData: $convertData) {
+    displayName,
+    id
+  }
+}
+
+query variables:
+{
+  "convertData":
+  {
+    "challengeID": "uuid"
+  }
+}

--- a/graphql-samples/mutations/convert/convert-opportunity-to-challenge
+++ b/graphql-samples/mutations/convert/convert-opportunity-to-challenge
@@ -1,0 +1,14 @@
+mutation ConvertOpportunityToChallenge($convertData: ConvertOpportunityToChallengeInput!) {
+  convertOpportunityToChallenge(convertData: $convertData) {
+    displayName,
+    id
+  }
+}
+
+query variables:
+{
+  "convertData":
+  {
+    "opportunityID": "uuid"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/apollo": "^10.0.6",
@@ -7416,6 +7416,16 @@
         "stream-to-it": "^0.2.2"
       }
     },
+    "node_modules/ipfs-utils/node_modules/node-fetch": {
+      "name": "@achingbrain/node-fetch",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
@@ -10334,6 +10344,25 @@
         }
       }
     },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
@@ -13050,6 +13079,7 @@
     "node_modules/tr46": {
       "version": "2.1.0",
       "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -13784,6 +13814,7 @@
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
       "engines": {
         "node": ">=10.4"
       }
@@ -13889,6 +13920,7 @@
     "node_modules/whatwg-url": {
       "version": "8.7.0",
       "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.7.0",
         "tr46": "^2.1.0",
@@ -19864,6 +19896,12 @@
         "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
         "react-native-fetch-api": "^2.0.0",
         "stream-to-it": "^0.2.2"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
+        }
       }
     },
     "is-arrayish": {
@@ -22092,6 +22130,27 @@
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-int64": {
@@ -24112,6 +24171,7 @@
     "tr46": {
       "version": "2.1.0",
       "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -24603,7 +24663,8 @@
     },
     "webidl-conversions": {
       "version": "6.1.0",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true
     },
     "webpack": {
       "version": "5.72.1",
@@ -24679,6 +24740,7 @@
     "whatwg-url": {
       "version": "8.7.0",
       "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.7.0",
         "tr46": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,6 +43,7 @@ import { DataloaderService } from '@core/dataloader/dataloader.service';
 import { DataloaderModule } from '@core/dataloader/dataloader.module';
 import * as redisStore from 'cache-manager-redis-store';
 import { RedisLockModule } from '@core/caching/redis/redis.lock.module';
+import { ConversionModule } from '@services/domain/conversion/conversion.module';
 
 @Module({
   imports: [
@@ -189,6 +190,7 @@ import { RedisLockModule } from '@core/caching/redis/redis.lock.module';
     AgentModule,
     RegistrationModule,
     RedisLockModule,
+    ConversionModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -153,6 +153,10 @@ export class ChallengeService {
     return savedChallenge;
   }
 
+  async save(challenge: IChallenge): Promise<IChallenge> {
+    return await this.challengeRepository.save(challenge);
+  }
+
   async updateChallenge(
     challengeData: UpdateChallengeInput
   ): Promise<IChallenge> {

--- a/src/domain/challenge/hub/hub.service.ts
+++ b/src/domain/challenge/hub/hub.service.ts
@@ -150,6 +150,10 @@ export class HubService {
       );
   }
 
+  async save(hub: IHub): Promise<IHub> {
+    return await this.hubRepository.save(hub);
+  }
+
   async update(hubData: UpdateHubInput): Promise<IHub> {
     const hub: IHub = await this.baseChallengeService.update(
       hubData,

--- a/src/domain/collaboration/opportunity/opportunity.service.ts
+++ b/src/domain/collaboration/opportunity/opportunity.service.ts
@@ -111,6 +111,10 @@ export class OpportunityService {
     return await this.saveOpportunity(opportunity);
   }
 
+  async save(opportunity: IOpportunity): Promise<IOpportunity> {
+    return await this.opportunityRepository.save(opportunity);
+  }
+
   async getOpportunityInNameableScopeOrFail(
     opportunityID: string,
     nameableScopeID: string,

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -474,7 +474,7 @@ export class CommunityService {
     if (action === CommunityContributorsUpdateType.ASSIGN) {
       if (userMembersCount === communityPolicyRole.maxUser) {
         throw new CommunityPolicyRoleLimitsException(
-          'Max limit of users reached, cannot assign new user.',
+          `Max limit of users reached for role '${role}': ${communityPolicyRole.maxUser}, cannot assign new user.`,
           LogContext.COMMUNITY
         );
       }
@@ -483,7 +483,7 @@ export class CommunityService {
     if (action === CommunityContributorsUpdateType.REMOVE) {
       if (userMembersCount === communityPolicyRole.minUser) {
         throw new CommunityPolicyRoleLimitsException(
-          'Min limit of users reached, cannot remove user.',
+          `Min limit of users reached for role '${role}': ${communityPolicyRole.minUser}, cannot remove user.`,
           LogContext.COMMUNITY
         );
       }
@@ -505,7 +505,7 @@ export class CommunityService {
     if (action === CommunityContributorsUpdateType.ASSIGN) {
       if (orgMemberCount === communityPolicyRole.maxOrg) {
         throw new CommunityPolicyRoleLimitsException(
-          'Max limit of organizations reached, cannot assign new organization.',
+          `Max limit of organizations reached for role '${role}': ${communityPolicyRole.maxOrg}, cannot assign new organization.`,
           LogContext.COMMUNITY
         );
       }
@@ -514,7 +514,7 @@ export class CommunityService {
     if (action === CommunityContributorsUpdateType.REMOVE) {
       if (orgMemberCount === communityPolicyRole.minOrg) {
         throw new CommunityPolicyRoleLimitsException(
-          'Min limit of organizations reached, cannot remove organization.',
+          `Min limit of organizations reached for role '${role}': ${communityPolicyRole.minOrg}, cannot remove organization.`,
           LogContext.COMMUNITY
         );
       }

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -181,6 +181,10 @@ export class CommunityService {
     return true;
   }
 
+  async save(community: ICommunity): Promise<ICommunity> {
+    return await this.communityRepository.save(community);
+  }
+
   async getParentCommunity(
     community: ICommunity
   ): Promise<ICommunity | undefined> {

--- a/src/services/domain/conversion/conversion.module.ts
+++ b/src/services/domain/conversion/conversion.module.ts
@@ -6,6 +6,7 @@ import { HubModule } from '@domain/challenge/hub/hub.module';
 import { ChallengeModule } from '@domain/challenge/challenge/challenge.module';
 import { CommunityModule } from '@domain/community/community/community.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { CommunicationModule } from '@domain/communication/communication/communication.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/a
     CommunityModule,
     AuthorizationModule,
     AuthorizationPolicyModule,
+    CommunicationModule,
   ],
   providers: [ConversionService, ConversionResolverMutations],
   exports: [ConversionService, ConversionResolverMutations],

--- a/src/services/domain/conversion/conversion.module.ts
+++ b/src/services/domain/conversion/conversion.module.ts
@@ -7,12 +7,14 @@ import { ChallengeModule } from '@domain/challenge/challenge/challenge.module';
 import { CommunityModule } from '@domain/community/community/community.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { CommunicationModule } from '@domain/communication/communication/communication.module';
+import { OpportunityModule } from '@domain/collaboration/opportunity/opportunity.module';
 
 @Module({
   imports: [
     AuthorizationModule,
     HubModule,
     ChallengeModule,
+    OpportunityModule,
     CommunityModule,
     AuthorizationModule,
     AuthorizationPolicyModule,

--- a/src/services/domain/conversion/conversion.module.ts
+++ b/src/services/domain/conversion/conversion.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConversionService } from './conversion.service';
+import { ConversionResolverMutations } from './conversion.resolver.mutations';
+import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { HubModule } from '@domain/challenge/hub/hub.module';
+import { ChallengeModule } from '@domain/challenge/challenge/challenge.module';
+import { CommunityModule } from '@domain/community/community/community.module';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+
+@Module({
+  imports: [
+    AuthorizationModule,
+    HubModule,
+    ChallengeModule,
+    CommunityModule,
+    AuthorizationModule,
+    AuthorizationPolicyModule,
+  ],
+  providers: [ConversionService, ConversionResolverMutations],
+  exports: [ConversionService, ConversionResolverMutations],
+})
+export class ConversionModule {}

--- a/src/services/domain/conversion/conversion.resolver.mutations.ts
+++ b/src/services/domain/conversion/conversion.resolver.mutations.ts
@@ -1,0 +1,58 @@
+import { Inject, LoggerService, UseGuards } from '@nestjs/common';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { CurrentUser, Profiling } from '@src/common/decorators';
+import { GraphqlGuard } from '@core/authorization';
+import { AgentInfo } from '@core/authentication';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { ConversionService } from './conversion.service';
+import { IHub } from '@domain/challenge/hub/hub.interface';
+import { AuthorizationRoleGlobal } from '@common/enums/authorization.credential.global';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { ConvertChallengeToHubInput } from './dto/convert.dto.challenge.to.hub.input';
+import { HubAuthorizationService } from '@domain/challenge/hub/hub.service.authorization';
+
+@Resolver()
+export class ConversionResolverMutations {
+  private authorizationGlobalAdminPolicy: IAuthorizationPolicy;
+
+  constructor(
+    private authorizationService: AuthorizationService,
+    private authorizationPolicyService: AuthorizationPolicyService,
+    private conversionService: ConversionService,
+    private hubAuthorizationService: HubAuthorizationService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
+  ) {
+    this.authorizationGlobalAdminPolicy =
+      this.authorizationPolicyService.createGlobalRolesAuthorizationPolicy(
+        [AuthorizationRoleGlobal.GLOBAL_ADMIN],
+        [AuthorizationPrivilege.CREATE_HUB]
+      );
+  }
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => IHub, {
+    description: 'Creates a new Hub by converting an existing Challenge. .',
+  })
+  @Profiling.api
+  async convertChallengeToHub(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('convertData') convertChallengeToHubData: ConvertChallengeToHubInput
+  ): Promise<IHub> {
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      this.authorizationGlobalAdminPolicy,
+      AuthorizationPrivilege.CREATE_HUB,
+      `convert challenge to hub: ${agentInfo.email}`
+    );
+    const newHub = await this.conversionService.convertChallengeToHub(
+      convertChallengeToHubData,
+      agentInfo
+    );
+
+    return await this.hubAuthorizationService.applyAuthorizationPolicy(newHub);
+  }
+}

--- a/src/services/domain/conversion/conversion.service.ts
+++ b/src/services/domain/conversion/conversion.service.ts
@@ -1,0 +1,182 @@
+import { Inject, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { AgentInfo } from '@core/authentication/agent-info';
+import { LogContext } from '@common/enums/logging.context';
+import { ConvertChallengeToHubInput } from './dto/convert.dto.challenge.to.hub.input';
+import { HubService } from '@domain/challenge/hub/hub.service';
+import { ChallengeService } from '@domain/challenge/challenge/challenge.service';
+import { IHub } from '@domain/challenge/hub/hub.interface';
+import { CommunityService } from '@domain/community/community/community.service';
+import {
+  EntityNotInitializedException,
+  ValidationException,
+} from '@common/exceptions';
+import { CommunityRole } from '@common/enums/community.role';
+import { CreateHubInput } from '@domain/challenge/hub/dto/hub.dto.create';
+import { CommunityType } from '@common/enums/community.type';
+
+export class ConversionService {
+  constructor(
+    private hubService: HubService,
+    private challengeService: ChallengeService,
+    private communityService: CommunityService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  async convertChallengeToHub(
+    conversionData: ConvertChallengeToHubInput,
+    agentInfo: AgentInfo
+  ): Promise<IHub> {
+    const challenge = await this.challengeService.getChallengeOrFail(
+      conversionData.challengeID,
+      {
+        relations: ['community', 'context'],
+      }
+    );
+    // check the community is in a fit state
+    const challengeCommunity = challenge.community;
+    if (!challengeCommunity) {
+      throw new EntityNotInitializedException(
+        `Unable to locate Community on Challenge: ${challenge.nameID}`,
+        LogContext.CHALLENGES
+      );
+    }
+    const challengeCommunityLeadOrgs =
+      await this.communityService.getOrganizationsWithRole(
+        challengeCommunity,
+        CommunityRole.LEAD
+      );
+    if (challengeCommunityLeadOrgs.length !== 1) {
+      throw new ValidationException(
+        `A Challenge must have exactly on Lead organization to be converted to a Hub: ${challenge.nameID} has ${challengeCommunityLeadOrgs.length}`,
+        LogContext.CHALLENGES
+      );
+    }
+    const hostOrg = challengeCommunityLeadOrgs[0];
+    const createHubInput: CreateHubInput = {
+      hostID: hostOrg.nameID,
+      nameID: challenge.nameID,
+      displayName: challenge.displayName,
+    };
+    const hub = await this.hubService.createHub(createHubInput, agentInfo);
+
+    // Swap the communities...
+    const hubCommunity = hub.community;
+    if (!hubCommunity) {
+      throw new EntityNotInitializedException(
+        `Unable to locate Community on Hub: ${hub.nameID}`,
+        LogContext.CHALLENGES
+      );
+    }
+
+    const userMembers = await this.communityService.getUsersWithRole(
+      challengeCommunity,
+      CommunityRole.MEMBER
+    );
+    const userLeads = await this.communityService.getUsersWithRole(
+      challengeCommunity,
+      CommunityRole.LEAD
+    );
+    const orgMembers = await this.communityService.getOrganizationsWithRole(
+      challengeCommunity,
+      CommunityRole.MEMBER
+    );
+
+    // Remove the contributors from old roles
+    for (const userMember of userMembers) {
+      await this.communityService.removeUserFromRole(
+        challengeCommunity,
+        userMember.id,
+        CommunityRole.MEMBER
+      );
+    }
+    for (const userLead of userLeads) {
+      await this.communityService.removeUserFromRole(
+        challengeCommunity,
+        userLead.id,
+        CommunityRole.LEAD
+      );
+    }
+    for (const orgMember of orgMembers) {
+      await this.communityService.removeOrganizationFromRole(
+        challengeCommunity,
+        orgMember.id,
+        CommunityRole.MEMBER
+      );
+    }
+    await this.communityService.removeOrganizationFromRole(
+      challengeCommunity,
+      hostOrg.id,
+      CommunityRole.LEAD
+    );
+
+    // Swap the communities
+    const hubCommunityPolicy =
+      this.communityService.getCommunityPolicy(hubCommunity);
+    const challengeCommunityPolicy =
+      this.communityService.getCommunityPolicy(challengeCommunity);
+    challengeCommunity.type = CommunityType.HUB;
+    challengeCommunity.hubID = hub.id;
+    challengeCommunity.parentCommunity = undefined;
+
+    hub.community = challengeCommunity;
+    challenge.community = hubCommunity;
+    this.communityService.setCommunityPolicy(hub.community, hubCommunityPolicy);
+    this.communityService.setCommunityPolicy(
+      challenge.community,
+      challengeCommunityPolicy
+    );
+    // Save both + then re-assign the roles
+    await this.hubService.save(hub);
+    await this.challengeService.save(challenge);
+
+    // Add the users into their new roles
+    const hubCommunityUpdated = hub.community;
+    if (!hubCommunityUpdated) {
+      throw new EntityNotInitializedException(
+        `Unable to locate updated Community on Hub: ${hub.nameID}`,
+        LogContext.CHALLENGES
+      );
+    }
+    for (const userMember of userMembers) {
+      await this.communityService.assignUserToRole(
+        hubCommunityUpdated,
+        userMember.id,
+        CommunityRole.MEMBER
+      );
+    }
+    for (const userLead of userLeads) {
+      await this.communityService.assignUserToRole(
+        hubCommunityUpdated,
+        userLead.id,
+        CommunityRole.LEAD
+      );
+    }
+    for (const orgMember of orgMembers) {
+      await this.communityService.assignOrganizationToRole(
+        hubCommunityUpdated,
+        orgMember.id,
+        CommunityRole.MEMBER
+      );
+    }
+
+    // Swap the contexts
+    const challengeContext = challenge.context;
+    const hubContext = hub.context;
+    hub.context = challengeContext;
+    challenge.context = hubContext;
+
+    // Finally delete the Challenge
+    await this.challengeService.deleteChallenge({
+      ID: challenge.id,
+    });
+
+    // Notes: (a) remove old membership credentials + add new ones
+    // (b) update the community policy
+    // convert opportunities into challenges
+    // update community parent
+    // Update hubID field everywhere where that is passed down (community, context), unless we re-use the challengeID as the new hubID...
+    // when deleting make sure not to delete re-used entities!!
+    return hub;
+  }
+}

--- a/src/services/domain/conversion/dto/convert.dto.challenge.to.hub.input.ts
+++ b/src/services/domain/conversion/dto/convert.dto.challenge.to.hub.input.ts
@@ -1,0 +1,12 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { UUID_NAMEID } from '@domain/common/scalars/scalar.uuid.nameid';
+
+@InputType()
+export class ConvertChallengeToHubInput {
+  @Field(() => UUID_NAMEID, {
+    nullable: false,
+    description:
+      'The Challenge to be promoted to be a new Hub. Note: the original Challenge will no longer exist after the conversion. ',
+  })
+  challengeID!: string;
+}

--- a/src/services/domain/conversion/dto/convert.dto.opportunity.to.challenge.input.ts
+++ b/src/services/domain/conversion/dto/convert.dto.opportunity.to.challenge.input.ts
@@ -1,0 +1,12 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { UUID_NAMEID } from '@domain/common/scalars/scalar.uuid.nameid';
+
+@InputType()
+export class ConvertOpportunityToChallengeInput {
+  @Field(() => UUID_NAMEID, {
+    nullable: false,
+    description:
+      'The Opportunity to be promoted to be a new Challenge. Note: the original Opportunity will no longer exist after the conversion. ',
+  })
+  opportunityID!: string;
+}


### PR DESCRIPTION
A new server: Conversion

It provides two mutations:
- to convert a challenge to a hub, recursively so also child opportunities get promoted
- to convert an opportunity to a challenge

For each conversion the following entities are maintained:
- contexts are fully re-used
- communications on community are re-used

In addition:
- users have old credentials removed + new ones assigned

Graphql samples are added.

This PR also improves some error messages related to community policy limits, and brings a bit of useful refactoring to the Hub service. 