### PR TITLE
Library with InnovationPacks

### DIFF
--- a/graphql-samples/mutations/authorization/reset-authorization-on-library
+++ b/graphql-samples/mutations/authorization/reset-authorization-on-library
@@ -1,0 +1,6 @@
+mutation authorizationPolicyResetOnLibrary {
+  authorizationPolicyResetOnLibrary {
+    id
+  }
+}
+

--- a/graphql-samples/mutations/create/create-innovation-pack-on-library
+++ b/graphql-samples/mutations/create/create-innovation-pack-on-library
@@ -1,0 +1,14 @@
+mutation createInnovationPackOnLibrary($data: CreateInnovationPackOnLibraryInput!){
+  createInnovationPackOnLibrary(packData: $data){
+    id
+  }
+}
+
+Variables:
+{
+	"data": {
+    "displayName": "innovationPack 1",
+    "nameID": "pack1",
+    "providerID": "uuid_nameid"
+  }
+}

--- a/graphql-samples/mutations/delete/delete-innovation-pack
+++ b/graphql-samples/mutations/delete/delete-innovation-pack
@@ -1,8 +1,6 @@
 mutation deleteInnovationPack($deleteData: DeleteInnovationPackInput!) {
   deleteInnovationPack(deleteData: $deleteData) {
-    info {
-      title
-    }
+    id
   }
 }
 

--- a/graphql-samples/mutations/delete/delete-innovation-pack
+++ b/graphql-samples/mutations/delete/delete-innovation-pack
@@ -1,0 +1,14 @@
+mutation deleteInnovationPack($deleteData: DeleteInnovationPackInput!) {
+  deleteInnovationPack(deleteData: $deleteData) {
+    info {
+      title
+    }
+  }
+}
+
+Variables:
+{
+  "deleteData": {
+      "ID": "uuid"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -47,6 +47,7 @@ import { ConversionModule } from '@services/api/conversion/conversion.module';
 import { SessionExtendMiddleware } from '@src/core/middleware';
 import { ActivityLogModule } from '@services/api/activity-log/activity.log.module';
 import { MessageModule } from '@domain/communication/message/message.module';
+import { LibraryModule } from '@library/library/library.module';
 
 @Module({
   imports: [
@@ -197,6 +198,7 @@ import { MessageModule } from '@domain/communication/message/message.module';
     RegistrationModule,
     RedisLockModule,
     ConversionModule,
+    LibraryModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/enums/authorization.credential.ts
+++ b/src/common/enums/authorization.credential.ts
@@ -26,6 +26,9 @@ export enum AuthorizationCredential {
   ORGANIZATION_ASSOCIATE = 'organization-associate', // Able to be a part of an organization
 
   USER_GROUP_MEMBER = 'user-group-member', // Able to be a part of an user group
+
+  // Library related credentials
+  INNOVATION_PACK_PROVIDER = 'innovation-pack-provider',
 }
 
 registerEnumType(AuthorizationCredential, {

--- a/src/common/enums/logging.context.ts
+++ b/src/common/enums/logging.context.ts
@@ -26,4 +26,5 @@ export enum LogContext {
   PAGINATION = 'pagination',
   ROLES = 'roles',
   TEMPLATES = 'templates',
+  LIBRARY = 'library',
 }

--- a/src/config/aliases.ts
+++ b/src/config/aliases.ts
@@ -13,6 +13,7 @@ moduleAlias.addAliases({
   '@core': path.join(rootCorePath),
   '@config': path.join(rootCorePath, 'config'),
   '@platform': path.join(rootCorePath, 'platform'),
+  '@library': path.join(rootCorePath, 'library'),
   '@templates': path.join(rootServicesPath, 'configuration', 'templates'),
   '@src': rootPath,
 });

--- a/src/library/innovation-pack/dto/innovation.pack.dto.create.ts
+++ b/src/library/innovation-pack/dto/innovation.pack.dto.create.ts
@@ -1,0 +1,12 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { CreateNameableInput } from '@domain/common/entity/nameable-entity/nameable.dto.create';
+import { UUID_NAMEID } from '@domain/common/scalars/scalar.uuid.nameid';
+
+@InputType()
+export class CreateInnovationPackInput extends CreateNameableInput {
+  @Field(() => UUID_NAMEID, {
+    nullable: false,
+    description: 'The provider Organization for the InnovationPack',
+  })
+  providerID!: string;
+}

--- a/src/library/innovation-pack/dto/innovation.pack.dto.update.ts
+++ b/src/library/innovation-pack/dto/innovation.pack.dto.update.ts
@@ -1,0 +1,21 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+import { UUID_NAMEID } from '@domain/common/scalars';
+import { UpdateNameableInput } from '@domain/common/entity/nameable-entity/nameable.dto.update';
+
+@InputType()
+export class UpdateInnovationPackInput extends UpdateNameableInput {
+  @Field(() => UUID_NAMEID, {
+    nullable: true,
+    description: 'Update the provider Organization for the InnovationPack.',
+  })
+  @IsOptional()
+  providerOrgID?: string;
+
+  // Override the type of entry accepted to accept the nameID also
+  @Field(() => UUID_NAMEID, {
+    nullable: false,
+    description: 'The ID or NameID of the InnovationPack.',
+  })
+  ID!: string;
+}

--- a/src/library/innovation-pack/dto/innovationPack.dto.delete.ts
+++ b/src/library/innovation-pack/dto/innovationPack.dto.delete.ts
@@ -1,0 +1,8 @@
+import { UUID_NAMEID } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class DeleteInnovationPackInput {
+  @Field(() => UUID_NAMEID, { nullable: false })
+  ID!: string;
+}

--- a/src/library/innovation-pack/index.ts
+++ b/src/library/innovation-pack/index.ts
@@ -1,0 +1,3 @@
+export * from './dto/innovation.pack.dto.update';
+export * from './dto/innovationPack.dto.delete';
+export * from './dto/innovation.pack.dto.create';

--- a/src/library/innovation-pack/innovation.pack.entity.ts
+++ b/src/library/innovation-pack/innovation.pack.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, JoinColumn, ManyToOne, OneToOne } from 'typeorm';
+import { TemplatesSet } from '@domain/template/templates-set/templates.set.entity';
+import { NameableEntity } from '@domain/common/entity/nameable-entity';
+import { Library } from '../library/library.entity';
+import { IInnovationPack } from './innovation.pack.interface';
+
+@Entity()
+export class InnovationPack extends NameableEntity implements IInnovationPack {
+  @ManyToOne(() => Library, library => library.innovationPacks, {
+    eager: false,
+    cascade: false,
+    onDelete: 'CASCADE',
+  })
+  library?: Library;
+
+  @OneToOne(() => TemplatesSet, {
+    eager: false,
+    cascade: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn()
+  templatesSet?: TemplatesSet;
+
+  constructor() {
+    super();
+  }
+}

--- a/src/library/innovation-pack/innovation.pack.interface.ts
+++ b/src/library/innovation-pack/innovation.pack.interface.ts
@@ -1,0 +1,8 @@
+import { ObjectType } from '@nestjs/graphql';
+import { ITemplatesSet } from '@domain/template/templates-set';
+import { INameable } from '@domain/common/entity/nameable-entity/nameable.interface';
+
+@ObjectType('InnovatonPack')
+export abstract class IInnovationPack extends INameable {
+  templatesSet?: ITemplatesSet;
+}

--- a/src/library/innovation-pack/innovation.pack.module.ts
+++ b/src/library/innovation-pack/innovation.pack.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TemplatesSetModule } from '@domain/template/templates-set/templates.set.module';
+import { InnovationPack } from './innovation.pack.entity';
+import { InnovationPackService } from './innovaton.pack.service';
+import { InnovationPackAuthorizationService } from './innovation.pack.service.authorization';
+import { InnovationPackResolverFields } from './innovation.pack.resolver.fields';
+import { InnovationPackResolverMutations } from './innovation.pack.resolver.mutations';
+
+@Module({
+  imports: [TemplatesSetModule, TypeOrmModule.forFeature([InnovationPack])],
+  providers: [
+    InnovationPackService,
+    InnovationPackAuthorizationService,
+    InnovationPackResolverFields,
+    InnovationPackResolverMutations,
+  ],
+  exports: [InnovationPackService, InnovationPackAuthorizationService],
+})
+export class InnovationPackModule {}

--- a/src/library/innovation-pack/innovation.pack.module.ts
+++ b/src/library/innovation-pack/innovation.pack.module.ts
@@ -6,9 +6,20 @@ import { InnovationPackService } from './innovaton.pack.service';
 import { InnovationPackAuthorizationService } from './innovation.pack.service.authorization';
 import { InnovationPackResolverFields } from './innovation.pack.resolver.fields';
 import { InnovationPackResolverMutations } from './innovation.pack.resolver.mutations';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { OrganizationModule } from '@domain/community/organization/organization.module';
+import { AgentModule } from '@domain/agent/agent/agent.module';
 
 @Module({
-  imports: [TemplatesSetModule, TypeOrmModule.forFeature([InnovationPack])],
+  imports: [
+    TemplatesSetModule,
+    AuthorizationModule,
+    AuthorizationPolicyModule,
+    OrganizationModule,
+    AgentModule,
+    TypeOrmModule.forFeature([InnovationPack]),
+  ],
   providers: [
     InnovationPackService,
     InnovationPackAuthorizationService,

--- a/src/library/innovation-pack/innovation.pack.resolver.fields.ts
+++ b/src/library/innovation-pack/innovation.pack.resolver.fields.ts
@@ -1,0 +1,39 @@
+import { AuthorizationPrivilege } from '@common/enums';
+import { GraphqlGuard } from '@core/authorization';
+import { IOrganization } from '@domain/community';
+import { UseGuards } from '@nestjs/common';
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { AuthorizationAgentPrivilege, Profiling } from '@src/common/decorators';
+import { ITemplatesSet } from '@domain/template/templates-set';
+import { IInnovationPack } from './innovation.pack.interface';
+import { InnovationPackService } from './innovaton.pack.service';
+
+@Resolver(() => IInnovationPack)
+export class InnovationPackResolverFields {
+  constructor(private innovationPackService: InnovationPackService) {}
+
+  @ResolveField('provider', () => IOrganization, {
+    nullable: true,
+    description: 'The InnovationPack provider.',
+  })
+  @Profiling.api
+  async provider(
+    @Parent() innovationPack: IInnovationPack
+  ): Promise<IOrganization | undefined> {
+    return await this.innovationPackService.getProvider(innovationPack.id);
+  }
+
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @ResolveField('templates', () => ITemplatesSet, {
+    nullable: true,
+    description: 'The templates in use by this InnovationPack',
+  })
+  @UseGuards(GraphqlGuard)
+  async templatesSet(
+    @Parent() innovationPack: IInnovationPack
+  ): Promise<ITemplatesSet> {
+    return await this.innovationPackService.getTemplatesSetOrFail(
+      innovationPack.id
+    );
+  }
+}

--- a/src/library/innovation-pack/innovation.pack.resolver.mutations.ts
+++ b/src/library/innovation-pack/innovation.pack.resolver.mutations.ts
@@ -1,0 +1,65 @@
+import { UseGuards } from '@nestjs/common';
+import { Resolver, Args, Mutation } from '@nestjs/graphql';
+import { CurrentUser, Profiling } from '@src/common/decorators';
+import { InnovationPackService } from './innovaton.pack.service';
+
+import { GraphqlGuard } from '@core/authorization';
+import { AgentInfo } from '@core/authentication';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { IInnovationPack } from './innovation.pack.interface';
+import { UpdateInnovationPackInput } from './dto/innovation.pack.dto.update';
+import { DeleteInnovationPackInput } from './dto/innovationPack.dto.delete';
+
+@Resolver()
+export class InnovationPackResolverMutations {
+  constructor(
+    private authorizationService: AuthorizationService,
+    private innovationPackService: InnovationPackService
+  ) {}
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => IInnovationPack, {
+    description: 'Updates the InnovationPack.',
+  })
+  @Profiling.api
+  async updateInnovationPack(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('innovationPackData') innovationPackData: UpdateInnovationPackInput
+  ): Promise<IInnovationPack> {
+    const innovationPack =
+      await this.innovationPackService.getInnovationPackOrFail(
+        innovationPackData.ID
+      );
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      innovationPack.authorization,
+      AuthorizationPrivilege.UPDATE,
+      `updateInnovationPack: ${innovationPack.nameID}`
+    );
+
+    // ensure working with UUID
+    innovationPackData.ID = innovationPack.id;
+
+    return await this.innovationPackService.update(innovationPackData);
+  }
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => IInnovationPack, {
+    description: 'Deletes the specified InnovationPack.',
+  })
+  async deleteInnovationPack(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('deleteData') deleteData: DeleteInnovationPackInput
+  ): Promise<IInnovationPack> {
+    const innovationPack =
+      await this.innovationPackService.getInnovationPackOrFail(deleteData.ID);
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      innovationPack.authorization,
+      AuthorizationPrivilege.DELETE,
+      `deleteInnovationPack: ${innovationPack.nameID}`
+    );
+    return await this.innovationPackService.deleteInnovationPack(deleteData);
+  }
+}

--- a/src/library/innovation-pack/innovation.pack.service.authorization.ts
+++ b/src/library/innovation-pack/innovation.pack.service.authorization.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InnovationPackService } from './innovaton.pack.service';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { IInnovationPack } from './innovation.pack.interface';
+import { InnovationPack } from './innovation.pack.entity';
+import { TemplatesSetAuthorizationService } from '@domain/template/templates-set/templates.set.service.authorization';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
+
+@Injectable()
+export class InnovationPackAuthorizationService {
+  constructor(
+    private authorizationPolicyService: AuthorizationPolicyService,
+    private templatesSetAuthorizationService: TemplatesSetAuthorizationService,
+    private innovationPackService: InnovationPackService,
+    @InjectRepository(InnovationPack)
+    private innovationPackRepository: Repository<InnovationPack>
+  ) {}
+
+  async applyAuthorizationPolicy(
+    innovationPack: IInnovationPack,
+    parentAuthorization: IAuthorizationPolicy | undefined
+  ): Promise<IInnovationPack> {
+    // Ensure always applying from a clean state
+    innovationPack.authorization = this.authorizationPolicyService.reset(
+      innovationPack.authorization
+    );
+    innovationPack.authorization =
+      this.authorizationPolicyService.inheritParentAuthorization(
+        innovationPack.authorization,
+        parentAuthorization
+      );
+
+    // Cascade down
+    const innovationPackPropagated =
+      await this.propagateAuthorizationToChildEntities(innovationPack);
+
+    return await this.innovationPackRepository.save(innovationPackPropagated);
+  }
+
+  private async propagateAuthorizationToChildEntities(
+    innovationPack: IInnovationPack
+  ): Promise<IInnovationPack> {
+    innovationPack.templatesSet =
+      await this.innovationPackService.getTemplatesSetOrFail(innovationPack.id);
+    innovationPack.templatesSet =
+      await this.templatesSetAuthorizationService.applyAuthorizationPolicy(
+        innovationPack.templatesSet,
+        innovationPack.authorization
+      );
+
+    return innovationPack;
+  }
+}

--- a/src/library/innovation-pack/innovation.pack.service.spec.ts
+++ b/src/library/innovation-pack/innovation.pack.service.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InnovationPackService } from './innovaton.pack.service';
+import { MockCacheManager } from '@test/mocks/cache-manager.mock';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { InnovationPack } from './innovation.pack.entity';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+
+describe('InnovationPackService', () => {
+  let service: InnovationPackService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InnovationPackService,
+        MockCacheManager,
+        MockWinstonProvider,
+        repositoryProviderMockFactory(InnovationPack),
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get<InnovationPackService>(InnovationPackService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/library/innovation-pack/innovaton.pack.service.ts
+++ b/src/library/innovation-pack/innovaton.pack.service.ts
@@ -1,0 +1,235 @@
+import { UUID_LENGTH } from '@common/constants';
+import { AuthorizationCredential, LogContext } from '@common/enums';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+  ValidationException,
+} from '@common/exceptions';
+
+import { IOrganization } from '@domain/community/organization/organization.interface';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FindOneOptions, Repository } from 'typeorm';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { InnovationPack } from './innovation.pack.entity';
+import { IInnovationPack } from './innovation.pack.interface';
+import { UpdateInnovationPackInput } from './dto/innovation.pack.dto.update';
+import { ITemplatesSet } from '@domain/template/templates-set/templates.set.interface';
+import { TemplatesSetService } from '@domain/template/templates-set/templates.set.service';
+import { OrganizationService } from '@domain/community/organization/organization.service';
+import { AgentService } from '@domain/agent/agent/agent.service';
+import { CreateInnovationPackInput } from './dto/innovation.pack.dto.create';
+import { DeleteInnovationPackInput } from './dto/innovationPack.dto.delete';
+
+@Injectable()
+export class InnovationPackService {
+  constructor(
+    private organizationService: OrganizationService,
+    private agentService: AgentService,
+    private templatesSetService: TemplatesSetService,
+    @InjectRepository(InnovationPack)
+    private innovationPackRepository: Repository<InnovationPack>,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  async createInnovationPack(
+    innovationPackData: CreateInnovationPackInput
+  ): Promise<IInnovationPack> {
+    const innovationPack: IInnovationPack =
+      InnovationPack.create(innovationPackData);
+
+    innovationPack.templatesSet =
+      await this.templatesSetService.createTemplatesSet();
+
+    // save before assigning host in case that fails
+    const savedInnovationPack = await this.innovationPackRepository.save(
+      innovationPack
+    );
+
+    await this.setInnovationPackProvider(
+      innovationPack.id,
+      innovationPackData.providerID
+    );
+
+    return savedInnovationPack;
+  }
+
+  async save(innovationPack: IInnovationPack): Promise<IInnovationPack> {
+    return await this.innovationPackRepository.save(innovationPack);
+  }
+
+  async update(
+    innovationPackData: UpdateInnovationPackInput
+  ): Promise<IInnovationPack> {
+    const innovationPack = await this.getInnovationPackOrFail(
+      innovationPackData.ID
+    );
+
+    if (innovationPackData.nameID) {
+      if (innovationPackData.nameID !== innovationPack.nameID) {
+        // updating the nameID, check new value is allowed
+        const updateAllowed = await this.isNameIdAvailable(
+          innovationPackData.nameID
+        );
+        if (!updateAllowed) {
+          throw new ValidationException(
+            `Unable to update InnovationPack nameID: the provided nameID is already taken: ${innovationPackData.nameID}`,
+            LogContext.CHALLENGES
+          );
+        }
+        innovationPack.nameID = innovationPackData.nameID;
+      }
+    }
+
+    if (innovationPackData.providerOrgID) {
+      await this.setInnovationPackProvider(
+        innovationPack.id,
+        innovationPackData.providerOrgID
+      );
+    }
+
+    return await this.innovationPackRepository.save(innovationPack);
+  }
+
+  async deleteInnovationPack(
+    deleteData: DeleteInnovationPackInput
+  ): Promise<IInnovationPack> {
+    const innovationPack = await this.getInnovationPackOrFail(deleteData.ID, {
+      relations: ['templatesSet'],
+    });
+
+    // Remove any host credentials
+    const providerOrg = await this.getProvider(innovationPack.id);
+    if (providerOrg) {
+      const agentHostOrg = await this.organizationService.getAgent(providerOrg);
+      providerOrg.agent = await this.agentService.revokeCredential({
+        agentID: agentHostOrg.id,
+        type: AuthorizationCredential.INNOVATION_PACK_PROVIDER,
+        resourceID: innovationPack.id,
+      });
+      await this.organizationService.save(providerOrg);
+    }
+
+    if (innovationPack.templatesSet) {
+      await this.templatesSetService.deleteTemplatesSet(
+        innovationPack.templatesSet.id
+      );
+    }
+
+    const result = await this.innovationPackRepository.remove(
+      innovationPack as InnovationPack
+    );
+    result.id = deleteData.ID;
+    return result;
+  }
+
+  async getInnovationPackOrFail(
+    innovationPackID: string,
+    options?: FindOneOptions<InnovationPack>
+  ): Promise<IInnovationPack> {
+    let innovationPack: IInnovationPack | undefined;
+    if (innovationPackID.length === UUID_LENGTH) {
+      innovationPack = await this.innovationPackRepository.findOne(
+        { id: innovationPackID },
+        options
+      );
+    }
+    if (!innovationPack) {
+      // look up based on nameID
+      innovationPack = await this.innovationPackRepository.findOne(
+        { nameID: innovationPackID },
+        options
+      );
+    }
+    if (!innovationPack)
+      throw new EntityNotFoundException(
+        `Unable to find InnovationPack with ID: ${innovationPackID}`,
+        LogContext.CHALLENGES
+      );
+    return innovationPack;
+  }
+
+  async getTemplatesSetOrFail(
+    innovationPackId: string
+  ): Promise<ITemplatesSet> {
+    const innovationPackWithTemplates = await this.getInnovationPackOrFail(
+      innovationPackId,
+      {
+        relations: ['templatesSet'],
+      }
+    );
+    const templatesSet = innovationPackWithTemplates.templatesSet;
+
+    if (!templatesSet) {
+      throw new EntityNotFoundException(
+        `Unable to find templatesSet for innovationPack with nameID: ${innovationPackWithTemplates.nameID}`,
+        LogContext.COMMUNITY
+      );
+    }
+
+    return templatesSet;
+  }
+
+  async setInnovationPackProvider(
+    innovationPackID: string,
+    hostOrgID: string
+  ): Promise<IInnovationPack> {
+    const organization = await this.organizationService.getOrganizationOrFail(
+      hostOrgID,
+      { relations: ['agent'] }
+    );
+
+    const existingHost = await this.getProvider(innovationPackID);
+
+    if (existingHost) {
+      const agentExisting = await this.organizationService.getAgent(
+        existingHost
+      );
+      organization.agent = await this.agentService.revokeCredential({
+        agentID: agentExisting.id,
+        type: AuthorizationCredential.INNOVATION_PACK_PROVIDER,
+        resourceID: innovationPackID,
+      });
+    }
+
+    // assign the credential
+    const agent = await this.organizationService.getAgent(organization);
+    organization.agent = await this.agentService.grantCredential({
+      agentID: agent.id,
+      type: AuthorizationCredential.INNOVATION_PACK_PROVIDER,
+      resourceID: innovationPackID,
+    });
+
+    await this.organizationService.save(organization);
+    return await this.getInnovationPackOrFail(innovationPackID);
+  }
+
+  async isNameIdAvailable(nameID: string): Promise<boolean> {
+    const innovationPackCount = await this.innovationPackRepository.count({
+      nameID: nameID,
+    });
+    if (innovationPackCount != 0) return false;
+
+    return true;
+  }
+
+  async getProvider(
+    innovationPackID: string
+  ): Promise<IOrganization | undefined> {
+    const organizations =
+      await this.organizationService.organizationsWithCredentials({
+        type: AuthorizationCredential.INNOVATION_PACK_PROVIDER,
+        resourceID: innovationPackID,
+      });
+    if (organizations.length == 0) {
+      return undefined;
+    }
+    if (organizations.length > 1) {
+      throw new RelationshipNotFoundException(
+        `More than one provider for InnovationPack ${innovationPackID} `,
+        LogContext.CHALLENGES
+      );
+    }
+    return organizations[0];
+  }
+}

--- a/src/library/innovation-pack/innovaton.pack.service.ts
+++ b/src/library/innovation-pack/innovaton.pack.service.ts
@@ -20,6 +20,7 @@ import { OrganizationService } from '@domain/community/organization/organization
 import { AgentService } from '@domain/agent/agent/agent.service';
 import { CreateInnovationPackInput } from './dto/innovation.pack.dto.create';
 import { DeleteInnovationPackInput } from './dto/innovationPack.dto.delete';
+import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
 
 @Injectable()
 export class InnovationPackService {
@@ -37,6 +38,7 @@ export class InnovationPackService {
   ): Promise<IInnovationPack> {
     const innovationPack: IInnovationPack =
       InnovationPack.create(innovationPackData);
+    innovationPack.authorization = new AuthorizationPolicy();
 
     innovationPack.templatesSet =
       await this.templatesSetService.createTemplatesSet();

--- a/src/library/library/dto/library.dto.create.innovation.pack.ts
+++ b/src/library/library/dto/library.dto.create.innovation.pack.ts
@@ -1,0 +1,9 @@
+import { UUID } from '@domain/common/scalars';
+import { CreateInnovationPackInput } from '@library/innovation-pack/dto/innovation.pack.dto.create';
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class CreateInnovationPackOnLibraryInput extends CreateInnovationPackInput {
+  @Field(() => UUID, { nullable: false })
+  libraryID!: string;
+}

--- a/src/library/library/dto/library.dto.create.innovation.pack.ts
+++ b/src/library/library/dto/library.dto.create.innovation.pack.ts
@@ -1,9 +1,5 @@
-import { UUID } from '@domain/common/scalars';
 import { CreateInnovationPackInput } from '@library/innovation-pack/dto/innovation.pack.dto.create';
-import { InputType, Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
 
 @InputType()
-export class CreateInnovationPackOnLibraryInput extends CreateInnovationPackInput {
-  @Field(() => UUID, { nullable: false })
-  libraryID!: string;
-}
+export class CreateInnovationPackOnLibraryInput extends CreateInnovationPackInput {}

--- a/src/library/library/library.entity.ts
+++ b/src/library/library/library.entity.ts
@@ -1,8 +1,9 @@
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { InnovationPack } from '@library/innovation-pack/innovation.pack.entity';
-import { OneToMany } from 'typeorm';
+import { Entity, OneToMany } from 'typeorm';
 import { ILibrary } from './library.interface';
 
+@Entity()
 export class Library extends AuthorizableEntity implements ILibrary {
   @OneToMany(() => InnovationPack, innovationPack => innovationPack.library, {
     eager: true,

--- a/src/library/library/library.entity.ts
+++ b/src/library/library/library.entity.ts
@@ -1,0 +1,12 @@
+import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
+import { InnovationPack } from '@library/innovation-pack/innovation.pack.entity';
+import { OneToMany } from 'typeorm';
+import { ILibrary } from './library.interface';
+
+export class Library extends AuthorizableEntity implements ILibrary {
+  @OneToMany(() => InnovationPack, innovationPack => innovationPack.library, {
+    eager: true,
+    cascade: true,
+  })
+  innovationPacks?: InnovationPack[];
+}

--- a/src/library/library/library.interface.ts
+++ b/src/library/library/library.interface.ts
@@ -1,0 +1,12 @@
+import { IAuthorizable } from '@domain/common/entity/authorizable-entity';
+import { IInnovationPack } from '@library/innovation-pack/innovation.pack.interface';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('Library')
+export abstract class ILibrary extends IAuthorizable {
+  @Field(() => [IInnovationPack], {
+    nullable: false,
+    description: 'Platform level library.',
+  })
+  innovationPacks?: IInnovationPack[];
+}

--- a/src/library/library/library.module.ts
+++ b/src/library/library/library.module.ts
@@ -1,0 +1,12 @@
+import { InnovationPackModule } from '@library/innovation-pack/innovation.pack.module';
+import { Module } from '@nestjs/common';
+import { NamingModule } from '@services/infrastructure/naming/naming.module';
+import { LibraryResolverQueries } from './library.resolver.queries';
+import { LibraryService } from './library.service';
+
+@Module({
+  imports: [InnovationPackModule, NamingModule],
+  providers: [LibraryResolverQueries, LibraryService],
+  exports: [LibraryService],
+})
+export class LibraryModule {}

--- a/src/library/library/library.module.ts
+++ b/src/library/library/library.module.ts
@@ -1,12 +1,31 @@
+import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { InnovationPackModule } from '@library/innovation-pack/innovation.pack.module';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PlatformAuthorizationModule } from '@platform/authorization/platform.authorization.module';
 import { NamingModule } from '@services/infrastructure/naming/naming.module';
+import { Library } from './library.entity';
+import { LibraryResolverMutations } from './library.resolver.mutations';
 import { LibraryResolverQueries } from './library.resolver.queries';
 import { LibraryService } from './library.service';
+import { LibraryAuthorizationService } from './library.service.authorization';
 
 @Module({
-  imports: [InnovationPackModule, NamingModule],
-  providers: [LibraryResolverQueries, LibraryService],
+  imports: [
+    InnovationPackModule,
+    NamingModule,
+    AuthorizationModule,
+    AuthorizationPolicyModule,
+    PlatformAuthorizationModule,
+    TypeOrmModule.forFeature([Library]),
+  ],
+  providers: [
+    LibraryResolverQueries,
+    LibraryResolverMutations,
+    LibraryService,
+    LibraryAuthorizationService,
+  ],
   exports: [LibraryService],
 })
 export class LibraryModule {}

--- a/src/library/library/library.resolver.mutations.ts
+++ b/src/library/library/library.resolver.mutations.ts
@@ -1,5 +1,5 @@
 import { UseGuards } from '@nestjs/common';
-import { Resolver, Mutation } from '@nestjs/graphql';
+import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { CurrentUser, Profiling } from '@src/common/decorators';
 import { GraphqlGuard } from '@core/authorization';
 import { AgentInfo } from '@core/authentication';
@@ -8,13 +8,17 @@ import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { LibraryService } from './library.service';
 import { ILibrary } from './library.interface';
 import { LibraryAuthorizationService } from './library.service.authorization';
+import { IInnovationPack } from '@library/innovation-pack/innovation.pack.interface';
+import { CreateInnovationPackOnLibraryInput } from './dto/library.dto.create.innovation.pack';
+import { InnovationPackAuthorizationService } from '@library/innovation-pack/innovation.pack.service.authorization';
 
 @Resolver()
 export class LibraryResolverMutations {
   constructor(
     private authorizationService: AuthorizationService,
     private libraryService: LibraryService,
-    private libraryAuthorizationService: LibraryAuthorizationService
+    private libraryAuthorizationService: LibraryAuthorizationService,
+    private innovationPackAuthorizationService: InnovationPackAuthorizationService
   ) {}
 
   @UseGuards(GraphqlGuard)
@@ -35,5 +39,34 @@ export class LibraryResolverMutations {
     return await this.libraryAuthorizationService.applyAuthorizationPolicy(
       library
     );
+  }
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => IInnovationPack, {
+    description: 'Create a new InnovatonPack on the Library.',
+  })
+  @Profiling.api
+  async createInnovationPackOnLibrary(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('packData') packData: CreateInnovationPackOnLibraryInput
+  ): Promise<IInnovationPack> {
+    const library = await this.libraryService.getLibraryOrFail();
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      library.authorization,
+      AuthorizationPrivilege.CREATE,
+      `create innovationPack on library: ${library.id}`
+    );
+
+    const innovationPack = await this.libraryService.createInnovationPack(
+      packData
+    );
+    const innovationPackAuthorized =
+      await this.innovationPackAuthorizationService.applyAuthorizationPolicy(
+        innovationPack,
+        library.authorization
+      );
+    return innovationPackAuthorized;
   }
 }

--- a/src/library/library/library.resolver.mutations.ts
+++ b/src/library/library/library.resolver.mutations.ts
@@ -1,0 +1,39 @@
+import { UseGuards } from '@nestjs/common';
+import { Resolver, Mutation } from '@nestjs/graphql';
+import { CurrentUser, Profiling } from '@src/common/decorators';
+import { GraphqlGuard } from '@core/authorization';
+import { AgentInfo } from '@core/authentication';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { LibraryService } from './library.service';
+import { ILibrary } from './library.interface';
+import { LibraryAuthorizationService } from './library.service.authorization';
+
+@Resolver()
+export class LibraryResolverMutations {
+  constructor(
+    private authorizationService: AuthorizationService,
+    private libraryService: LibraryService,
+    private libraryAuthorizationService: LibraryAuthorizationService
+  ) {}
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => ILibrary, {
+    description: 'Reset the Authorization Policy on the specified Library.',
+  })
+  @Profiling.api
+  async authorizationPolicyResetOnLibrary(
+    @CurrentUser() agentInfo: AgentInfo
+  ): Promise<ILibrary> {
+    const library = await this.libraryService.getLibraryOrFail();
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      library.authorization,
+      AuthorizationPrivilege.UPDATE, // todo: replace with AUTHORIZATION_RESET once that has been granted
+      `reset authorization on library: ${agentInfo.email}`
+    );
+    return await this.libraryAuthorizationService.applyAuthorizationPolicy(
+      library
+    );
+  }
+}

--- a/src/library/library/library.resolver.queries.spec.ts
+++ b/src/library/library/library.resolver.queries.spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockCacheManager } from '@test/mocks/cache-manager.mock';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { LibraryResolverQueries } from './library.resolver.queries';
+
+describe('LibraryResolver', () => {
+  let resolver: LibraryResolverQueries;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LibraryResolverQueries,
+        MockCacheManager,
+        MockWinstonProvider,
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    resolver = module.get(LibraryResolverQueries);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/src/library/library/library.resolver.queries.ts
+++ b/src/library/library/library.resolver.queries.ts
@@ -10,7 +10,7 @@ export class LibraryResolverQueries {
     nullable: false,
     description: 'Alkemio Library',
   })
-  async metadata(): Promise<ILibrary> {
+  async library(): Promise<ILibrary> {
     return await this.libraryService.getLibraryOrFail();
   }
 }

--- a/src/library/library/library.resolver.queries.ts
+++ b/src/library/library/library.resolver.queries.ts
@@ -1,0 +1,16 @@
+import { Query, Resolver } from '@nestjs/graphql';
+import { ILibrary } from './library.interface';
+import { LibraryService } from './library.service';
+
+@Resolver(() => ILibrary)
+export class LibraryResolverQueries {
+  constructor(private libraryService: LibraryService) {}
+
+  @Query(() => ILibrary, {
+    nullable: false,
+    description: 'Alkemio Library',
+  })
+  async metadata(): Promise<ILibrary> {
+    return await this.libraryService.getLibraryOrFail();
+  }
+}

--- a/src/library/library/library.service.authorization.ts
+++ b/src/library/library/library.service.authorization.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { PlatformAuthorizationService } from '@src/platform/authorization/platform.authorization.service';
+import { Library } from './library.entity';
+import { LibraryService } from './library.service';
+import { ILibrary } from './library.interface';
+import { InnovationPackAuthorizationService } from '@library/innovation-pack/innovation.pack.service.authorization';
+
+@Injectable()
+export class LibraryAuthorizationService {
+  constructor(
+    private authorizationPolicyService: AuthorizationPolicyService,
+    private platformAuthorizationService: PlatformAuthorizationService,
+    private innovationPackAuthorizationService: InnovationPackAuthorizationService,
+    private libraryService: LibraryService,
+    @InjectRepository(Library)
+    private libraryRepository: Repository<Library>
+  ) {}
+
+  async applyAuthorizationPolicy(library: ILibrary): Promise<ILibrary> {
+    // Ensure always applying from a clean state
+    library.authorization = this.authorizationPolicyService.reset(
+      library.authorization
+    );
+    library.authorization.anonymousReadAccess = true;
+    library.authorization =
+      this.platformAuthorizationService.inheritPlatformAuthorization(
+        library.authorization
+      );
+
+    // Cascade down
+    const libraryPropagated = await this.propagateAuthorizationToChildEntities(
+      library
+    );
+
+    return await this.libraryRepository.save(libraryPropagated);
+  }
+
+  private async propagateAuthorizationToChildEntities(
+    library: ILibrary
+  ): Promise<ILibrary> {
+    library.innovationPacks = await this.libraryService.getInnovationPacks(
+      library
+    );
+    for (const innovationPack of library.innovationPacks) {
+      await this.innovationPackAuthorizationService.applyAuthorizationPolicy(
+        innovationPack,
+        library.authorization
+      );
+    }
+
+    return library;
+  }
+}

--- a/src/library/library/library.service.ts
+++ b/src/library/library/library.service.ts
@@ -1,0 +1,81 @@
+import { LogContext } from '@common/enums/logging.context';
+import { EntityNotFoundException } from '@common/exceptions/entity.not.found.exception';
+import { EntityNotInitializedException } from '@common/exceptions/entity.not.initialized.exception';
+import { ValidationException } from '@common/exceptions/validation.exception';
+import { IInnovationPack } from '@library/innovation-pack/innovation.pack.interface';
+import { InnovationPackService } from '@library/innovation-pack/innovaton.pack.service';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { NamingService } from '@services/infrastructure/naming/naming.service';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { Repository } from 'typeorm';
+import { CreateInnovationPackOnLibraryInput } from './dto/library.dto.create.innovation.pack';
+import { Library } from './library.entity';
+import { ILibrary } from './library.interface';
+
+@Injectable()
+export class LibraryService {
+  constructor(
+    private innovationPackService: InnovationPackService,
+    private namingService: NamingService,
+    @InjectRepository(Library)
+    private libraryRepository: Repository<Library>,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  async getLibraryOrFail(): Promise<ILibrary> {
+    const library = await this.libraryRepository.findOne();
+    if (!library)
+      throw new EntityNotFoundException(
+        'No Library found!',
+        LogContext.LIBRARY
+      );
+    return library;
+  }
+
+  public async getInnovationPacks(
+    library: ILibrary
+  ): Promise<IInnovationPack[]> {
+    const innovationPacks = library.innovationPacks;
+    if (!innovationPacks)
+      throw new EntityNotFoundException(
+        `Undefined innovation packs found: ${library.id}`,
+        LogContext.LIBRARY
+      );
+
+    return innovationPacks;
+  }
+
+  public async createInnovationPack(
+    innovationPackData: CreateInnovationPackOnLibraryInput
+  ): Promise<IInnovationPack> {
+    const library = await this.getLibraryOrFail();
+    if (!library.innovationPacks)
+      throw new EntityNotInitializedException(
+        `Library (${library}) not initialised`,
+        LogContext.CONTEXT
+      );
+
+    if (innovationPackData.nameID && innovationPackData.nameID.length > 0) {
+      const nameAvailable = await this.innovationPackService.isNameIdAvailable(
+        innovationPackData.nameID
+      );
+      if (!nameAvailable)
+        throw new ValidationException(
+          `Unable to create InnovationPack: the provided nameID is already taken: ${innovationPackData.nameID}`,
+          LogContext.LIBRARY
+        );
+    } else {
+      innovationPackData.nameID = this.namingService.createNameID(
+        `${innovationPackData.displayName}`
+      );
+    }
+
+    const innovationPack =
+      await this.innovationPackService.createInnovationPack(innovationPackData);
+    library.innovationPacks.push(innovationPack);
+    await this.libraryRepository.save(library);
+
+    return innovationPack;
+  }
+}

--- a/src/migrations/1667420764375-library.ts
+++ b/src/migrations/1667420764375-library.ts
@@ -1,0 +1,9 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class library1667420764375 implements MigrationInterface {
+  name = 'library1667420764375';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {}
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/migrations/1667420764375-library.ts
+++ b/src/migrations/1667420764375-library.ts
@@ -1,5 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 import { randomUUID } from 'crypto';
+import { escapeString } from './utils/escape-string';
 
 export class library1667420764375 implements MigrationInterface {
   name = 'library1667420764375';
@@ -23,11 +24,17 @@ export class library1667420764375 implements MigrationInterface {
                  \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
                   \`version\` int NOT NULL,
                   \`authorizationId\` varchar(36) NULL,
+                  \`nameID\` varchar(36) NOT NULL,
+                  \`displayName\` varchar(255) NOT NULL,
                   \`libraryId\` varchar(36) NULL,
+                  \`templatesSetId\` varchar(36) NULL,
                     UNIQUE INDEX \`REL_22222ccdda9ba57d8e3a634cd8\` (\`authorizationId\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`
     );
     await queryRunner.query(
       `ALTER TABLE \`innovation_pack\` ADD CONSTRAINT \`FK_22222901817dd09d5906537e088\` FOREIGN KEY (\`authorizationId\`) REFERENCES \`authorization_policy\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_pack\` ADD CONSTRAINT \`FK_55555901817dd09d5906537e088\` FOREIGN KEY (\`templatesSetId\`) REFERENCES \`templates_set\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
     );
 
     // Link innovation_pack to library
@@ -38,8 +45,10 @@ export class library1667420764375 implements MigrationInterface {
     // create library instance with authorization
     const authID = randomUUID();
     const libraryID = randomUUID();
+    const libraryAuthPolicy = `[{"type":"global-admin","resourceID":"","grantedPrivileges":["create","read","update","delete"],"inheritable":true},{"type":"global-admin-hubs","resourceID":"","grantedPrivileges":["create","read","update","delete"],"inheritable":true}]`;
+
     await queryRunner.query(
-      `INSERT INTO authorization_policy VALUES ('${authID}', NOW(), NOW(), 1, '', '', 0, '')`
+      `INSERT INTO authorization_policy VALUES ('${authID}', NOW(), NOW(), 1, '${libraryAuthPolicy}', '', 0, '')`
     );
     await queryRunner.query(
       `INSERT INTO library (id, createdDate, updatedDate, version, authorizationId) VALUES ('${libraryID}', NOW(), NOW(), 1, '${authID}')`
@@ -47,7 +56,19 @@ export class library1667420764375 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('DROP TABLE `innovation-pack`');
+    await queryRunner.query(
+      `ALTER TABLE \`library\` DROP FOREIGN KEY \`FK_33333901817dd09d5906537e088\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_pack\` DROP FOREIGN KEY \`FK_22222901817dd09d5906537e088\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_pack\` DROP FOREIGN KEY \`FK_77777450cf75dc486700ca034c6\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_pack\` DROP FOREIGN KEY \`FK_55555901817dd09d5906537e088\``
+    );
+    await queryRunner.query('DROP TABLE `innovation_pack`');
     await queryRunner.query('DROP TABLE `library`');
   }
 }

--- a/src/migrations/1667420764375-library.ts
+++ b/src/migrations/1667420764375-library.ts
@@ -1,9 +1,53 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
 
 export class library1667420764375 implements MigrationInterface {
   name = 'library1667420764375';
 
-  public async up(queryRunner: QueryRunner): Promise<void> {}
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create Library
+    await queryRunner.query(
+      `CREATE TABLE \`library\` (\`id\` char(36) NOT NULL, \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+             \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+              \`version\` int NOT NULL,
+              \`authorizationId\` varchar(36) NULL,
+                UNIQUE INDEX \`REL_33333ccdda9ba57d8e3a634cd8\` (\`authorizationId\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`library\` ADD CONSTRAINT \`FK_33333901817dd09d5906537e088\` FOREIGN KEY (\`authorizationId\`) REFERENCES \`authorization_policy\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
 
-  public async down(queryRunner: QueryRunner): Promise<void> {}
+    // Create innovatonPack
+    await queryRunner.query(
+      `CREATE TABLE \`innovation_pack\` (\`id\` char(36) NOT NULL, \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                 \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                  \`version\` int NOT NULL,
+                  \`authorizationId\` varchar(36) NULL,
+                  \`libraryId\` varchar(36) NULL,
+                    UNIQUE INDEX \`REL_22222ccdda9ba57d8e3a634cd8\` (\`authorizationId\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_pack\` ADD CONSTRAINT \`FK_22222901817dd09d5906537e088\` FOREIGN KEY (\`authorizationId\`) REFERENCES \`authorization_policy\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+
+    // Link innovation_pack to library
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_pack\` ADD CONSTRAINT \`FK_77777450cf75dc486700ca034c6\` FOREIGN KEY (\`libraryId\`) REFERENCES \`library\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+
+    // create library instance with authorization
+    const authID = randomUUID();
+    const libraryID = randomUUID();
+    await queryRunner.query(
+      `INSERT INTO authorization_policy VALUES ('${authID}', NOW(), NOW(), 1, '', '', 0, '')`
+    );
+    await queryRunner.query(
+      `INSERT INTO library (id, createdDate, updatedDate, version, authorizationId) VALUES ('${libraryID}', NOW(), NOW(), 1, '${authID}')`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `innovation-pack`');
+    await queryRunner.query('DROP TABLE `library`');
+  }
 }

--- a/test/config/jest.config.js
+++ b/test/config/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
     '@common/(.*)': ['<rootDir>/src/common/$1'],
     '@core/(.*)': ['<rootDir>/src/core/$1'],
     '@platform/(.*)': ['<rootDir>/src/platform/$1'],
+    '@library/(.*)': ['<rootDir>/src/library/$1'],
     '@config/(.*)': ['<rootDir>/src/config/$1'],
     '@templates/(.*)': ['<rootDir>/src/platform/configuration/templates/$1'],
     '@src/(.*)': ['<rootDir>/src/$1'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "@common/*": ["src/common/*"],
       "@core/*": ["src/core/*"],
       "@platform/*": ["src/platform/*"],
+      "@library/*": ["src/library/*"],
       "@services/*": ["src/services/*"],
       "@constants/*": ["src/common/constants/*"],
       "@templates/*": ["src/platform/configuration/templates/*"],


### PR DESCRIPTION
Top level Library entity
New entity InnovationPack to be associated with an Organization and hold a TemplatesSet

Mutations to create, update and delete InnovationPacks

Sample graphql queries

Authorization propagated from Library to InnovationPacks + child entities

Only global admins + global hub admins have rights for now. 

UP + down migrations added 

Simple enough api update but opening up a very important whole new area of the domain model...