### PR TITLE
Added GRANT to GA and GHA

### DIFF
--- a/src/platform/authorization/platform.authorization.policy.service.ts
+++ b/src/platform/authorization/platform.authorization.policy.service.ts
@@ -82,6 +82,7 @@ export class PlatformAuthorizationPolicyService {
           AuthorizationPrivilege.READ,
           AuthorizationPrivilege.UPDATE,
           AuthorizationPrivilege.DELETE,
+          AuthorizationPrivilege.GRANT,
         ],
         [
           AuthorizationCredential.GLOBAL_ADMIN,


### PR DESCRIPTION
Added GRANT privilege to GA and GHA on platform level. The only privilege that GHA should not have is GRANT_GLOBAL_ADMINS. I believe GRANT should be done there.

Otherwise, private challenges, deriving from root authorization policy, should get GRANT from another rule. I don't believe this is the correct approach thou.