### PR TITLE
Release: Archiving Hubs, Updated Platform Links, Users + Orgs Filtering, Card + Canvas Activity Links Fix

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -346,16 +346,16 @@ platform:
   about: ${PLATFORM_ABOUT}:https://alkemio.foundation/about/
 
   # Home page - Impact
-  impact: ${PLATFORM_IMPACT}:https://alkemio.foundation
+  impact: ${PLATFORM_IMPACT}:https://alkemio.foundation/manifesto
 
   # Home page - Foundation
-  foundation: ${PLATFORM_FOUNDATION}:https://alkemio.foundation/vision/
+  foundation: ${PLATFORM_FOUNDATION}:https://alkemio.foundation/
 
   # Home page - Opensource
   opensource: ${PLATFORM_OPENSOURCE}:https://github.com/alkem-io
 
   # Home page - Opensource
-  releases: ${PLATFORM_RELEASES}:https://www.alkemio.foundation/releases
+  releases: ${PLATFORM_RELEASES}:https://alkemio.foundation/releases
 
 ssi:
   # Jolocom SDK is used for providing SSI capabilities on the platform.

--- a/graphql-samples/mutations/update/update-hub-visibility
+++ b/graphql-samples/mutations/update/update-hub-visibility
@@ -1,0 +1,13 @@
+mutation updateHubVisibility($visibilityData: UpdateHubVisibilityInput!) {
+  updateHubVisibility(visibilityData: $visibilityData) {
+    id
+  }
+}
+
+Variables:
+{
+  "visibilityData": {
+    "hubID": "uuid_nameid",
+    "visibility": "ARCHIVED"
+  }
+}

--- a/graphql-samples/queries/hubs-visibility
+++ b/graphql-samples/queries/hubs-visibility
@@ -1,0 +1,7 @@
+query {
+  hubs(filter: {visibilities: [ARCHIVED, ACTIVE, DEMO]}) {
+    nameID
+    visibility
+
+  }
+}

--- a/graphql-samples/queries/roles-user-visibilities
+++ b/graphql-samples/queries/roles-user-visibilities
@@ -1,0 +1,30 @@
+query {
+  rolesUser(rolesData: {userID: "admin-alkemio", filter: {visibilities: [ARCHIVED, ACTIVE, DEMO]}}) {
+   	hubs {
+      nameID
+      id
+      roles
+      challenges {
+        nameID
+        id
+        roles
+      }
+      opportunities {
+        nameID
+        displayName
+        id
+        roles
+      }
+      userGroups {
+        nameID
+        id
+      }
+    }
+    organizations {
+      nameID
+      id
+      roles
+    }
+  }
+
+}

--- a/graphql-samples/queries/users-filtered
+++ b/graphql-samples/queries/users-filtered
@@ -1,0 +1,5 @@
+query {
+  users(filter: {credentials: [HUB_HOST]}) {
+    nameID
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.33.3",
+  "version": "0.33.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.33.3",
+      "version": "0.33.4",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/apollo": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.33.3",
+  "version": "0.33.4",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/common/enums/hub.visibility.ts
+++ b/src/common/enums/hub.visibility.ts
@@ -1,0 +1,11 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum HubVisibility {
+  ACTIVE = 'active',
+  ARCHIVED = 'archived',
+  DEMO = 'demo',
+}
+
+registerEnumType(HubVisibility, {
+  name: 'HubVisibility',
+});

--- a/src/domain/challenge/challenge/challenge.entity.ts
+++ b/src/domain/challenge/challenge/challenge.entity.ts
@@ -42,7 +42,7 @@ export class Challenge extends BaseChallenge implements IChallenge {
   parentHub?: Hub;
 
   @Column()
-  hubID!: string;
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 
   @OneToOne(() => PreferenceSet, {
     eager: false,

--- a/src/domain/challenge/challenge/challenge.interface.ts
+++ b/src/domain/challenge/challenge/challenge.interface.ts
@@ -10,6 +10,9 @@ export abstract class IChallenge extends IBaseChallenge implements ISearchable {
   childChallenges?: IChallenge[];
   opportunities?: IOpportunity[];
 
-  @Field(() => String)
-  hubID!: string;
+  @Field(() => String, {
+    description: 'The ID of the containing Hub.',
+    nullable: false,
+  })
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 }

--- a/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
+++ b/src/domain/challenge/hub/dto/hub.args.query.hubs.ts
@@ -1,0 +1,11 @@
+import { ArgsType, Field } from '@nestjs/graphql';
+import { HubFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
+
+@ArgsType()
+export class HubsQueryArgs {
+  @Field(() => HubFilterInput, {
+    nullable: true,
+    description: 'Return Hubs matching the provided filter.',
+  })
+  filter!: HubFilterInput;
+}

--- a/src/domain/challenge/hub/dto/hub.dto.update.visibility.ts
+++ b/src/domain/challenge/hub/dto/hub.dto.update.visibility.ts
@@ -1,0 +1,18 @@
+import { HubVisibility } from '@common/enums/hub.visibility';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateHubVisibilityInput {
+  @Field(() => String, {
+    nullable: false,
+    description:
+      'The identifier for the Hub whose visibility is to be updated.',
+  })
+  hubID!: string;
+
+  @Field(() => HubVisibility, {
+    nullable: false,
+    description: 'Visibility of the Hub.',
+  })
+  visibility!: HubVisibility;
+}

--- a/src/domain/challenge/hub/hub.entity.ts
+++ b/src/domain/challenge/hub/hub.entity.ts
@@ -1,11 +1,19 @@
-import { Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
 import { IHub } from '@domain/challenge/hub/hub.interface';
 import { BaseChallenge } from '@domain/challenge/base-challenge/base.challenge.entity';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
 import { PreferenceSet } from '@domain/common/preference-set/preference.set.entity';
 import { TemplatesSet } from '@domain/template/templates-set/templates.set.entity';
+import { HubVisibility } from '@common/enums/hub.visibility';
 @Entity()
 export class Hub extends BaseChallenge implements IHub {
+  @Column('varchar', {
+    length: 255,
+    nullable: false,
+    default: HubVisibility.ACTIVE,
+  })
+  visibility?: HubVisibility;
+
   @OneToMany(() => Challenge, challenge => challenge.parentHub, {
     eager: false,
     cascade: true,

--- a/src/domain/challenge/hub/hub.interface.ts
+++ b/src/domain/challenge/hub/hub.interface.ts
@@ -1,13 +1,20 @@
 import { IChallenge } from '@domain/challenge/challenge/challenge.interface';
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { IBaseChallenge } from '@domain/challenge/base-challenge/base.challenge.interface';
 import { ITemplatesSet } from '@domain/template/templates-set';
 import { ISearchable } from '@domain/common/interfaces/searchable.interface';
+import { HubVisibility } from '@common/enums/hub.visibility';
 
 @ObjectType('Hub', {
   implements: () => [ISearchable],
 })
 export abstract class IHub extends IBaseChallenge {
+  @Field(() => HubVisibility, {
+    description: 'Visibility of the Hub.',
+    nullable: false,
+  })
+  visibility?: HubVisibility;
+
   challenges?: IChallenge[];
 
   templatesSet?: ITemplatesSet;

--- a/src/domain/challenge/hub/hub.module.ts
+++ b/src/domain/challenge/hub/hub.module.ts
@@ -26,6 +26,7 @@ import { PreferenceModule } from '@domain/common/preference';
 import { PreferenceSetModule } from '@domain/common/preference-set/preference.set.module';
 import { TemplatesSetModule } from '@domain/template/templates-set/templates.set.module';
 import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
+import { HubFilterModule } from '@services/domain/hub-filter/hub.filter.module';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { PlatformAuthorizationModule } from '@src/platform/authorization/platfor
     PreferenceModule,
     PreferenceSetModule,
     TemplatesSetModule,
+    HubFilterModule,
     TypeOrmModule.forFeature([Hub]),
   ],
   providers: [

--- a/src/domain/challenge/hub/hub.resolver.queries.ts
+++ b/src/domain/challenge/hub/hub.resolver.queries.ts
@@ -4,6 +4,7 @@ import { HubService } from './hub.service';
 import { IHub } from './hub.interface';
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { UUID_NAMEID } from '@domain/common/scalars';
+import { HubsQueryArgs } from './dto/hub.args.query.hubs';
 
 @Resolver()
 export class HubResolverQueries {
@@ -14,8 +15,8 @@ export class HubResolverQueries {
     description: 'The Hubs on this platform',
   })
   @Profiling.api
-  async hubs(): Promise<IHub[]> {
-    return await this.hubService.getHubs();
+  async hubs(@Args({ nullable: true }) args: HubsQueryArgs): Promise<IHub[]> {
+    return await this.hubService.getHubs(args);
   }
 
   @Query(() => IHub, {

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -59,6 +59,8 @@ export class CollaborationService {
           calloutDefault,
           communicationGroupID
         );
+        // default callouts are already published
+        callout.visibility = CalloutVisibility.PUBLISHED;
         savedCollaboration.callouts?.push(callout);
       }
     }

--- a/src/domain/collaboration/opportunity/opportunity.entity.ts
+++ b/src/domain/collaboration/opportunity/opportunity.entity.ts
@@ -20,7 +20,7 @@ export class Opportunity extends BaseChallenge implements IOpportunity {
   projects?: Project[];
 
   @Column()
-  hubID!: string;
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 
   constructor() {
     super();

--- a/src/domain/collaboration/opportunity/opportunity.interface.ts
+++ b/src/domain/collaboration/opportunity/opportunity.interface.ts
@@ -16,7 +16,7 @@ export abstract class IOpportunity
   })
   projects?: IProject[];
 
-  hubID!: string;
+  hubID?: string; //toDo make mandatory https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/alkem-io/server/2196
 
   @Field(() => IChallenge, {
     nullable: true,

--- a/src/domain/community/contributor/dto/contributor.dto.filter.ts
+++ b/src/domain/community/contributor/dto/contributor.dto.filter.ts
@@ -1,0 +1,11 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { AuthorizationCredential } from '@common/enums/authorization.credential';
+
+@InputType()
+export class ContributorFilterInput {
+  @Field(() => [AuthorizationCredential], {
+    nullable: true,
+    description: 'Return contributors with credentials in the provided list',
+  })
+  credentials?: AuthorizationCredential[];
+}

--- a/src/domain/community/contributor/dto/contributor.query.args.ts
+++ b/src/domain/community/contributor/dto/contributor.query.args.ts
@@ -1,0 +1,28 @@
+import { ContributorFilterInput } from '@domain/community/contributor/dto/contributor.dto.filter';
+import { ArgsType, Field, Float } from '@nestjs/graphql';
+
+@ArgsType()
+export class ContributorQueryArgs {
+  @Field(() => Float, {
+    name: 'limit',
+    description:
+      'The number of contributors to return; if omitted return all Contributors.',
+    nullable: true,
+  })
+  limit?: number;
+
+  @Field(() => Boolean, {
+    name: 'shuffle',
+    description:
+      'If true and limit is specified then return a random selection of Contributors. Defaults to false.',
+    nullable: true,
+  })
+  shuffle?: boolean;
+
+  @Field(() => ContributorFilterInput, {
+    name: 'filter',
+    description: 'Filtering criteria for returning results.',
+    nullable: true,
+  })
+  filter?: ContributorFilterInput;
+}

--- a/src/domain/community/organization/organization.resolver.queries.ts
+++ b/src/domain/community/organization/organization.resolver.queries.ts
@@ -1,5 +1,5 @@
 import { UUID_NAMEID } from '@domain/common/scalars';
-import { Args, Float, Query, Resolver } from '@nestjs/graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { Profiling } from '@src/common/decorators';
 import { IOrganization } from './organization.interface';
 import { OrganizationService } from './organization.service';
@@ -8,6 +8,7 @@ import { PaginationArgs } from '@core/pagination';
 import { OrganizationFilterInput } from '@core/filtering';
 import { UseGuards } from '@nestjs/common';
 import { PaginatedOrganization } from '@core/pagination/paginated.organization';
+import { ContributorQueryArgs } from '../contributor/dto/contributor.query.args';
 
 @Resolver()
 export class OrganizationResolverQueries {
@@ -19,24 +20,9 @@ export class OrganizationResolverQueries {
   })
   @Profiling.api
   async organizations(
-    @Args({
-      name: 'limit',
-      type: () => Float,
-      description:
-        'The number of Organizations to return; if omitted return all Organizations.',
-      nullable: true,
-    })
-    limit: number,
-    @Args({
-      name: 'shuffle',
-      type: () => Boolean,
-      description:
-        'If true and limit is specified then return the Organizations based on a random selection. Defaults to false.',
-      nullable: true,
-    })
-    shuffle: boolean
+    @Args({ nullable: true }) args: ContributorQueryArgs
   ): Promise<IOrganization[]> {
-    return await this.organizationService.getOrganizations(limit, shuffle);
+    return await this.organizationService.getOrganizations(args);
   }
 
   @Query(() => IOrganization, {

--- a/src/migrations/1663786651174-hub-visibility.ts
+++ b/src/migrations/1663786651174-hub-visibility.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class hubVisibility1663786651174 implements MigrationInterface {
+  name = 'hubVisibility1663786651174';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`hub\` ADD \`visibility\` varchar(255) NULL`
+    );
+    const hubs: any[] = await queryRunner.query(`SELECT id from hub`);
+    for (const hub of hubs) {
+      await queryRunner.query(
+        `UPDATE \`hub\` SET \`visibility\` = 'active' WHERE \`id\`= '${hub.id}'`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`hub\` DROP COLUMN \`visibility\``);
+  }
+}

--- a/src/migrations/1664212708443-activity-parentID2.ts
+++ b/src/migrations/1664212708443-activity-parentID2.ts
@@ -17,12 +17,14 @@ export class activityParentID21664212708443 implements MigrationInterface {
           const calloutsAspects = await queryRunner.query(
             `SELECT id, calloutId from aspect where id='${activity.resourceID}'`
           );
+          if (!calloutsAspects?.[0].calloutId) continue;
           parentID = calloutsAspects[0].calloutId;
           break;
         case 'canvas-created':
           const calloutsCanvases = await queryRunner.query(
             `SELECT id, calloutId from canvas where id='${activity.resourceID}'`
           );
+          if (!calloutsCanvases?.[0].calloutId) continue;
           parentID = calloutsCanvases[0].calloutId;
           break;
       }

--- a/src/migrations/1664212708443-activity-parentID2.ts
+++ b/src/migrations/1664212708443-activity-parentID2.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class activityParentID21664212708443 implements MigrationInterface {
+  name = 'activityParentID21664212708443';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const activities: any[] = await queryRunner.query(
+      `SELECT id, resourceID, parentID, type from activity`
+    );
+    for (const activity of activities) {
+      if (activity.parentID) continue;
+      let parentID = undefined;
+      switch (activity.type) {
+        case 'card-created':
+        case 'card-comment':
+          // set callout ID as parent ID
+          const calloutsAspects = await queryRunner.query(
+            `SELECT id, calloutId from aspect where id='${activity.resourceID}'`
+          );
+          parentID = calloutsAspects[0].calloutId;
+          break;
+        case 'canvas-created':
+          const calloutsCanvases = await queryRunner.query(
+            `SELECT id, calloutId from canvas where id='${activity.resourceID}'`
+          );
+          parentID = calloutsCanvases[0].calloutId;
+          break;
+      }
+
+      await queryRunner.query(
+        `UPDATE activity SET parentID= '${parentID}' WHERE id= '${activity.id}'`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/migrations/1664212708443-activity-parentID2.ts
+++ b/src/migrations/1664212708443-activity-parentID2.ts
@@ -17,14 +17,14 @@ export class activityParentID21664212708443 implements MigrationInterface {
           const calloutsAspects = await queryRunner.query(
             `SELECT id, calloutId from aspect where id='${activity.resourceID}'`
           );
-          if (!calloutsAspects?.[0].calloutId) continue;
+          if (!calloutsAspects?.[0]?.calloutId) continue;
           parentID = calloutsAspects[0].calloutId;
           break;
         case 'canvas-created':
           const calloutsCanvases = await queryRunner.query(
             `SELECT id, calloutId from canvas where id='${activity.resourceID}'`
           );
-          if (!calloutsCanvases?.[0].calloutId) continue;
+          if (!calloutsCanvases?.[0]?.calloutId) continue;
           parentID = calloutsCanvases[0].calloutId;
           break;
       }

--- a/src/migrations/1664212708443-activity-parentID2.ts
+++ b/src/migrations/1664212708443-activity-parentID2.ts
@@ -17,23 +17,33 @@ export class activityParentID21664212708443 implements MigrationInterface {
           const calloutsAspects = await queryRunner.query(
             `SELECT id, calloutId from aspect where id='${activity.resourceID}'`
           );
-          if (!calloutsAspects?.[0]?.calloutId) continue;
+          if (!this.hasCalloutId(calloutsAspects)) continue;
           parentID = calloutsAspects[0].calloutId;
           break;
         case 'canvas-created':
           const calloutsCanvases = await queryRunner.query(
             `SELECT id, calloutId from canvas where id='${activity.resourceID}'`
           );
-          if (!calloutsCanvases?.[0]?.calloutId) continue;
+          if (!this.hasCalloutId(calloutsCanvases))  continue;
           parentID = calloutsCanvases[0].calloutId;
           break;
       }
 
-      await queryRunner.query(
-        `UPDATE activity SET parentID= '${parentID}' WHERE id= '${activity.id}'`
-      );
+      if(parentID)
+        await queryRunner.query(
+          `UPDATE activity SET parentID= '${parentID}' WHERE id= '${activity.id}'`
+        );
     }
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {}
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE activity SET parentID = NULL`
+    );
+  }
+
+  private hasCalloutId(calloutsChildren: any): boolean {
+    if(!calloutsChildren || !calloutsChildren[0] || !calloutsChildren[0].calloutId) return false;
+    return true
+  }
 }

--- a/src/services/domain/conversion/conversion.resolver.mutations.ts
+++ b/src/services/domain/conversion/conversion.resolver.mutations.ts
@@ -90,10 +90,12 @@ export class ConversionResolverMutations {
     const newChallenge =
       await this.conversionService.convertOpportunityToChallenge(
         convertOpportunityToChallengeData.opportunityID,
-        opportunity.hubID,
+        this.opportunityService.getHubID(opportunity),
         agentInfo
       );
-    const parentHub = await this.hubService.getHubOrFail(newChallenge.hubID);
+    const parentHub = await this.hubService.getHubOrFail(
+      this.challengeService.getHubID(newChallenge)
+    );
     await this.hubAuthorizationService.applyAuthorizationPolicy(parentHub);
     return this.challengeService.getChallengeOrFail(newChallenge.id);
   }

--- a/src/services/domain/hub-filter/dto/hub.filter.dto.input.ts
+++ b/src/services/domain/hub-filter/dto/hub.filter.dto.input.ts
@@ -1,0 +1,12 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { HubVisibility } from '@common/enums/hub.visibility';
+
+@InputType()
+export class HubFilterInput {
+  @Field(() => [HubVisibility], {
+    nullable: true,
+    description:
+      'Return Hubs with a Visibility matching one of the provided types.',
+  })
+  visibilities!: HubVisibility[];
+}

--- a/src/services/domain/hub-filter/hub.filter.module.ts
+++ b/src/services/domain/hub-filter/hub.filter.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HubFilterService } from './hub.filter.service';
+
+@Module({
+  imports: [],
+  providers: [HubFilterService],
+  exports: [HubFilterService],
+})
+export class HubFilterModule {}

--- a/src/services/domain/hub-filter/hub.filter.service.ts
+++ b/src/services/domain/hub-filter/hub.filter.service.ts
@@ -1,0 +1,41 @@
+import { HubVisibility } from '@common/enums/hub.visibility';
+import { LogContext } from '@common/enums/logging.context';
+import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
+import { Inject, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { HubFilterInput } from './dto/hub.filter.dto.input';
+
+export class HubFilterService {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  public getAllowedVisibilities(
+    filter: HubFilterInput | undefined
+  ): HubVisibility[] {
+    let visibilities = [HubVisibility.ACTIVE];
+    if (filter && filter.visibilities && filter.visibilities.length > 0) {
+      visibilities = filter.visibilities;
+    }
+    this.logger.verbose?.(
+      `Loading hubs with visibilities: ${visibilities}`,
+      LogContext.CHALLENGES
+    );
+    return visibilities;
+  }
+
+  public isVisible(
+    visibility: HubVisibility | undefined,
+    allowedVisibilities: HubVisibility[]
+  ): boolean {
+    if (!visibility) {
+      throw new RelationshipNotFoundException(
+        `Hub Visibility not provided when searching for ${allowedVisibilities}`,
+        LogContext.CHALLENGES
+      );
+    }
+    const result = allowedVisibilities.find(v => v === visibility);
+    if (result) return true;
+    return false;
+  }
+}

--- a/src/services/domain/metadata/metadata.service.ts
+++ b/src/services/domain/metadata/metadata.service.ts
@@ -53,7 +53,7 @@ export class MetadataService {
     hubsTopic.id = 'hubs';
     activity.push(hubsTopic);
 
-    const challengesCount = await this.challengeService.getChallengeCount();
+    const challengesCount = await this.challengeService.getChallengesCount();
     const challengesTopic = new NVP('challenges', challengesCount.toString());
     challengesTopic.id = 'challenges';
     activity.push(challengesTopic);

--- a/src/services/domain/roles/dto/roles.dto.input.organization.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.organization.ts
@@ -1,5 +1,6 @@
 import { UUID_NAMEID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
+import { HubFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @InputType()
 export class RolesOrganizationInput {
@@ -8,4 +9,10 @@ export class RolesOrganizationInput {
     description: 'The ID of the organization to retrieve the roles of.',
   })
   organizationID!: string;
+
+  @Field(() => HubFilterInput, {
+    nullable: true,
+    description: 'Return membership in Hubs matching the provided filter.',
+  })
+  filter?: HubFilterInput;
 }

--- a/src/services/domain/roles/dto/roles.dto.input.user.ts
+++ b/src/services/domain/roles/dto/roles.dto.input.user.ts
@@ -1,5 +1,6 @@
 import { UUID_NAMEID_EMAIL } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
+import { HubFilterInput } from '@services/domain/hub-filter/dto/hub.filter.dto.input';
 
 @InputType()
 export class RolesUserInput {
@@ -8,4 +9,10 @@ export class RolesUserInput {
     description: 'The ID of the user to retrieve the roles of.',
   })
   userID!: string;
+
+  @Field(() => HubFilterInput, {
+    nullable: true,
+    description: 'Return membership in Hubs matching the provided filter.',
+  })
+  filter?: HubFilterInput;
 }

--- a/src/services/domain/roles/roles.module.ts
+++ b/src/services/domain/roles/roles.module.ts
@@ -15,6 +15,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Opportunity } from '@domain/collaboration/opportunity/opportunity.entity';
 import { Challenge } from '@domain/challenge/challenge/challenge.entity';
 import { PlatformAuthorizationModule } from '@src/platform/authorization/platform.authorization.module';
+import { HubFilterModule } from '../hub-filter/hub.filter.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { PlatformAuthorizationModule } from '@src/platform/authorization/platfor
     OrganizationModule,
     HubModule,
     PlatformAuthorizationModule,
+    HubFilterModule,
     TypeOrmModule.forFeature([Challenge]),
     TypeOrmModule.forFeature([Opportunity]),
   ],

--- a/src/services/domain/roles/roles.service.spec.ts
+++ b/src/services/domain/roles/roles.service.spec.ts
@@ -7,6 +7,7 @@ import { MockOrganizationService } from '@test/mocks/organization.service.mock';
 import { MockUserGroupService } from '@test/mocks/user.group.service.mock';
 import { MockUserService } from '@test/mocks/user.service.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { MockHubFilterService } from '@test/mocks/hub.filter.service.mock';
 import { Test } from '@nestjs/testing';
 import { RolesService } from './roles.service';
 import { UserService } from '@domain/community/user/user.service';
@@ -16,6 +17,7 @@ import { OpportunityService } from '@domain/collaboration/opportunity/opportunit
 import { ApplicationService } from '@domain/community/application/application.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { CommunityService } from '@domain/community/community/community.service';
+import { HubFilterService } from '../hub-filter/hub.filter.service';
 import { asyncToThrow, testData } from '@test/utils';
 import { RelationshipNotFoundException } from '@common/exceptions';
 
@@ -24,6 +26,7 @@ describe('RolesService', () => {
   let userService: UserService;
   let hubService: HubService;
   let challengeSerivce: ChallengeService;
+  let hubFilterService: HubFilterService;
   let opportunityService: OpportunityService;
   let applicationService: ApplicationService;
   let organizationService: OrganizationService;
@@ -40,6 +43,7 @@ describe('RolesService', () => {
         MockCommunityService,
         MockOpportunityService,
         MockOrganizationService,
+        MockHubFilterService,
         MockWinstonProvider,
         RolesService,
       ],
@@ -53,6 +57,7 @@ describe('RolesService', () => {
     applicationService = moduleRef.get(ApplicationService);
     organizationService = moduleRef.get(OrganizationService);
     communityService = moduleRef.get(CommunityService);
+    hubFilterService = moduleRef.get(HubFilterService);
   });
 
   it('should be defined', () => {
@@ -93,6 +98,8 @@ describe('RolesService', () => {
         .spyOn(applicationService, 'getApplicationState')
         .mockResolvedValue('new');
 
+      jest.spyOn(hubFilterService, 'isVisible').mockReturnValue(true);
+
       jest.spyOn(communityService, 'isHubCommunity').mockResolvedValue(true);
 
       const res = await rolesService.getUserRoles({
@@ -115,6 +122,8 @@ describe('RolesService', () => {
           }),
         ])
       );
+
+      console.log(JSON.stringify(res.hubs));
 
       expect(res.hubs).toEqual(
         expect.arrayContaining([

--- a/test/config/jest.config.ci.js
+++ b/test/config/jest.config.ci.js
@@ -1,7 +1,5 @@
 module.exports = {
   ...require('./jest.config'),
-  testMatch: [
-    '**/?(*.)+(spec).ts',
-  ],
+  testMatch: ['**/?(*.)+(spec).ts'],
   coverageDirectory: '<rootDir>/coverage-ci',
 };

--- a/test/mocks/challenge.service.mock.ts
+++ b/test/mocks/challenge.service.mock.ts
@@ -8,5 +8,6 @@ export const MockChallengeService: ValueProvider<PublicPart<ChallengeService>> =
     useValue: {
       getChallengeOrFail: jest.fn(),
       getChallengeForCommunity: jest.fn(),
+      getHubID: jest.fn(),
     },
   };

--- a/test/mocks/hub.filter.service.mock.ts
+++ b/test/mocks/hub.filter.service.mock.ts
@@ -1,0 +1,12 @@
+import { ValueProvider } from '@nestjs/common';
+import { HubFilterService } from '@services/domain/hub-filter/hub.filter.service';
+import { PublicPart } from '../utils/public-part';
+
+export const MockHubFilterService: ValueProvider<PublicPart<HubFilterService>> =
+  {
+    provide: HubFilterService,
+    useValue: {
+      getAllowedVisibilities: jest.fn(),
+      isVisible: jest.fn(),
+    },
+  };

--- a/test/mocks/opportunity.service.mock.ts
+++ b/test/mocks/opportunity.service.mock.ts
@@ -9,5 +9,6 @@ export const MockOpportunityService: ValueProvider<
   useValue: {
     getOpportunityForCommunity: jest.fn(),
     getOpportunityOrFail: jest.fn(),
+    getHubID: jest.fn(),
   },
 };


### PR DESCRIPTION
## API
   - Added an option to change the state of hubs to ARCHIVE / DEMO and then filter Hubs based on the state
   - Updated platform links
   - Default `Callouts` now are in `Published` state upon creation

## Fixes
   - Added a migration to set parentID for migrated `Card` + `Canvas` `Activity`