### PR TITLE
Some Ids migrated to char(36) and UUID strategy improvement

### DIFF
--- a/graphql-samples/mutations/create/create-innovation-hub
+++ b/graphql-samples/mutations/create/create-innovation-hub
@@ -19,13 +19,13 @@ mutation createInnovationHub($input: CreateInnovationHubInput!){
 
 query variables:
 {
-    "input": {
-      "subdomain": "test",
-      "type": "LIST",
-      "nameID": "test-space",
-      "profileData": {
-        "displayName": "test space"
-      },
-      "spaceListFilter": ["889ed0cf-4cd9-41d6-8ce0-d27b65cb149e"]
-    }
+  "input": {
+    "subdomain": "test",
+    "type": "LIST",
+    "nameID": "test-space",
+    "profileData": {
+      "displayName": "test space"
+    },
+    "spaceListFilter": ["889ed0cf-4cd9-41d6-8ce0-d27b65cb149e"]
   }
+}

--- a/src/config/fix.uuid.column.type.ts
+++ b/src/config/fix.uuid.column.type.ts
@@ -1,0 +1,30 @@
+import { ColumnType, Driver } from 'typeorm';
+
+export type DriverWithUUIDFixed = Driver & {
+  oldNormalizeType: Driver['normalizeType'];
+};
+
+/***
+ * Adds a new function *oldNormalizeType* to the existing TypeORM Driver interface
+ * which is the exact clone of *normalizeType* to preserve it's value.
+ * *normalizeType* is overwritten to return *char* column type
+ * for UUID generated columns instead of the *varchar* as in *typeorm@0.3.11*.
+ */
+const fixUUIDColumnType = (driver: Driver): DriverWithUUIDFixed => {
+  const driverWithUUIDFixed = driver as DriverWithUUIDFixed;
+
+  driverWithUUIDFixed.oldNormalizeType = driver.normalizeType;
+  driverWithUUIDFixed.normalizeType = (column: {
+    type: ColumnType;
+    length?: number | string;
+    precision?: number | null;
+    scale?: number;
+  }): string => {
+    return column.type === 'uuid'
+      ? 'char'
+      : driverWithUUIDFixed.oldNormalizeType(column);
+  };
+
+  return driverWithUUIDFixed;
+};
+export default fixUUIDColumnType;

--- a/src/config/migration.create.config.ts
+++ b/src/config/migration.create.config.ts
@@ -1,6 +1,10 @@
 import { DataSource } from 'typeorm';
 import { typeormCliConfig } from './typeorm.cli.config';
+import fixUUIDColumnType from './fix.uuid.column.type';
 
 const datasource = new DataSource(typeormCliConfig);
+
+const driver = datasource.driver;
+datasource.driver = fixUUIDColumnType(driver);
 datasource.initialize();
 export default datasource;

--- a/src/domain/common/entity/base-entity/base.alkemio.entity.ts
+++ b/src/domain/common/entity/base-entity/base.alkemio.entity.ts
@@ -1,13 +1,18 @@
 import {
   BaseEntity,
+  Column,
   CreateDateColumn,
-  PrimaryGeneratedColumn,
   UpdateDateColumn,
   VersionColumn,
 } from 'typeorm';
+import { UUID_LENGTH } from '@common/constants';
 
 export abstract class BaseAlkemioEntity extends BaseEntity {
-  @PrimaryGeneratedColumn('uuid')
+  @Column('char', {
+    length: UUID_LENGTH,
+    primary: true,
+    generated: 'uuid',
+  })
   id!: string;
 
   @CreateDateColumn()

--- a/src/migrations/1687782644019-primaryIdsTypeMigrated.ts
+++ b/src/migrations/1687782644019-primaryIdsTypeMigrated.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class primaryIdsTypeMigrated1687782644019 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` DROP FOREIGN KEY \`FK_b411e4f27d77a96eccdabbf4b45\``
+    ); // authorizationId
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` DROP FOREIGN KEY \`FK_36c8905c2c6c59467c60d94fd8a\``
+    ); // profileId
+
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` MODIFY \`id\` char(36) NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` MODIFY \`authorizationId\` char(36) NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` MODIFY \`profileId\` char(36) NULL`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` ADD CONSTRAINT \`FK_b411e4f27d77a96eccdabbf4b45\` FOREIGN KEY (\`authorizationId\`) REFERENCES \`authorization_policy\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` ADD CONSTRAINT \`FK_36c8905c2c6c59467c60d94fd8a\` FOREIGN KEY (\`profileId\`) REFERENCES \`profile\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` DROP FOREIGN KEY \`FK_b411e4f27d77a96eccdabbf4b45\``
+    ); // authorizationId
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` DROP FOREIGN KEY \`FK_36c8905c2c6c59467c60d94fd8a\``
+    ); // profileId
+
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` MODIFY \`id\` varchar(36) NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` MODIFY \`authorizationId\` varchar(36) NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` MODIFY \`profileId\` varchar(36) NULL`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` ADD CONSTRAINT \`FK_b411e4f27d77a96eccdabbf4b45\` FOREIGN KEY (\`authorizationId\`) REFERENCES \`authorization_policy\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`innovation_hub\` ADD CONSTRAINT \`FK_36c8905c2c6c59467c60d94fd8a\` FOREIGN KEY (\`profileId\`) REFERENCES \`profile\`(\`id\`) ON DELETE SET NULL ON UPDATE NO ACTION`
+    );
+  }
+}


### PR DESCRIPTION
This PR includes
- innovation_hub id, authorizationId, profileId migrated to char(36)
- the TypeORM data source driver to handle UUID generation strategy [correctly](https://github.com/typeorm/typeorm/issues/7228) with a workaround

I seem to have found the core issue with the migration generation not working correctly - generating a couple of hundred of "alter" statements.
At some point in time, TypeORM has changed the default behavior of some primary column generation strategies and the migration module is trying to migrate that to the newest strategy.
I have made an adjustment to handle at least our case for the UUID strategy - now the primary IDs are going to be correctly generated as char(36) instead of varchar(36).
**Unfortunately, that won't fix the generation, but at least more of the statement will be correct now.**