### PR TITLE
rolesUser and rolesOrganization queries refactored

### DIFF
--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -1,7 +1,6 @@
 export * from './entity.field.length.constants';
 export * from './default.hub.constants';
 export * from './providers';
-export * from './role.constants';
 export * from './rabbitmq.constants';
 export * from './communication.constants';
 export * from './authorization';

--- a/src/common/constants/role.constants.ts
+++ b/src/common/constants/role.constants.ts
@@ -1,4 +1,0 @@
-export const ROLE_MEMBER = 'member';
-export const ROLE_ASSOCIATE = 'associate';
-export const ROLE_LEAD = 'lead';
-export const ROLE_HOST = 'host';

--- a/src/common/enums/community.role.ts
+++ b/src/common/enums/community.role.ts
@@ -1,4 +1,8 @@
 export enum CommunityRole {
   MEMBER = 'member',
+  ASSOCIATE = 'associate',
   LEAD = 'lead',
+  HOST = 'host',
+  ADMIN = 'admin',
+  OWNER = 'owner',
 }

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -1,33 +1,28 @@
 import { MockApplicationService } from '@test/mocks/application.service.mock';
 import { MockChallengeService } from '@test/mocks/challenge.service.mock';
 import { MockCommunityService } from '@test/mocks/community.service.mock';
-import { MockHubService } from '@test/mocks/hub.service.mock';
 import { MockOpportunityService } from '@test/mocks/opportunity.service.mock';
 import { MockOrganizationService } from '@test/mocks/organization.service.mock';
-import { MockUserGroupService } from '@test/mocks/user.group.service.mock';
 import { MockUserService } from '@test/mocks/user.service.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { MockHubFilterService } from '@test/mocks/hub.filter.service.mock';
+import { EntityManagerProvider } from '@test/mocks';
 import { Test } from '@nestjs/testing';
 import { RolesService } from './roles.service';
 import { UserService } from '@domain/community/user/user.service';
-import { HubService } from '@domain/challenge/hub/hub.service';
-import { ChallengeService } from '@domain/challenge/challenge/challenge.service';
-import { OpportunityService } from '@domain/collaboration/opportunity/opportunity.service';
 import { ApplicationService } from '@domain/community/application/application.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { CommunityService } from '@domain/community/community/community.service';
 import { HubFilterService } from '@services/infrastructure/hub-filter/hub.filter.service';
 import { asyncToThrow, testData } from '@test/utils';
 import { RelationshipNotFoundException } from '@common/exceptions';
+import { HubVisibility } from '@common/enums/hub.visibility';
+import * as getUserRolesEntityData from './util/get.user.roles.entity.data';
 
 describe('RolesService', () => {
   let rolesService: RolesService;
   let userService: UserService;
-  let hubService: HubService;
-  let challengeSerivce: ChallengeService;
   let hubFilterService: HubFilterService;
-  let opportunityService: OpportunityService;
   let applicationService: ApplicationService;
   let organizationService: OrganizationService;
   let communityService: CommunityService;
@@ -36,55 +31,44 @@ describe('RolesService', () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
         MockUserService,
-        MockUserGroupService,
-        MockHubService,
         MockChallengeService,
         MockApplicationService,
         MockCommunityService,
         MockOpportunityService,
-        MockOrganizationService,
         MockHubFilterService,
+        MockOrganizationService,
         MockWinstonProvider,
+        EntityManagerProvider,
         RolesService,
       ],
     }).compile();
 
     rolesService = moduleRef.get(RolesService);
     userService = moduleRef.get(UserService);
-    opportunityService = moduleRef.get(OpportunityService);
-    challengeSerivce = moduleRef.get(ChallengeService);
-    hubService = moduleRef.get(HubService);
     applicationService = moduleRef.get(ApplicationService);
     organizationService = moduleRef.get(OrganizationService);
     communityService = moduleRef.get(CommunityService);
     hubFilterService = moduleRef.get(HubFilterService);
   });
 
-  it('should be defined', () => {
-    expect(rolesService).toBeDefined();
-  });
-
   describe('User Roles', () => {
-    it('Should get user roles', async () => {
+    beforeEach(() => {
       jest
         .spyOn(userService, 'getUserWithAgent')
         .mockResolvedValue(testData.user);
 
       jest
-        .spyOn(hubService, 'getHubOrFail')
-        .mockResolvedValue(testData.hub as any);
+        .spyOn(hubFilterService, 'getAllowedVisibilities')
+        .mockReturnValue([HubVisibility.ACTIVE]);
 
       jest
-        .spyOn(challengeSerivce, 'getChallengeOrFail')
-        .mockResolvedValue(testData.challenge as any);
-
-      jest
-        .spyOn(organizationService, 'getOrganizationOrFail')
-        .mockResolvedValue(testData.organization as any);
-
-      jest
-        .spyOn(opportunityService, 'getOpportunityOrFail')
-        .mockResolvedValue(testData.opportunity as any);
+        .spyOn(getUserRolesEntityData, 'getUserRolesEntityData')
+        .mockResolvedValue({
+          hubs: [testData.hub as any],
+          challenges: [testData.challenge as any],
+          opportunities: [testData.opportunity as any],
+          organizations: [testData.organization as any],
+        });
 
       jest
         .spyOn(applicationService, 'findApplicationsForUser')
@@ -98,10 +82,10 @@ describe('RolesService', () => {
         .spyOn(applicationService, 'getApplicationState')
         .mockResolvedValue('new');
 
-      jest.spyOn(hubFilterService, 'isVisible').mockReturnValue(true);
-
       jest.spyOn(communityService, 'isHubCommunity').mockResolvedValue(true);
+    });
 
+    it('Should get user roles', async () => {
       const res = await rolesService.getUserRoles({
         userID: testData.user.id,
       });
@@ -134,38 +118,8 @@ describe('RolesService', () => {
 
     it('Should throw exception when community parent is not found', async () => {
       jest
-        .spyOn(userService, 'getUserWithAgent')
-        .mockResolvedValue(testData.user);
-
-      jest
-        .spyOn(hubService, 'getHubOrFail')
-        .mockResolvedValue(testData.hub as any);
-
-      jest
-        .spyOn(challengeSerivce, 'getChallengeOrFail')
-        .mockResolvedValue(testData.challenge as any);
-
-      jest
-        .spyOn(organizationService, 'getOrganizationOrFail')
-        .mockResolvedValue(testData.organization as any);
-
-      jest
-        .spyOn(opportunityService, 'getOpportunityOrFail')
-        .mockResolvedValue(testData.opportunity as any);
-
-      jest
-        .spyOn(applicationService, 'findApplicationsForUser')
-        .mockResolvedValue(testData.applications as any);
-
-      jest
-        .spyOn(applicationService, 'isFinalizedApplication')
-        .mockResolvedValue(false);
-
-      jest
-        .spyOn(applicationService, 'getApplicationState')
-        .mockResolvedValue('new');
-
-      jest.spyOn(communityService, 'isHubCommunity').mockResolvedValue(false);
+        .spyOn(communityService, 'isHubCommunity')
+        .mockResolvedValueOnce(false);
 
       await asyncToThrow(
         rolesService.getUserRoles({
@@ -177,38 +131,8 @@ describe('RolesService', () => {
 
     it('Should skip application that is finalized', async () => {
       jest
-        .spyOn(userService, 'getUserWithAgent')
-        .mockResolvedValue(testData.user);
-
-      jest
-        .spyOn(hubService, 'getHubOrFail')
-        .mockResolvedValue(testData.hub as any);
-
-      jest
-        .spyOn(challengeSerivce, 'getChallengeOrFail')
-        .mockResolvedValue(testData.challenge as any);
-
-      jest
-        .spyOn(organizationService, 'getOrganizationOrFail')
-        .mockResolvedValue(testData.organization as any);
-
-      jest
-        .spyOn(opportunityService, 'getOpportunityOrFail')
-        .mockResolvedValue(testData.opportunity as any);
-
-      jest
-        .spyOn(applicationService, 'findApplicationsForUser')
-        .mockResolvedValue(testData.applications as any);
-
-      jest
         .spyOn(applicationService, 'isFinalizedApplication')
-        .mockResolvedValue(true);
-
-      jest
-        .spyOn(applicationService, 'getApplicationState')
-        .mockResolvedValue('new');
-
-      jest.spyOn(communityService, 'isHubCommunity').mockResolvedValue(true);
+        .mockResolvedValueOnce(true);
 
       const res = await rolesService.getUserRoles({
         userID: testData.user.id,
@@ -226,22 +150,6 @@ describe('RolesService', () => {
           organization: testData.organization as any,
           agent: testData.agent,
         });
-
-      jest
-        .spyOn(hubService, 'getHubOrFail')
-        .mockResolvedValue(testData.hub as any);
-
-      jest
-        .spyOn(challengeSerivce, 'getChallengeOrFail')
-        .mockResolvedValue(testData.challenge as any);
-
-      jest
-        .spyOn(organizationService, 'getOrganizationOrFail')
-        .mockResolvedValue(testData.organization as any);
-
-      jest
-        .spyOn(opportunityService, 'getOpportunityOrFail')
-        .mockResolvedValue(testData.opportunity as any);
 
       const res = await rolesService.getOrganizationRoles({
         organizationID: testData.organization.id,

--- a/src/services/api/roles/roles.service.ts
+++ b/src/services/api/roles/roles.service.ts
@@ -2,10 +2,8 @@ import { EntityManager } from 'typeorm';
 import { Inject, LoggerService } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { HubService } from '@domain/challenge/hub/hub.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { UserService } from '@domain/community/user/user.service';
-import { UserGroupService } from '@domain/community/user-group/user-group.service';
 import { ChallengeService } from '@domain/challenge/challenge/challenge.service';
 import { LogContext } from '@common/enums';
 import { ICommunity } from '@domain/community/community';
@@ -28,8 +26,6 @@ export class RolesService {
   constructor(
     @InjectEntityManager() private entityManager: EntityManager,
     private userService: UserService,
-    private userGroupService: UserGroupService,
-    private hubService: HubService,
     private challengeService: ChallengeService,
     private applicationService: ApplicationService,
     private communityService: CommunityService,

--- a/src/services/api/roles/roles.service.ts
+++ b/src/services/api/roles/roles.service.ts
@@ -1,45 +1,32 @@
+import { EntityManager } from 'typeorm';
 import { Inject, LoggerService } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { HubService } from '@domain/challenge/hub/hub.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { UserService } from '@domain/community/user/user.service';
 import { UserGroupService } from '@domain/community/user-group/user-group.service';
 import { ChallengeService } from '@domain/challenge/challenge/challenge.service';
-import { AuthorizationCredential, LogContext } from '@common/enums';
-import { IUserGroup } from '@domain/community/user-group';
+import { LogContext } from '@common/enums';
 import { ICommunity } from '@domain/community/community';
 import { OpportunityService } from '@domain/collaboration/opportunity/opportunity.service';
 import { ApplicationService } from '@domain/community/application/application.service';
 import { IUser } from '@domain/community/user/user.interface';
 import { CommunityService } from '@domain/community/community/community.service';
 import { RelationshipNotFoundException } from '@common/exceptions';
-import { IGroupable } from '@domain/common/interfaces/groupable.interface';
-import { RolesResult } from './dto/roles.dto.result';
-import { RolesResultOrganization } from './dto/roles.dto.result.organization';
-import { ApplicationForRoleResult } from './dto/roles.dto.result.application';
-import { RolesUserInput } from './dto/roles.dto.input.user';
-import { ContributorRoles } from './dto/roles.dto.result.contributor';
-import { RolesOrganizationInput } from './dto/roles.dto.input.organization';
-import { RolesResultHub } from './dto/roles.dto.result.hub';
 import { ICredential } from '@domain/agent/credential/credential.interface';
-import {
-  ROLE_ASSOCIATE,
-  ROLE_HOST,
-  ROLE_LEAD,
-  ROLE_MEMBER,
-} from '@common/constants';
 import { IApplication } from '@domain/community';
-import { isCommunity, isOrganization } from '@common/utils/groupable.util';
-import { RolesResultCommunity } from './dto/roles.dto.result.community';
 import { HubVisibility } from '@common/enums/hub.visibility';
 import { HubFilterService } from '@services/infrastructure/hub-filter/hub.filter.service';
+import { RolesUserInput } from './dto/roles.dto.input.user';
+import { ContributorRoles } from './dto/roles.dto.result.contributor';
+import { ApplicationForRoleResult } from './dto/roles.dto.result.application';
+import { RolesOrganizationInput } from './dto/roles.dto.input.organization';
+import { mapCredentialsToRoles } from './util/map.credentials.to.roles';
 
-export type UserGroupResult = {
-  userGroup: IUserGroup;
-  userGroupParent: IGroupable;
-};
 export class RolesService {
   constructor(
+    @InjectEntityManager() private entityManager: EntityManager,
     private userService: UserService,
     private userGroupService: UserGroupService,
     private hubService: HubService,
@@ -55,6 +42,7 @@ export class RolesService {
     membershipData: RolesUserInput
   ): Promise<ContributorRoles> {
     const user = await this.userService.getUserWithAgent(membershipData.userID);
+
     const allowedVisibilities = this.hubFilterService.getAllowedVisibilities(
       membershipData.filter
     );
@@ -64,7 +52,9 @@ export class RolesService {
       user.id,
       allowedVisibilities
     );
+
     contributorRoles.applications = await this.getUserApplications(user);
+
     return contributorRoles;
   }
 
@@ -78,12 +68,11 @@ export class RolesService {
     const allowedVisibilities = this.hubFilterService.getAllowedVisibilities(
       membershipData.filter
     );
-    const contributorRoles = await this.getContributorRoles(
+    return this.getContributorRoles(
       agent?.credentials || [],
       organization.id,
       allowedVisibilities
     );
-    return contributorRoles;
   }
 
   private async getContributorRoles(
@@ -94,273 +83,16 @@ export class RolesService {
     const membership = new ContributorRoles();
 
     membership.id = contributorID;
-    const hubsMap: Map<string, RolesResultHub> = new Map();
-    const orgsMap: Map<string, RolesResultOrganization> = new Map();
-    await this.mapCredentialsToRoles(
+
+    const maps = await mapCredentialsToRoles(
+      this.entityManager,
       credentials,
-      orgsMap,
-      hubsMap,
       hubVisibilities
     );
-
-    membership.hubs.push(...hubsMap.values());
-    membership.organizations.push(...orgsMap.values());
+    membership.hubs = maps.hubs;
+    membership.organizations = maps.organizations;
 
     return membership;
-  }
-
-  private async mapCredentialsToRoles(
-    credentials: ICredential[],
-    orgsMap: Map<string, RolesResultOrganization>,
-    hubsMap: Map<string, RolesResultHub>,
-    allowedVisibilities: HubVisibility[]
-  ) {
-    for (const credential of credentials) {
-      switch (credential.type) {
-        case AuthorizationCredential.ORGANIZATION_ASSOCIATE:
-          await this.addOrganizationAssociateRole(orgsMap, credential);
-          break;
-        case AuthorizationCredential.HUB_MEMBER:
-          await this.addHubMemberRole(hubsMap, credential);
-          break;
-        case AuthorizationCredential.HUB_HOST:
-          await this.addHubHostRole(hubsMap, credential);
-          break;
-        case AuthorizationCredential.CHALLENGE_LEAD:
-          await this.addChallengeLeadRole(hubsMap, credential);
-          break;
-        case AuthorizationCredential.CHALLENGE_MEMBER:
-          await this.addChallengeMemberRole(hubsMap, credential);
-          break;
-        case AuthorizationCredential.OPPORTUNITY_MEMBER:
-          await this.addOpportunityMemberRole(hubsMap, credential);
-          break;
-        case AuthorizationCredential.OPPORTUNITY_LEAD:
-          await this.addOpportunityLeadRole(hubsMap, credential);
-          break;
-        case AuthorizationCredential.USER_GROUP_MEMBER:
-          await this.addUserGroupMemberRole(hubsMap, orgsMap, credential);
-          break;
-      }
-    }
-    // Iterate over the hubsMap and remove those whose visibility does not match the provided filter
-    for (const hubResult of hubsMap.values()) {
-      const visibilityMatched = this.hubFilterService.isVisible(
-        hubResult.hub.visibility,
-        allowedVisibilities
-      );
-      if (!visibilityMatched) {
-        hubsMap.delete(hubResult.hubID);
-      }
-    }
-  }
-
-  private async addUserGroupMemberRole(
-    hubsMap: Map<string, RolesResultHub>,
-    orgsMap: Map<string, RolesResultOrganization>,
-    credential: ICredential
-  ) {
-    const group = await this.userGroupService.getUserGroupOrFail(
-      credential.resourceID
-    );
-    const parent = await this.userGroupService.getParent(group);
-    if (isCommunity(parent)) {
-      const hubResult = await this.ensureHubRolesResult(hubsMap, parent.hubID);
-      const groupResult = new RolesResult(group.name, group.id, group.name);
-      hubResult.userGroups.push(groupResult);
-    } else if (isOrganization(parent)) {
-      const orgResult = await this.ensureOrganizationRolesResult(
-        orgsMap,
-        parent.id
-      );
-      const groupResult = new RolesResult(group.name, group.id, group.name);
-      orgResult.userGroups.push(groupResult);
-    }
-
-    // throw
-  }
-
-  private async addOpportunityLeadRole(
-    hubsMap: Map<string, RolesResultHub>,
-    credential: ICredential
-  ) {
-    const opportunityResult = await this.ensureOpportunityRolesResult(
-      hubsMap,
-      credential.resourceID
-    );
-    this.addRole(opportunityResult, ROLE_LEAD);
-  }
-
-  private async addOpportunityMemberRole(
-    hubsMap: Map<string, RolesResultHub>,
-    credential: ICredential
-  ) {
-    const opportunityResult = await this.ensureOpportunityRolesResult(
-      hubsMap,
-      credential.resourceID
-    );
-    this.addRole(opportunityResult, ROLE_MEMBER);
-  }
-
-  private async addChallengeLeadRole(
-    hubsMap: Map<string, RolesResultHub>,
-    credential: ICredential
-  ) {
-    const challengeResult = await this.ensureChallengeRolesResult(
-      hubsMap,
-      credential.resourceID
-    );
-    this.addRole(challengeResult, ROLE_LEAD);
-  }
-
-  private async addChallengeMemberRole(
-    hubsMap: Map<string, RolesResultHub>,
-    credential: ICredential
-  ) {
-    const challengeResult = await this.ensureChallengeRolesResult(
-      hubsMap,
-      credential.resourceID
-    );
-    this.addRole(challengeResult, ROLE_MEMBER);
-  }
-
-  private async addHubHostRole(
-    hubsMap: Map<string, RolesResultHub>,
-    credential: ICredential
-  ) {
-    const hubResult = await this.ensureHubRolesResult(
-      hubsMap,
-      credential.resourceID
-    );
-    this.addRole(hubResult, ROLE_HOST);
-  }
-
-  private async addHubMemberRole(
-    hubsMap: Map<string, RolesResultHub>,
-    credential: ICredential
-  ) {
-    const hubResult = await this.ensureHubRolesResult(
-      hubsMap,
-      credential.resourceID
-    );
-    this.addRole(hubResult, ROLE_MEMBER);
-  }
-
-  private async addOrganizationAssociateRole(
-    orgsMap: Map<string, RolesResultOrganization>,
-    credential: ICredential
-  ) {
-    const orgResult = await this.ensureOrganizationRolesResult(
-      orgsMap,
-      credential.resourceID
-    );
-    this.addRole(orgResult, ROLE_ASSOCIATE);
-  }
-
-  private async ensureOrganizationRolesResult(
-    orgsMap: Map<string, RolesResultOrganization>,
-    organizationID: string
-  ): Promise<RolesResultOrganization> {
-    const existingOrgResult = orgsMap.get(organizationID);
-    if (existingOrgResult) {
-      return existingOrgResult;
-    }
-    // New org for roles, add an entry
-    const organization = await this.organizationService.getOrganizationOrFail(
-      organizationID,
-      {
-        relations: ['profile'],
-      }
-    );
-    const newOrgResult = new RolesResultOrganization(
-      organization,
-      organization.profile.displayName
-    );
-    orgsMap.set(organization.id, newOrgResult);
-    return newOrgResult;
-  }
-
-  private addRole(rolesResult: RolesResult, roleToAdd: string): void {
-    if (rolesResult.roles.includes(roleToAdd)) {
-      this.logger.warn?.(
-        `Duplicate addition of role in result: ${roleToAdd} - already had '${rolesResult.roles}`,
-        LogContext.ROLES
-      );
-    }
-    rolesResult.roles.push(roleToAdd);
-  }
-
-  private async ensureHubRolesResult(
-    hubsMap: Map<string, RolesResultHub>,
-    hubID: string
-  ): Promise<RolesResultHub> {
-    const existingHubResult = hubsMap.get(hubID);
-    if (existingHubResult) {
-      return existingHubResult;
-    }
-    // New hub for roles, add an entry
-    const hub = await this.hubService.getHubOrFail(hubID, {
-      relations: ['community', 'profile'],
-    });
-    const newHubResult = new RolesResultHub(hub);
-    hubsMap.set(hub.id, newHubResult);
-    return newHubResult;
-  }
-
-  private async ensureChallengeRolesResult(
-    hubsMap: Map<string, RolesResultHub>,
-    challengeID: string
-  ): Promise<RolesResult> {
-    const challenge = await this.challengeService.getChallengeOrFail(
-      challengeID,
-      { relations: ['community', 'profile'] }
-    );
-    const hubResult = await this.ensureHubRolesResult(
-      hubsMap,
-      this.challengeService.getHubID(challenge)
-    );
-
-    const existingChallengeResult = hubResult.challenges.find(
-      challengeResult => challengeResult.nameID === challenge.nameID
-    );
-    if (existingChallengeResult) return existingChallengeResult;
-
-    // New challenge in this Hub
-    const newChallengeResult = new RolesResultCommunity(
-      challenge.nameID,
-      challenge.id,
-      challenge.profile.displayName
-    );
-    hubResult.challenges.push(newChallengeResult);
-    return newChallengeResult;
-  }
-
-  private async ensureOpportunityRolesResult(
-    hubsMap: Map<string, RolesResultHub>,
-    opportunityID: string
-  ): Promise<RolesResult> {
-    const opportunity = await this.opportunityService.getOpportunityOrFail(
-      opportunityID,
-      { relations: ['community', 'profile'] }
-    );
-    const hubResult = await this.ensureHubRolesResult(
-      hubsMap,
-      this.opportunityService.getHubID(opportunity)
-    );
-
-    const existingOpportunityResult = hubResult.opportunities.find(
-      opportunityResult => opportunityResult.nameID === opportunity.nameID
-    );
-    if (existingOpportunityResult) return existingOpportunityResult;
-
-    // New opportunity in this Hub
-    const newOpportunityResult = new RolesResultCommunity(
-      opportunity.nameID,
-      opportunity.id,
-      opportunity.profile.displayName
-    );
-    hubResult.opportunities.push(newOpportunityResult);
-    return newOpportunityResult;
   }
 
   private async getUserApplications(

--- a/src/services/api/roles/util/get.user.roles.entity.data.ts
+++ b/src/services/api/roles/util/get.user.roles.entity.data.ts
@@ -6,7 +6,6 @@ import { Opportunity } from '@domain/collaboration/opportunity';
 import { HubVisibility } from '@common/enums/hub.visibility';
 import { BaseChallenge } from '@domain/challenge/base-challenge/base.challenge.entity';
 
-// todo can be refactored
 export const getUserRolesEntityData = async (
   entityManager: EntityManager,
   hubIds: string[],

--- a/src/services/api/roles/util/get.user.roles.entity.data.ts
+++ b/src/services/api/roles/util/get.user.roles.entity.data.ts
@@ -1,0 +1,44 @@
+import { EntityManager, EntityTarget, FindManyOptions, In } from 'typeorm';
+import { Organization } from '@src/domain';
+import { Hub } from '@domain/challenge/hub/hub.entity';
+import { Challenge } from '@domain/challenge/challenge/challenge.entity';
+import { Opportunity } from '@domain/collaboration/opportunity';
+import { HubVisibility } from '@common/enums/hub.visibility';
+import { BaseChallenge } from '@domain/challenge/base-challenge/base.challenge.entity';
+
+// todo can be refactored
+export const getUserRolesEntityData = async (
+  entityManager: EntityManager,
+  hubIds: string[],
+  hubAllowedVisibilities: HubVisibility[],
+  challengeIds: string[],
+  opportunityIds: string[],
+  organizationIds: string[]
+) => {
+  const fetchData = <T extends Hub | BaseChallenge | Organization>(
+    ref: EntityTarget<T>,
+    ids: string[],
+    visibility?: HubVisibility[]
+  ): Promise<T[]> => {
+    return entityManager.find(ref, {
+      where: {
+        id: In(ids),
+        visibility: visibility ? In(visibility) : undefined,
+      },
+      relations: { profile: true },
+      select: {
+        profile: {
+          displayName: true,
+        },
+      },
+    } as FindManyOptions);
+  };
+  const [hubs, challenges, opportunities, organizations] = await Promise.all([
+    fetchData(Hub, hubIds, hubAllowedVisibilities),
+    fetchData(Challenge, challengeIds),
+    fetchData(Opportunity, opportunityIds),
+    fetchData(Organization, organizationIds),
+  ]);
+
+  return { hubs, challenges, opportunities, organizations };
+};

--- a/src/services/api/roles/util/get.user.roles.query.result.ts
+++ b/src/services/api/roles/util/get.user.roles.query.result.ts
@@ -1,0 +1,61 @@
+import { Hub } from '@domain/challenge/hub/hub.entity';
+import { Challenge } from '@domain/challenge/challenge/challenge.entity';
+import { Opportunity } from '@domain/collaboration/opportunity';
+import { Organization } from '@src/domain';
+import { RolesResultHub } from '../dto/roles.dto.result.hub';
+import { RolesResultCommunity } from '../dto/roles.dto.result.community';
+import { RolesResultOrganization } from '../dto/roles.dto.result.organization';
+import { CredentialMap } from './group.credentials.by.entity';
+
+export const getUserRolesQueryResult = (
+  map: CredentialMap,
+  hubs: Hub[],
+  challenges: Challenge[],
+  opportunities: Opportunity[],
+  organizations: Organization[]
+) => {
+  return {
+    hubs: hubs.map(hub => {
+      const hubResult = new RolesResultHub(hub);
+
+      hubResult.userGroups = [];
+      hubResult.roles = map.get('hubs')?.get(hub.id) ?? [];
+
+      hubResult.challenges = challenges
+        .filter(challenge => challenge.hubID === hub.id)
+        .map(x => {
+          const challengeResult = new RolesResultCommunity(
+            x.nameID,
+            x.id,
+            x.profile.displayName
+          );
+          challengeResult.userGroups = [];
+          challengeResult.roles = map.get('challenges')?.get(x.id) ?? [];
+          return challengeResult;
+        });
+
+      hubResult.opportunities = opportunities
+        .filter(opp => opp.hubID === hub.id)
+        .map(x => {
+          const oppResult = new RolesResultCommunity(
+            x.nameID,
+            x.id,
+            x.profile.displayName
+          );
+          oppResult.userGroups = [];
+          oppResult.roles = map.get('opportunities')?.get(x.id) ?? [];
+          return oppResult;
+        });
+      return hubResult;
+    }),
+    organizations: organizations.map(org => {
+      const orgResult = new RolesResultOrganization(
+        org,
+        org.profile.displayName
+      );
+      orgResult.userGroups = [];
+      orgResult.roles = map.get('organizations')?.get(org.id) ?? [];
+      return orgResult;
+    }),
+  };
+};

--- a/src/services/api/roles/util/group.credentials.by.entity.ts
+++ b/src/services/api/roles/util/group.credentials.by.entity.ts
@@ -83,7 +83,7 @@ const setMap = (
 };
 
 const credentialTypeToRole = (type: AuthorizationCredential): CommunityRole => {
-  const roleMap = {
+  const roleMap: Partial<Record<AuthorizationCredential, CommunityRole>> = {
     [AuthorizationCredential.HUB_ADMIN]: CommunityRole.ADMIN,
     [AuthorizationCredential.CHALLENGE_ADMIN]: CommunityRole.ADMIN,
     [AuthorizationCredential.OPPORTUNITY_ADMIN]: CommunityRole.ADMIN,
@@ -102,14 +102,7 @@ const credentialTypeToRole = (type: AuthorizationCredential): CommunityRole => {
     [AuthorizationCredential.ORGANIZATION_OWNER]: CommunityRole.OWNER,
 
     [AuthorizationCredential.USER_GROUP_MEMBER]: CommunityRole.MEMBER,
-
-    [AuthorizationCredential.GLOBAL_ADMIN]: undefined,
-    [AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY]: undefined,
-    [AuthorizationCredential.GLOBAL_ADMIN_HUBS]: undefined,
-    [AuthorizationCredential.GLOBAL_REGISTERED]: undefined,
-    [AuthorizationCredential.USER_SELF_MANAGEMENT]: undefined,
-    [AuthorizationCredential.INNOVATION_PACK_PROVIDER]: undefined,
-  } as const;
+  };
 
   const role = roleMap[type];
 

--- a/src/services/api/roles/util/group.credentials.by.entity.ts
+++ b/src/services/api/roles/util/group.credentials.by.entity.ts
@@ -1,0 +1,121 @@
+import { ICredential } from '@src/domain';
+import { AuthorizationCredential } from '@common/enums';
+import { CommunityRole } from '@common/enums/community.role';
+
+export type EntityCredentialType =
+  | 'hubs'
+  | 'challenges'
+  | 'opportunities'
+  | 'organizations'
+  | 'groups';
+
+export type CredentialMap = Map<
+  EntityCredentialType,
+  Map<string, CommunityRole[]>
+>;
+
+/***
+ * Groups credentials by the entity category they are related to and attaches the credential type
+ * returns Map of Maps in the following fashion
+ * Map<'hubs', Map<'hubUUID1', ['type1', 'type2']>>
+ * - where 'hubs' is the category,
+ * - 'hubUUID1' is the identifier for a hub
+ * - ['type1', 'type2'] are the types of credentials associated with 'hubUUID1'.
+ * The types are represented by an array because they are guaranteed unique,
+ * meaning an User (whose credentials are parsed here) can't have two credentials of type 'hub-admin' for the same Hub
+ */
+export const groupCredentialsByEntity = (credentials: ICredential[]) => {
+  return credentials.reduce<CredentialMap>((map, credential) => {
+    if (
+      credential.type === AuthorizationCredential.HUB_ADMIN ||
+      credential.type === AuthorizationCredential.HUB_HOST ||
+      credential.type === AuthorizationCredential.HUB_MEMBER
+    ) {
+      return setMap(map, 'hubs', credential);
+    } else if (
+      credential.type === AuthorizationCredential.CHALLENGE_ADMIN ||
+      credential.type === AuthorizationCredential.CHALLENGE_LEAD ||
+      credential.type === AuthorizationCredential.CHALLENGE_MEMBER
+    ) {
+      return setMap(map, 'challenges', credential);
+    } else if (
+      credential.type === AuthorizationCredential.OPPORTUNITY_ADMIN ||
+      credential.type === AuthorizationCredential.OPPORTUNITY_LEAD ||
+      credential.type === AuthorizationCredential.OPPORTUNITY_MEMBER
+    ) {
+      return setMap(map, 'opportunities', credential);
+    } else if (
+      credential.type === AuthorizationCredential.ORGANIZATION_ADMIN ||
+      credential.type === AuthorizationCredential.ORGANIZATION_OWNER ||
+      credential.type === AuthorizationCredential.ORGANIZATION_ASSOCIATE
+    ) {
+      return setMap(map, 'organizations', credential);
+    }
+
+    return map;
+  }, new Map());
+};
+
+const setMap = (
+  map: CredentialMap,
+  type: EntityCredentialType,
+  credential: ICredential
+) => {
+  const roleMap = map.get(type);
+  if (roleMap) {
+    roleMap.set(
+      credential.resourceID,
+      (roleMap.get(credential.resourceID) ?? []).concat(
+        credentialTypeToRole(credential.type as AuthorizationCredential)
+      )
+    );
+    return map.set(type, roleMap);
+  }
+  return map.set(
+    type,
+    new Map([
+      [
+        credential.resourceID,
+        [credentialTypeToRole(credential.type as AuthorizationCredential)],
+      ],
+    ])
+  );
+};
+
+const credentialTypeToRole = (type: AuthorizationCredential): CommunityRole => {
+  const roleMap = {
+    [AuthorizationCredential.HUB_ADMIN]: CommunityRole.ADMIN,
+    [AuthorizationCredential.CHALLENGE_ADMIN]: CommunityRole.ADMIN,
+    [AuthorizationCredential.OPPORTUNITY_ADMIN]: CommunityRole.ADMIN,
+    [AuthorizationCredential.ORGANIZATION_ADMIN]: CommunityRole.ADMIN,
+
+    [AuthorizationCredential.HUB_HOST]: CommunityRole.HOST,
+
+    [AuthorizationCredential.CHALLENGE_LEAD]: CommunityRole.LEAD,
+    [AuthorizationCredential.OPPORTUNITY_LEAD]: CommunityRole.LEAD,
+
+    [AuthorizationCredential.HUB_MEMBER]: CommunityRole.MEMBER,
+    [AuthorizationCredential.CHALLENGE_MEMBER]: CommunityRole.MEMBER,
+    [AuthorizationCredential.OPPORTUNITY_MEMBER]: CommunityRole.MEMBER,
+
+    [AuthorizationCredential.ORGANIZATION_ASSOCIATE]: CommunityRole.ASSOCIATE,
+    [AuthorizationCredential.ORGANIZATION_OWNER]: CommunityRole.OWNER,
+
+    [AuthorizationCredential.USER_GROUP_MEMBER]: CommunityRole.MEMBER,
+
+    [AuthorizationCredential.GLOBAL_ADMIN]: undefined,
+    [AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY]: undefined,
+    [AuthorizationCredential.GLOBAL_ADMIN_HUBS]: undefined,
+    [AuthorizationCredential.GLOBAL_REGISTERED]: undefined,
+    [AuthorizationCredential.USER_SELF_MANAGEMENT]: undefined,
+    [AuthorizationCredential.INNOVATION_PACK_PROVIDER]: undefined,
+  } as const;
+
+  const role = roleMap[type];
+
+  if (!role) {
+    throw Error(`Unable to convert ${type} credential to role name`);
+  }
+
+  return role;
+};

--- a/src/services/api/roles/util/map.credentials.to.roles.ts
+++ b/src/services/api/roles/util/map.credentials.to.roles.ts
@@ -1,0 +1,39 @@
+import { EntityManager } from 'typeorm';
+import { ICredential } from '@src/domain';
+import { HubVisibility } from '@common/enums/hub.visibility';
+import { groupCredentialsByEntity } from './group.credentials.by.entity';
+import { getUserRolesEntityData } from './get.user.roles.entity.data';
+import { getUserRolesQueryResult } from './get.user.roles.query.result';
+
+export const mapCredentialsToRoles = async (
+  entityManager: EntityManager,
+  credentials: ICredential[],
+  allowedVisibilities: HubVisibility[]
+) => {
+  const credentialMap = groupCredentialsByEntity(credentials);
+
+  const hubIds = Array.from(credentialMap.get('hubs')?.keys() ?? []);
+  const challengeIds = Array.from(
+    credentialMap.get('challenges')?.keys() ?? []
+  );
+  const oppIds = Array.from(credentialMap.get('opportunities')?.keys() ?? []);
+  const orgIds = Array.from(credentialMap.get('organizations')?.keys() ?? []);
+
+  const { hubs, challenges, opportunities, organizations } =
+    await getUserRolesEntityData(
+      entityManager,
+      hubIds,
+      allowedVisibilities,
+      challengeIds,
+      oppIds,
+      orgIds
+    );
+
+  return getUserRolesQueryResult(
+    credentialMap,
+    hubs,
+    challenges,
+    opportunities,
+    organizations
+  );
+};

--- a/test/mocks/entity.manager.provider.mock.ts
+++ b/test/mocks/entity.manager.provider.mock.ts
@@ -1,0 +1,10 @@
+import { EntityManager } from 'typeorm';
+import { ValueProvider } from '@nestjs/common';
+import { PublicPart } from '../utils/public-part';
+
+export const EntityManagerProvider: ValueProvider<PublicPart<EntityManager>> = {
+  provide: EntityManager,
+  useValue: {
+    find: jest.fn(),
+  },
+};

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -23,3 +23,4 @@ export * from './user.authorization.service.mock';
 export * from './user.group.service.mock';
 export * from './user.service.mock';
 export * from './winston.provider.mock';
+export * from './entity.manager.provider.mock';


### PR DESCRIPTION
- The `test:roles` script was ran to verify the query does not have any regressions.
- Refer to the tables below for before and after

The table below shows the metrics before and after the refactor of the core function generating the result
Function Name | Average Time (ms) | Standard Deviation (ms) | 25th Percentile (ms) | 50th Percentile (ms) | 75th Percentile (ms) | 95th Percentile (ms)
-- | -- | -- | -- | -- | -- | --
mapCredentialsToRoles | 409.04 | 44.32 | 373.18 | 390.53 | 441.47 | 494.68
mapCredentialsToRoles2 | 19.32 | 5.29 | 15.28 | 16.53 | 20.34 | 28.57
---
The table below shows the response times before and after the refactor
Function | Mean | Standard Deviation | 25th Percentile | 50th Percentile | 75th Percentile | 95th Percentile
-- | -- | -- | -- | -- | -- | --
rolesUser | 411.77ms | 76.52ms | 381ms | 413ms | 441ms | 489ms
rolesUser2 | 67.02ms | 19.09ms | 52ms | 55ms | 74ms | 104ms