### PR TITLE
isolated platform authorization 

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -46,7 +46,6 @@ import { RedisLockModule } from '@core/caching/redis/redis.lock.module';
 import { ConversionModule } from '@services/domain/conversion/conversion.module';
 import { SessionExtendMiddleware } from '@src/core/middleware';
 import { ActivityLogModule } from '@services/domain/activity-log/activity.log.module';
-import { PlatformAuthorizationModule } from './platform/authorization/platform.authorization.module';
 
 @Module({
   imports: [
@@ -184,7 +183,6 @@ import { PlatformAuthorizationModule } from './platform/authorization/platform.a
     AuthorizationModule,
     HubModule,
     MetadataModule,
-    PlatformAuthorizationModule,
     BootstrapModule,
     SearchModule,
     ActivityLogModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -46,6 +46,7 @@ import { RedisLockModule } from '@core/caching/redis/redis.lock.module';
 import { ConversionModule } from '@services/domain/conversion/conversion.module';
 import { SessionExtendMiddleware } from '@src/core/middleware';
 import { ActivityLogModule } from '@services/domain/activity-log/activity.log.module';
+import { PlatformAuthorizationModule } from './platform/authorization/platform.authorization.module';
 
 @Module({
   imports: [
@@ -183,6 +184,7 @@ import { ActivityLogModule } from '@services/domain/activity-log/activity.log.mo
     AuthorizationModule,
     HubModule,
     MetadataModule,
+    PlatformAuthorizationModule,
     BootstrapModule,
     SearchModule,
     ActivityLogModule,

--- a/src/domain/challenge/hub/hub.module.ts
+++ b/src/domain/challenge/hub/hub.module.ts
@@ -25,6 +25,7 @@ import { UserModule } from '@domain/community/user/user.module';
 import { PreferenceModule } from '@domain/common/preference';
 import { PreferenceSetModule } from '@domain/common/preference-set/preference.set.module';
 import { TemplatesSetModule } from '@domain/template/templates-set/templates.set.module';
+import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { TemplatesSetModule } from '@domain/template/templates-set/templates.set
     BaseChallengeModule,
     LifecycleModule,
     OpportunityModule,
+    PlatformAuthorizationModule,
     ProjectModule,
     OrganizationModule,
     TagsetModule,

--- a/src/domain/challenge/hub/hub.resolver.mutations.ts
+++ b/src/domain/challenge/hub/hub.resolver.mutations.ts
@@ -20,7 +20,6 @@ import { AssignHubAdminInput } from './dto/hub.dto.assign.admin';
 import { RemoveHubAdminInput } from './dto/hub.dto.remove.admin';
 import { HubAuthorizationResetInput } from './dto/hub.dto.reset.authorization';
 import { CreateChallengeOnHubInput } from '../challenge/dto/challenge.dto.create.in.hub';
-import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { PreferenceService } from '@domain/common/preference/preference.service';
 import { IPreference } from '@domain/common/preference/preference.interface';
 import { PreferenceDefinitionSet } from '@common/enums/preference.definition.set';
@@ -28,17 +27,18 @@ import { UpdateHubPreferenceInput } from './dto/hub.dto.update.preference';
 import { PreferenceSetService } from '@domain/common/preference-set/preference.set.service';
 import { UpdateChallengePreferenceInput } from '@domain/challenge/challenge/dto/challenge.dto.update.preference';
 import { ChallengeService } from '@domain/challenge/challenge/challenge.service';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 @Resolver()
 export class HubResolverMutations {
   constructor(
     private authorizationService: AuthorizationService,
-    private authorizationPolicyService: AuthorizationPolicyService,
     private hubService: HubService,
     private hubAuthorizationService: HubAuthorizationService,
     private challengeService: ChallengeService,
     private challengeAuthorizationService: ChallengeAuthorizationService,
     private preferenceService: PreferenceService,
-    private preferenceSetService: PreferenceSetService
+    private preferenceSetService: PreferenceSetService,
+    private platformAuthorizationService: PlatformAuthorizationService
   ) {}
 
   @UseGuards(GraphqlGuard)
@@ -51,7 +51,7 @@ export class HubResolverMutations {
     @Args('hubData') hubData: CreateHubInput
   ): Promise<IHub> {
     const authorizationPolicy =
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy();
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy();
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
       authorizationPolicy,

--- a/src/domain/challenge/hub/hub.service.authorization.ts
+++ b/src/domain/challenge/hub/hub.service.authorization.ts
@@ -19,6 +19,7 @@ import { PreferenceSetAuthorizationService } from '@domain/common/preference-set
 import { PreferenceSetService } from '@domain/common/preference-set/preference.set.service';
 import { IPreferenceSet } from '@domain/common/preference-set';
 import { TemplatesSetAuthorizationService } from '@domain/template/templates-set/templates.set.service.authorization';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Injectable()
 export class HubAuthorizationService {
@@ -29,6 +30,7 @@ export class HubAuthorizationService {
     private templatesSetAuthorizationService: TemplatesSetAuthorizationService,
     private preferenceSetAuthorizationService: PreferenceSetAuthorizationService,
     private preferenceSetService: PreferenceSetService,
+    private platformAuthorizationService: PlatformAuthorizationService,
     private hubService: HubService,
     @InjectRepository(Hub)
     private hubRepository: Repository<Hub>
@@ -42,7 +44,7 @@ export class HubAuthorizationService {
       hub.authorization
     );
     hub.authorization =
-      this.authorizationPolicyService.inheritPlatformAuthorization(
+      this.platformAuthorizationService.inheritPlatformAuthorization(
         hub.authorization
       );
     hub.authorization = this.extendAuthorizationPolicy(

--- a/src/domain/common/authorization-policy/authorization.policy.module.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthorizationPolicy } from './authorization.policy.entity';
 import { AuthorizationPolicyResolverFields } from './authorization.policy.resolver.fields';
-import { AuthorizationPolicyResolverQueries } from './authorization.policy.resolver.queries';
+
 import { AuthorizationPolicyService } from './authorization.policy.service';
 
 @Module({
@@ -11,11 +11,7 @@ import { AuthorizationPolicyService } from './authorization.policy.service';
     AuthorizationModule,
     TypeOrmModule.forFeature([AuthorizationPolicy]),
   ],
-  providers: [
-    AuthorizationPolicyService,
-    AuthorizationPolicyResolverFields,
-    AuthorizationPolicyResolverQueries,
-  ],
+  providers: [AuthorizationPolicyService, AuthorizationPolicyResolverFields],
   exports: [AuthorizationPolicyService],
 })
 export class AuthorizationPolicyModule {}

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -27,17 +27,13 @@ import { IAuthorizationPolicyRuleVerifiedCredential } from '@core/authorization/
 
 @Injectable()
 export class AuthorizationPolicyService {
-  private platformAuthorizationPolicy: IAuthorizationPolicy;
-
   constructor(
     @InjectRepository(AuthorizationPolicy)
     private authorizationPolicyRepository: Repository<AuthorizationPolicy>,
     private authorizationService: AuthorizationService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
-  ) {
-    this.platformAuthorizationPolicy = this.createPlatformAuthorizationPolicy();
-  }
+  ) {}
 
   reset(
     authorizationPolicy: IAuthorizationPolicy | undefined
@@ -166,15 +162,6 @@ export class AuthorizationPolicyService {
     return auth;
   }
 
-  inheritPlatformAuthorization(
-    childAuthorization: IAuthorizationPolicy | undefined
-  ): IAuthorizationPolicy {
-    return this.inheritParentAuthorization(
-      childAuthorization,
-      this.platformAuthorizationPolicy
-    );
-  }
-
   inheritParentAuthorization(
     childAuthorization: IAuthorizationPolicy | undefined,
     parentAuthorization: IAuthorizationPolicy | undefined
@@ -289,147 +276,5 @@ export class AuthorizationPolicyService {
     this.appendCredentialAuthorizationRules(authorization, newRules);
 
     return authorization;
-  }
-
-  private createPlatformAuthorizationPolicy(): IAuthorizationPolicy {
-    const platformAuthorization = new AuthorizationPolicy();
-
-    const credentialRules = this.createPlatformCredentialRules();
-
-    const platformAuthCredRules = this.appendCredentialAuthorizationRules(
-      platformAuthorization,
-      credentialRules
-    );
-
-    const privilegeRules = this.createPrivilegeRules();
-    return this.appendPrivilegeAuthorizationRules(
-      platformAuthCredRules,
-      privilegeRules
-    );
-  }
-
-  private createPlatformCredentialRules(): AuthorizationPolicyRuleCredential[] {
-    const credentialRules: AuthorizationPolicyRuleCredential[] = [];
-
-    const globalAdmin = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE,
-        AuthorizationPrivilege.GRANT,
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-        AuthorizationPrivilege.DELETE,
-      ],
-      AuthorizationCredential.GLOBAL_ADMIN
-    );
-    credentialRules.push(globalAdmin);
-
-    const globalHubsAdmin = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE,
-        AuthorizationPrivilege.GRANT,
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-        AuthorizationPrivilege.DELETE,
-      ],
-      AuthorizationCredential.GLOBAL_ADMIN_HUBS
-    );
-    credentialRules.push(globalHubsAdmin);
-
-    // Allow global admins to manage global privileges, access Platform mgmt
-    const globalAdminNotInherited = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.GRANT_GLOBAL_ADMINS,
-        AuthorizationPrivilege.PLATFORM_ADMIN,
-        AuthorizationPrivilege.ADMIN,
-      ],
-      AuthorizationCredential.GLOBAL_ADMIN
-    );
-    globalAdminNotInherited.inheritable = false;
-    credentialRules.push(globalAdminNotInherited);
-
-    // Allow global admin Hubs to access Platform mgmt
-    const globalAdminHubsNotInherited = new AuthorizationPolicyRuleCredential(
-      [AuthorizationPrivilege.PLATFORM_ADMIN, AuthorizationPrivilege.ADMIN],
-      AuthorizationCredential.GLOBAL_ADMIN_HUBS
-    );
-    globalAdminHubsNotInherited.inheritable = false;
-    credentialRules.push(globalAdminHubsNotInherited);
-
-    // Allow global admin Communities to access Platform mgmt
-    const globalAdminCommunitiesNotInherited =
-      new AuthorizationPolicyRuleCredential(
-        [AuthorizationPrivilege.PLATFORM_ADMIN, AuthorizationPrivilege.ADMIN],
-        AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
-      );
-    globalAdminCommunitiesNotInherited.inheritable = false;
-    credentialRules.push(globalAdminCommunitiesNotInherited);
-
-    // Allow all registered users to query non-protected user information
-    const userNotInherited = new AuthorizationPolicyRuleCredential(
-      [AuthorizationPrivilege.READ_USERS],
-      AuthorizationCredential.GLOBAL_REGISTERED
-    );
-    userNotInherited.inheritable = false;
-    credentialRules.push(userNotInherited);
-
-    // Allow hub admins to create new organizations
-    const hubAdminsNotInherited = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE_ORGANIZATION,
-        AuthorizationPrivilege.ADMIN,
-      ],
-      AuthorizationCredential.HUB_ADMIN
-    );
-    hubAdminsNotInherited.inheritable = false;
-    credentialRules.push(hubAdminsNotInherited);
-
-    // Allow challenge admins to create new organizations + access platform admin
-    const challengeAdminsNotInherited = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE_ORGANIZATION,
-        AuthorizationPrivilege.ADMIN,
-      ],
-      AuthorizationCredential.CHALLENGE_ADMIN
-    );
-    challengeAdminsNotInherited.inheritable = false;
-    credentialRules.push(challengeAdminsNotInherited);
-
-    // Allow Opportunity admins to access admin
-    const opportunityAdminNotInherited = new AuthorizationPolicyRuleCredential(
-      [AuthorizationPrivilege.ADMIN],
-      AuthorizationCredential.OPPORTUNITY_ADMIN
-    );
-    opportunityAdminNotInherited.inheritable = false;
-    credentialRules.push(opportunityAdminNotInherited);
-
-    // Allow Organization admins to access platform admin
-    const organizationAdminsNotInherited =
-      new AuthorizationPolicyRuleCredential(
-        [AuthorizationPrivilege.ADMIN],
-        AuthorizationCredential.ORGANIZATION_ADMIN
-      );
-    organizationAdminsNotInherited.inheritable = false;
-    credentialRules.push(organizationAdminsNotInherited);
-
-    return credentialRules;
-  }
-
-  private createPrivilegeRules(): AuthorizationPolicyRulePrivilege[] {
-    const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
-
-    const createPrivilege = new AuthorizationPolicyRulePrivilege(
-      [
-        AuthorizationPrivilege.CREATE_HUB,
-        AuthorizationPrivilege.CREATE_ORGANIZATION,
-      ],
-      AuthorizationPrivilege.CREATE
-    );
-    privilegeRules.push(createPrivilege);
-
-    return privilegeRules;
-  }
-
-  getPlatformAuthorizationPolicy(): IAuthorizationPolicy {
-    return this.platformAuthorizationPolicy;
   }
 }

--- a/src/domain/community/organization/organization.module.ts
+++ b/src/domain/community/organization/organization.module.ts
@@ -18,6 +18,7 @@ import { OrganizationVerificationModule } from '../organization-verification/org
 import { PreferenceModule } from '@domain/common/preference';
 import { PreferenceSetModule } from '@domain/common/preference-set/preference.set.module';
 import { OrganizationDataloaderService } from './organization.dataloader.service';
+import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { OrganizationDataloaderService } from './organization.dataloader.service
     UserGroupModule,
     TagsetModule,
     NamingModule,
+    PlatformAuthorizationModule,
     ProfileModule,
     PreferenceModule,
     PreferenceSetModule,

--- a/src/domain/community/organization/organization.resolver.mutations.ts
+++ b/src/domain/community/organization/organization.resolver.mutations.ts
@@ -13,7 +13,6 @@ import { GraphqlGuard } from '@core/authorization';
 import { AuthorizationPrivilege } from '@common/enums';
 import { OrganizationAuthorizationService } from './organization.service.authorization';
 import { AgentInfo } from '@core/authentication/agent-info';
-import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IUser } from '@domain/community/user/user.interface';
 import { OrganizationAuthorizationResetInput } from './dto/organization.dto.reset.authorization';
 import { UserGroupAuthorizationService } from '../user-group/user-group.service.authorization';
@@ -29,17 +28,18 @@ import { PreferenceDefinitionSet } from '@common/enums/preference.definition.set
 import { UpdateOrganizationPreferenceInput } from '@domain/community/organization/dto/organization.dto.update.preference';
 import { PreferenceSetService } from '@domain/common/preference-set/preference.set.service';
 import { CreateUserGroupInput } from '../user-group/dto';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Resolver(() => IOrganization)
 export class OrganizationResolverMutations {
   constructor(
-    private authorizationPolicyService: AuthorizationPolicyService,
     private userGroupAuthorizationService: UserGroupAuthorizationService,
     private organizationAuthorizationService: OrganizationAuthorizationService,
     private organizationService: OrganizationService,
     private authorizationService: AuthorizationService,
     private preferenceService: PreferenceService,
-    private preferenceSetService: PreferenceSetService
+    private preferenceSetService: PreferenceSetService,
+    private platformAuthorizationService: PlatformAuthorizationService
   ) {}
 
   @UseGuards(GraphqlGuard)
@@ -52,7 +52,7 @@ export class OrganizationResolverMutations {
     @Args('organizationData') organizationData: CreateOrganizationInput
   ): Promise<IOrganization> {
     const authorizationPolicy =
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy();
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy();
 
     await this.authorizationService.grantAccessOrFail(
       agentInfo,

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -13,6 +13,7 @@ import { UserGroupAuthorizationService } from '../user-group/user-group.service.
 import { OrganizationVerificationAuthorizationService } from '../organization-verification/organization.verification.service.authorization';
 import { AuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential';
 import { PreferenceSetAuthorizationService } from '@domain/common/preference-set/preference.set.service.authorization';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Injectable()
 export class OrganizationAuthorizationService {
@@ -22,6 +23,7 @@ export class OrganizationAuthorizationService {
     private authorizationPolicyService: AuthorizationPolicyService,
     private userGroupAuthorizationService: UserGroupAuthorizationService,
     private organizationVerificationAuthorizationService: OrganizationVerificationAuthorizationService,
+    private platformAuthorizationService: PlatformAuthorizationService,
     private profileAuthorizationService: ProfileAuthorizationService,
     private preferenceSetAuthorizationService: PreferenceSetAuthorizationService,
     @InjectRepository(Organization)
@@ -35,7 +37,7 @@ export class OrganizationAuthorizationService {
       organization.authorization
     );
     organization.authorization =
-      this.authorizationPolicyService.inheritPlatformAuthorization(
+      this.platformAuthorizationService.inheritPlatformAuthorization(
         organization.authorization
       );
     organization.authorization = this.appendCredentialRules(

--- a/src/domain/community/user/user.module.ts
+++ b/src/domain/community/user/user.module.ts
@@ -20,6 +20,7 @@ import { ConfigModule } from '@nestjs/config';
 import { PreferenceSetModule } from '@domain/common/preference-set/preference.set.module';
 import { PreferenceModule } from '@domain/common/preference';
 import { UserDataloaderService } from './user.dataloader.service';
+import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { UserDataloaderService } from './user.dataloader.service';
     IdentityResolverModule,
     RoomModule,
     MicroservicesModule,
+    PlatformAuthorizationModule,
     PreferenceModule,
     PreferenceSetModule,
     KonfigModule,

--- a/src/domain/community/user/user.resolver.mutations.ts
+++ b/src/domain/community/user/user.resolver.mutations.ts
@@ -20,22 +20,22 @@ import { ClientProxy } from '@nestjs/microservices';
 import { EventType } from '@common/enums/event.type';
 import { NotificationsPayloadBuilder } from '@core/microservices';
 import { NOTIFICATIONS_SERVICE } from '@common/constants/providers';
-import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IPreference } from '@domain/common/preference/preference.interface';
 import { PreferenceService } from '@domain/common/preference';
 import { UpdateUserPreferenceInput } from './dto/user.dto.update.preference';
 import { PreferenceSetService } from '@domain/common/preference-set/preference.set.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Resolver(() => IUser)
 export class UserResolverMutations {
   constructor(
     private communicationAdapter: CommunicationAdapter,
     private authorizationService: AuthorizationService,
-    private authorizationPolicyService: AuthorizationPolicyService,
     private userService: UserService,
     private userAuthorizationService: UserAuthorizationService,
     private notificationsPayloadBuilder: NotificationsPayloadBuilder,
+    private platformAuthorizationService: PlatformAuthorizationService,
     private preferenceService: PreferenceService,
     private preferenceSetService: PreferenceSetService,
     @Inject(NOTIFICATIONS_SERVICE) private notificationsClient: ClientProxy,
@@ -53,7 +53,7 @@ export class UserResolverMutations {
     @Args('userData') userData: CreateUserInput
   ): Promise<IUser> {
     const authorization =
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy();
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy();
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
       authorization,

--- a/src/domain/community/user/user.resolver.queries.ts
+++ b/src/domain/community/user/user.resolver.queries.ts
@@ -6,7 +6,6 @@ import { GraphqlGuard } from '@core/authorization';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AgentService } from '@domain/agent/agent/agent.service';
 import { CredentialMetadataOutput } from '@domain/agent/verified-credential/dto/verified.credential.dto.metadata';
-import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
 import { UseGuards } from '@nestjs/common';
 import { Args, Float, Query, Resolver } from '@nestjs/graphql';
@@ -16,12 +15,13 @@ import { PaginationArgs, PaginatedUsers } from '@core/pagination';
 import { UserService } from './user.service';
 import { IUser } from './';
 import { UserFilterInput } from '@core/filtering';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Resolver(() => IUser)
 export class UserResolverQueries {
   constructor(
     private authorizationService: AuthorizationService,
-    private authorizationPolicyService: AuthorizationPolicyService,
+    private platformAuthorizationService: PlatformAuthorizationService,
     private userService: UserService,
     private agentService: AgentService
   ) {}
@@ -53,7 +53,7 @@ export class UserResolverQueries {
   ): Promise<IUser[]> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
       AuthorizationPrivilege.READ_USERS,
       `users query: ${agentInfo.email}`
     );
@@ -73,7 +73,7 @@ export class UserResolverQueries {
   ): Promise<PaginatedUsers> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
       AuthorizationPrivilege.READ_USERS,
       `users query: ${agentInfo.email}`
     );
@@ -93,7 +93,7 @@ export class UserResolverQueries {
   ): Promise<IUser> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
       AuthorizationPrivilege.READ_USERS,
       `user query: ${agentInfo.email}`
     );
@@ -112,7 +112,7 @@ export class UserResolverQueries {
   ): Promise<IUser[]> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
       AuthorizationPrivilege.READ_USERS,
       `users query: ${agentInfo.email}`
     );

--- a/src/domain/community/user/user.resolver.spec.ts
+++ b/src/domain/community/user/user.resolver.spec.ts
@@ -13,6 +13,7 @@ import { MockNotificationsPayloadBuilder } from '@test/mocks/notifications.paylo
 import { MockPreferenceService } from '@test/mocks/preference.service.mock';
 import { MockPreferenceSetService } from '@test/mocks/preference.set.service.mock';
 import { MockNotificationsService } from '@test/mocks/notifications.service.mock';
+import { MockPlatformAuthorizationService } from '@test/mocks/platform.authorization.service.mock';
 
 describe('UserResolver', () => {
   let resolver: UserResolverQueries;
@@ -27,6 +28,7 @@ describe('UserResolver', () => {
         MockAgentService,
         MockAuthorizationService,
         MockAuthorizationPolicyService,
+        MockPlatformAuthorizationService,
         MockCommunicationAdapter,
         MockUserAuthorizationService,
         MockNotificationsPayloadBuilder,

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -13,12 +13,14 @@ import { EntityNotInitializedException } from '@common/exceptions';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { AuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential';
 import { PreferenceSetAuthorizationService } from '@domain/common/preference-set/preference.set.service.authorization';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Injectable()
 export class UserAuthorizationService {
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
     private profileAuthorizationService: ProfileAuthorizationService,
+    private platformAuthorizationService: PlatformAuthorizationService,
     private preferenceSetAuthorizationService: PreferenceSetAuthorizationService,
     private agentService: AgentService,
     private userService: UserService
@@ -30,7 +32,7 @@ export class UserAuthorizationService {
       user.authorization
     );
     user.authorization =
-      this.authorizationPolicyService.inheritPlatformAuthorization(
+      this.platformAuthorizationService.inheritPlatformAuthorization(
         user.authorization
       );
 

--- a/src/platform/authorization/platform.authorization.module.ts
+++ b/src/platform/authorization/platform.authorization.module.ts
@@ -1,0 +1,14 @@
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { Module } from '@nestjs/common';
+import { PlatformAuthorizationResolverQueries } from './platform.authorization.resolver.queries';
+import { PlatformAuthorizationService } from './platform.authorization.service';
+
+@Module({
+  imports: [AuthorizationPolicyModule],
+  providers: [
+    PlatformAuthorizationService,
+    PlatformAuthorizationResolverQueries,
+  ],
+  exports: [PlatformAuthorizationService, PlatformAuthorizationResolverQueries],
+})
+export class PlatformAuthorizationModule {}

--- a/src/platform/authorization/platform.authorization.resolver.queries.ts
+++ b/src/platform/authorization/platform.authorization.resolver.queries.ts
@@ -1,11 +1,13 @@
 import { Resolver, Query } from '@nestjs/graphql';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { Profiling } from '@common/decorators/profiling.decorator';
-import { AuthorizationPolicyService } from './authorization.policy.service';
+import { PlatformAuthorizationService } from './platform.authorization.service';
 
 @Resolver()
-export class AuthorizationPolicyResolverQueries {
-  constructor(private authorizationPolicyService: AuthorizationPolicyService) {}
+export class PlatformAuthorizationResolverQueries {
+  constructor(
+    private platformAuthorizationService: PlatformAuthorizationService
+  ) {}
 
   @Query(() => IAuthorizationPolicy, {
     nullable: false,
@@ -13,6 +15,6 @@ export class AuthorizationPolicyResolverQueries {
   })
   @Profiling.api
   authorization(): IAuthorizationPolicy {
-    return this.authorizationPolicyService.getPlatformAuthorizationPolicy();
+    return this.platformAuthorizationService.getPlatformAuthorizationPolicy();
   }
 }

--- a/src/platform/authorization/platform.authorization.service.ts
+++ b/src/platform/authorization/platform.authorization.service.ts
@@ -8,17 +8,17 @@ import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorizat
 
 @Injectable()
 export class PlatformAuthorizationService {
-  private platformAuthorizationPolicy: IAuthorizationPolicy;
+  private readonly platformAuthorizationPolicy: IAuthorizationPolicy;
 
   constructor(private authorizationPolicyService: AuthorizationPolicyService) {
     this.platformAuthorizationPolicy = this.createPlatformAuthorizationPolicy();
   }
 
-  getPlatformAuthorizationPolicy(): IAuthorizationPolicy {
+  public getPlatformAuthorizationPolicy(): IAuthorizationPolicy {
     return this.platformAuthorizationPolicy;
   }
 
-  inheritPlatformAuthorization(
+  public inheritPlatformAuthorization(
     childAuthorization: IAuthorizationPolicy | undefined
   ): IAuthorizationPolicy {
     return this.authorizationPolicyService.inheritParentAuthorization(

--- a/src/platform/authorization/platform.authorization.service.ts
+++ b/src/platform/authorization/platform.authorization.service.ts
@@ -1,0 +1,168 @@
+import { Injectable } from '@nestjs/common';
+import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
+import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
+import { AuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
+
+@Injectable()
+export class PlatformAuthorizationService {
+  private platformAuthorizationPolicy: IAuthorizationPolicy;
+
+  constructor(private authorizationPolicyService: AuthorizationPolicyService) {
+    this.platformAuthorizationPolicy = this.createPlatformAuthorizationPolicy();
+  }
+
+  getPlatformAuthorizationPolicy(): IAuthorizationPolicy {
+    return this.platformAuthorizationPolicy;
+  }
+
+  inheritPlatformAuthorization(
+    childAuthorization: IAuthorizationPolicy | undefined
+  ): IAuthorizationPolicy {
+    return this.authorizationPolicyService.inheritParentAuthorization(
+      childAuthorization,
+      this.platformAuthorizationPolicy
+    );
+  }
+
+  private createPlatformAuthorizationPolicy(): IAuthorizationPolicy {
+    const platformAuthorization = new AuthorizationPolicy();
+
+    const credentialRules = this.createPlatformCredentialRules();
+
+    const platformAuthCredRules =
+      this.authorizationPolicyService.appendCredentialAuthorizationRules(
+        platformAuthorization,
+        credentialRules
+      );
+
+    const privilegeRules = this.createPrivilegeRules();
+    return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
+      platformAuthCredRules,
+      privilegeRules
+    );
+  }
+
+  private createPlatformCredentialRules(): AuthorizationPolicyRuleCredential[] {
+    const credentialRules: AuthorizationPolicyRuleCredential[] = [];
+
+    const globalAdmin = new AuthorizationPolicyRuleCredential(
+      [
+        AuthorizationPrivilege.CREATE,
+        AuthorizationPrivilege.GRANT,
+        AuthorizationPrivilege.READ,
+        AuthorizationPrivilege.UPDATE,
+        AuthorizationPrivilege.DELETE,
+      ],
+      AuthorizationCredential.GLOBAL_ADMIN
+    );
+    credentialRules.push(globalAdmin);
+
+    const globalHubsAdmin = new AuthorizationPolicyRuleCredential(
+      [
+        AuthorizationPrivilege.CREATE,
+        AuthorizationPrivilege.GRANT,
+        AuthorizationPrivilege.READ,
+        AuthorizationPrivilege.UPDATE,
+        AuthorizationPrivilege.DELETE,
+      ],
+      AuthorizationCredential.GLOBAL_ADMIN_HUBS
+    );
+    credentialRules.push(globalHubsAdmin);
+
+    // Allow global admins to manage global privileges, access Platform mgmt
+    const globalAdminNotInherited = new AuthorizationPolicyRuleCredential(
+      [
+        AuthorizationPrivilege.GRANT_GLOBAL_ADMINS,
+        AuthorizationPrivilege.PLATFORM_ADMIN,
+        AuthorizationPrivilege.ADMIN,
+      ],
+      AuthorizationCredential.GLOBAL_ADMIN
+    );
+    globalAdminNotInherited.inheritable = false;
+    credentialRules.push(globalAdminNotInherited);
+
+    // Allow global admin Hubs to access Platform mgmt
+    const globalAdminHubsNotInherited = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.PLATFORM_ADMIN, AuthorizationPrivilege.ADMIN],
+      AuthorizationCredential.GLOBAL_ADMIN_HUBS
+    );
+    globalAdminHubsNotInherited.inheritable = false;
+    credentialRules.push(globalAdminHubsNotInherited);
+
+    // Allow global admin Communities to access Platform mgmt
+    const globalAdminCommunitiesNotInherited =
+      new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.PLATFORM_ADMIN, AuthorizationPrivilege.ADMIN],
+        AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY
+      );
+    globalAdminCommunitiesNotInherited.inheritable = false;
+    credentialRules.push(globalAdminCommunitiesNotInherited);
+
+    // Allow all registered users to query non-protected user information
+    const userNotInherited = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.READ_USERS],
+      AuthorizationCredential.GLOBAL_REGISTERED
+    );
+    userNotInherited.inheritable = false;
+    credentialRules.push(userNotInherited);
+
+    // Allow hub admins to create new organizations
+    const hubAdminsNotInherited = new AuthorizationPolicyRuleCredential(
+      [
+        AuthorizationPrivilege.CREATE_ORGANIZATION,
+        AuthorizationPrivilege.ADMIN,
+      ],
+      AuthorizationCredential.HUB_ADMIN
+    );
+    hubAdminsNotInherited.inheritable = false;
+    credentialRules.push(hubAdminsNotInherited);
+
+    // Allow challenge admins to create new organizations + access platform admin
+    const challengeAdminsNotInherited = new AuthorizationPolicyRuleCredential(
+      [
+        AuthorizationPrivilege.CREATE_ORGANIZATION,
+        AuthorizationPrivilege.ADMIN,
+      ],
+      AuthorizationCredential.CHALLENGE_ADMIN
+    );
+    challengeAdminsNotInherited.inheritable = false;
+    credentialRules.push(challengeAdminsNotInherited);
+
+    // Allow Opportunity admins to access admin
+    const opportunityAdminNotInherited = new AuthorizationPolicyRuleCredential(
+      [AuthorizationPrivilege.ADMIN],
+      AuthorizationCredential.OPPORTUNITY_ADMIN
+    );
+    opportunityAdminNotInherited.inheritable = false;
+    credentialRules.push(opportunityAdminNotInherited);
+
+    // Allow Organization admins to access platform admin
+    const organizationAdminsNotInherited =
+      new AuthorizationPolicyRuleCredential(
+        [AuthorizationPrivilege.ADMIN],
+        AuthorizationCredential.ORGANIZATION_ADMIN
+      );
+    organizationAdminsNotInherited.inheritable = false;
+    credentialRules.push(organizationAdminsNotInherited);
+
+    return credentialRules;
+  }
+
+  private createPrivilegeRules(): AuthorizationPolicyRulePrivilege[] {
+    const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
+
+    const createPrivilege = new AuthorizationPolicyRulePrivilege(
+      [
+        AuthorizationPrivilege.CREATE_HUB,
+        AuthorizationPrivilege.CREATE_ORGANIZATION,
+      ],
+      AuthorizationPrivilege.CREATE
+    );
+    privilegeRules.push(createPrivilege);
+
+    return privilegeRules;
+  }
+}

--- a/src/services/admin/authorization/admin.authorization.module.ts
+++ b/src/services/admin/authorization/admin.authorization.module.ts
@@ -7,6 +7,7 @@ import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { AdminAuthorizationResolverMutations } from './admin.authorization.resolver.mutations';
 import { AdminAuthorizationResolverQueries } from './admin.authorization.resolver.queries';
 import { AdminAuthorizationService } from './admin.authorization.service';
+import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AdminAuthorizationService } from './admin.authorization.service';
     AgentModule,
     UserModule,
     CredentialModule,
+    PlatformAuthorizationModule,
   ],
   providers: [
     AdminAuthorizationService,

--- a/src/services/admin/authorization/admin.authorization.resolver.queries.ts
+++ b/src/services/admin/authorization/admin.authorization.resolver.queries.ts
@@ -9,14 +9,14 @@ import { AuthorizationService } from '@core/authorization/authorization.service'
 import { AgentInfo } from '@core/authentication/agent-info';
 import { AdminAuthorizationService } from './admin.authorization.service';
 import { UsersWithAuthorizationCredentialInput } from './dto/authorization.dto.users.with.credential';
-import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Resolver()
 export class AdminAuthorizationResolverQueries {
   constructor(
-    private authorizationPolicyService: AuthorizationPolicyService,
     private authorizationService: AuthorizationService,
-    private adminAuthorizationService: AdminAuthorizationService
+    private adminAuthorizationService: AdminAuthorizationService,
+    private platformAuthorizationService: PlatformAuthorizationService
   ) {}
 
   @Query(() => [IUser], {
@@ -33,7 +33,7 @@ export class AdminAuthorizationResolverQueries {
   ): Promise<IUser[]> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
       AuthorizationPrivilege.READ_USERS,
       `authorization query: ${agentInfo.email}`
     );
@@ -56,7 +56,7 @@ export class AdminAuthorizationResolverQueries {
   ): Promise<AuthorizationPrivilege[]> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
       AuthorizationPrivilege.READ_USERS,
       `authorization query: ${agentInfo.email}`
     );

--- a/src/services/domain/roles/roles.module.ts
+++ b/src/services/domain/roles/roles.module.ts
@@ -14,6 +14,7 @@ import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/a
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Opportunity } from '@domain/collaboration/opportunity/opportunity.entity';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
+import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { Challenge } from '@domain/challenge/challenge/challenge.entity';
     CommunityModule,
     OrganizationModule,
     HubModule,
+    PlatformAuthorizationModule,
     TypeOrmModule.forFeature([Challenge]),
     TypeOrmModule.forFeature([Opportunity]),
   ],

--- a/src/services/domain/roles/roles.resolver.queries.ts
+++ b/src/services/domain/roles/roles.resolver.queries.ts
@@ -4,19 +4,19 @@ import { CurrentUser, Profiling } from '@src/common/decorators';
 import { GraphqlGuard } from '@core/authorization';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AgentInfo } from '@core/authentication';
-import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { RolesOrganizationInput } from './dto/roles.dto.input.organization';
 import { RolesService } from './roles.service';
 import { RolesUserInput } from './dto/roles.dto.input.user';
 import { ContributorRoles } from './dto/roles.dto.result.contributor';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
 
 @Resolver()
 export class RolesResolverQueries {
   constructor(
     private authorizationService: AuthorizationService,
-    private authorizationPolicyService: AuthorizationPolicyService,
-    private rolesServices: RolesService
+    private rolesServices: RolesService,
+    private platformAuthorizationService: PlatformAuthorizationService
   ) {}
 
   @UseGuards(GraphqlGuard)
@@ -31,7 +31,7 @@ export class RolesResolverQueries {
   ): Promise<ContributorRoles> {
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      this.authorizationPolicyService.getPlatformAuthorizationPolicy(),
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
       AuthorizationPrivilege.READ_USERS,
       `roles user query: ${agentInfo.email}`
     );

--- a/test/mocks/authorization.policy.service.mock.ts
+++ b/test/mocks/authorization.policy.service.mock.ts
@@ -6,7 +6,5 @@ export const MockAuthorizationPolicyService: ValueProvider<
   PublicPart<AuthorizationPolicyService>
 > = {
   provide: AuthorizationPolicyService,
-  useValue: {
-    getPlatformAuthorizationPolicy: jest.fn(),
-  },
+  useValue: {},
 };

--- a/test/mocks/platform.authorization.service.mock.ts
+++ b/test/mocks/platform.authorization.service.mock.ts
@@ -1,0 +1,10 @@
+import { ValueProvider } from '@nestjs/common';
+import { PublicPart } from '@test/utils';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
+
+export const MockPlatformAuthorizationService: ValueProvider<
+  PublicPart<PlatformAuthorizationService>
+> = {
+  provide: PlatformAuthorizationService,
+  useValue: {},
+};


### PR DESCRIPTION
query and definition are now split out of the authorizationPolicy module, and are a separate module under platform

Note: this is a pure refactor, no functionality is added or removed: api is the same, platform authorization policy definition is the same, no new database entries.

The issue was that we had all the management of the key platform authorization policy definition within the AuthorizationPolicy module, which was simply wrong. 
