### PR TITLE
allow supression of event transition errors

### DIFF
--- a/src/domain/common/canvas-checkout/canvas.checkout.lifecycle.options.provider.ts
+++ b/src/domain/common/canvas-checkout/canvas.checkout.lifecycle.options.provider.ts
@@ -38,15 +38,26 @@ export class CanvasCheckoutLifecycleOptionsProvider {
 
     this.logCheckoutStatus(eventName, canvasCheckout, 'event triggered');
 
-    await this.lifecycleService.event(
-      {
-        ID: canvasCheckout.lifecycle.id,
-        eventName: eventName,
-      },
-      this.CanvasCheckoutLifecycleMachineOptions,
-      agentInfo,
-      canvasCheckout.authorization
-    );
+    try {
+      await this.lifecycleService.event(
+        {
+          ID: canvasCheckout.lifecycle.id,
+          eventName: eventName,
+        },
+        this.CanvasCheckoutLifecycleMachineOptions,
+        agentInfo,
+        canvasCheckout.authorization
+      );
+    } catch (error) {
+      if (canvasCheckoutEventData.errorOnFailedTransition) {
+        throw error;
+      } else {
+        this.logger.warn(
+          `Transition failed on event '${eventName}': ${error}`,
+          LogContext.CONTEXT
+        );
+      }
+    }
 
     // Todo: there is likely a race condition related to lifecycles + events they trigger.
     // Events that are triggered by XState are fire and forget. So they above event will potentially return

--- a/src/domain/common/canvas-checkout/dto/canvas.checkout.dto.event.ts
+++ b/src/domain/common/canvas-checkout/dto/canvas.checkout.dto.event.ts
@@ -11,4 +11,11 @@ export class CanvasCheckoutEventInput {
   @Field({ nullable: false })
   @MaxLength(SMALL_TEXT_LENGTH)
   eventName!: string;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description: 'Report an error if this event fails to trigger a transition.',
+    defaultValue: true,
+  })
+  errorOnFailedTransition!: boolean;
 }


### PR DESCRIPTION
Stop errors being triggered if event transition fails

Requires client to also be updated