### PR TITLE
Release: New Activity log and Notification only on Published Callout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.33.1",
+      "version": "0.33.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/apollo": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -162,9 +162,13 @@ export class CalloutResolverMutations {
       AuthorizationPrivilege.UPDATE,
       `update callout: ${callout.id}`
     );
+    const oldVisibility = callout.visibility;
     const result = await this.calloutService.updateCallout(calloutData);
 
-    if (result.visibility === CalloutVisibility.PUBLISHED) {
+    if (
+      oldVisibility === CalloutVisibility.DRAFT &&
+      result.visibility === CalloutVisibility.PUBLISHED
+    ) {
       const payload =
         await this.notificationsPayloadBuilder.buildCalloutPublishedPayload(
           agentInfo.userID,


### PR DESCRIPTION
## Notifications
- Notification is sent only when the Callout has been published

## Activity
- A new Activity entry is created only when the Callout has been published