### PR TITLE
no longer save canvasCheckout as part of updating the authorizationPolicy

### DIFF
--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -73,6 +73,12 @@ export class AuthorizationPolicyService {
     );
   }
 
+  async save(
+    authorizationPolicy: IAuthorizationPolicy
+  ): Promise<IAuthorizationPolicy> {
+    return await this.authorizationPolicyRepository.save(authorizationPolicy);
+  }
+
   validateAuthorization(
     authorization: IAuthorizationPolicy | undefined
   ): IAuthorizationPolicy {

--- a/src/domain/common/canvas-checkout/canvas.checkout.service.authorization.ts
+++ b/src/domain/common/canvas-checkout/canvas.checkout.service.authorization.ts
@@ -5,28 +5,23 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { ICanvasCheckout } from './canvas.checkout.interface';
 import { AuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential';
-import { CanvasCheckoutService } from './canvas.checkout.service';
 
 @Injectable()
 export class CanvasCheckoutAuthorizationService {
-  constructor(
-    private authorizationPolicyService: AuthorizationPolicyService,
-    private canvasCheckoutService: CanvasCheckoutService
-  ) {}
+  constructor(private authorizationPolicyService: AuthorizationPolicyService) {}
 
   async applyAuthorizationPolicy(
     canvasCheckout: ICanvasCheckout,
     parentAuthorization: IAuthorizationPolicy | undefined
-  ): Promise<ICanvasCheckout> {
+  ): Promise<IAuthorizationPolicy> {
     canvasCheckout.authorization =
       this.authorizationPolicyService.inheritParentAuthorization(
         canvasCheckout.authorization,
         parentAuthorization
       );
-    canvasCheckout.authorization =
+    const extendedAuthPolicy =
       this.extendAuthorizationPolicyForCheckoutOwner(canvasCheckout);
-
-    return await this.canvasCheckoutService.save(canvasCheckout);
+    return await this.authorizationPolicyService.save(extendedAuthPolicy);
   }
 
   private extendAuthorizationPolicyForCheckoutOwner(

--- a/src/domain/common/canvas-checkout/canvas.checkout.service.ts
+++ b/src/domain/common/canvas-checkout/canvas.checkout.service.ts
@@ -62,8 +62,8 @@ export class CanvasCheckoutService {
     return result;
   }
 
-  async save(CanvasCheckout: ICanvasCheckout): Promise<ICanvasCheckout> {
-    return await this.canvasCheckoutRepository.save(CanvasCheckout);
+  async save(canvasCheckout: ICanvasCheckout): Promise<ICanvasCheckout> {
+    return await this.canvasCheckoutRepository.save(canvasCheckout);
   }
 
   async getCanvasCheckoutOrFail(

--- a/src/domain/common/canvas/canvas.resolver.mutations.ts
+++ b/src/domain/common/canvas/canvas.resolver.mutations.ts
@@ -20,12 +20,14 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LogContext } from '@common/enums/logging.context';
 import { getRandomId } from '@src/common';
 import { DeleteCanvasInput } from './dto/canvas.dto.delete';
+import { CanvasCheckoutService } from '../canvas-checkout/canvas.checkout.service';
 
 @Resolver(() => ICanvas)
 export class CanvasResolverMutations {
   constructor(
     private authorizationService: AuthorizationService,
     private canvasService: CanvasService,
+    private canvasCheckoutService: CanvasCheckoutService,
     private canvasCheckoutAuthorizationService: CanvasCheckoutAuthorizationService,
     private canvasCheckoutLifecycleOptionsProvider: CanvasCheckoutLifecycleOptionsProvider,
     @Inject(SUBSCRIPTION_CANVAS_CONTENT)
@@ -50,9 +52,12 @@ export class CanvasResolverMutations {
     const canvas = await this.canvasService.getCanvasOrFail(
       canvasCheckout.canvasID
     );
-    return await this.canvasCheckoutAuthorizationService.applyAuthorizationPolicy(
+    await this.canvasCheckoutAuthorizationService.applyAuthorizationPolicy(
       canvasCheckout,
       canvas.authorization
+    );
+    return this.canvasCheckoutService.getCanvasCheckoutOrFail(
+      canvasCheckout.id
     );
   }
 

--- a/src/domain/common/canvas/canvas.service.authorization.ts
+++ b/src/domain/common/canvas/canvas.service.authorization.ts
@@ -33,7 +33,7 @@ export class CanvasAuthorizationService {
     canvas.authorization = this.appendPrivilegeRules(canvas.authorization);
 
     if (canvas.checkout) {
-      canvas.checkout =
+      canvas.checkout.authorization =
         await this.canvasCheckoutAuthorizationService.applyAuthorizationPolicy(
           canvas.checkout,
           canvas.authorization


### PR DESCRIPTION
The canvasCheckout should not be saved except during the commands triggered during the XState event handling