### PR TITLE
Landing sits under /landing locally

### DIFF
--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -219,7 +219,7 @@ http:
         - 'rabbitmq-management'
 
     homepage: # if basePath is changed in the nextjs app this path also will have to change
-      rule: 'PathPrefix(`/home`)'
+      rule: 'PathPrefix(`/landing`)'
       service: 'homepage'
       entryPoints:
         - 'web'


### PR DESCRIPTION
## Problem
When the client is being developed, it's inconvenient to workaround the mismatch between redirects on the client and local Traefik rules.
## Solution
This one puts the local config in accordance with the deployment/production one.

_________

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
