### PR TITLE
Archiving of Hubs

### DIFF
--- a/graphql-samples/mutations/update/update-hub-visibility
+++ b/graphql-samples/mutations/update/update-hub-visibility
@@ -8,6 +8,6 @@ Variables:
 {
   "visibilityData": {
     "hubID": "uuid_nameid",
-    "visibility": "active"
+    "visibility": "ARCHIVED"
   }
 }

--- a/graphql-samples/mutations/update/update-hub-visibility
+++ b/graphql-samples/mutations/update/update-hub-visibility
@@ -1,0 +1,13 @@
+mutation updateHubVisibility($visibilityData: UpdateHubVisibilityInput!) {
+  updateHubVisibility(visibilityData: $visibilityData) {
+    id
+  }
+}
+
+Variables:
+{
+  "visibilityData": {
+    "hubID": "uuid_nameid",
+    "visibility": "active"
+  }
+}

--- a/graphql-samples/queries/hubs-visibility
+++ b/graphql-samples/queries/hubs-visibility
@@ -1,0 +1,7 @@
+query {
+  hubs(visibilities: [ARCHIVED, ACTIVE, DEMO]) {
+    nameID
+    visibility
+
+  }
+}

--- a/graphql-samples/queries/hubs-visibility
+++ b/graphql-samples/queries/hubs-visibility
@@ -1,5 +1,5 @@
 query {
-  hubs(visibilities: [ARCHIVED, ACTIVE, DEMO]) {
+  hubs(filter: {visibilities: [ARCHIVED, ACTIVE, DEMO]}) {
     nameID
     visibility
 

--- a/graphql-samples/queries/roles-user-visibilities
+++ b/graphql-samples/queries/roles-user-visibilities
@@ -1,0 +1,30 @@
+query {
+  rolesUser(rolesData: {userID: "admin-alkemio", filter: {visibilities: [ARCHIVED, ACTIVE, DEMO]}}) {
+   	hubs {
+      nameID
+      id
+      roles
+      challenges {
+        nameID
+        id
+        roles
+      }
+      opportunities {
+        nameID
+        displayName
+        id
+        roles
+      }
+      userGroups {
+        nameID
+        id
+      }
+    }
+    organizations {
+      nameID
+      id
+      roles
+    }
+  }
+
+}

--- a/src/common/enums/hub.visibility.ts
+++ b/src/common/enums/hub.visibility.ts
@@ -1,0 +1,11 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum HubVisibility {
+  ACTIVE = 'active',
+  ARCHIVED = 'archived',
+  DEMO = 'demo',
+}
+
+registerEnumType(HubVisibility, {
+  name: 'HubVisibility',
+});

--- a/src/domain/challenge/challenge/challenge.entity.ts
+++ b/src/domain/challenge/challenge/challenge.entity.ts
@@ -42,7 +42,7 @@ export class Challenge extends BaseChallenge implements IChallenge {
   parentHub?: Hub;
 
   @Column()
-  hubID?: string;
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 
   @OneToOne(() => PreferenceSet, {
     eager: false,

--- a/src/domain/challenge/challenge/challenge.entity.ts
+++ b/src/domain/challenge/challenge/challenge.entity.ts
@@ -42,7 +42,7 @@ export class Challenge extends BaseChallenge implements IChallenge {
   parentHub?: Hub;
 
   @Column()
-  hubID!: string;
+  hubID?: string;
 
   @OneToOne(() => PreferenceSet, {
     eager: false,

--- a/src/domain/challenge/challenge/challenge.interface.ts
+++ b/src/domain/challenge/challenge/challenge.interface.ts
@@ -14,5 +14,5 @@ export abstract class IChallenge extends IBaseChallenge implements ISearchable {
     description: 'The ID of the containing Hub.',
     nullable: false,
   })
-  hubID?: string;
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 }

--- a/src/domain/challenge/challenge/challenge.interface.ts
+++ b/src/domain/challenge/challenge/challenge.interface.ts
@@ -10,6 +10,9 @@ export abstract class IChallenge extends IBaseChallenge implements ISearchable {
   childChallenges?: IChallenge[];
   opportunities?: IOpportunity[];
 
-  @Field(() => String)
-  hubID!: string;
+  @Field(() => String, {
+    description: 'The ID of the containing Hub.',
+    nullable: false,
+  })
+  hubID?: string;
 }

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -516,7 +516,7 @@ export class ChallengeService {
     const hubID = challenge.hubID;
     if (!hubID) {
       throw new RelationshipNotFoundException(
-        `Unable to load child challenges for challenge ${challenge.id} `,
+        `Unable to find hubID for challenge: ${challenge.id} `,
         LogContext.CHALLENGES
       );
     }

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -576,7 +576,7 @@ export class ChallengeService {
     return count;
   }
 
-  async getChallengeCount(visibility = HubVisibility.ACTIVE): Promise<number> {
+  async getChallengesCount(visibility = HubVisibility.ACTIVE): Promise<number> {
     const sqlQuery = `SELECT COUNT(*) as challengesCount FROM challenge RIGHT JOIN hub ON challenge.hubID = hub.id WHERE hub.visibility = '${visibility}'`;
     const [queryResult]: {
       challengesCount: number;

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -172,7 +172,7 @@ export class ChallengeService {
         // updating the nameID, check new value is allowed
         await this.baseChallengeService.isNameAvailableOrFail(
           challengeData.nameID,
-          challenge.hubID
+          this.getHubID(challenge)
         );
         challenge.nameID = challengeData.nameID;
         await this.challengeRepository.save(challenge);
@@ -198,7 +198,7 @@ export class ChallengeService {
     const machineConfig: ILifecycleDefinition =
       await this.lifecycleTemplateService.getLifecycleDefinitionFromTemplate(
         challengeData.innovationFlowTemplateID,
-        challenge.hubID,
+        this.getHubID(challenge),
         LifecycleType.CHALLENGE
       );
 
@@ -486,14 +486,15 @@ export class ChallengeService {
       relations: ['childChallenges', 'community'],
     });
 
+    const hubID = this.getHubID(challenge);
     await this.baseChallengeService.isNameAvailableOrFail(
       challengeData.nameID,
-      challenge.hubID
+      hubID
     );
 
     const childChallenge = await this.createChallenge(
       challengeData,
-      challenge.hubID,
+      hubID,
       agentInfo
     );
 
@@ -508,6 +509,17 @@ export class ChallengeService {
     await this.challengeRepository.save(challenge);
 
     return childChallenge;
+  }
+
+  getHubID(challenge: IChallenge): string {
+    const hubID = challenge.hubID;
+    if (!hubID) {
+      throw new RelationshipNotFoundException(
+        `Unable to load child challenges for challenge ${challenge.id} `,
+        LogContext.CHALLENGES
+      );
+    }
+    return hubID;
   }
 
   async createOpportunity(
@@ -526,14 +538,15 @@ export class ChallengeService {
       }
     );
 
+    const hubID = this.getHubID(challenge);
     await this.baseChallengeService.isNameAvailableOrFail(
       opportunityData.nameID,
-      challenge.hubID
+      hubID
     );
 
     const opportunity = await this.opportunityService.createOpportunity(
       opportunityData,
-      challenge.hubID,
+      hubID,
       agentInfo
     );
 

--- a/src/domain/challenge/challenge/challenge.service.ts
+++ b/src/domain/challenge/challenge/challenge.service.ts
@@ -23,7 +23,7 @@ import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { CommunityService } from '@domain/community/community/community.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, Repository } from 'typeorm';
+import { FindOneOptions, getConnection, Repository } from 'typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { IOrganization } from '@domain/community/organization';
 import { ICommunity } from '@domain/community/community';
@@ -55,6 +55,7 @@ import { ICollaboration } from '@domain/collaboration/collaboration/collaboratio
 import { LifecycleTemplateService } from '@domain/template/lifecycle-template/lifecycle.template.service';
 import { LifecycleType } from '@common/enums/lifecycle.type';
 import { ILifecycleDefinition } from '@interfaces/lifecycle.definition.interface';
+import { HubVisibility } from '@common/enums/hub.visibility';
 
 @Injectable()
 export class ChallengeService {
@@ -575,8 +576,13 @@ export class ChallengeService {
     return count;
   }
 
-  async getChallengeCount(): Promise<number> {
-    return await this.challengeRepository.count();
+  async getChallengeCount(visibility = HubVisibility.ACTIVE): Promise<number> {
+    const sqlQuery = `SELECT COUNT(*) as challengesCount FROM challenge RIGHT JOIN hub ON challenge.hubID = hub.id WHERE hub.visibility = '${visibility}'`;
+    const [queryResult]: {
+      challengesCount: number;
+    }[] = await getConnection().query(sqlQuery);
+
+    return queryResult.challengesCount;
   }
 
   async getChildChallengesCount(challengeID: string): Promise<number> {

--- a/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
+++ b/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
@@ -1,0 +1,12 @@
+import { ArgsType, Field } from '@nestjs/graphql';
+import { HubVisibility } from '@common/enums/hub.visibility';
+
+@ArgsType()
+export class HubsQueryInput {
+  @Field(() => [HubVisibility], {
+    nullable: true,
+    description:
+      'Return Hubs with a Visibility matching one of the provided types.',
+  })
+  visibilities!: HubVisibility[];
+}

--- a/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
+++ b/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
@@ -1,12 +1,11 @@
 import { ArgsType, Field } from '@nestjs/graphql';
-import { HubVisibility } from '@common/enums/hub.visibility';
+import { HubsFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @ArgsType()
-export class HubsQueryInput {
-  @Field(() => [HubVisibility], {
+export class HubsQueryArgs {
+  @Field(() => HubsFilterInput, {
     nullable: true,
-    description:
-      'Return Hubs with a Visibility matching one of the provided types.',
+    description: 'Return Hubs matching the provided filter.',
   })
-  visibilities!: HubVisibility[];
+  filter!: HubsFilterInput;
 }

--- a/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
+++ b/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
@@ -1,11 +1,11 @@
 import { ArgsType, Field } from '@nestjs/graphql';
-import { HubsFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
+import { HubFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @ArgsType()
 export class HubsQueryArgs {
-  @Field(() => HubsFilterInput, {
+  @Field(() => HubFilterInput, {
     nullable: true,
     description: 'Return Hubs matching the provided filter.',
   })
-  filter!: HubsFilterInput;
+  filter!: HubFilterInput;
 }

--- a/src/domain/challenge/hub/dto/hub.dto.update.visibility.ts
+++ b/src/domain/challenge/hub/dto/hub.dto.update.visibility.ts
@@ -1,0 +1,18 @@
+import { HubVisibility } from '@common/enums/hub.visibility';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateHubVisibilityInput {
+  @Field(() => String, {
+    nullable: false,
+    description:
+      'The identifier for the Hub whose visibility is to be updated.',
+  })
+  hubID!: string;
+
+  @Field(() => HubVisibility, {
+    nullable: false,
+    description: 'Visibility of the Hub.',
+  })
+  visibility!: HubVisibility;
+}

--- a/src/domain/challenge/hub/hub.entity.ts
+++ b/src/domain/challenge/hub/hub.entity.ts
@@ -1,11 +1,19 @@
-import { Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
 import { IHub } from '@domain/challenge/hub/hub.interface';
 import { BaseChallenge } from '@domain/challenge/base-challenge/base.challenge.entity';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
 import { PreferenceSet } from '@domain/common/preference-set/preference.set.entity';
 import { TemplatesSet } from '@domain/template/templates-set/templates.set.entity';
+import { HubVisibility } from '@common/enums/hub.visibility';
 @Entity()
 export class Hub extends BaseChallenge implements IHub {
+  @Column('varchar', {
+    length: 255,
+    nullable: false,
+    default: HubVisibility.ACTIVE,
+  })
+  visibility?: HubVisibility;
+
   @OneToMany(() => Challenge, challenge => challenge.parentHub, {
     eager: false,
     cascade: true,

--- a/src/domain/challenge/hub/hub.interface.ts
+++ b/src/domain/challenge/hub/hub.interface.ts
@@ -1,13 +1,20 @@
 import { IChallenge } from '@domain/challenge/challenge/challenge.interface';
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { IBaseChallenge } from '@domain/challenge/base-challenge/base.challenge.interface';
 import { ITemplatesSet } from '@domain/template/templates-set';
 import { ISearchable } from '@domain/common/interfaces/searchable.interface';
+import { HubVisibility } from '@common/enums/hub.visibility';
 
 @ObjectType('Hub', {
   implements: () => [ISearchable],
 })
 export abstract class IHub extends IBaseChallenge {
+  @Field(() => HubVisibility, {
+    description: 'Visibility of the Hub.',
+    nullable: false,
+  })
+  visibility?: HubVisibility;
+
   challenges?: IChallenge[];
 
   templatesSet?: ITemplatesSet;

--- a/src/domain/challenge/hub/hub.module.ts
+++ b/src/domain/challenge/hub/hub.module.ts
@@ -26,6 +26,7 @@ import { PreferenceModule } from '@domain/common/preference';
 import { PreferenceSetModule } from '@domain/common/preference-set/preference.set.module';
 import { TemplatesSetModule } from '@domain/template/templates-set/templates.set.module';
 import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
+import { HubFilterModule } from '@services/domain/hub-filter/hub.filter.module';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { PlatformAuthorizationModule } from '@src/platform/authorization/platfor
     PreferenceModule,
     PreferenceSetModule,
     TemplatesSetModule,
+    HubFilterModule,
     TypeOrmModule.forFeature([Hub]),
   ],
   providers: [

--- a/src/domain/challenge/hub/hub.resolver.mutations.ts
+++ b/src/domain/challenge/hub/hub.resolver.mutations.ts
@@ -188,7 +188,9 @@ export class HubResolverMutations {
       preferenceData.value
     );
 
-    const hub = await this.hubService.getHubOrFail(challenge.hubID);
+    const hub = await this.hubService.getHubOrFail(
+      this.challengeService.getHubID(challenge)
+    );
     const hubCommunityCredential =
       await this.hubService.getCommunityMembershipCredential(hub);
     // As the preferences may update the authorization, the authorization policy will need to be reset

--- a/src/domain/challenge/hub/hub.resolver.mutations.ts
+++ b/src/domain/challenge/hub/hub.resolver.mutations.ts
@@ -28,6 +28,7 @@ import { PreferenceSetService } from '@domain/common/preference-set/preference.s
 import { UpdateChallengePreferenceInput } from '@domain/challenge/challenge/dto/challenge.dto.update.preference';
 import { ChallengeService } from '@domain/challenge/challenge/challenge.service';
 import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
+import { UpdateHubVisibilityInput } from './dto/hub.dto.update.visibility';
 @Resolver()
 export class HubResolverMutations {
   constructor(
@@ -86,6 +87,33 @@ export class HubResolverMutations {
   }
 
   @UseGuards(GraphqlGuard)
+  @Mutation(() => IHub, {
+    description: 'Update the visibility of the specified Hub.',
+  })
+  @Profiling.api
+  async updateHubVisibility(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('visibilityData') visibilityData: UpdateHubVisibilityInput
+  ): Promise<IHub> {
+    const hub = await this.hubService.getHubOrFail(visibilityData.hubID);
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      hub.authorization,
+      AuthorizationPrivilege.UPDATE,
+      `update visibility on hub: ${hub.id}`
+    );
+    const oldVisibility = hub.visibility;
+    const result = await this.hubService.updateHubVisibility(visibilityData);
+    if (oldVisibility !== result.visibility) {
+      return await this.hubAuthorizationService.applyAuthorizationPolicy(
+        result
+      );
+    }
+
+    return result;
+  }
+
+  @UseGuards(GraphqlGuard)
   @Mutation(() => IPreference, {
     description: 'Updates one of the Preferences on a Hub',
   })
@@ -97,7 +125,7 @@ export class HubResolverMutations {
     const hub = await this.hubService.getHubOrFail(preferenceData.hubID);
     const preferenceSet = await this.hubService.getPreferenceSetOrFail(hub.id);
 
-    const preference = await this.preferenceSetService.getPreferenceOrFail(
+    const preference = this.preferenceSetService.getPreferenceOrFail(
       preferenceSet,
       preferenceData.type
     );

--- a/src/domain/challenge/hub/hub.resolver.queries.ts
+++ b/src/domain/challenge/hub/hub.resolver.queries.ts
@@ -4,6 +4,7 @@ import { HubService } from './hub.service';
 import { IHub } from './hub.interface';
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { UUID_NAMEID } from '@domain/common/scalars';
+import { HubsQueryInput } from './dto/hub.args.query.hubs';
 
 @Resolver()
 export class HubResolverQueries {
@@ -14,8 +15,8 @@ export class HubResolverQueries {
     description: 'The Hubs on this platform',
   })
   @Profiling.api
-  async hubs(): Promise<IHub[]> {
-    return await this.hubService.getHubs();
+  async hubs(@Args({ nullable: true }) args: HubsQueryInput): Promise<IHub[]> {
+    return await this.hubService.getHubs(args);
   }
 
   @Query(() => IHub, {

--- a/src/domain/challenge/hub/hub.resolver.queries.ts
+++ b/src/domain/challenge/hub/hub.resolver.queries.ts
@@ -4,7 +4,7 @@ import { HubService } from './hub.service';
 import { IHub } from './hub.interface';
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { UUID_NAMEID } from '@domain/common/scalars';
-import { HubsQueryInput } from './dto/hub.args.query.hubs';
+import { HubsQueryArgs } from './dto/hub.args.query.hubs';
 
 @Resolver()
 export class HubResolverQueries {
@@ -15,7 +15,7 @@ export class HubResolverQueries {
     description: 'The Hubs on this platform',
   })
   @Profiling.api
-  async hubs(@Args({ nullable: true }) args: HubsQueryInput): Promise<IHub[]> {
+  async hubs(@Args({ nullable: true }) args: HubsQueryArgs): Promise<IHub[]> {
     return await this.hubService.getHubs(args);
   }
 

--- a/src/domain/challenge/hub/hub.service.ts
+++ b/src/domain/challenge/hub/hub.service.ts
@@ -57,6 +57,7 @@ import { TemplatesSetService } from '@domain/template/templates-set/templates.se
 import { ICollaboration } from '@domain/collaboration/collaboration/collaboration.interface';
 import { ILifecycleTemplate } from '@domain/template/lifecycle-template/lifecycle.template.interface';
 import { LifecycleType } from '@common/enums/lifecycle.type';
+import { UpdateHubVisibilityInput } from './dto/hub.dto.update.visibility';
 
 @Injectable()
 export class HubService {
@@ -181,6 +182,16 @@ export class HubService {
     }
 
     return await this.hubRepository.save(hub);
+  }
+
+  public async updateHubVisibility(
+    visibilityData: UpdateHubVisibilityInput
+  ): Promise<IHub> {
+    const hub = await this.getHubOrFail(visibilityData.hubID);
+
+    hub.visibility = visibilityData.visibility;
+
+    return await this.save(hub);
   }
 
   async deleteHub(deleteData: DeleteHubInput): Promise<IHub> {

--- a/src/domain/challenge/hub/hub.service.ts
+++ b/src/domain/challenge/hub/hub.service.ts
@@ -89,6 +89,8 @@ export class HubService {
   ): Promise<IHub> {
     await this.validateHubData(hubData);
     const hub: IHub = Hub.create(hubData);
+    // default to active hub
+    hub.visibility = HubVisibility.ACTIVE;
 
     // remove context before saving as want to control that creation
     hub.context = undefined;

--- a/src/domain/challenge/hub/hub.service.ts
+++ b/src/domain/challenge/hub/hub.service.ts
@@ -727,8 +727,10 @@ export class HubService {
     );
   }
 
-  async getHubCount(): Promise<number> {
-    return await this.hubRepository.count();
+  async getHubCount(visibility = HubVisibility.ACTIVE): Promise<number> {
+    return await this.hubRepository.count({
+      where: { visibility: visibility },
+    });
   }
 
   async getHost(hubID: string): Promise<IOrganization | undefined> {

--- a/src/domain/challenge/hub/hub.service.ts
+++ b/src/domain/challenge/hub/hub.service.ts
@@ -241,7 +241,7 @@ export class HubService {
   }
 
   async getHubs(args: HubsQueryArgs): Promise<IHub[]> {
-    const visibilities = this.hubsFilterService.getVisibilityToFilter(
+    const visibilities = this.hubsFilterService.getAllowedVisibilities(
       args.filter
     );
     // Load the hubs

--- a/src/domain/collaboration/opportunity/opportunity.entity.ts
+++ b/src/domain/collaboration/opportunity/opportunity.entity.ts
@@ -20,7 +20,7 @@ export class Opportunity extends BaseChallenge implements IOpportunity {
   projects?: Project[];
 
   @Column()
-  hubID?: string;
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 
   constructor() {
     super();

--- a/src/domain/collaboration/opportunity/opportunity.entity.ts
+++ b/src/domain/collaboration/opportunity/opportunity.entity.ts
@@ -20,7 +20,7 @@ export class Opportunity extends BaseChallenge implements IOpportunity {
   projects?: Project[];
 
   @Column()
-  hubID!: string;
+  hubID?: string;
 
   constructor() {
     super();

--- a/src/domain/collaboration/opportunity/opportunity.interface.ts
+++ b/src/domain/collaboration/opportunity/opportunity.interface.ts
@@ -16,7 +16,7 @@ export abstract class IOpportunity
   })
   projects?: IProject[];
 
-  hubID!: string;
+  hubID?: string;
 
   @Field(() => IChallenge, {
     nullable: true,

--- a/src/domain/collaboration/opportunity/opportunity.interface.ts
+++ b/src/domain/collaboration/opportunity/opportunity.interface.ts
@@ -16,7 +16,7 @@ export abstract class IOpportunity
   })
   projects?: IProject[];
 
-  hubID?: string;
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 
   @Field(() => IChallenge, {
     nullable: true,

--- a/src/domain/collaboration/opportunity/opportunity.service.ts
+++ b/src/domain/collaboration/opportunity/opportunity.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, Repository } from 'typeorm';
+import { FindOneOptions, getConnection, Repository } from 'typeorm';
 import {
   EntityNotFoundException,
   EntityNotInitializedException,
@@ -38,6 +38,7 @@ import { ICollaboration } from '../collaboration/collaboration.interface';
 import { LifecycleTemplateService } from '@domain/template/lifecycle-template/lifecycle.template.service';
 import { LifecycleType } from '@common/enums/lifecycle.type';
 import { ILifecycleDefinition } from '@interfaces/lifecycle.definition.interface';
+import { HubVisibility } from '@common/enums/hub.visibility';
 
 @Injectable()
 export class OpportunityService {
@@ -365,8 +366,15 @@ export class OpportunityService {
     });
   }
 
-  async getOpportunitiesCount(): Promise<number> {
-    return await this.opportunityRepository.count();
+  async getOpportunitiesCount(
+    visibility = HubVisibility.ACTIVE
+  ): Promise<number> {
+    const sqlQuery = `SELECT COUNT(*) as opportunitiesCount FROM opportunity RIGHT JOIN hub ON opportunity.hubID = hub.id WHERE hub.visibility = '${visibility}'`;
+    const [queryResult]: {
+      opportunitiesCount: number;
+    }[] = await getConnection().query(sqlQuery);
+
+    return queryResult.opportunitiesCount;
   }
 
   async getOpportunitiesInChallengeCount(challengeID: string): Promise<number> {

--- a/src/migrations/1663786651174-hub-visibility.ts
+++ b/src/migrations/1663786651174-hub-visibility.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class hubVisibility1663786651174 implements MigrationInterface {
+  name = 'hubVisibility1663786651174';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`hub\` ADD \`visibility\` varchar(255) NULL`
+    );
+    const hubs: any[] = await queryRunner.query(`SELECT id from hub`);
+    for (const hub of hubs) {
+      await queryRunner.query(
+        `UPDATE \`hub\` SET \`visibility\` = 'active' WHERE \`id\`= '${hub.id}'`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`hub\` DROP COLUMN \`visibility\``);
+  }
+}

--- a/src/services/domain/conversion/conversion.resolver.mutations.ts
+++ b/src/services/domain/conversion/conversion.resolver.mutations.ts
@@ -93,7 +93,9 @@ export class ConversionResolverMutations {
         opportunity.hubID,
         agentInfo
       );
-    const parentHub = await this.hubService.getHubOrFail(newChallenge.hubID);
+    const parentHub = await this.hubService.getHubOrFail(
+      this.challengeService.getHubID(newChallenge)
+    );
     await this.hubAuthorizationService.applyAuthorizationPolicy(parentHub);
     return this.challengeService.getChallengeOrFail(newChallenge.id);
   }

--- a/src/services/domain/conversion/conversion.resolver.mutations.ts
+++ b/src/services/domain/conversion/conversion.resolver.mutations.ts
@@ -90,7 +90,7 @@ export class ConversionResolverMutations {
     const newChallenge =
       await this.conversionService.convertOpportunityToChallenge(
         convertOpportunityToChallengeData.opportunityID,
-        opportunity.hubID,
+        this.opportunityService.getHubID(opportunity),
         agentInfo
       );
     const parentHub = await this.hubService.getHubOrFail(

--- a/src/services/domain/hub-filter/dto/hub.filter.dto.input.ts
+++ b/src/services/domain/hub-filter/dto/hub.filter.dto.input.ts
@@ -1,0 +1,12 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { HubVisibility } from '@common/enums/hub.visibility';
+
+@InputType()
+export class HubsFilterInput {
+  @Field(() => [HubVisibility], {
+    nullable: true,
+    description:
+      'Return Hubs with a Visibility matching one of the provided types.',
+  })
+  visibilities!: HubVisibility[];
+}

--- a/src/services/domain/hub-filter/dto/hub.filter.dto.input.ts
+++ b/src/services/domain/hub-filter/dto/hub.filter.dto.input.ts
@@ -2,7 +2,7 @@ import { Field, InputType } from '@nestjs/graphql';
 import { HubVisibility } from '@common/enums/hub.visibility';
 
 @InputType()
-export class HubsFilterInput {
+export class HubFilterInput {
   @Field(() => [HubVisibility], {
     nullable: true,
     description:

--- a/src/services/domain/hub-filter/hub.filter.module.ts
+++ b/src/services/domain/hub-filter/hub.filter.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HubFilterService } from './hub.filter.service';
+
+@Module({
+  imports: [],
+  providers: [HubFilterService],
+  exports: [HubFilterService],
+})
+export class HubFilterModule {}

--- a/src/services/domain/hub-filter/hub.filter.service.ts
+++ b/src/services/domain/hub-filter/hub.filter.service.ts
@@ -1,0 +1,39 @@
+import { HubVisibility } from '@common/enums/hub.visibility';
+import { LogContext } from '@common/enums/logging.context';
+import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
+import { Inject, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { HubsFilterInput } from './dto/hub.filter.dto.input';
+
+export class HubFilterService {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  getVisibilityToFilter(filter: HubsFilterInput | undefined) {
+    let visibilities = [HubVisibility.ACTIVE];
+    if (filter && filter.visibilities && filter.visibilities.length > 0) {
+      visibilities = filter.visibilities;
+    }
+    this.logger.verbose?.(
+      `Loading hubs with visibilities: ${visibilities}`,
+      LogContext.CHALLENGES
+    );
+    return visibilities;
+  }
+
+  isVisible(
+    visibility: HubVisibility | undefined,
+    allowedVisibilities: HubVisibility[]
+  ) {
+    if (!visibility) {
+      throw new RelationshipNotFoundException(
+        `Hub Visibility not provided when searching for ${allowedVisibilities}`,
+        LogContext.CHALLENGES
+      );
+    }
+    const result = allowedVisibilities.find(v => v === visibility);
+    if (result) return true;
+    return false;
+  }
+}

--- a/src/services/domain/hub-filter/hub.filter.service.ts
+++ b/src/services/domain/hub-filter/hub.filter.service.ts
@@ -10,7 +10,9 @@ export class HubFilterService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  getAllowedVisibilities(filter: HubFilterInput | undefined) {
+  public getAllowedVisibilities(
+    filter: HubFilterInput | undefined
+  ): HubVisibility[] {
     let visibilities = [HubVisibility.ACTIVE];
     if (filter && filter.visibilities && filter.visibilities.length > 0) {
       visibilities = filter.visibilities;
@@ -22,10 +24,10 @@ export class HubFilterService {
     return visibilities;
   }
 
-  isVisible(
+  public isVisible(
     visibility: HubVisibility | undefined,
     allowedVisibilities: HubVisibility[]
-  ) {
+  ): boolean {
     if (!visibility) {
       throw new RelationshipNotFoundException(
         `Hub Visibility not provided when searching for ${allowedVisibilities}`,

--- a/src/services/domain/hub-filter/hub.filter.service.ts
+++ b/src/services/domain/hub-filter/hub.filter.service.ts
@@ -3,14 +3,14 @@ import { LogContext } from '@common/enums/logging.context';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
 import { Inject, LoggerService } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { HubsFilterInput } from './dto/hub.filter.dto.input';
+import { HubFilterInput } from './dto/hub.filter.dto.input';
 
 export class HubFilterService {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  getVisibilityToFilter(filter: HubsFilterInput | undefined) {
+  getVisibilityToFilter(filter: HubFilterInput | undefined) {
     let visibilities = [HubVisibility.ACTIVE];
     if (filter && filter.visibilities && filter.visibilities.length > 0) {
       visibilities = filter.visibilities;

--- a/src/services/domain/hub-filter/hub.filter.service.ts
+++ b/src/services/domain/hub-filter/hub.filter.service.ts
@@ -10,7 +10,7 @@ export class HubFilterService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  getVisibilityToFilter(filter: HubFilterInput | undefined) {
+  getAllowedVisibilities(filter: HubFilterInput | undefined) {
     let visibilities = [HubVisibility.ACTIVE];
     if (filter && filter.visibilities && filter.visibilities.length > 0) {
       visibilities = filter.visibilities;

--- a/src/services/domain/metadata/metadata.service.ts
+++ b/src/services/domain/metadata/metadata.service.ts
@@ -53,7 +53,7 @@ export class MetadataService {
     hubsTopic.id = 'hubs';
     activity.push(hubsTopic);
 
-    const challengesCount = await this.challengeService.getChallengeCount();
+    const challengesCount = await this.challengeService.getChallengesCount();
     const challengesTopic = new NVP('challenges', challengesCount.toString());
     challengesTopic.id = 'challenges';
     activity.push(challengesTopic);

--- a/src/services/domain/roles/dto/roles.dto.input.organization.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.organization.ts
@@ -14,5 +14,5 @@ export class RolesOrganizationInput {
     nullable: true,
     description: 'Return membership in Hubs matching the provided filter.',
   })
-  filter!: HubFilterInput;
+  filter?: HubFilterInput;
 }

--- a/src/services/domain/roles/dto/roles.dto.input.organization.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.organization.ts
@@ -1,6 +1,6 @@
-import { HubVisibility } from '@common/enums/hub.visibility';
 import { UUID_NAMEID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
+import { HubsFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @InputType()
 export class RolesOrganizationInput {
@@ -10,10 +10,9 @@ export class RolesOrganizationInput {
   })
   organizationID!: string;
 
-  @Field(() => [HubVisibility], {
+  @Field(() => HubsFilterInput, {
     nullable: true,
-    description:
-      'Return roles in Hubs with a Visibility matching one of the provided types.',
+    description: 'Return membership in Hubs matching the provided filter.',
   })
-  visibilities?: HubVisibility[];
+  filter!: HubsFilterInput;
 }

--- a/src/services/domain/roles/dto/roles.dto.input.organization.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.organization.ts
@@ -1,3 +1,4 @@
+import { HubVisibility } from '@common/enums/hub.visibility';
 import { UUID_NAMEID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
 
@@ -8,4 +9,11 @@ export class RolesOrganizationInput {
     description: 'The ID of the organization to retrieve the roles of.',
   })
   organizationID!: string;
+
+  @Field(() => [HubVisibility], {
+    nullable: true,
+    description:
+      'Return roles in Hubs with a Visibility matching one of the provided types.',
+  })
+  visibilities?: HubVisibility[];
 }

--- a/src/services/domain/roles/dto/roles.dto.input.organization.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.organization.ts
@@ -1,6 +1,6 @@
 import { UUID_NAMEID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
-import { HubsFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
+import { HubFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @InputType()
 export class RolesOrganizationInput {
@@ -10,9 +10,9 @@ export class RolesOrganizationInput {
   })
   organizationID!: string;
 
-  @Field(() => HubsFilterInput, {
+  @Field(() => HubFilterInput, {
     nullable: true,
     description: 'Return membership in Hubs matching the provided filter.',
   })
-  filter!: HubsFilterInput;
+  filter!: HubFilterInput;
 }

--- a/src/services/domain/roles/dto/roles.dto.input.user.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.user.ts
@@ -1,3 +1,4 @@
+import { HubVisibility } from '@common/enums/hub.visibility';
 import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
 
@@ -8,4 +9,11 @@ export class RolesUserInput {
     description: 'The ID of the user to retrieve the roles of.',
   })
   userID!: string;
+
+  @Field(() => [HubVisibility], {
+    nullable: true,
+    description:
+      'Return roles in Hubs with a Visibility matching one of the provided types.',
+  })
+  visibilities?: HubVisibility[];
 }

--- a/src/services/domain/roles/dto/roles.dto.input.user.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.user.ts
@@ -1,6 +1,6 @@
 import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
-import { HubsFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
+import { HubFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @InputType()
 export class RolesUserInput {
@@ -10,9 +10,9 @@ export class RolesUserInput {
   })
   userID!: string;
 
-  @Field(() => HubsFilterInput, {
+  @Field(() => HubFilterInput, {
     nullable: true,
     description: 'Return membership in Hubs matching the provided filter.',
   })
-  filter!: HubsFilterInput;
+  filter!: HubFilterInput;
 }

--- a/src/services/domain/roles/dto/roles.dto.input.user.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.user.ts
@@ -14,5 +14,5 @@ export class RolesUserInput {
     nullable: true,
     description: 'Return membership in Hubs matching the provided filter.',
   })
-  filter!: HubFilterInput;
+  filter?: HubFilterInput;
 }

--- a/src/services/domain/roles/dto/roles.dto.input.user.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.user.ts
@@ -1,6 +1,6 @@
-import { HubVisibility } from '@common/enums/hub.visibility';
 import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
+import { HubsFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @InputType()
 export class RolesUserInput {
@@ -10,10 +10,9 @@ export class RolesUserInput {
   })
   userID!: string;
 
-  @Field(() => [HubVisibility], {
+  @Field(() => HubsFilterInput, {
     nullable: true,
-    description:
-      'Return roles in Hubs with a Visibility matching one of the provided types.',
+    description: 'Return membership in Hubs matching the provided filter.',
   })
-  visibilities?: HubVisibility[];
+  filter!: HubsFilterInput;
 }

--- a/src/services/domain/roles/roles.module.ts
+++ b/src/services/domain/roles/roles.module.ts
@@ -15,6 +15,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Opportunity } from '@domain/collaboration/opportunity/opportunity.entity';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
 import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
+import { HubFilterModule } from '../hub-filter/hub.filter.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { PlatformAuthorizationModule } from '@src/platform/authorization/platfor
     OrganizationModule,
     HubModule,
     PlatformAuthorizationModule,
+    HubFilterModule,
     TypeOrmModule.forFeature([Challenge]),
     TypeOrmModule.forFeature([Opportunity]),
   ],

--- a/src/services/domain/roles/roles.service.spec.ts
+++ b/src/services/domain/roles/roles.service.spec.ts
@@ -7,6 +7,7 @@ import { MockOrganizationService } from '@test/mocks/organization.service.mock';
 import { MockUserGroupService } from '@test/mocks/user.group.service.mock';
 import { MockUserService } from '@test/mocks/user.service.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { MockHubFilterService } from '@test/mocks/hub.filter.service.mock';
 import { Test } from '@nestjs/testing';
 import { RolesService } from './roles.service';
 import { UserService } from '@domain/community/user/user.service';
@@ -16,15 +17,16 @@ import { OpportunityService } from '@domain/collaboration/opportunity/opportunit
 import { ApplicationService } from '@domain/community/application/application.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { CommunityService } from '@domain/community/community/community.service';
+import { HubFilterService } from '../hub-filter/hub.filter.service';
 import { asyncToThrow, testData } from '@test/utils';
 import { RelationshipNotFoundException } from '@common/exceptions';
-import { MockHubFilterService } from '@test/mocks/hub.filter.service.mock';
 
 describe('RolesService', () => {
   let rolesService: RolesService;
   let userService: UserService;
   let hubService: HubService;
   let challengeSerivce: ChallengeService;
+  let hubFilterService: HubFilterService;
   let opportunityService: OpportunityService;
   let applicationService: ApplicationService;
   let organizationService: OrganizationService;
@@ -55,6 +57,7 @@ describe('RolesService', () => {
     applicationService = moduleRef.get(ApplicationService);
     organizationService = moduleRef.get(OrganizationService);
     communityService = moduleRef.get(CommunityService);
+    hubFilterService = moduleRef.get(HubFilterService);
   });
 
   it('should be defined', () => {
@@ -95,6 +98,8 @@ describe('RolesService', () => {
         .spyOn(applicationService, 'getApplicationState')
         .mockResolvedValue('new');
 
+      jest.spyOn(hubFilterService, 'isVisible').mockResolvedValue(true);
+
       jest.spyOn(communityService, 'isHubCommunity').mockResolvedValue(true);
 
       const res = await rolesService.getUserRoles({
@@ -117,6 +122,8 @@ describe('RolesService', () => {
           }),
         ])
       );
+
+      console.log(JSON.stringify(res.hubs));
 
       expect(res.hubs).toEqual(
         expect.arrayContaining([

--- a/src/services/domain/roles/roles.service.spec.ts
+++ b/src/services/domain/roles/roles.service.spec.ts
@@ -18,6 +18,7 @@ import { OrganizationService } from '@domain/community/organization/organization
 import { CommunityService } from '@domain/community/community/community.service';
 import { asyncToThrow, testData } from '@test/utils';
 import { RelationshipNotFoundException } from '@common/exceptions';
+import { MockHubFilterService } from '@test/mocks/hub.filter.service.mock';
 
 describe('RolesService', () => {
   let rolesService: RolesService;
@@ -40,6 +41,7 @@ describe('RolesService', () => {
         MockCommunityService,
         MockOpportunityService,
         MockOrganizationService,
+        MockHubFilterService,
         MockWinstonProvider,
         RolesService,
       ],

--- a/src/services/domain/roles/roles.service.spec.ts
+++ b/src/services/domain/roles/roles.service.spec.ts
@@ -98,7 +98,7 @@ describe('RolesService', () => {
         .spyOn(applicationService, 'getApplicationState')
         .mockResolvedValue('new');
 
-      jest.spyOn(hubFilterService, 'isVisible').mockResolvedValue(true);
+      jest.spyOn(hubFilterService, 'isVisible').mockReturnValue(true);
 
       jest.spyOn(communityService, 'isHubCommunity').mockResolvedValue(true);
 

--- a/src/services/domain/roles/roles.service.ts
+++ b/src/services/domain/roles/roles.service.ts
@@ -280,7 +280,10 @@ export class RolesService {
       challengeID,
       { relations: ['community'] }
     );
-    const hubResult = await this.ensureHubRolesResult(hubsMap, challenge.hubID);
+    const hubResult = await this.ensureHubRolesResult(
+      hubsMap,
+      this.challengeService.getHubID(challenge)
+    );
 
     const existingChallengeResult = hubResult.challenges.find(
       challengeResult => challengeResult.nameID === challenge.nameID

--- a/src/services/domain/roles/roles.service.ts
+++ b/src/services/domain/roles/roles.service.ts
@@ -55,7 +55,7 @@ export class RolesService {
     membershipData: RolesUserInput
   ): Promise<ContributorRoles> {
     const user = await this.userService.getUserWithAgent(membershipData.userID);
-    const allowedVisibilities = this.hubFilterService.getVisibilityToFilter(
+    const allowedVisibilities = this.hubFilterService.getAllowedVisibilities(
       membershipData.filter
     );
 
@@ -75,7 +75,7 @@ export class RolesService {
       await this.organizationService.getOrganizationAndAgent(
         membershipData.organizationID
       );
-    const allowedVisibilities = this.hubFilterService.getVisibilityToFilter(
+    const allowedVisibilities = this.hubFilterService.getAllowedVisibilities(
       membershipData.filter
     );
     const contributorRoles = await this.getContributorRoles(

--- a/test/config/jest.config.ci.js
+++ b/test/config/jest.config.ci.js
@@ -1,7 +1,5 @@
 module.exports = {
   ...require('./jest.config'),
-  testMatch: [
-    '**/?(*.)+(spec).ts',
-  ],
+  testMatch: ['**/?(*.)+(spec).ts'],
   coverageDirectory: '<rootDir>/coverage-ci',
 };

--- a/test/mocks/challenge.service.mock.ts
+++ b/test/mocks/challenge.service.mock.ts
@@ -8,5 +8,6 @@ export const MockChallengeService: ValueProvider<PublicPart<ChallengeService>> =
     useValue: {
       getChallengeOrFail: jest.fn(),
       getChallengeForCommunity: jest.fn(),
+      getHubID: jest.fn(),
     },
   };

--- a/test/mocks/hub.filter.service.mock.ts
+++ b/test/mocks/hub.filter.service.mock.ts
@@ -1,0 +1,12 @@
+import { ValueProvider } from '@nestjs/common';
+import { HubFilterService } from '@services/domain/hub-filter/hub.filter.service';
+import { PublicPart } from '../utils/public-part';
+
+export const MockHubFilterService: ValueProvider<PublicPart<HubFilterService>> =
+  {
+    provide: HubFilterService,
+    useValue: {
+      getAllowedVisibilities: jest.fn(),
+      isVisible: jest.fn(),
+    },
+  };

--- a/test/mocks/hub.service.mock.ts
+++ b/test/mocks/hub.service.mock.ts
@@ -6,6 +6,5 @@ export const MockHubService: ValueProvider<PublicPart<HubService>> = {
   provide: HubService,
   useValue: {
     getHubOrFail: jest.fn(),
-    getHubID: jest.fn(),
   },
 };

--- a/test/mocks/hub.service.mock.ts
+++ b/test/mocks/hub.service.mock.ts
@@ -6,5 +6,6 @@ export const MockHubService: ValueProvider<PublicPart<HubService>> = {
   provide: HubService,
   useValue: {
     getHubOrFail: jest.fn(),
+    getHubID: jest.fn(),
   },
 };

--- a/test/mocks/opportunity.service.mock.ts
+++ b/test/mocks/opportunity.service.mock.ts
@@ -9,5 +9,6 @@ export const MockOpportunityService: ValueProvider<
   useValue: {
     getOpportunityForCommunity: jest.fn(),
     getOpportunityOrFail: jest.fn(),
+    getHubID: jest.fn(),
   },
 };


### PR DESCRIPTION
Extend Hub with a field to control its visibility, which can be ACTIVE, ARCHIVED or DEMO. 
- demo visibility is for later

api:
* New mutation to allow updating the hub visibility: updateHubVisibility
* hubs() query: takes optional argument to allow filtering of hubs by visiblity; defaults to active hubs
* metadata query metrics are updated to show only active hubs, challenges, opportunities counts

modules:
* new HubFilter module to manage the filtering of Hubs based on visibility in a consistent way

samples:
* new sample query to get hubs by visibility
* new sample query to get roles by visibility of Hubs for which credentials are for

Key changes:
* Updated HubAuthorizationService so that if Hub is archived then the HubAdmin does not get assigned privileges, nor do any privileges cascade down into the contained entities. 

Note: due to VS Code changes had to mark hubID on Challenge / Opportunity to be optional as otherwise type validations were failing.

Search:
* search is filtering out results based on users access, so to test it out in action run the search as a **non-global-admin** user

There are likely to be additional enhancements identified re filtering as we move demo onto prod + do the FFE e.g.
* metadata metrics to be specified to the url being used?
* ...

To look at it the authorization in action, run the following query:
query {
  hubs {
    nameID
    visibility
    authorization {
      anonymousReadAccess
      credentialRules {
        grantedPrivileges
        resourceID
        type
      }
    }
  }
}

and then run the mutation to update the visibility to be archived. When in active visibility then credential rules looks like: 
![image](https://user-images.githubusercontent.com/30729240/191598029-54540652-bfd3-4f23-a6e2-83f912a05eca.png)


when archived:

![image](https://user-images.githubusercontent.com/30729240/191598133-912a615b-6288-4379-b533-51c2869deee5.png)
