### PR TITLE
added additional default callout for new journeys as per product design

### DIFF
--- a/src/domain/collaboration/collaboration/collaboration.defaults.ts
+++ b/src/domain/collaboration/collaboration/collaboration.defaults.ts
@@ -6,26 +6,6 @@ import { CommunityType } from '@common/enums/community.type';
 export const collaborationDefaults: any = {
   callouts: [
     {
-      type: CalloutType.CANVAS,
-      displayName: 'Collaborate visually',
-      nameID: `${CalloutType.CANVAS}-default`,
-      description:
-        'Collaborate visually using Canvases. Create a new Canvas from a template, or explore Canvases already created.',
-      visibility: CalloutVisibility.PUBLISHED,
-      state: CalloutState.OPEN,
-      sortOrder: 5,
-    },
-    {
-      type: CalloutType.CARD,
-      displayName: 'Contribute',
-      nameID: `${CalloutType.CARD}-default`,
-      description:
-        'Contribute your insights to understanding the context. It is about surfacing up the wisdom of the community. Add your own card, or comment on aspects added by others.',
-      visibility: CalloutVisibility.PUBLISHED,
-      state: CalloutState.OPEN,
-      sortOrder: 3,
-    },
-    {
       type: CalloutType.COMMENTS,
       communityType: CommunityType.HUB,
       displayName: 'Welcome, please introduce yourself to the community!',
@@ -46,6 +26,35 @@ export const collaborationDefaults: any = {
       visibility: CalloutVisibility.PUBLISHED,
       state: CalloutState.OPEN,
       sortOrder: 1,
+    },
+    {
+      type: CalloutType.COMMENTS,
+      displayName: 'Suggestions, Questions, and Feedback',
+      nameID: 'suggestions',
+      description: 'Please share it here :)',
+      visibility: CalloutVisibility.PUBLISHED,
+      state: CalloutState.OPEN,
+      sortOrder: 3,
+    },
+    {
+      type: CalloutType.CARD,
+      displayName: 'Contribute',
+      nameID: `${CalloutType.CARD}-default`,
+      description:
+        'Contribute your insights to understanding the context. It is about surfacing up the wisdom of the community. Add your own card, or comment on aspects added by others.',
+      visibility: CalloutVisibility.PUBLISHED,
+      state: CalloutState.OPEN,
+      sortOrder: 5,
+    },
+    {
+      type: CalloutType.CANVAS,
+      displayName: 'Collaborate visually',
+      nameID: `${CalloutType.CANVAS}-default`,
+      description:
+        'Collaborate visually using Canvases. Create a new Canvas from a template, or explore Canvases already created.',
+      visibility: CalloutVisibility.PUBLISHED,
+      state: CalloutState.OPEN,
+      sortOrder: 10,
     },
   ],
 };


### PR DESCRIPTION
For new Hubs, Challenges + Opportunities there is now an additional callout by default:

![image](https://user-images.githubusercontent.com/30729240/196610362-4bacfa8a-dee5-438b-9f00-3c664c3c49b3.png)
