### PR TITLE
added default callouts for new collaborations

### DIFF
--- a/src/domain/collaboration/collaboration/collaboration.defaults.ts
+++ b/src/domain/collaboration/collaboration/collaboration.defaults.ts
@@ -1,0 +1,26 @@
+import { CalloutState } from '@common/enums/callout.state';
+import { CalloutType } from '@common/enums/callout.type';
+import { CalloutVisibility } from '@common/enums/callout.visibility';
+
+export const collaborationDefaults: any = {
+  callouts: [
+    {
+      type: CalloutType.CANVAS,
+      displayName: 'Collaborate visually',
+      nameID: `${CalloutType.CANVAS}-default`,
+      description:
+        'Collaborate visually using Canvases. Create a new Canvas from a template, or explore Canvases already created.',
+      visibility: CalloutVisibility.PUBLISHED,
+      state: CalloutState.OPEN,
+    },
+    {
+      type: CalloutType.CARD,
+      displayName: 'Contribute',
+      nameID: `${CalloutType.CARD}-default`,
+      description:
+        'Contribute your insights to understanding the context. It is about surfacing up the wisdom of the community. Add your own card, or comment on aspects added by others.',
+      visibility: CalloutVisibility.PUBLISHED,
+      state: CalloutState.OPEN,
+    },
+  ],
+};

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -21,6 +21,7 @@ import { RelationService } from '@domain/collaboration/relation/relation.service
 import { CredentialDefinition } from '@domain/agent/credential/credential.definition';
 import { CalloutVisibility } from '@common/enums/callout.visibility';
 import { limitAndShuffle } from '@common/utils/limitAndShuffle';
+import { collaborationDefaults } from './collaboration.defaults';
 
 @Injectable()
 export class CollaborationService {
@@ -35,9 +36,14 @@ export class CollaborationService {
 
   async createCollaboration(): Promise<ICollaboration> {
     const collaboration: ICollaboration = Collaboration.create();
+    collaboration.authorization = new AuthorizationPolicy();
     collaboration.relations = [];
     collaboration.callouts = [];
-    collaboration.authorization = new AuthorizationPolicy();
+
+    for (const calloutDefault of collaborationDefaults.callouts) {
+      const callout = await this.calloutService.createCallout(calloutDefault);
+      collaboration.callouts.push(callout);
+    }
     return collaboration;
   }
 


### PR DESCRIPTION
New collaborations now get default call outs to ensure that the core messages of that tab are clear