### PR TITLE
filter callouts that can be returned to a user based on the privileges

### DIFF
--- a/src/domain/collaboration/callout/callout.interface.ts
+++ b/src/domain/collaboration/callout/callout.interface.ts
@@ -65,5 +65,4 @@ export abstract class ICallout extends INameable {
 
   publishedBy!: string;
   publishedDate!: Date;
-
 }

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -197,7 +197,7 @@ export class CalloutResolverMutations {
     const callout = await this.calloutService.getCalloutOrFail(
       calloutData.calloutID
     );
-    await this.authorizationService.grantAccessOrFail(
+    this.authorizationService.grantAccessOrFail(
       agentInfo,
       callout.authorization,
       AuthorizationPrivilege.UPDATE,
@@ -208,28 +208,27 @@ export class CalloutResolverMutations {
       calloutData
     );
 
-    if (
-      oldVisibility === CalloutVisibility.DRAFT &&
-      callout.visibility === CalloutVisibility.PUBLISHED
-    ) {
-      // Save published info
-      await this.calloutService.updateCalloutPublishInfo(
-        savedCallout,
-        agentInfo.userID,
-        Date.now()
-      );
+    if (callout.visibility !== oldVisibility) {
+      if (callout.visibility === CalloutVisibility.PUBLISHED) {
+        // Save published info
+        await this.calloutService.updateCalloutPublishInfo(
+          savedCallout,
+          agentInfo.userID,
+          Date.now()
+        );
 
-      const notificationInput: NotificationInputCalloutPublished = {
-        triggeredBy: agentInfo.userID,
-        callout: savedCallout,
-      };
-      await this.notificationAdapter.calloutPublished(notificationInput);
+        const notificationInput: NotificationInputCalloutPublished = {
+          triggeredBy: agentInfo.userID,
+          callout: savedCallout,
+        };
+        await this.notificationAdapter.calloutPublished(notificationInput);
 
-      const activityLogInput: ActivityInputCalloutPublished = {
-        triggeredBy: agentInfo.userID,
-        callout: callout,
-      };
-      this.activityAdapter.calloutPublished(activityLogInput);
+        const activityLogInput: ActivityInputCalloutPublished = {
+          triggeredBy: agentInfo.userID,
+          callout: callout,
+        };
+        this.activityAdapter.calloutPublished(activityLogInput);
+      }
     }
 
     return savedCallout;

--- a/src/domain/collaboration/callout/callout.service.authorization.ts
+++ b/src/domain/collaboration/callout/callout.service.authorization.ts
@@ -52,10 +52,7 @@ export class CalloutAuthorizationService {
       callout.type
     );
 
-    callout.authorization = this.appendCredentialRules(
-      callout.authorization,
-      communityPolicy
-    );
+    callout.authorization = this.appendCredentialRules(callout.authorization);
 
     callout.aspects = await this.calloutService.getAspectsFromCallout(callout);
     for (const aspect of callout.aspects) {
@@ -102,12 +99,11 @@ export class CalloutAuthorizationService {
   }
 
   private appendCredentialRules(
-    authorization: IAuthorizationPolicy | undefined,
-    policy: ICommunityPolicy
+    authorization: IAuthorizationPolicy | undefined
   ): IAuthorizationPolicy {
     if (!authorization)
       throw new EntityNotInitializedException(
-        `Authorization definition not found for Callout: ${policy}`,
+        'Authorization definition not found for Callout',
         LogContext.COLLABORATION
       );
     const newRules: IAuthorizationPolicyRuleCredential[] = [];

--- a/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
+++ b/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
@@ -1,5 +1,9 @@
 import { Args, Context, Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { AuthorizationAgentPrivilege, Profiling } from '@src/common/decorators';
+import {
+  AuthorizationAgentPrivilege,
+  CurrentUser,
+  Profiling,
+} from '@src/common/decorators';
 import { IRelation } from '@domain/collaboration/relation/relation.interface';
 import { AuthorizationPrivilege } from '@common/enums';
 import { UseGuards } from '@nestjs/common/decorators';
@@ -9,6 +13,7 @@ import { ICollaboration } from '@domain/collaboration/collaboration/collaboratio
 import { CollaborationService } from '@domain/collaboration/collaboration/collaboration.service';
 import { ICallout } from '../callout/callout.interface';
 import { CollaborationArgsCallouts } from './dto/collaboration.args.callouts';
+import { AgentInfo } from '@core/authentication/agent-info';
 
 @Resolver(() => ICollaboration)
 export class CollaborationResolverFields {
@@ -37,11 +42,13 @@ export class CollaborationResolverFields {
   @Profiling.api
   async callouts(
     @Parent() collaboration: Collaboration,
+    @CurrentUser() agentInfo: AgentInfo,
     @Args({ nullable: true }) args: CollaborationArgsCallouts
   ) {
     return await this.collaborationService.getCalloutsFromCollaboration(
       collaboration,
-      args
+      args,
+      agentInfo
     );
   }
 }


### PR DESCRIPTION
The field "callouts" on a Collaboration now returns results as follows:
- if visibility is published, then check the READ privilege
- if visibility is draft, then check the UPDATE privilege

Not ideal, as would prefer to do it all via authorization policy, but the alternative was a very deep update to the authorization setup which needs a deeper design.