### PR TITLE
TemplatesSet re-usable for InnovationPacks

### DIFF
--- a/graphql-samples/mutations/delete/delete-lifecycle-template
+++ b/graphql-samples/mutations/delete/delete-lifecycle-template
@@ -1,8 +1,6 @@
 mutation deleteLifecycleTemplate($deleteData: DeleteLifecycleTemplateInput!) {
   deleteLifecycleTemplate(deleteData: $deleteData) {
-    info {
-      title
-    }
+    id
   }
 }
 

--- a/src/domain/challenge/hub/hub.service.ts
+++ b/src/domain/challenge/hub/hub.service.ts
@@ -117,7 +117,12 @@ export class HubService {
       this.createPreferenceDefaults()
     );
 
-    hub.templatesSet = await this.templatesSetService.createTemplatesSet();
+    hub.templatesSet = await this.templatesSetService.createTemplatesSet(
+      {
+        minInnovationFlow: 1,
+      },
+      true
+    );
 
     // Lifecycle
 

--- a/src/domain/template/lifecycle-template/dto/lifecycle.template.dto.delete.ts
+++ b/src/domain/template/lifecycle-template/dto/lifecycle.template.dto.delete.ts
@@ -1,5 +1,0 @@
-import { DeleteTemplateBaseInput } from '@domain/template/template-base/dto/template.base.dto.delete';
-import { InputType } from '@nestjs/graphql';
-
-@InputType()
-export class DeleteLifecycleTemplateInput extends DeleteTemplateBaseInput {}

--- a/src/domain/template/lifecycle-template/lifecycle.template.interface.ts
+++ b/src/domain/template/lifecycle-template/lifecycle.template.interface.ts
@@ -2,6 +2,7 @@ import { LifecycleType } from '@common/enums/lifecycle.type';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { ITemplateBase } from '../template-base/template.base.interface';
 import { LifecycleDefinitionScalar } from '@domain/common/scalars/scalar.lifecycle.definition';
+import { ITemplatesSet } from '../templates-set';
 
 @ObjectType('LifecycleTemplate')
 export abstract class ILifecycleTemplate extends ITemplateBase {
@@ -16,4 +17,6 @@ export abstract class ILifecycleTemplate extends ITemplateBase {
     description: 'The XState definition for this LifecycleTemplate.',
   })
   definition!: string;
+
+  templatesSet?: ITemplatesSet;
 }

--- a/src/domain/template/lifecycle-template/lifecycle.template.resolver.mutations.ts
+++ b/src/domain/template/lifecycle-template/lifecycle.template.resolver.mutations.ts
@@ -8,7 +8,6 @@ import { ILifecycleTemplate } from './lifecycle.template.interface';
 import { CurrentUser } from '@common/decorators/current-user.decorator';
 import { AgentInfo } from '@core/authentication/agent-info';
 import { UpdateLifecycleTemplateInput } from './dto/lifecycle.template.dto.update';
-import { DeleteLifecycleTemplateInput } from './dto/lifecycle.template.dto.delete';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 
 @Resolver()
@@ -41,29 +40,6 @@ export class LifecycleTemplateResolverMutations {
     return await this.lifecycleTemplateService.updateLifecycleTemplate(
       lifecycleTemplate,
       lifecycleTemplateInput
-    );
-  }
-
-  @UseGuards(GraphqlGuard)
-  @Mutation(() => ILifecycleTemplate, {
-    description: 'Deletes the specified LifecycleTemplate.',
-  })
-  async deleteLifecycleTemplate(
-    @CurrentUser() agentInfo: AgentInfo,
-    @Args('deleteData') deleteData: DeleteLifecycleTemplateInput
-  ): Promise<ILifecycleTemplate> {
-    const lifecycleTemplate =
-      await this.lifecycleTemplateService.getLifecycleTemplateOrFail(
-        deleteData.ID
-      );
-    await this.authorizationService.grantAccessOrFail(
-      agentInfo,
-      lifecycleTemplate.authorization,
-      AuthorizationPrivilege.DELETE,
-      `lifecycle template delete: ${lifecycleTemplate.id}`
-    );
-    return await this.lifecycleTemplateService.deleteLifecycleTemplate(
-      lifecycleTemplate
     );
   }
 }

--- a/src/domain/template/lifecycle-template/lifecycle.template.service.ts
+++ b/src/domain/template/lifecycle-template/lifecycle.template.service.ts
@@ -1,10 +1,7 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, getConnection } from 'typeorm';
-import {
-  EntityNotFoundException,
-  ValidationException,
-} from '@common/exceptions';
+import { EntityNotFoundException } from '@common/exceptions';
 import { LogContext } from '@common/enums';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LifecycleTemplate } from './lifecycle.template.entity';
@@ -69,29 +66,8 @@ export class LifecycleTemplateService {
   }
 
   async deleteLifecycleTemplate(
-    lifecycleTemplate: ILifecycleTemplate,
-    forceDelete = false
+    lifecycleTemplate: ILifecycleTemplate
   ): Promise<ILifecycleTemplate> {
-    const [queryResult]: {
-      lifecycleTemplatesCount: string;
-      templatesSetId: string;
-    }[] = await getConnection().query(
-      `
-      SELECT COUNT(*) as lifecycleTemplatesCount, \`templates_set\`.\`id\` AS templatesSetId
-      FROM \`templates_set\` JOIN \`lifecycle_template\`
-      ON \`lifecycle_template\`.\`templatesSetId\` = \`templates_set\`.\`id\`
-      WHERE \`lifecycle_template\`.\`type\`='${lifecycleTemplate.type}' AND \`templates_set\`.\`id\` =
-      (SELECT \`lifecycle_template\`.\`templatesSetId\` FROM \`lifecycle_template\`
-      WHERE \`lifecycle_template\`.\`id\` = '${lifecycleTemplate.id}');
-      `
-    );
-
-    if (!forceDelete && queryResult.lifecycleTemplatesCount === '1') {
-      throw new ValidationException(
-        `Cannot delete last lifecycle template: ${lifecycleTemplate.id} of type ${lifecycleTemplate.type} from templateSet: ${queryResult.templatesSetId}!`,
-        LogContext.LIFECYCLE
-      );
-    }
     const templateId: string = lifecycleTemplate.id;
     await this.templateBaseService.deleteEntities(lifecycleTemplate);
     const result = await this.lifecycleTemplateRepository.remove(

--- a/src/domain/template/lifecycle-template/lifecycle.template.service.ts
+++ b/src/domain/template/lifecycle-template/lifecycle.template.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, getConnection } from 'typeorm';
+import { Repository, getConnection, FindOneOptions } from 'typeorm';
 import { EntityNotFoundException } from '@common/exceptions';
 import { LogContext } from '@common/enums';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
@@ -37,11 +37,16 @@ export class LifecycleTemplateService {
   }
 
   async getLifecycleTemplateOrFail(
-    lifecycleTemplateID: string
+    lifecycleTemplateID: string,
+    options?: FindOneOptions<LifecycleTemplate>
   ): Promise<ILifecycleTemplate> {
-    const lifecycleTemplate = await this.lifecycleTemplateRepository.findOne({
-      id: lifecycleTemplateID,
-    });
+    const lifecycleTemplate = await this.lifecycleTemplateRepository.findOne(
+      {
+        id: lifecycleTemplateID,
+      },
+      options
+    );
+
     if (!lifecycleTemplate)
       throw new EntityNotFoundException(
         `Not able to locate LifecycleTemplate with the specified ID: ${lifecycleTemplateID}`,

--- a/src/domain/template/templates-set-policy/templates.set.policy.interface.ts
+++ b/src/domain/template/templates-set-policy/templates.set.policy.interface.ts
@@ -1,0 +1,7 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('TemplatesSetPolicy')
+export abstract class ITemplatesSetPolicy {
+  @Field(() => Number)
+  minInnovationFlow!: number;
+}

--- a/src/domain/template/templates-set-policy/templates.set.policy.ts
+++ b/src/domain/template/templates-set-policy/templates.set.policy.ts
@@ -1,0 +1,5 @@
+import { ITemplatesSetPolicy } from './templates.set.policy.interface';
+
+export class TemplatesSetPolicy implements ITemplatesSetPolicy {
+  minInnovationFlow!: number;
+}

--- a/src/domain/template/templates-set/dto/lifecycle.template.dto.delete.on.templates.set.ts
+++ b/src/domain/template/templates-set/dto/lifecycle.template.dto.delete.on.templates.set.ts
@@ -1,0 +1,9 @@
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { DeleteTemplateBaseInput } from '@domain/template/template-base/dto/template.base.dto.delete';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class DeleteLifecycleTemplateOnTemplatesSetInput extends DeleteTemplateBaseInput {
+  @Field(() => UUID, { nullable: false })
+  templatesSetID!: string;
+}

--- a/src/domain/template/templates-set/dto/lifecycle.template.dto.delete.on.templates.set.ts
+++ b/src/domain/template/templates-set/dto/lifecycle.template.dto.delete.on.templates.set.ts
@@ -1,9 +1,5 @@
-import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { DeleteTemplateBaseInput } from '@domain/template/template-base/dto/template.base.dto.delete';
-import { Field, InputType } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
 
 @InputType()
-export class DeleteLifecycleTemplateOnTemplatesSetInput extends DeleteTemplateBaseInput {
-  @Field(() => UUID, { nullable: false })
-  templatesSetID!: string;
-}
+export class DeleteLifecycleTemplateInput extends DeleteTemplateBaseInput {}

--- a/src/domain/template/templates-set/templates.set.entity.ts
+++ b/src/domain/template/templates-set/templates.set.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, OneToMany } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { ITemplatesSet } from './templates.set.interface';
 import { AspectTemplate } from '../aspect-template/aspect.template.entity';
@@ -36,4 +36,7 @@ export class TemplatesSet extends AuthorizableEntity implements ITemplatesSet {
     }
   )
   lifecycleTemplates?: LifecycleTemplate[];
+
+  @Column('text')
+  policy!: string;
 }

--- a/src/domain/template/templates-set/templates.set.interface.ts
+++ b/src/domain/template/templates-set/templates.set.interface.ts
@@ -9,5 +9,8 @@ export abstract class ITemplatesSet extends IAuthorizable {
   aspectTemplates?: IAspectTemplate[];
 
   canvasTemplates?: ICanvasTemplate[];
+
   lifecycleTemplates?: ILifecycleTemplate[];
+
+  policy!: string;
 }

--- a/src/domain/template/templates-set/templates.set.resolver.fields.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.fields.ts
@@ -8,6 +8,7 @@ import { TemplatesSetService } from './templates.set.service';
 import { ITemplatesSet } from './templates.set.interface';
 import { ICanvasTemplate } from '../canvas-template/canvas.template.interface';
 import { ILifecycleTemplate } from '../lifecycle-template/lifecycle.template.interface';
+import { ITemplatesSetPolicy } from '../templates-set-policy/templates.set.policy.interface';
 
 @Resolver(() => ITemplatesSet)
 export class TemplatesSetResolverFields {
@@ -82,7 +83,9 @@ export class TemplatesSetResolverFields {
   async lifecycleTemplates(
     @Parent() templatesSet: ITemplatesSet
   ): Promise<ILifecycleTemplate[]> {
-    return await this.templatesSetService.getInnovationFlowTemplates(templatesSet);
+    return await this.templatesSetService.getInnovationFlowTemplates(
+      templatesSet
+    );
   }
 
   @UseGuards(GraphqlGuard)
@@ -101,5 +104,17 @@ export class TemplatesSetResolverFields {
     ID: string
   ): Promise<ILifecycleTemplate> {
     return this.templatesSetService.getLifecycleTemplate(ID);
+  }
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField('policy', () => ITemplatesSetPolicy, {
+    nullable: true,
+    description: 'The policy for this TemplatesSet.',
+  })
+  @Profiling.api
+  async policy(
+    @Parent() templatesSet: ITemplatesSet
+  ): Promise<ITemplatesSetPolicy> {
+    return this.templatesSetService.getPolicy(templatesSet);
   }
 }

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.ts
@@ -16,12 +16,15 @@ import { CanvasTemplateAuthorizationService } from '../canvas-template/canvas.te
 import { CreateLifecycleTemplateOnTemplatesSetInput } from './dto/lifecycle.template.dto.create.on.templates.set';
 import { ILifecycleTemplate } from '../lifecycle-template/lifecycle.template.interface';
 import { LifecycleTemplateAuthorizationService } from '../lifecycle-template/lifecycle.template.service.authorization';
+import { DeleteLifecycleTemplateOnTemplatesSetInput } from './dto/lifecycle.template.dto.delete.on.templates.set';
+import { LifecycleTemplateService } from '../lifecycle-template/lifecycle.template.service';
 
 @Resolver()
 export class TemplatesSetResolverMutations {
   constructor(
     private authorizationService: AuthorizationService,
     private templatesSetService: TemplatesSetService,
+    private lifecycleTemplateService: LifecycleTemplateService,
     private aspectTemplateAuthorizationService: AspectTemplateAuthorizationService,
     private canvasTemplateAuthorizationService: CanvasTemplateAuthorizationService,
     private lifecycleTemplateAuthorizationService: LifecycleTemplateAuthorizationService,
@@ -124,5 +127,29 @@ export class TemplatesSetResolverMutations {
       templatesSet.authorization
     );
     return lifecycleTemplate;
+  }
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => ILifecycleTemplate, {
+    description: 'Deletes the specified LifecycleTemplate.',
+  })
+  async deleteLifecycleTemplate(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('deleteData') deleteData: DeleteLifecycleTemplateOnTemplatesSetInput
+  ): Promise<ILifecycleTemplate> {
+    const lifecycleTemplate =
+      await this.lifecycleTemplateService.getLifecycleTemplateOrFail(
+        deleteData.ID
+      );
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      lifecycleTemplate.authorization,
+      AuthorizationPrivilege.DELETE,
+      `lifecycle template delete: ${lifecycleTemplate.id}`
+    );
+    return await this.templatesSetService.deleteInnovationFlowTemplate(
+      lifecycleTemplate,
+      deleteData.templatesSetID
+    );
   }
 }

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.ts
@@ -16,8 +16,10 @@ import { CanvasTemplateAuthorizationService } from '../canvas-template/canvas.te
 import { CreateLifecycleTemplateOnTemplatesSetInput } from './dto/lifecycle.template.dto.create.on.templates.set';
 import { ILifecycleTemplate } from '../lifecycle-template/lifecycle.template.interface';
 import { LifecycleTemplateAuthorizationService } from '../lifecycle-template/lifecycle.template.service.authorization';
-import { DeleteLifecycleTemplateOnTemplatesSetInput } from './dto/lifecycle.template.dto.delete.on.templates.set';
 import { LifecycleTemplateService } from '../lifecycle-template/lifecycle.template.service';
+import { RelationshipNotFoundException } from '@common/exceptions';
+import { LogContext } from '@common/enums';
+import { DeleteLifecycleTemplateInput } from './dto/lifecycle.template.dto.delete.on.templates.set';
 
 @Resolver()
 export class TemplatesSetResolverMutations {
@@ -135,21 +137,31 @@ export class TemplatesSetResolverMutations {
   })
   async deleteLifecycleTemplate(
     @CurrentUser() agentInfo: AgentInfo,
-    @Args('deleteData') deleteData: DeleteLifecycleTemplateOnTemplatesSetInput
+    @Args('deleteData') deleteData: DeleteLifecycleTemplateInput
   ): Promise<ILifecycleTemplate> {
-    const lifecycleTemplate =
+    const innovationFlowTemplate =
       await this.lifecycleTemplateService.getLifecycleTemplateOrFail(
-        deleteData.ID
+        deleteData.ID,
+        {
+          relations: ['templatesSet'],
+        }
       );
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      lifecycleTemplate.authorization,
+      innovationFlowTemplate.authorization,
       AuthorizationPrivilege.DELETE,
-      `lifecycle template delete: ${lifecycleTemplate.id}`
+      `lifecycle template delete: ${innovationFlowTemplate.id}`
     );
+    const templatesSet = innovationFlowTemplate.templatesSet;
+    if (!templatesSet) {
+      throw new RelationshipNotFoundException(
+        `Unable to load TemplatesSet for innovation flow template: ${innovationFlowTemplate.id}`,
+        LogContext.TEMPLATES
+      );
+    }
     return await this.templatesSetService.deleteInnovationFlowTemplate(
-      lifecycleTemplate,
-      deleteData.templatesSetID
+      innovationFlowTemplate,
+      templatesSet
     );
   }
 }

--- a/src/domain/template/templates-set/templates.set.service.ts
+++ b/src/domain/template/templates-set/templates.set.service.ts
@@ -226,9 +226,8 @@ export class TemplatesSetService {
 
   async deleteInnovationFlowTemplate(
     innovationFlowTemplate: ILifecycleTemplate,
-    templatesSetID: string
+    templatesSet: ITemplatesSet
   ): Promise<ILifecycleTemplate> {
-    const templatesSet = await this.getTemplatesSetOrFail(templatesSetID);
     const innovationFlowTemplates = await this.getInnovationFlowTemplates(
       templatesSet
     );

--- a/src/domain/template/templates-set/templates.set.service.ts
+++ b/src/domain/template/templates-set/templates.set.service.ts
@@ -22,6 +22,7 @@ import { CreateCanvasTemplateInput } from '../canvas-template/dto/canvas.templat
 import { ILifecycleTemplate } from '../lifecycle-template/lifecycle.template.interface';
 import { CreateInnovationFlowTemplateInput } from '../lifecycle-template/dto/lifecycle.template.dto.create';
 import { LifecycleTemplateService } from '../lifecycle-template/lifecycle.template.service';
+import { ITemplatesSetPolicy } from '../templates-set-policy/templates.set.policy.interface';
 
 @Injectable()
 export class TemplatesSetService {
@@ -35,28 +36,34 @@ export class TemplatesSetService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  async createTemplatesSet(): Promise<ITemplatesSet> {
+  async createTemplatesSet(
+    policy: ITemplatesSetPolicy,
+    addDefaults: boolean
+  ): Promise<ITemplatesSet> {
     const templatesSet: ITemplatesSet = TemplatesSet.create();
     templatesSet.authorization = new AuthorizationPolicy();
+    templatesSet.policy = this.convertPolicy(policy);
     templatesSet.aspectTemplates = [];
-    for (const aspectTemplateDefault of templatesSetDefaults.aspects) {
-      const aspectTemplate =
-        await this.aspectTemplateService.createAspectTemplate(
-          aspectTemplateDefault
-        );
-      templatesSet.aspectTemplates.push(aspectTemplate);
-    }
-
-    templatesSet.lifecycleTemplates = [];
-    for (const lifecycleTemplateDefault of templatesSetDefaults.lifecycles) {
-      const lifecycleTemplate =
-        await this.lifecycleTemplateService.createInnovationFLowTemplate(
-          lifecycleTemplateDefault
-        );
-      templatesSet.lifecycleTemplates.push(lifecycleTemplate);
-    }
-
     templatesSet.canvasTemplates = [];
+    templatesSet.lifecycleTemplates = [];
+
+    if (addDefaults) {
+      for (const aspectTemplateDefault of templatesSetDefaults.aspects) {
+        const aspectTemplate =
+          await this.aspectTemplateService.createAspectTemplate(
+            aspectTemplateDefault
+          );
+        templatesSet.aspectTemplates.push(aspectTemplate);
+      }
+
+      for (const lifecycleTemplateDefault of templatesSetDefaults.lifecycles) {
+        const lifecycleTemplate =
+          await this.lifecycleTemplateService.createInnovationFLowTemplate(
+            lifecycleTemplateDefault
+          );
+        templatesSet.lifecycleTemplates.push(lifecycleTemplate);
+      }
+    }
 
     return await this.templatesSetRepository.save(templatesSet);
   }
@@ -103,8 +110,7 @@ export class TemplatesSetService {
     if (templatesSet.lifecycleTemplates) {
       for (const lifecycleTemplate of templatesSet.lifecycleTemplates) {
         await this.lifecycleTemplateService.deleteLifecycleTemplate(
-          lifecycleTemplate,
-          true
+          lifecycleTemplate
         );
       }
     }
@@ -218,6 +224,30 @@ export class TemplatesSetService {
     return templatesSetPopulated.lifecycleTemplates;
   }
 
+  async deleteInnovationFlowTemplate(
+    innovationFlowTemplate: ILifecycleTemplate,
+    templatesSetID: string
+  ): Promise<ILifecycleTemplate> {
+    const templatesSet = await this.getTemplatesSetOrFail(templatesSetID);
+    const innovationFlowTemplates = await this.getInnovationFlowTemplates(
+      templatesSet
+    );
+    const typeCount = innovationFlowTemplates.filter(
+      t => t.type === innovationFlowTemplate.type
+    ).length;
+    const policy = this.getPolicy(templatesSet);
+
+    if (typeCount <= policy.minInnovationFlow) {
+      throw new ValidationException(
+        `Cannot delete last lifecycle template: ${innovationFlowTemplate.id} of type ${innovationFlowTemplate.type} from templateSet: ${templatesSet.id}!`,
+        LogContext.LIFECYCLE
+      );
+    }
+    return await this.lifecycleTemplateService.deleteLifecycleTemplate(
+      innovationFlowTemplate
+    );
+  }
+
   async createInnovationFlowTemplate(
     templatesSet: ITemplatesSet,
     innovationFlowTemplateInput: CreateInnovationFlowTemplateInput
@@ -232,5 +262,20 @@ export class TemplatesSetService {
     templatesSet.lifecycleTemplates.push(innovationFlowTemplate);
     await this.templatesSetRepository.save(templatesSet);
     return innovationFlowTemplate;
+  }
+
+  getPolicy(templatesSet: ITemplatesSet): ITemplatesSetPolicy {
+    if (!templatesSet.policy) {
+      throw new EntityNotInitializedException(
+        `Unable to locate policy for TemplatesSet: ${templatesSet.id}`,
+        LogContext.COMMUNITY
+      );
+    }
+    const policy = JSON.parse(templatesSet.policy);
+    return policy;
+  }
+
+  convertPolicy(policy: ITemplatesSetPolicy): string {
+    return JSON.stringify(policy);
   }
 }

--- a/src/library/innovation-pack/innovaton.pack.service.ts
+++ b/src/library/innovation-pack/innovaton.pack.service.ts
@@ -41,7 +41,12 @@ export class InnovationPackService {
     innovationPack.authorization = new AuthorizationPolicy();
 
     innovationPack.templatesSet =
-      await this.templatesSetService.createTemplatesSet();
+      await this.templatesSetService.createTemplatesSet(
+        {
+          minInnovationFlow: 0,
+        },
+        false
+      );
 
     // save before assigning host in case that fails
     const savedInnovationPack = await this.innovationPackRepository.save(

--- a/src/library/library/library.service.authorization.ts
+++ b/src/library/library/library.service.authorization.ts
@@ -24,11 +24,11 @@ export class LibraryAuthorizationService {
     library.authorization = this.authorizationPolicyService.reset(
       library.authorization
     );
-    library.authorization.anonymousReadAccess = true;
     library.authorization =
       this.platformAuthorizationService.inheritPlatformAuthorization(
         library.authorization
       );
+    library.authorization.anonymousReadAccess = true;
 
     // Cascade down
     const libraryPropagated = await this.propagateAuthorizationToChildEntities(

--- a/src/migrations/1667631156513-templates-set-policy.ts
+++ b/src/migrations/1667631156513-templates-set-policy.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class templatesSetPolicy1667631156513 implements MigrationInterface {
+  name = 'templatesSetPolicy1667631156513';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`templates_set\` ADD \`policy\` text NULL`
+    );
+    const templatesSets: any[] = await queryRunner.query(
+      `SELECT id FROM templates_set`
+    );
+    for (const templatesSet of templatesSets) {
+      const policy = {
+        minInnovationFlow: 1,
+      };
+      await queryRunner.query(
+        `UPDATE templates_set SET policy = '${JSON.stringify(
+          policy
+        )}' WHERE (id = '${templatesSet.id}')`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`templates_set\` DROP COLUMN \`policy\``
+    );
+  }
+}


### PR DESCRIPTION
TemplatesSet entity and InnovationFlowTemplate entity had business logic that was specific to the usage of that entity for Hub Templates. 

Addressed:
* moved mutation re minimum number of innovation flow templates out of innovation flow template + to templates set,
* added a policy that can be set at creation time, with migration up / down 
* added flag to control adding of defaults to a templates set
* fixed bug with authorization policy not being anonymous read access = true on library