### PR TITLE
Split PLATFORM_ADMIN from any ADMIN privileges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/apollo": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -8,6 +8,7 @@ export enum AuthorizationPrivilege {
   GRANT = 'grant', // allow the issuing / revoking of credentials of the same type within a given scope
   GRANT_GLOBAL_ADMINS = 'grant-global-admins',
   AUTHORIZATION_RESET = 'authorization-reset',
+  ADMIN = 'admin',
   PLATFORM_ADMIN = 'platform-admin', // To determine if the user should have access to the platform administration
   CREATE_CANVAS = 'create-canvas',
   CREATE_ASPECT = 'create-aspect',

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -394,6 +394,14 @@ export class AuthorizationPolicyService {
     challengeAdminsNotInherited.inheritable = false;
     credentialRules.push(challengeAdminsNotInherited);
 
+    // Allow Opportunity admins to access admin
+    const opportunityAdminNotInherited = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.ADMIN],
+      AuthorizationCredential.OPPORTUNITY_ADMIN
+    );
+    opportunityAdminNotInherited.inheritable = false;
+    credentialRules.push(opportunityAdminNotInherited);
+
     // Allow Organization admins to access platform admin
     const organizationAdminsNotInherited =
       new AuthorizationPolicyRuleCredential(

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -340,6 +340,7 @@ export class AuthorizationPolicyService {
       [
         AuthorizationPrivilege.GRANT_GLOBAL_ADMINS,
         AuthorizationPrivilege.PLATFORM_ADMIN,
+        AuthorizationPrivilege.ADMIN,
       ],
       AuthorizationCredential.GLOBAL_ADMIN
     );
@@ -348,7 +349,7 @@ export class AuthorizationPolicyService {
 
     // Allow global admin Hubs to access Platform mgmt
     const globalAdminHubsNotInherited = new AuthorizationPolicyRuleCredential(
-      [AuthorizationPrivilege.PLATFORM_ADMIN],
+      [AuthorizationPrivilege.PLATFORM_ADMIN, AuthorizationPrivilege.ADMIN],
       AuthorizationCredential.GLOBAL_ADMIN_HUBS
     );
     globalAdminHubsNotInherited.inheritable = false;
@@ -357,7 +358,7 @@ export class AuthorizationPolicyService {
     // Allow global admin Communities to access Platform mgmt
     const globalAdminCommunitiesNotInherited =
       new AuthorizationPolicyRuleCredential(
-        [AuthorizationPrivilege.PLATFORM_ADMIN],
+        [AuthorizationPrivilege.PLATFORM_ADMIN, AuthorizationPrivilege.ADMIN],
         AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
       );
     globalAdminCommunitiesNotInherited.inheritable = false;
@@ -375,7 +376,7 @@ export class AuthorizationPolicyService {
     const hubAdminsNotInherited = new AuthorizationPolicyRuleCredential(
       [
         AuthorizationPrivilege.CREATE_ORGANIZATION,
-        AuthorizationPrivilege.PLATFORM_ADMIN,
+        AuthorizationPrivilege.ADMIN,
       ],
       AuthorizationCredential.HUB_ADMIN
     );
@@ -386,7 +387,7 @@ export class AuthorizationPolicyService {
     const challengeAdminsNotInherited = new AuthorizationPolicyRuleCredential(
       [
         AuthorizationPrivilege.CREATE_ORGANIZATION,
-        AuthorizationPrivilege.PLATFORM_ADMIN,
+        AuthorizationPrivilege.ADMIN,
       ],
       AuthorizationCredential.CHALLENGE_ADMIN
     );
@@ -396,7 +397,7 @@ export class AuthorizationPolicyService {
     // Allow Organization admins to access platform admin
     const organizationAdminsNotInherited =
       new AuthorizationPolicyRuleCredential(
-        [AuthorizationPrivilege.PLATFORM_ADMIN],
+        [AuthorizationPrivilege.ADMIN],
         AuthorizationCredential.ORGANIZATION_ADMIN
       );
     organizationAdminsNotInherited.inheritable = false;


### PR DESCRIPTION
- Split `PLATFORM_ADMIN` from ` any `ADMIN` `AuthorizationPrivilege`
- `OPPORTUNITY_ADMIN` was omitted from the `credentialRules`. Added it and made a `credentialRule` with it assigning it `ADMIN` `AuthorizationPrivilege`

Currently, the client PR https://github.com/alkem-io/client-web/pull/2606 maps the top right menu `Admin` to `ADMIN` `AuthorizationPrivilege`, effectively any admin, including `OPPORTUNITY_ADMIN`