### PR TITLE
Downgraded to typeorm@0.3.11, which resolves the paths correctly on win

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "redlock": "^5.0.0-beta.2",
         "replace-special-characters": "^1.2.5",
         "rxjs": "^7.3.0",
-        "typeorm": "0.3.12",
+        "typeorm": "0.3.11",
         "winston": "^3.3.3",
         "xstate": "^4.26.1",
         "yaml": "^2.0.0-7"
@@ -6774,7 +6774,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10990,7 +10989,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13031,27 +13029,27 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typeorm": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.12.tgz",
-      "integrity": "sha512-sYSxBmCf1nJLLTcYtwqZ+lQIRtLPyUoO93rHTOKk9vJCyT4UfRtU7oRsJvfvKP3nnZTD1hzz2SEy2zwPEN6OyA==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.11.tgz",
+      "integrity": "sha512-pzdOyWbVuz/z8Ww6gqvBW4nylsM0KLdUCDExr2gR20/x1khGSVxQkjNV/3YqliG90jrWzrknYbYscpk8yxFJVg==",
       "dependencies": {
-        "@sqltools/formatter": "^1.2.5",
-        "app-root-path": "^3.1.0",
+        "@sqltools/formatter": "^1.2.2",
+        "app-root-path": "^3.0.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.2",
+        "chalk": "^4.1.0",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.29.3",
-        "debug": "^4.3.4",
-        "dotenv": "^16.0.3",
-        "glob": "^8.1.0",
+        "date-fns": "^2.28.0",
+        "debug": "^4.3.3",
+        "dotenv": "^16.0.0",
+        "glob": "^7.2.0",
         "js-yaml": "^4.1.0",
-        "mkdirp": "^2.1.3",
+        "mkdirp": "^1.0.4",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.5.0",
-        "uuid": "^9.0.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2",
         "xml2js": "^0.4.23",
-        "yargs": "^17.6.2"
+        "yargs": "^17.3.1"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -13072,7 +13070,7 @@
         "ioredis": "^5.0.4",
         "mongodb": "^3.6.0",
         "mssql": "^7.3.0",
-        "mysql2": "^2.2.5 || ^3.0.1",
+        "mysql2": "^2.2.5",
         "oracledb": "^5.1.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
@@ -13142,14 +13140,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/typeorm/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -13173,24 +13163,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/typeorm/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/typeorm/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -13202,37 +13174,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/typeorm/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/typeorm/node_modules/mkdirp": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz",
-      "integrity": "sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
+        "mkdirp": "bin/cmd.js"
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typeorm/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/typescript": {
@@ -19158,7 +19108,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -22358,8 +22307,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -23857,41 +23805,33 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typeorm": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.12.tgz",
-      "integrity": "sha512-sYSxBmCf1nJLLTcYtwqZ+lQIRtLPyUoO93rHTOKk9vJCyT4UfRtU7oRsJvfvKP3nnZTD1hzz2SEy2zwPEN6OyA==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.11.tgz",
+      "integrity": "sha512-pzdOyWbVuz/z8Ww6gqvBW4nylsM0KLdUCDExr2gR20/x1khGSVxQkjNV/3YqliG90jrWzrknYbYscpk8yxFJVg==",
       "requires": {
-        "@sqltools/formatter": "^1.2.5",
-        "app-root-path": "^3.1.0",
+        "@sqltools/formatter": "^1.2.2",
+        "app-root-path": "^3.0.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.2",
+        "chalk": "^4.1.0",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.29.3",
-        "debug": "^4.3.4",
-        "dotenv": "^16.0.3",
-        "glob": "^8.1.0",
+        "date-fns": "^2.28.0",
+        "debug": "^4.3.3",
+        "dotenv": "^16.0.0",
+        "glob": "^7.2.0",
         "js-yaml": "^4.1.0",
-        "mkdirp": "^2.1.3",
+        "mkdirp": "^1.0.4",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.5.0",
-        "uuid": "^9.0.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2",
         "xml2js": "^0.4.23",
-        "yargs": "^17.6.2"
+        "yargs": "^17.3.1"
       },
       "dependencies": {
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
         },
         "chalk": {
           "version": "4.1.2",
@@ -23907,18 +23847,6 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
           "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
         },
-        "glob": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -23927,23 +23855,10 @@
             "argparse": "^2.0.1"
           }
         },
-        "minimatch": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
         "mkdirp": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz",
-          "integrity": "sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw=="
-        },
-        "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "redlock": "^5.0.0-beta.2",
     "replace-special-characters": "^1.2.5",
     "rxjs": "^7.3.0",
-    "typeorm": "0.3.12",
+    "typeorm": "0.3.11",
     "winston": "^3.3.3",
     "xstate": "^4.26.1",
     "yaml": "^2.0.0-7"


### PR DESCRIPTION
https://github.com/typeorm/typeorm/issues/9840#issuecomment-1464948483
> I found out the reason is the version of the dependency "glob" and the use of PlatformTools.pathNormalize in the file [DirectoryExportedClassesLoader.ts](https://github.com/typeorm/typeorm/blob/master/src/util/DirectoryExportedClassesLoader.ts) at line 37.
When using glob@8.1.0, patterns using backslashes as directory separator doesn't seem to work.
If you're on Windows, the forward slashes in the migrations and entities paths are replaced by backslashes when typeorm calls pathNormalize, so glob can't find any files.
Typeorm should make sure all path separators are forward slashes instead of using OS's default.
I fixed my code by downgrading typeorm from version 0.3.12 to 0.3.11.
I think it's simple to resolve. I'm rushing another project right now, but if nobody opens a PR in the next days, I will do it.