### PR TITLE
UUID_NAMEID for callout field resolver & subscription

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/apollo": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/domain/collaboration/callout/callout.resolver.subscriptions.ts
+++ b/src/domain/collaboration/callout/callout.resolver.subscriptions.ts
@@ -12,7 +12,7 @@ import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { SUBSCRIPTION_CALLOUT_ASPECT_CREATED } from '@common/constants/providers';
 import { CalloutService } from '@domain/collaboration/callout/callout.service';
 import { CalloutAspectCreated } from '@domain/collaboration/callout';
-import { UUID_NAMEID } from '@domain/common/scalars';
+import { UUID } from '@domain/common/scalars';
 
 @Resolver()
 export class CalloutResolverSubscriptions {
@@ -68,8 +68,8 @@ export class CalloutResolverSubscriptions {
     @CurrentUser() agentInfo: AgentInfo,
     @Args({
       name: 'calloutID',
-      type: () => UUID_NAMEID,
-      description: 'The ID or NameID of the Callout to subscribe to.',
+      type: () => UUID,
+      description: 'The ID of the Callout to subscribe to.',
       nullable: false,
     })
     calloutID: string

--- a/src/domain/collaboration/callout/callout.resolver.subscriptions.ts
+++ b/src/domain/collaboration/callout/callout.resolver.subscriptions.ts
@@ -7,12 +7,12 @@ import { Args, Resolver, Subscription } from '@nestjs/graphql';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { PubSubEngine } from 'graphql-subscriptions';
 import { LogContext } from '@common/enums/logging.context';
-import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { SUBSCRIPTION_CALLOUT_ASPECT_CREATED } from '@common/constants/providers';
 import { CalloutService } from '@domain/collaboration/callout/callout.service';
 import { CalloutAspectCreated } from '@domain/collaboration/callout';
+import { UUID_NAMEID } from '@domain/common/scalars';
 
 @Resolver()
 export class CalloutResolverSubscriptions {
@@ -68,8 +68,8 @@ export class CalloutResolverSubscriptions {
     @CurrentUser() agentInfo: AgentInfo,
     @Args({
       name: 'calloutID',
-      type: () => UUID,
-      description: 'The ID of the Callout to subscribe to.',
+      type: () => UUID_NAMEID,
+      description: 'The ID or NameID of the Callout to subscribe to.',
       nullable: false,
     })
     calloutID: string

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -26,6 +26,7 @@ import { limitAndShuffle } from '@common/utils';
 import { Canvas } from '@domain/common/canvas/canvas.entity';
 import { ICanvas } from '@domain/common/canvas/canvas.interface';
 import { NamingService } from '@src/services/domain/naming/naming.service';
+import { UUID_LENGTH } from '@common/constants/entity.field.length.constants';
 
 @Injectable()
 export class CalloutService {
@@ -50,10 +51,20 @@ export class CalloutService {
     calloutID: string,
     options?: FindOneOptions<Callout>
   ): Promise<ICallout> {
-    const callout = await this.calloutRepository.findOne(
-      { id: calloutID },
-      options
-    );
+    let callout: ICallout | undefined;
+    if (calloutID.length === UUID_LENGTH) {
+      callout = await this.calloutRepository.findOne(
+        { id: calloutID },
+        options
+      );
+    }
+    if (!callout) {
+      // look up based on nameID
+      callout = await this.calloutRepository.findOne(
+        { nameID: calloutID },
+        options
+      );
+    }
     if (!callout)
       throw new EntityNotFoundException(
         `No Callout found with the given id: ${calloutID}`,

--- a/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
+++ b/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
@@ -15,7 +15,7 @@ import { Collaboration } from '@domain/collaboration/collaboration/collaboration
 import { ICollaboration } from '@domain/collaboration/collaboration/collaboration.interface';
 import { CollaborationService } from '@domain/collaboration/collaboration/collaboration.service';
 import { ICallout } from '../callout/callout.interface';
-import { UUID } from '@domain/common/scalars';
+import { UUID_NAMEID } from '@domain/common/scalars';
 
 @Resolver(() => ICollaboration)
 export class CollaborationResolverFields {
@@ -46,7 +46,7 @@ export class CollaborationResolverFields {
     @Parent() collaboration: Collaboration,
     @Args({
       name: 'IDs',
-      type: () => [UUID],
+      type: () => [UUID_NAMEID],
       description: 'The IDs of the callouts to return',
       nullable: true,
     })

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -22,6 +22,7 @@ import { CredentialDefinition } from '@domain/agent/credential/credential.defini
 import { CalloutVisibility } from '@common/enums/callout.visibility';
 import { limitAndShuffle } from '@common/utils/limitAndShuffle';
 import { collaborationDefaults } from './collaboration.defaults';
+import { UUID_LENGTH } from '@common/constants/entity.field.length.constants';
 
 @Injectable()
 export class CollaborationService {
@@ -164,10 +165,18 @@ export class CollaborationService {
       return limitAndShuffled;
     }
     const results: ICallout[] = [];
+
     for (const calloutID of calloutIDs) {
-      const callout = collaborationLoaded.callouts.find(
-        callout => callout.id === calloutID
-      );
+      let callout;
+      if (calloutID.length === UUID_LENGTH)
+        callout = collaborationLoaded.callouts.find(
+          callout => callout.id === calloutID
+        );
+      else
+        callout = collaborationLoaded.callouts.find(
+          callout => callout.nameID === calloutID
+        );
+
       if (!callout)
         throw new EntityNotFoundException(
           `Callout with requested ID (${calloutID}) not located within current Collaboration: : ${collaboration.id}`,


### PR DESCRIPTION
- Extended CalloutService to be able to get Callout by UUID_NAMEID instead of only UUID 
- Extended CalloutAspectCreated subscription to accept UUID_NAMEID
- Extended Callout FieldResolver in Collaboration receive UUID_NAMEID

* Changes should be backwards compatible