### PR TITLE
added filtering to users + organizations queries to support getting via credential types

### DIFF
--- a/graphql-samples/queries/users-filtered
+++ b/graphql-samples/queries/users-filtered
@@ -1,0 +1,5 @@
+query {
+  users(filter: {credentials: [HUB_HOST]}) {
+    nameID
+  }
+}

--- a/src/domain/community/contributor/dto/contributor.dto.filter.ts
+++ b/src/domain/community/contributor/dto/contributor.dto.filter.ts
@@ -1,0 +1,11 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { AuthorizationCredential } from '@common/enums/authorization.credential';
+
+@InputType()
+export class ContributorFilterInput {
+  @Field(() => [AuthorizationCredential], {
+    nullable: true,
+    description: 'Return contributors with credentials in the provided list',
+  })
+  credentials?: AuthorizationCredential[];
+}

--- a/src/domain/community/contributor/dto/contributor.query.args.ts
+++ b/src/domain/community/contributor/dto/contributor.query.args.ts
@@ -1,0 +1,28 @@
+import { ContributorFilterInput } from '@domain/community/contributor/dto/contributor.dto.filter';
+import { ArgsType, Field, Float } from '@nestjs/graphql';
+
+@ArgsType()
+export class ContributorQueryArgs {
+  @Field(() => Float, {
+    name: 'limit',
+    description:
+      'The number of contributors to return; if omitted return all Contributors.',
+    nullable: true,
+  })
+  limit?: number;
+
+  @Field(() => Boolean, {
+    name: 'shuffle',
+    description:
+      'If true and limit is specified then return a random selection of Contributors. Defaults to false.',
+    nullable: true,
+  })
+  shuffle?: boolean;
+
+  @Field(() => ContributorFilterInput, {
+    name: 'filter',
+    description: 'Filtering criteria for returning results.',
+    nullable: true,
+  })
+  filter?: ContributorFilterInput;
+}

--- a/src/domain/community/organization/organization.resolver.queries.ts
+++ b/src/domain/community/organization/organization.resolver.queries.ts
@@ -1,5 +1,5 @@
 import { UUID_NAMEID } from '@domain/common/scalars';
-import { Args, Float, Query, Resolver } from '@nestjs/graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { Profiling } from '@src/common/decorators';
 import { IOrganization } from './organization.interface';
 import { OrganizationService } from './organization.service';
@@ -8,6 +8,7 @@ import { PaginationArgs } from '@core/pagination';
 import { OrganizationFilterInput } from '@core/filtering';
 import { UseGuards } from '@nestjs/common';
 import { PaginatedOrganization } from '@core/pagination/paginated.organization';
+import { ContributorQueryArgs } from '../contributor/dto/contributor.query.args';
 
 @Resolver()
 export class OrganizationResolverQueries {
@@ -19,24 +20,9 @@ export class OrganizationResolverQueries {
   })
   @Profiling.api
   async organizations(
-    @Args({
-      name: 'limit',
-      type: () => Float,
-      description:
-        'The number of Organizations to return; if omitted return all Organizations.',
-      nullable: true,
-    })
-    limit: number,
-    @Args({
-      name: 'shuffle',
-      type: () => Boolean,
-      description:
-        'If true and limit is specified then return the Organizations based on a random selection. Defaults to false.',
-      nullable: true,
-    })
-    shuffle: boolean
+    @Args({ nullable: true }) args: ContributorQueryArgs
   ): Promise<IOrganization[]> {
-    return await this.organizationService.getOrganizations(limit, shuffle);
+    return await this.organizationService.getOrganizations(args);
   }
 
   @Query(() => IOrganization, {


### PR DESCRIPTION
Shared code for the filtering of contributors

Fixed a bug related to the type of values accepted into usersByIDs query: this is only UUIDs

Fixed a performance issue whereby usersByIDs was getting first *all* users from the db and then filtering by ID, which was a super heavy hit to return one user.

