### PR TITLE
added sortOrder to Callout and sort results based on it

### DIFF
--- a/src/domain/collaboration/callout/callout.entity.ts
+++ b/src/domain/collaboration/callout/callout.entity.ts
@@ -56,4 +56,7 @@ export class Callout extends NameableEntity implements ICallout {
     onDelete: 'CASCADE',
   })
   collaboration?: Collaboration;
+
+  @Column('int')
+  sortOrder!: number;
 }

--- a/src/domain/collaboration/callout/callout.interface.ts
+++ b/src/domain/collaboration/callout/callout.interface.ts
@@ -47,4 +47,10 @@ export abstract class ICallout extends INameable {
     description: 'The Comments object for this Callout.',
   })
   comments?: IComments;
+
+  @Field(() => Number, {
+    nullable: false,
+    description: 'The sorting order for this Callout.',
+  })
+  sortOrder!: number;
 }

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -94,6 +94,9 @@ export class CalloutService {
     if (calloutUpdateData.displayName)
       callout.displayName = calloutUpdateData.displayName;
 
+    if (calloutUpdateData.sortOrder)
+      callout.sortOrder = calloutUpdateData.sortOrder;
+
     return await this.calloutRepository.save(callout);
   }
 

--- a/src/domain/collaboration/callout/dto/callout.dto.create.ts
+++ b/src/domain/collaboration/callout/dto/callout.dto.create.ts
@@ -34,4 +34,10 @@ export class CreateCalloutInput extends CreateNameableInput {
     description: 'A readable identifier, unique within the containing scope.',
   })
   nameID!: string;
+
+  @Field(() => Number, {
+    nullable: true,
+    description: 'The sort order to assign to this Callout.',
+  })
+  sortOrder!: number;
 }

--- a/src/domain/collaboration/callout/dto/callout.dto.update.ts
+++ b/src/domain/collaboration/callout/dto/callout.dto.update.ts
@@ -32,4 +32,10 @@ export class UpdateCalloutInput extends UpdateNameableInput {
     description: 'Visibility of the Callout.',
   })
   visibility?: CalloutVisibility;
+
+  @Field(() => Number, {
+    nullable: true,
+    description: 'The sort order to assign to this Callout.',
+  })
+  sortOrder!: number;
 }

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -173,12 +173,19 @@ export class CollaborationService {
       );
 
     if (!calloutIDs) {
-      const limitAndShuffled = limitAndShuffle(
-        collaborationLoaded.callouts,
-        limit,
-        shuffle
+      if (shuffle) {
+        return limitAndShuffle(collaborationLoaded.callouts, limit, shuffle);
+      }
+      let results = collaborationLoaded.callouts;
+      if (limit) {
+        results = limitAndShuffle(collaborationLoaded.callouts, limit, false);
+      }
+
+      // Sort according to order
+      const sortedCallouts = results.sort((a, b) =>
+        a.sortOrder > b.sortOrder ? 1 : -1
       );
-      return limitAndShuffled;
+      return sortedCallouts;
     }
     const results: ICallout[] = [];
 

--- a/src/migrations/1662878852718-callout-order.ts
+++ b/src/migrations/1662878852718-callout-order.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class calloutOrder1662878852718 implements MigrationInterface {
+  name = 'calloutOrder1662878852718';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`callout\` ADD \`sortOrder\` int NOT NULL`
+    );
+    const callouts: any[] = await queryRunner.query(`SELECT id from callout`);
+    for (const callout of callouts) {
+      await queryRunner.query(
+        `UPDATE \`callout\` SET \`sortOrder\` = '1' WHERE \`id\`= '${callout.id}'`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`callout\` DROP COLUMN \`sortOrder\` `
+    );
+  }
+}

--- a/src/migrations/1662878852718-callout-order.ts
+++ b/src/migrations/1662878852718-callout-order.ts
@@ -10,7 +10,7 @@ export class calloutOrder1662878852718 implements MigrationInterface {
     const callouts: any[] = await queryRunner.query(`SELECT id from callout`);
     for (const callout of callouts) {
       await queryRunner.query(
-        `UPDATE \`callout\` SET \`sortOrder\` = '1' WHERE \`id\`= '${callout.id}'`
+        `UPDATE \`callout\` SET \`sortOrder\` = '10' WHERE \`id\`= '${callout.id}'`
       );
     }
   }


### PR DESCRIPTION
Migration to add sortOrder to callout entity
Update and Create DTOs for Callout now have an optional sortOrder parameter

Results are sorted based on sortOrder if shuffle is not specified as true.