### PR TITLE
Authorization safety

### DIFF
--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -234,7 +234,7 @@ export class ChallengeAuthorizationService {
 
     authorization = this.authorizationPolicyService.reset(authorization);
     authorization =
-      this.platformAuthorizationService.inheritPlatformAuthorizationPolicy(
+      this.platformAuthorizationService.inheritRootAuthorizationPolicy(
         authorization
       );
     authorization.anonymousReadAccess = false;

--- a/src/domain/challenge/hub/hub.service.authorization.ts
+++ b/src/domain/challenge/hub/hub.service.authorization.ts
@@ -56,7 +56,7 @@ export class HubAuthorizationService {
     );
     hub.authorization.anonymousReadAccess = false;
     hub.authorization =
-      this.platformAuthorizationService.inheritPlatformAuthorizationPolicy(
+      this.platformAuthorizationService.inheritRootAuthorizationPolicy(
         hub.authorization
       );
 

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -37,7 +37,7 @@ export class OrganizationAuthorizationService {
       organization.authorization
     );
     organization.authorization =
-      this.platformAuthorizationService.inheritPlatformAuthorizationPolicy(
+      this.platformAuthorizationService.inheritRootAuthorizationPolicy(
         organization.authorization
       );
     organization.authorization = this.appendCredentialRules(

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -33,7 +33,7 @@ export class UserAuthorizationService {
       user.authorization
     );
     user.authorization =
-      this.platformAuthorizationService.inheritPlatformAuthorizationPolicy(
+      this.platformAuthorizationService.inheritRootAuthorizationPolicy(
         user.authorization
       );
 

--- a/src/library/library/library.module.ts
+++ b/src/library/library/library.module.ts
@@ -3,7 +3,6 @@ import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/a
 import { InnovationPackModule } from '@library/innovation-pack/innovation.pack.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
 import { NamingModule } from '@services/infrastructure/naming/naming.module';
 import { Library } from './library.entity';
 import { LibraryResolverFields } from './library.resolver.fields';
@@ -17,7 +16,6 @@ import { LibraryAuthorizationService } from './library.service.authorization';
     NamingModule,
     AuthorizationModule,
     AuthorizationPolicyModule,
-    PlatformAuthorizationPolicyModule,
     TypeOrmModule.forFeature([Library]),
   ],
   providers: [

--- a/src/platform/authorization/platform.authorization.policy.service.ts
+++ b/src/platform/authorization/platform.authorization.policy.service.ts
@@ -29,6 +29,17 @@ export class PlatformAuthorizationPolicyService {
     );
   }
 
+  private createRootAuthorizationPolicy(): IAuthorizationPolicy {
+    const rootAuthorization = new AuthorizationPolicy();
+
+    const credentialRules = this.createRootCredentialRules();
+
+    return this.authorizationPolicyService.appendCredentialAuthorizationRules(
+      rootAuthorization,
+      credentialRules
+    );
+  }
+
   private createPlatformAuthorizationPolicy(): IAuthorizationPolicy {
     let platformAuthorization: IAuthorizationPolicy = new AuthorizationPolicy();
     platformAuthorization =
@@ -45,25 +56,7 @@ export class PlatformAuthorizationPolicyService {
         credentialRules
       );
 
-    const privilegeRules = this.createRootPrivilegeRules();
-    return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
-      platformAuthCredRules,
-      privilegeRules
-    );
-  }
-
-  private createRootAuthorizationPolicy(): IAuthorizationPolicy {
-    const rootAuthorization = new AuthorizationPolicy();
-
-    const credentialRules = this.createRootCredentialRules();
-
-    const platformAuthCredRules =
-      this.authorizationPolicyService.appendCredentialAuthorizationRules(
-        rootAuthorization,
-        credentialRules
-      );
-
-    const privilegeRules = this.createRootPrivilegeRules();
+    const privilegeRules = this.createPlatformPrivilegeRules();
     return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
       platformAuthCredRules,
       privilegeRules
@@ -157,7 +150,7 @@ export class PlatformAuthorizationPolicyService {
     return credentialRules;
   }
 
-  private createRootPrivilegeRules(): AuthorizationPolicyRulePrivilege[] {
+  private createPlatformPrivilegeRules(): AuthorizationPolicyRulePrivilege[] {
     const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
 
     const createPrivilege = new AuthorizationPolicyRulePrivilege(

--- a/src/platform/platfrom/platform.service.authorization.ts
+++ b/src/platform/platfrom/platform.service.authorization.ts
@@ -51,7 +51,8 @@ export class PlatformAuthorizationService {
   ): Promise<IPlatform> {
     if (platform.library) {
       await this.libraryAuthorizationService.applyAuthorizationPolicy(
-        platform.library
+        platform.library,
+        platform.authorization
       );
     }
 


### PR DESCRIPTION
Split the static authorization policies into two:
- root: that is used to inherit by other entities such as user, org, hub, platform etc
- platform: which has the specific rules that govern platform level permissions

This avoids any situation whereby modification to platform can impact the rules applied to other entities. It is simply much safer.

Also fixed an issue with the library as it should inherit from platform authorization via a parameter rather than going directly.

Note: kept the authorization policy as a separate module to avoid having linked dependencies between lots of the domain modules and the platform module. 