### PR TITLE
Extended kratos identity schema to include picture

### DIFF
--- a/.build/ory/kratos/email-password/identity.schema.json
+++ b/.build/ory/kratos/email-password/identity.schema.json
@@ -42,6 +42,10 @@
         "accepted_terms": {
           "title": "TERMS_MESSAGE",
           "type": "boolean"
+        },
+        "picture": {
+          "title": "Profile Picture",
+          "type": "string"
         }
       },
       "required": ["email", "accepted_terms"],

--- a/.build/ory/kratos/email-password/oidc.linkedin.jsonnet
+++ b/.build/ory/kratos/email-password/oidc.linkedin.jsonnet
@@ -1,0 +1,19 @@
+local claims =
+{
+  email_verified: false
+} + std.extVar('claims');
+{
+  identity:
+  {
+    traits:
+    {
+      email: claims.email,
+      picture: claims.picture,
+      name:
+      {
+        first: claims.name,
+        last: claims.last_name,
+      }
+    },
+  },
+}

--- a/src/core/authentication/ory.default.identity.schema.ts
+++ b/src/core/authentication/ory.default.identity.schema.ts
@@ -18,6 +18,7 @@ export interface OryDefaultIdentitySchema extends Identity {
   state_changed_at: string;
   traits: {
     accepted_terms: boolean;
+    picture: string;
     email: string;
     name: {
       first: string;


### PR DESCRIPTION
- Extended identity schema to include picture
- Claim is supported out-of-the-box by Ory Kratos
- Already created identities will not have their identity schema changed - that needs to be dealt separately and is not out-of-the-box provided by Ory Kratos
- Extended identity schema type