### PR TITLE
Authorization policy credential rules accept array of criteria

### DIFF
--- a/src/core/authorization/authorization.policy.rule.credential.interface.ts
+++ b/src/core/authorization/authorization.policy.rule.credential.interface.ts
@@ -1,13 +1,11 @@
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType('AuthorizationPolicyRuleCredential')
 export abstract class IAuthorizationPolicyRuleCredential {
-  @Field(() => String)
-  type!: string;
-
-  @Field(() => String)
-  resourceID!: string;
+  @Field(() => [ICredentialDefinition])
+  criterias!: ICredentialDefinition[];
 
   @Field(() => [AuthorizationPrivilege])
   grantedPrivileges!: AuthorizationPrivilege[];

--- a/src/core/authorization/authorization.policy.rule.credential.ts
+++ b/src/core/authorization/authorization.policy.rule.credential.ts
@@ -1,11 +1,11 @@
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 import { IAuthorizationPolicyRuleCredential } from './authorization.policy.rule.credential.interface';
 
 export class AuthorizationPolicyRuleCredential
   implements IAuthorizationPolicyRuleCredential
 {
-  type: string;
-  resourceID: string;
+  criterias: ICredentialDefinition[];
   grantedPrivileges: AuthorizationPrivilege[];
   inheritable: boolean;
 
@@ -14,8 +14,11 @@ export class AuthorizationPolicyRuleCredential
     type: string,
     resourceID?: string
   ) {
-    this.type = type;
-    this.resourceID = resourceID || '';
+    const criteria: ICredentialDefinition = {
+      type: type,
+      resourceID: resourceID || '',
+    };
+    this.criterias = [criteria];
     this.grantedPrivileges = grantedPrivileges;
     this.inheritable = true;
   }

--- a/src/core/authorization/authorization.policy.rule.credential.ts
+++ b/src/core/authorization/authorization.policy.rule.credential.ts
@@ -22,4 +22,12 @@ export class AuthorizationPolicyRuleCredential
     this.grantedPrivileges = grantedPrivileges;
     this.inheritable = true;
   }
+
+  appendCriteria(type: string, resourceID?: string) {
+    const criteria: ICredentialDefinition = {
+      type: type,
+      resourceID: resourceID || '',
+    };
+    this.criterias.push(criteria);
+  }
 }

--- a/src/core/authorization/authorization.service.ts
+++ b/src/core/authorization/authorization.service.ts
@@ -200,12 +200,14 @@ export class AuthorizationService {
     credential: ICredential,
     credentialRule: IAuthorizationPolicyRuleCredential
   ): boolean {
-    if (credential.type === credentialRule.type) {
-      if (
-        credentialRule.resourceID === '' ||
-        credential.resourceID === credentialRule.resourceID
-      ) {
-        return true;
+    for (const criteria of credentialRule.criterias) {
+      if (credential.type === criteria.type) {
+        if (
+          criteria.resourceID === '' ||
+          credential.resourceID === criteria.resourceID
+        ) {
+          return true;
+        }
       }
     }
     return false;

--- a/src/migrations/1667933499673-credentials.ts
+++ b/src/migrations/1667933499673-credentials.ts
@@ -43,7 +43,6 @@ export class credentials1667933499673 implements MigrationInterface {
     );
     for (const authorization of authorizations) {
       if (!authorization.credentialRules) {
-        //console.log(`No credential rules found for policy with id: ${authorization.id}`);
         continue;
       }
       const rules: newCredentialRule[] = JSON.parse(

--- a/src/platform/authorization/platform.authorization.service.ts
+++ b/src/platform/authorization/platform.authorization.service.ts
@@ -48,7 +48,7 @@ export class PlatformAuthorizationService {
   private createPlatformCredentialRules(): AuthorizationPolicyRuleCredential[] {
     const credentialRules: AuthorizationPolicyRuleCredential[] = [];
 
-    const globalAdmin = new AuthorizationPolicyRuleCredential(
+    const globalAdmins = new AuthorizationPolicyRuleCredential(
       [
         AuthorizationPrivilege.CREATE,
         AuthorizationPrivilege.READ,
@@ -58,19 +58,8 @@ export class PlatformAuthorizationService {
       ],
       AuthorizationCredential.GLOBAL_ADMIN
     );
-    credentialRules.push(globalAdmin);
-
-    const globalHubsAdmin = new AuthorizationPolicyRuleCredential(
-      [
-        AuthorizationPrivilege.CREATE,
-        AuthorizationPrivilege.READ,
-        AuthorizationPrivilege.UPDATE,
-        AuthorizationPrivilege.DELETE,
-        AuthorizationPrivilege.MOVE_CARD,
-      ],
-      AuthorizationCredential.GLOBAL_ADMIN_HUBS
-    );
-    credentialRules.push(globalHubsAdmin);
+    globalAdmins.appendCriteria(AuthorizationCredential.GLOBAL_ADMIN_HUBS);
+    credentialRules.push(globalAdmins);
 
     // Allow global admins to manage global privileges, access Platform mgmt
     const globalAdminNotInherited = new AuthorizationPolicyRuleCredential(


### PR DESCRIPTION
The authorization policy credential rules now accept an array of criteria.

This does already simplify some of the existing authorization policies, but that is not the main reason.

The key reason is that this is absolutely required for when we start accepting multiple credential types for having member privileges in communities e.g. so a hub member has the same rights as a challenge member etc. Otherwise we get an explosion of credential rules. 

Up / down migration added. 

Applied in one location to keep the set of changes isolated. Once this is in then there is a follow up action to review all authorization policies to pass in arrays of accepted criteria - but did not want to do it in this go so as to keep the change to having arrays of criteria clear. 