### PR TITLE
added location to cardProfile; extended location to have additional fields

### DIFF
--- a/src/domain/collaboration/card-profile/card.profile.entity.ts
+++ b/src/domain/collaboration/card-profile/card.profile.entity.ts
@@ -3,6 +3,7 @@ import { Reference } from '@domain/common/reference/reference.entity';
 import { Tagset } from '@domain/common/tagset/tagset.entity';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { ICardProfile } from './card.profile.interface';
+import { Location } from '@domain/common/location/location.entity';
 
 @Entity()
 export class CardProfile extends AuthorizableEntity implements ICardProfile {
@@ -18,4 +19,12 @@ export class CardProfile extends AuthorizableEntity implements ICardProfile {
 
   @Column('text', { nullable: true })
   description = '';
+
+  @OneToOne(() => Location, {
+    eager: false,
+    cascade: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn()
+  location?: Location;
 }

--- a/src/domain/collaboration/card-profile/card.profile.interface.ts
+++ b/src/domain/collaboration/card-profile/card.profile.interface.ts
@@ -1,4 +1,5 @@
 import { IAuthorizable } from '@domain/common/entity/authorizable-entity';
+import { ILocation } from '@domain/common/location/location.interface';
 import { IReference } from '@domain/common/reference/reference.interface';
 import { Markdown } from '@domain/common/scalars/scalar.markdown';
 import { ITagset } from '@domain/common/tagset/tagset.interface';
@@ -7,6 +8,8 @@ import { Field, ObjectType } from '@nestjs/graphql';
 @ObjectType('CardProfile')
 export abstract class ICardProfile extends IAuthorizable {
   references?: IReference[];
+
+  location?: ILocation;
 
   @Field(() => ITagset, {
     nullable: true,

--- a/src/domain/collaboration/card-profile/card.profile.module.ts
+++ b/src/domain/collaboration/card-profile/card.profile.module.ts
@@ -9,6 +9,7 @@ import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { CardProfileAuthorizationService } from './card.profile.service.authorization';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { CardProfileResolverFields } from './card.profile.resolver.fields';
+import { LocationModule } from '@domain/common/location';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { CardProfileResolverFields } from './card.profile.resolver.fields';
     AuthorizationPolicyModule,
     TagsetModule,
     ReferenceModule,
+    LocationModule,
     TypeOrmModule.forFeature([CardProfile]),
   ],
   providers: [

--- a/src/domain/collaboration/card-profile/card.profile.resolver.fields.ts
+++ b/src/domain/collaboration/card-profile/card.profile.resolver.fields.ts
@@ -6,6 +6,7 @@ import { GraphqlGuard } from '@core/authorization/graphql.guard';
 import { IReference } from '@domain/common/reference/reference.interface';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { CardProfileService } from './card.profile.service';
+import { ILocation } from '@domain/common/location/location.interface';
 
 @Resolver(() => ICardProfile)
 export class CardProfileResolverFields {
@@ -20,5 +21,15 @@ export class CardProfileResolverFields {
   @Profiling.api
   async references(@Parent() cardProfile: ICardProfile) {
     return await this.cardProfileService.getReferences(cardProfile);
+  }
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField('location', () => ILocation, {
+    nullable: true,
+    description: 'The location for this Profile.',
+  })
+  @Profiling.api
+  async location(@Parent() cardProfile: ICardProfile): Promise<ILocation> {
+    return await this.cardProfileService.getLocation(cardProfile);
   }
 }

--- a/src/domain/collaboration/card-profile/card.profile.service.ts
+++ b/src/domain/collaboration/card-profile/card.profile.service.ts
@@ -20,12 +20,14 @@ import { RestrictedTagsetNames } from '@domain/common/tagset';
 import { CardProfile } from './card.profile.entity';
 import { ICardProfile } from './card.profile.interface';
 import { CreateReferenceOnCardProfileInput } from './dto/card.profile.dto.create.reference';
+import { ILocation, LocationService } from '@domain/common/location';
 
 @Injectable()
 export class CardProfileService {
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
     private tagsetService: TagsetService,
+    private locationService: LocationService,
     private referenceService: ReferenceService,
     @InjectRepository(CardProfile)
     private cardProfileRepository: Repository<CardProfile>,
@@ -50,6 +52,10 @@ export class CardProfileService {
       cardProfile.references = [];
     }
 
+    cardProfile.location = await this.locationService.createLocation(
+      cardProfile?.location
+    );
+
     await this.cardProfileRepository.save(cardProfile);
     this.logger.verbose?.(
       `Created new cardProfile with id: ${cardProfile.id}`,
@@ -63,7 +69,7 @@ export class CardProfileService {
     cardProfileData: UpdateCardProfileInput
   ): Promise<ICardProfile> {
     const cardProfile = await this.getCardProfileOrFail(cardProfileOrig.id, {
-      relations: ['references', 'tagset', 'authorization'],
+      relations: ['references', 'tagset', 'authorization', 'location'],
     });
 
     if (cardProfileData.description) {
@@ -74,6 +80,13 @@ export class CardProfileService {
       cardProfile.references = this.referenceService.updateReferences(
         cardProfile.references,
         cardProfileData.references
+      );
+    }
+
+    if (cardProfileData.location) {
+      this.locationService.updateLocationValues(
+        cardProfile.location,
+        cardProfileData.location
       );
     }
 
@@ -93,7 +106,7 @@ export class CardProfileService {
   async deleteCardProfile(cardProfileID: string): Promise<ICardProfile> {
     // Note need to load it in with all contained entities so can remove fully
     const cardProfile = await this.getCardProfileOrFail(cardProfileID, {
-      relations: ['references', 'tagset', 'authorization'],
+      relations: ['references', 'tagset', 'authorization', 'location'],
     });
 
     if (cardProfile.tagset) {
@@ -106,6 +119,10 @@ export class CardProfileService {
           ID: reference.id,
         });
       }
+    }
+
+    if (cardProfile.location) {
+      await this.locationService.removeLocation(cardProfile.location);
     }
 
     if (cardProfile.authorization)
@@ -176,6 +193,19 @@ export class CardProfileService {
       );
     }
     return cardProfile.references;
+  }
+
+  async getLocation(cardProfileInput: ICardProfile): Promise<ILocation> {
+    const cardProfile = await this.getCardProfileOrFail(cardProfileInput.id, {
+      relations: ['location'],
+    });
+    if (!cardProfile.location) {
+      throw new EntityNotInitializedException(
+        `CardProfile not initialized: ${cardProfile.id}`,
+        LogContext.COLLABORATION
+      );
+    }
+    return cardProfile.location;
   }
 
   async getTagset(cardProfileID: string): Promise<ITagset> {

--- a/src/domain/collaboration/card-profile/dto/card.profile.dto.create.ts
+++ b/src/domain/collaboration/card-profile/dto/card.profile.dto.create.ts
@@ -3,6 +3,7 @@ import { IsOptional, MaxLength, ValidateNested } from 'class-validator';
 import { LONG_TEXT_LENGTH } from '@src/common/constants';
 import { CreateReferenceInput } from '@domain/common/reference';
 import { Type } from 'class-transformer';
+import { CreateLocationInput } from '@domain/common/location/dto/location.dto.create';
 
 @InputType()
 export class CreateCardProfileInput {
@@ -20,4 +21,10 @@ export class CreateCardProfileInput {
   @ValidateNested({ each: true })
   @Type(() => CreateReferenceInput)
   referencesData?: CreateReferenceInput[];
+
+  @Field(() => CreateLocationInput, { nullable: true })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateLocationInput)
+  location?: CreateLocationInput;
 }

--- a/src/domain/collaboration/card-profile/dto/card.profile.dto.update.ts
+++ b/src/domain/collaboration/card-profile/dto/card.profile.dto.update.ts
@@ -3,6 +3,7 @@ import { IsOptional, MaxLength, ValidateNested } from 'class-validator';
 import { LONG_TEXT_LENGTH } from '@src/common/constants';
 import { UpdateReferenceInput } from '@domain/common/reference';
 import { Type } from 'class-transformer';
+import { UpdateLocationInput } from '@domain/common/location/dto/location.dto.update';
 
 @InputType()
 export class UpdateCardProfileInput {
@@ -23,4 +24,10 @@ export class UpdateCardProfileInput {
   })
   @IsOptional()
   tags?: string[];
+
+  @Field(() => UpdateLocationInput, { nullable: true })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateLocationInput)
+  location?: UpdateLocationInput;
 }

--- a/src/domain/common/location/dto/location.dto.create.ts
+++ b/src/domain/common/location/dto/location.dto.create.ts
@@ -13,4 +13,24 @@ export class CreateLocationInput {
   @IsOptional()
   @MaxLength(SMALL_TEXT_LENGTH)
   country?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  stateOrProvince?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  addressLine1?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  addressLine2?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  postalCode?: string;
 }

--- a/src/domain/common/location/dto/location.dto.update.ts
+++ b/src/domain/common/location/dto/location.dto.update.ts
@@ -13,4 +13,24 @@ export class UpdateLocationInput {
   @IsOptional()
   @MaxLength(SMALL_TEXT_LENGTH)
   country?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  stateOrProvince?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  addressLine1?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  addressLine2?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  postalCode?: string;
 }

--- a/src/domain/common/location/location.entity.ts
+++ b/src/domain/common/location/location.entity.ts
@@ -10,6 +10,18 @@ export class Location extends BaseAlkemioEntity implements ILocation {
   @Column('varchar', { length: 255, nullable: true })
   country = '';
 
+  @Column('varchar', { length: 255, nullable: true })
+  addressLine1 = '';
+
+  @Column('varchar', { length: 255, nullable: true })
+  addressLine2 = '';
+
+  @Column('varchar', { length: 255, nullable: true })
+  stateOrProvince = '';
+
+  @Column('varchar', { length: 255, nullable: true })
+  postalCode = '';
+
   constructor(city?: string, country?: string) {
     super();
     this.city = city || '';

--- a/src/domain/common/location/location.interface.ts
+++ b/src/domain/common/location/location.interface.ts
@@ -8,4 +8,16 @@ export abstract class ILocation extends IBaseAlkemio {
 
   @Field(() => String)
   country!: string;
+
+  @Field(() => String)
+  addressLine1!: string;
+
+  @Field(() => String)
+  addressLine2!: string;
+
+  @Field(() => String)
+  stateOrProvince!: string;
+
+  @Field(() => String)
+  postalCode!: string;
 }

--- a/src/domain/common/location/location.service.ts
+++ b/src/domain/common/location/location.service.ts
@@ -39,6 +39,22 @@ export class LocationService {
     if (locationData.country || locationData.country === '') {
       location.country = locationData.country;
     }
+
+    if (locationData.addressLine1 || locationData.addressLine1 === '') {
+      location.addressLine1 = locationData.addressLine1;
+    }
+
+    if (locationData.addressLine2 || locationData.addressLine2 === '') {
+      location.addressLine2 = locationData.addressLine2;
+    }
+
+    if (locationData.postalCode || locationData.postalCode === '') {
+      location.postalCode = locationData.postalCode;
+    }
+
+    if (locationData.stateOrProvince || locationData.stateOrProvince === '') {
+      location.stateOrProvince = locationData.stateOrProvince;
+    }
   }
 
   async updateLocation(

--- a/src/domain/timeline/calendar/calendar.resolver.fields.ts
+++ b/src/domain/timeline/calendar/calendar.resolver.fields.ts
@@ -52,7 +52,7 @@ export class CalendarResolverFields {
     nullable: true,
     description: 'The list of CalendarEvents for this Calendar.',
   })
-  async callouts(
+  async events(
     @Parent() calendar: ICalendar,
     @CurrentUser() agentInfo: AgentInfo,
     @Args({ nullable: true }) args: CalendarArgsEvents

--- a/src/domain/timeline/calendar/calendar.service.ts
+++ b/src/domain/timeline/calendar/calendar.service.ts
@@ -168,7 +168,9 @@ export class CalendarService {
     if (args.IDs) {
       const results: ICalendarEvent[] = [];
       for (const eventID of args.IDs) {
-        const event = readableCallouts.find(e => e.id === eventID);
+        const event = readableCallouts.find(
+          e => e.id === eventID || e.nameID === eventID
+        );
 
         if (!event)
           throw new EntityNotFoundException(

--- a/src/domain/timeline/calendar/calendar.service.ts
+++ b/src/domain/timeline/calendar/calendar.service.ts
@@ -159,16 +159,16 @@ export class CalendarService {
         LogContext.CALENDAR
       );
 
-    // First filter the callouts the current user has READ privilege to
-    const readableCallouts = allEvents.filter(callout =>
-      this.hasAgentAccessToCallout(callout, agentInfo)
+    // First filter the events the current user has READ privilege to
+    const readableEvents = allEvents.filter(event =>
+      this.hasAgentAccessToEvent(event, agentInfo)
     );
 
     // (a) by IDs, results in order specified by IDs
     if (args.IDs) {
       const results: ICalendarEvent[] = [];
       for (const eventID of args.IDs) {
-        const event = readableCallouts.find(
+        const event = readableEvents.find(
           e => e.id === eventID || e.nameID === eventID
         );
 
@@ -184,13 +184,13 @@ export class CalendarService {
 
     // (b) limit number of results
     if (args.limit) {
-      return limitAndShuffle(readableCallouts, args.limit, false);
+      return limitAndShuffle(readableEvents, args.limit, false);
     }
 
-    return readableCallouts;
+    return readableEvents;
   }
 
-  private hasAgentAccessToCallout(
+  private hasAgentAccessToEvent(
     event: ICalendarEvent,
     agentInfo: AgentInfo
   ): boolean {

--- a/src/domain/timeline/calendar/dto/calendar.args.events.ts
+++ b/src/domain/timeline/calendar/dto/calendar.args.events.ts
@@ -1,11 +1,11 @@
-import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { UUID_NAMEID } from '@domain/common/scalars';
 import { ArgsType, Field, Float } from '@nestjs/graphql';
 
 @ArgsType()
 export class CalendarArgsEvents {
-  @Field(() => [UUID], {
+  @Field(() => [UUID_NAMEID], {
     name: 'IDs',
-    description: 'The IDs of the CalendarEvents to return',
+    description: 'The IDs or NAMEIDS of the CalendarEvents to return',
     nullable: true,
   })
   IDs?: string[];

--- a/src/migrations/1674841101938-locationOnEvents.ts
+++ b/src/migrations/1674841101938-locationOnEvents.ts
@@ -16,10 +16,10 @@ export class locationOnEvents1674841101938 implements MigrationInterface {
       `ALTER TABLE \`card_profile\` ADD CONSTRAINT \`FK_87777ca8ac212b8357637794d6f\` FOREIGN KEY (\`locationId\`) REFERENCES \`location\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
     );
     await queryRunner.query(
-      `ALTER TABLE \`location\` ADD \`addressLine1\` varchar(255) NOT NULL DEFAULT '',
-                                ADD \`addressLine2\` varchar(255) NOT NULL DEFAULT '',
-                                ADD \`stateOrProvince\` varchar(255) NOT NULL DEFAULT '',
-                                ADD \`postalCode\` varchar(36) NOT NULL DEFAULT ''`
+      `ALTER TABLE \`location\` ADD \`addressLine1\` varchar(128) NOT NULL DEFAULT '',
+                                ADD \`addressLine2\` varchar(128) NOT NULL DEFAULT '',
+                                ADD \`stateOrProvince\` varchar(128) NOT NULL DEFAULT '',
+                                ADD \`postalCode\` varchar(128) NOT NULL DEFAULT ''`
     );
 
     const cardProfiles: any[] = await queryRunner.query(

--- a/src/migrations/1674841101938-locationOnEvents.ts
+++ b/src/migrations/1674841101938-locationOnEvents.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+export class locationOnEvents1674841101938 implements MigrationInterface {
+  name = 'locationOnEvents1674841101938';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add location to profiles
+    await queryRunner.query(
+      `ALTER TABLE \`card_profile\` ADD \`locationId\` char(36) NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`card_profile\` ADD UNIQUE INDEX \`IDX_87777ca8ac212b8357637794d6\` (\`locationId\`)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`card_profile\` ADD CONSTRAINT \`FK_87777ca8ac212b8357637794d6f\` FOREIGN KEY (\`locationId\`) REFERENCES \`location\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`location\` ADD \`addressLine1\` varchar(255) NOT NULL DEFAULT '',
+                                ADD \`addressLine2\` varchar(255) NOT NULL DEFAULT '',
+                                ADD \`stateOrProvince\` varchar(255) NOT NULL DEFAULT '',
+                                ADD \`postalCode\` varchar(36) NOT NULL DEFAULT ''`
+    );
+
+    const cardProfiles: any[] = await queryRunner.query(
+      `SELECT id from card_profile`
+    );
+    for (const cardProfile of cardProfiles) {
+      console.log(`Retrieved profile with id: ${cardProfile.id}`);
+      const locationID = randomUUID();
+      await queryRunner.query(
+        `INSERT INTO location (id, version, city, country)
+            values ('${locationID}', 1,  '', '')`
+      );
+      await queryRunner.query(
+        `UPDATE card_profile SET locationId = '${locationID}' WHERE (id = '${cardProfile.id}')`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`card_profile\` DROP FOREIGN KEY \`FK_87777ca8ac212b8357637794d6f\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`card_profile\` DROP INDEX \`IDX_87777ca8ac212b8357637794d6\`, DROP COLUMN \`locationId\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`location\` DROP COLUMN \`addressLine1\`, DROP COLUMN \`addressLine2\`, DROP COLUMN \`stateOrProvince\`, DROP COLUMN \`postalCode\``
+    );
+  }
+}


### PR DESCRIPTION
Location now has the following additional fields:
- addressLine1
- addressLine2
- postalCode
- stateOrProvince

The CardProfile entity is updated to also have a Location field. 

Filtering by event IDs also now accepts NAMEIDs.

Note: the choice to put location on the CardProfile is in part due to the pending merging of Profile + CardProfile entities. 
