### PR TITLE
Moved aspects / canvases counts to collaboration

### DIFF
--- a/src/domain/challenge/base-challenge/base.challenge.module.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.module.ts
@@ -10,8 +10,6 @@ import { BaseChallengeService } from './base.challenge.service';
 import { BaseChallengeAuthorizationService } from './base.challenge.service.authorization';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { CollaborationModule } from '@domain/collaboration/collaboration/collaboration.module';
-import { AspectModule } from '@domain/collaboration/aspect/aspect.module';
-import { CanvasModule } from '@domain/common/canvas/canvas.module';
 
 @Module({
   imports: [
@@ -24,8 +22,6 @@ import { CanvasModule } from '@domain/common/canvas/canvas.module';
     TagsetModule,
     NamingModule,
     CollaborationModule,
-    AspectModule,
-    CanvasModule,
   ],
   providers: [BaseChallengeService, BaseChallengeAuthorizationService],
   exports: [BaseChallengeService, BaseChallengeAuthorizationService],

--- a/src/domain/challenge/base-challenge/base.challenge.service.ts
+++ b/src/domain/challenge/base-challenge/base.challenge.service.ts
@@ -31,8 +31,6 @@ import { CommunityRole } from '@common/enums/community.role';
 import { ICommunityPolicy } from '@domain/community/community-policy/community.policy.interface';
 import { CollaborationService } from '@domain/collaboration/collaboration/collaboration.service';
 import { ICollaboration } from '@domain/collaboration/collaboration/collaboration.interface';
-import { CanvasService } from '@domain/common/canvas/canvas.service';
-import { AspectService } from '@domain/collaboration/aspect/aspect.service';
 
 @Injectable()
 export class BaseChallengeService {
@@ -45,8 +43,6 @@ export class BaseChallengeService {
     private tagsetService: TagsetService,
     private lifecycleService: LifecycleService,
     private collaborationService: CollaborationService,
-    private aspectsService: AspectService,
-    private canvasService: CanvasService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
@@ -337,17 +333,8 @@ export class BaseChallengeService {
       baseChallenge.id,
       repository
     );
-    const callouts = await this.collaborationService.getCalloutsOnCollaboration(
-      collaboration
-    );
 
-    let aspectsCount = 0;
-    for (const callout of callouts) {
-      aspectsCount += await this.aspectsService.getAspectsInCalloutCount(
-        callout.id
-      );
-    }
-    return aspectsCount;
+    return await this.collaborationService.getAspectsCount(collaboration);
   }
 
   public async getCanvasesCount(
@@ -358,15 +345,17 @@ export class BaseChallengeService {
       baseChallenge.id,
       repository
     );
-    const callouts = await this.collaborationService.getCalloutsOnCollaboration(
-      collaboration
+    return await this.collaborationService.getCanvasesCount(collaboration);
+  }
+
+  public async getRelationsCount(
+    baseChallenge: IBaseChallenge,
+    repository: Repository<BaseChallenge>
+  ): Promise<number> {
+    const collaboration = await this.getCollaboration(
+      baseChallenge.id,
+      repository
     );
-    let canvasesCount = 0;
-    for (const callout of callouts) {
-      canvasesCount += await this.canvasService.getCanvasesInCalloutCount(
-        callout.id
-      );
-    }
-    return canvasesCount;
+    return await this.collaborationService.getRelationsCount(collaboration);
   }
 }

--- a/src/domain/collaboration/collaboration/collaboration.module.ts
+++ b/src/domain/collaboration/collaboration/collaboration.module.ts
@@ -11,6 +11,8 @@ import { CollaborationResolverFields } from '@domain/collaboration/collaboration
 import { RelationModule } from '@domain/collaboration/relation/relation.module';
 import { CollaborationDataloaderService } from './collaboration.dataloader.service';
 import { CollaborationAuthorizationService } from './collaboration.service.authorization';
+import { CanvasModule } from '@domain/common/canvas/canvas.module';
+import { AspectModule } from '../aspect/aspect.module';
 
 @Module({
   imports: [
@@ -19,6 +21,8 @@ import { CollaborationAuthorizationService } from './collaboration.service.autho
     CalloutModule,
     NamingModule,
     RelationModule,
+    CanvasModule,
+    AspectModule,
     TypeOrmModule.forFeature([Collaboration]),
   ],
   providers: [

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -18,6 +18,8 @@ import { CreateCalloutOnCollaborationInput } from '@domain/collaboration/collabo
 import { CreateRelationOnCollaborationInput } from '@domain/collaboration/collaboration/dto/collaboration.dto.create.relation';
 import { IRelation } from '@domain/collaboration/relation/relation.interface';
 import { RelationService } from '@domain/collaboration/relation/relation.service';
+import { AspectService } from '../aspect/aspect.service';
+import { CanvasService } from '@domain/common/canvas/canvas.service';
 
 @Injectable()
 export class CollaborationService {
@@ -26,6 +28,8 @@ export class CollaborationService {
     private calloutService: CalloutService,
     private namingService: NamingService,
     private relationService: RelationService,
+    private aspectService: AspectService,
+    private canvasService: CanvasService,
     @InjectRepository(Collaboration)
     private collaborationRepository: Repository<Collaboration>
   ) {}
@@ -172,5 +176,41 @@ export class CollaborationService {
       );
 
     return loadedCollaboration.relations;
+  }
+
+  public async getAspectsCount(collaboration: ICollaboration): Promise<number> {
+    const callouts = await this.getCalloutsOnCollaboration(collaboration);
+
+    let aspectsCount = 0;
+    for (const callout of callouts) {
+      aspectsCount += await this.aspectService.getAspectsInCalloutCount(
+        callout.id
+      );
+    }
+    return aspectsCount;
+  }
+
+  public async getCanvasesCount(
+    collaboration: ICollaboration
+  ): Promise<number> {
+    const callouts = await this.getCalloutsOnCollaboration(collaboration);
+    let canvasesCount = 0;
+    for (const callout of callouts) {
+      canvasesCount += await this.canvasService.getCanvasesInCalloutCount(
+        callout.id
+      );
+    }
+    return canvasesCount;
+  }
+
+  public async getRelationsCount(
+    collaboration: ICollaboration
+  ): Promise<number> {
+    const aspectsCount =
+      await this.relationService.getRelationsInCollaborationCount(
+        collaboration.id
+      );
+
+    return aspectsCount;
   }
 }

--- a/src/domain/collaboration/opportunity/opportunity.service.ts
+++ b/src/domain/collaboration/opportunity/opportunity.service.ts
@@ -320,7 +320,9 @@ export class OpportunityService {
 
     // Relations
     const relationsCount =
-      await this.relationService.getRelationsInOpportunityCount(opportunity.id);
+      await this.relationService.getRelationsInCollaborationCount(
+        opportunity.id
+      );
     const relationsTopic = new NVP('relations', relationsCount.toString());
     relationsTopic.id = `relations-${opportunity.id}`;
     activity.push(relationsTopic);

--- a/src/domain/collaboration/relation/relation.service.ts
+++ b/src/domain/collaboration/relation/relation.service.ts
@@ -87,9 +87,11 @@ export class RelationService {
     return await this.relationRepository.save(relation);
   }
 
-  async getRelationsInOpportunityCount(opportunityID: string): Promise<number> {
+  async getRelationsInCollaborationCount(
+    collaborationID: string
+  ): Promise<number> {
     return await this.relationRepository.count({
-      where: { opportunity: opportunityID },
+      where: { collaboration: collaborationID },
     });
   }
 }


### PR DESCRIPTION
I saw that the activity was failing on opportunity so put in a fix. Found that since my merge another fix had gone in. 

However there was still the issue that the BaseChallenge service should never need to be importing the CanvasModule or AspectModule - these should only be known at the collaboration entity level. 