### PR TITLE
Callout(s) by ID in Collaboration field resolver

### DIFF
--- a/src/domain/collaboration/callout/callout.resolver.fields.ts
+++ b/src/domain/collaboration/callout/callout.resolver.fields.ts
@@ -74,7 +74,7 @@ export class CalloutResolverFields {
       name: 'limit',
       type: () => Float,
       description:
-        'The number of Organizations to return; if omitted return all Organizations.',
+        'The number of Canvases to return; if omitted return all Canvases.',
       nullable: true,
     })
     limit: number,
@@ -82,7 +82,7 @@ export class CalloutResolverFields {
       name: 'shuffle',
       type: () => Boolean,
       description:
-        'If true and limit is specified then return the Organizations based on a random selection. Defaults to false.',
+        'If true and limit is specified then return the Canvases based on a random selection. Defaults to false.',
       nullable: true,
     })
     shuffle: boolean

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -310,7 +310,7 @@ export class CalloutService {
       );
       if (!aspect)
         throw new EntityNotFoundException(
-          `Aspect with requested ID (${aspectID}) not located within current Context: : ${callout.id}`,
+          `Aspect with requested ID (${aspectID}) not located within current Callout: ${callout.id}`,
           LogContext.COLLABORATION
         );
       results.push(aspect);

--- a/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
+++ b/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
@@ -1,4 +1,11 @@
-import { Context, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import {
+  Args,
+  Context,
+  Float,
+  Parent,
+  ResolveField,
+  Resolver,
+} from '@nestjs/graphql';
 import { AuthorizationAgentPrivilege, Profiling } from '@src/common/decorators';
 import { IRelation } from '@domain/collaboration/relation';
 import { AuthorizationPrivilege } from '@common/enums';
@@ -8,6 +15,7 @@ import { Collaboration } from '@domain/collaboration/collaboration/collaboration
 import { ICollaboration } from '@domain/collaboration/collaboration/collaboration.interface';
 import { CollaborationService } from '@domain/collaboration/collaboration/collaboration.service';
 import { ICallout } from '../callout/callout.interface';
+import { UUID } from '@domain/common/scalars';
 
 @Resolver(() => ICollaboration)
 export class CollaborationResolverFields {
@@ -36,8 +44,35 @@ export class CollaborationResolverFields {
   @Profiling.api
   async callouts(
     @Parent() collaboration: Collaboration,
-    @Context() { loaders }: IGraphQLContext
+    @Args({
+      name: 'IDs',
+      type: () => [UUID],
+      description: 'The IDs of the callouts to return',
+      nullable: true,
+    })
+    ids: string[],
+    @Args({
+      name: 'limit',
+      type: () => Float,
+      description:
+        'The number of Callouts to return; if omitted return all Callouts.',
+      nullable: true,
+    })
+    limit: number,
+    @Args({
+      name: 'shuffle',
+      type: () => Boolean,
+      description:
+        'If true and limit is specified then return the Callouts based on a random selection. Defaults to false.',
+      nullable: true,
+    })
+    shuffle: boolean
   ) {
-    return loaders.calloutsLoader.load(collaboration.id);
+    return await this.collaborationService.getCalloutsFromCollaboration(
+      collaboration,
+      ids,
+      limit,
+      shuffle
+    );
   }
 }

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -19,6 +19,7 @@ import { CreateRelationOnCollaborationInput } from '@domain/collaboration/collab
 import { IRelation } from '@domain/collaboration/relation/relation.interface';
 import { RelationService } from '@domain/collaboration/relation/relation.service';
 import { CredentialDefinition } from '@domain/agent/credential/credential.definition';
+import { limitAndShuffle } from '@common/utils/limitAndShuffle';
 
 @Injectable()
 export class CollaborationService {
@@ -116,6 +117,47 @@ export class CollaborationService {
     collaboration.callouts.push(callout);
     await this.collaborationRepository.save(collaboration);
     return callout;
+  }
+
+  public async getCalloutsFromCollaboration(
+    collaboration: ICollaboration,
+    calloutIDs?: string[],
+    limit?: number,
+    shuffle?: boolean
+  ): Promise<ICallout[]> {
+    const collaborationLoaded = await this.getCollaborationOrFail(
+      collaboration.id,
+      {
+        relations: ['callouts'],
+      }
+    );
+    if (!collaborationLoaded.callouts)
+      throw new EntityNotFoundException(
+        `Callout not initialised, no canvases: ${collaboration.id}`,
+        LogContext.COLLABORATION
+      );
+
+    if (!calloutIDs) {
+      const limitAndShuffled = limitAndShuffle(
+        collaborationLoaded.callouts,
+        limit,
+        shuffle
+      );
+      return limitAndShuffled;
+    }
+    const results: ICallout[] = [];
+    for (const calloutID of calloutIDs) {
+      const callout = collaborationLoaded.callouts.find(
+        callout => callout.id === calloutID
+      );
+      if (!callout)
+        throw new EntityNotFoundException(
+          `Callout with requested ID (${calloutID}) not located within current Collaboration: : ${collaboration.id}`,
+          LogContext.COLLABORATION
+        );
+      results.push(callout);
+    }
+    return results;
   }
 
   public async getCalloutsOnCollaboration(


### PR DESCRIPTION
Adjusted query to work with:

```gql
query hubCanvasValues($hubId: UUID_NAMEID!, $canvasId: UUID!, $calloutId: UUID!) {
  hub(ID: $hubId) {
    id
    collaboration {
      id
      callouts(IDs: [$calloutId]) {
        id
        type
        authorization {
          id
          myPrivileges
          __typename
        }
        canvases(IDs: [$canvasId]) {
          ...CanvasDetails
          ...CanvasValue
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
}

fragment CanvasDetails on Canvas {
  ...CanvasSummary
  authorization {
    id
    myPrivileges
    anonymousReadAccess
    __typename
  }
  checkout {
    ...CheckoutDetails
    __typename
  }
  preview {
    ...VisualFull
    __typename
  }
  __typename
}

fragment CanvasSummary on Canvas {
  id
  nameID
  displayName
  __typename
}

fragment CheckoutDetails on CanvasCheckout {
  id
  lockedBy
  status
  lifecycle {
    id
    nextEvents
    __typename
  }
  authorization {
    id
    myPrivileges
    __typename
  }
  __typename
}

fragment VisualFull on Visual {
  id
  uri
  name
  allowedTypes
  aspectRatio
  maxHeight
  maxWidth
  minHeight
  minWidth
  __typename
}

fragment CanvasValue on Canvas {
  id
  value
  __typename
}
```

vars
```json
{
  "hubId": "open-innovation",
  "canvasId": "75b8133f-d5c4-4898-b308-90cd30fecf9d",
  "calloutId": "963f9537-e004-4404-8504-d94fd41ac965"
}
```

Adjusting client