### PR TITLE
alidate whether the displayName for a call out is already existing

### DIFF
--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -120,6 +120,17 @@ export class CollaborationService {
       );
     }
 
+    const displayNameAvailable =
+      await this.namingService.isCalloutDisplayNameAvailableInCollaboration(
+        calloutData.displayName,
+        collaboration.id
+      );
+    if (!displayNameAvailable)
+      throw new ValidationException(
+        `Unable to create Callout: the provided displayName is already taken: ${calloutData.displayName}`,
+        LogContext.CHALLENGES
+      );
+
     const callout = await this.calloutService.createCallout(calloutData);
     collaboration.callouts.push(callout);
     await this.collaborationRepository.save(collaboration);

--- a/src/services/domain/naming/naming.service.ts
+++ b/src/services/domain/naming/naming.service.ts
@@ -116,6 +116,27 @@ export class NamingService {
     return true;
   }
 
+  async isCalloutDisplayNameAvailableInCollaboration(
+    displayName: string,
+    collaborationID: string
+  ): Promise<boolean> {
+    const query = this.calloutRepository
+      .createQueryBuilder('callout')
+      .leftJoinAndSelect('callout.collaboration', 'collaboration')
+      .where('collaboration.id = :id')
+      .andWhere('callout.displayName = :displayName')
+      .setParameters({
+        id: `${collaborationID}`,
+        displayName: `${displayName}`,
+      });
+    const calloutsWithDisplayName = await query.getOne();
+    if (calloutsWithDisplayName) {
+      return false;
+    }
+
+    return true;
+  }
+
   isValidNameID(nameID: string): boolean {
     if (nameID.length > NameID.MAX_LENGTH) return false;
     return NameID.REGEX.test(nameID);


### PR DESCRIPTION
This ok to add now to the server as the client should also now be checking for existing displayName in the collaboration