### PR TITLE
removed property on from being required on states

### DIFF
--- a/src/core/validation/xstate/machine.schema.simple.json
+++ b/src/core/validation/xstate/machine.schema.simple.json
@@ -63,7 +63,7 @@
           }
         }
       },
-      "required": ["on"]
+      "required": []
     },
     "transitionObject": {
       "type": "object",


### PR DESCRIPTION
The following JSON should be accepted as a MachineDef:
```json
{
  "id": "Machine Name",
  "initial": "First State",
  "states": {
    "First State": {
      "on": {
        "Event": {
          "target": "Second State"
        }
      }
    },
    "Second State": {}
  }
}
```