### PR TITLE
added optional parameter to publish mutation on callout to control if notification is sent

### DIFF
--- a/graphql-samples/mutations/update/update-callout-visibility
+++ b/graphql-samples/mutations/update/update-callout-visibility
@@ -8,6 +8,7 @@ Variables:
 {
   "calloutData": {
     "calloutID": "uuid",
-    "visibility": "published"
+    "visibility": "published",
+    "notification": true
   }
 }

--- a/graphql-samples/mutations/update/update-callout-visibility
+++ b/graphql-samples/mutations/update/update-callout-visibility
@@ -8,7 +8,7 @@ Variables:
 {
   "calloutData": {
     "calloutID": "uuid",
-    "visibility": "published",
-    "notification": true
+    "visibility": "PUBLISHED",
+    "sendNotification": true
   }
 }

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -217,9 +217,7 @@ export class CalloutResolverMutations {
           Date.now()
         );
 
-        // Optionally trigger a notification
-        const sendNotification = calloutData.notification;
-        if (sendNotification) {
+        if (calloutData.sendNotification) {
           const notificationInput: NotificationInputCalloutPublished = {
             triggeredBy: agentInfo.userID,
             callout: savedCallout,

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -217,11 +217,15 @@ export class CalloutResolverMutations {
           Date.now()
         );
 
-        const notificationInput: NotificationInputCalloutPublished = {
-          triggeredBy: agentInfo.userID,
-          callout: savedCallout,
-        };
-        await this.notificationAdapter.calloutPublished(notificationInput);
+        // Optionally trigger a notification
+        const sendNotification = calloutData.notification;
+        if (sendNotification) {
+          const notificationInput: NotificationInputCalloutPublished = {
+            triggeredBy: agentInfo.userID,
+            callout: savedCallout,
+          };
+          await this.notificationAdapter.calloutPublished(notificationInput);
+        }
 
         const activityLogInput: ActivityInputCalloutPublished = {
           triggeredBy: agentInfo.userID,

--- a/src/domain/collaboration/callout/dto/callout.dto.update.visibility.ts
+++ b/src/domain/collaboration/callout/dto/callout.dto.update.visibility.ts
@@ -24,5 +24,5 @@ export class UpdateCalloutVisibilityInput {
     defaultValue: true,
     description: 'Send a notification on publishing.',
   })
-  notification!: boolean;
+  sendNotification!: boolean;
 }

--- a/src/domain/collaboration/callout/dto/callout.dto.update.visibility.ts
+++ b/src/domain/collaboration/callout/dto/callout.dto.update.visibility.ts
@@ -18,4 +18,11 @@ export class UpdateCalloutVisibilityInput {
     description: 'Visibility of the Callout.',
   })
   visibility!: CalloutVisibility;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    defaultValue: true,
+    description: 'Send a notification on publishing.',
+  })
+  notification!: boolean;
 }


### PR DESCRIPTION
Parameter is optional, and defaults to true so that existing mutation usage is not affected. 

Separate issue to be raised to allow this flag to be set from the client, for now we can use this via the api.