### PR TITLE
Extends FILE_UPLOAD privileges for space, challenge + platform

### DIFF
--- a/graphql-samples/mutations/authorization/reset-authorization-all
+++ b/graphql-samples/mutations/authorization/reset-authorization-all
@@ -1,0 +1,4 @@
+mutation authorizationPolicyResetAll() {
+  authorizationPolicyResetAll()
+}
+

--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -21,6 +21,8 @@ export const CREDENTIAL_RULE_SPACE_MEMBERS_READ =
   'credentialRule-spaceMembersRead';
 export const CREDENTIAL_RULE_SPACE_HOST_ASSOCIATES_JOIN =
   'credentialRule-spaceHostAssociatesJoin';
+export const CREDENTIAL_RULE_SPACE_FILE_UPLOAD =
+  'credentialRule-spaceMemberFileUpload';
 export const CREDENTIAL_RULE_POST_CREATED_BY = 'credentialRule-postCreatedBy';
 export const CREDENTIAL_RULE_POST_ADMINS_MOVE = 'credentialRule-postAdminsMove';
 export const CREDENTIAL_RULE_CALLOUT_CREATED_BY =
@@ -66,3 +68,7 @@ export const CREDENTIAL_RULE_DOCUMENT_CREATED_BY =
   'credentialRule-documentCreatedBy';
 export const CREDENTIAL_RULE_LIBRARY_INNOVATION_PACK_PROVIDER_ADMIN =
   'credentialRule-libraryInnovationPackProvider';
+export const CREDENTIAL_RULE_ORGANIZATION_FILE_UPLOAD =
+  'credentialRule-organizationAssociateFileUpload';
+export const CREDENTIAL_RULE_STORAGE_BUCKET_FILE_UPLOAD =
+  'credentialRule-storageBucketUpdaterFileUpload';

--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -70,5 +70,3 @@ export const CREDENTIAL_RULE_LIBRARY_INNOVATION_PACK_PROVIDER_ADMIN =
   'credentialRule-libraryInnovationPackProvider';
 export const CREDENTIAL_RULE_ORGANIZATION_FILE_UPLOAD =
   'credentialRule-organizationAssociateFileUpload';
-export const CREDENTIAL_RULE_STORAGE_BUCKET_FILE_UPLOAD =
-  'credentialRule-storageBucketUpdaterFileUpload';

--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -6,6 +6,8 @@ export const CREDENTIAL_RULE_CHALLENGE_MEMBER_READ =
   'credentialRule-challengeMemberRead';
 export const CREDENTIAL_RULE_CHALLENGE_CREATE_OPPORTUNITY =
   'credentialRule-challengeCreateOpportunity';
+export const CREDENTIAL_RULE_CHALLENGE_FILE_UPLOAD =
+  'credentialRule-challengeMemberFileUpload';
 export const CREDENTIAL_RULE_CHALLENGE_SPACE_MEMBER_JOIN =
   'credentialRule-challengeSpaceMemberJoin';
 export const CREDENTIAL_RULE_CHALLENGE_SPACE_MEMBER_APPLY =

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -8,8 +8,6 @@ export const CREDENTIAL_RULE_TYPES_SPACE_AUTHORIZATION_GLOBAL_ADMIN_GRANT =
   'credentialRuleTypes-spaceAuthorizationGlobalAdminGrant';
 export const CREDENTIAL_RULE_TYPES_SPACE_COMMUNITY_APPLY_GLOBAL_REGISTERED =
   'credentialRuleTypes-spaceCommunityApplyGlobalRegistered';
-export const CREDENTIAL_RULE_TYPES_SPACE_STORAGE_FILE_UPLOAD =
-  'credentialRuleTypes-spaceStoargeFileUpload';
 export const CREDENTIAL_RULE_TYPES_SPACE_COMMUNITY_JOIN_GLOBAL_REGISTERED =
   'credentialRuleTypes-spaceCommunityJoinGlobalRegistered';
 export const CREDENTIAL_RULE_TYPES_CALLOUT_UPDATE_PUBLISHER_ADMINS =
@@ -48,3 +46,7 @@ export const CREDENTIAL_RULE_TYPES_PLATFORM_CREATE_ORG_FILE_UPLOAD =
   'credentialRuleTypes-platformCreateOrgFileUpload';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN =
   'credentialRuleTypes-platformAnyAdmin';
+export const CREDENTIAL_RULE_TYPES_LIBRARY_FILE_UPLOAD_ANY_USER =
+  'credentialRuleTypes-libraryFileUploadAnyUser';
+export const CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER =
+  'credentialRuleTypes-libraryFileUploadAnyUser';

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -8,6 +8,8 @@ export const CREDENTIAL_RULE_TYPES_SPACE_AUTHORIZATION_GLOBAL_ADMIN_GRANT =
   'credentialRuleTypes-spaceAuthorizationGlobalAdminGrant';
 export const CREDENTIAL_RULE_TYPES_SPACE_COMMUNITY_APPLY_GLOBAL_REGISTERED =
   'credentialRuleTypes-spaceCommunityApplyGlobalRegistered';
+export const CREDENTIAL_RULE_TYPES_SPACE_STORAGE_FILE_UPLOAD =
+  'credentialRuleTypes-spaceStoargeFileUpload';
 export const CREDENTIAL_RULE_TYPES_SPACE_COMMUNITY_JOIN_GLOBAL_REGISTERED =
   'credentialRuleTypes-spaceCommunityJoinGlobalRegistered';
 export const CREDENTIAL_RULE_TYPES_CALLOUT_UPDATE_PUBLISHER_ADMINS =

--- a/src/common/constants/authorization/policy.rule.constants.ts
+++ b/src/common/constants/authorization/policy.rule.constants.ts
@@ -19,4 +19,4 @@ export const POLICY_RULE_COLLABORATION_CREATE =
 export const POLICY_RULE_COMMUNITY_INVITE = 'policyRule-communityInvite';
 export const POLICY_RULE_COMMUNITY_ADD_MEMBER = 'policyRule-communityAddMember';
 export const POLICY_RULE_STORAGE_BUCKET_FILE_UPLOAD =
-  'credentialRule-storageBucketUpdaterFileUpload';
+  'policyRule-storageBucketUpdaterFileUpload';

--- a/src/common/constants/authorization/policy.rule.constants.ts
+++ b/src/common/constants/authorization/policy.rule.constants.ts
@@ -18,3 +18,5 @@ export const POLICY_RULE_COLLABORATION_CREATE =
   'policyRule-collaborationCreate';
 export const POLICY_RULE_COMMUNITY_INVITE = 'policyRule-communityInvite';
 export const POLICY_RULE_COMMUNITY_ADD_MEMBER = 'policyRule-communityAddMember';
+export const POLICY_RULE_STORAGE_BUCKET_FILE_UPLOAD =
+  'credentialRule-storageBucketUpdaterFileUpload';

--- a/src/domain/challenge/challenge/challenge.service.authorization.ts
+++ b/src/domain/challenge/challenge/challenge.service.authorization.ts
@@ -503,7 +503,7 @@ export class ChallengeAuthorizationService {
     const membersCanUpload =
       this.authorizationPolicyService.createCredentialRule(
         [AuthorizationPrivilege.FILE_UPLOAD],
-        [this.communityPolicyService.getMembershipCredential(policy)],
+        this.getContributorCriteria(policy),
         CREDENTIAL_RULE_CHALLENGE_FILE_UPLOAD
       );
     membersCanUpload.cascade = false;

--- a/src/domain/challenge/space/space.service.authorization.ts
+++ b/src/domain/challenge/space/space.service.authorization.ts
@@ -39,7 +39,7 @@ import {
   CREDENTIAL_RULE_TYPES_SPACE_COMMUNITY_APPLY_GLOBAL_REGISTERED,
   CREDENTIAL_RULE_TYPES_SPACE_COMMUNITY_JOIN_GLOBAL_REGISTERED,
   CREDENTIAL_RULE_SPACE_HOST_ASSOCIATES_JOIN,
-  CREDENTIAL_RULE_TYPES_SPACE_STORAGE_FILE_UPLOAD,
+  CREDENTIAL_RULE_SPACE_FILE_UPLOAD,
 } from '@common/constants';
 import { StorageBucketAuthorizationService } from '@domain/storage/storage-bucket/storage.bucket.service.authorization';
 
@@ -529,7 +529,7 @@ export class SpaceAuthorizationService {
       this.authorizationPolicyService.createCredentialRule(
         [AuthorizationPrivilege.FILE_UPLOAD],
         [this.communityPolicyService.getMembershipCredential(policy)],
-        CREDENTIAL_RULE_TYPES_SPACE_STORAGE_FILE_UPLOAD
+        CREDENTIAL_RULE_SPACE_FILE_UPLOAD
       );
     membersCanUpload.cascade = false;
     newRules.push(membersCanUpload);

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -21,6 +21,7 @@ import {
   CREDENTIAL_RULE_ORGANIZATION_ADMIN,
   CREDENTIAL_RULE_ORGANIZATION_READ,
   CREDENTIAL_RULE_ORGANIZATION_SELF_REMOVAL,
+  CREDENTIAL_RULE_ORGANIZATION_FILE_UPLOAD,
 } from '@common/constants';
 import { StorageBucketAuthorizationService } from '@domain/storage/storage-bucket/storage.bucket.service.authorization';
 
@@ -248,7 +249,7 @@ export class OrganizationAuthorizationService {
             resourceID: organization.id,
           },
         ],
-        'credentialRuleOrganizationStorage'
+        CREDENTIAL_RULE_ORGANIZATION_FILE_UPLOAD
       );
     associatesCanUpload.cascade = false;
     newRules.push(associatesCanUpload);

--- a/src/domain/storage/storage-bucket/storage.bucket.service.authorization.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.authorization.ts
@@ -9,7 +9,10 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { DocumentAuthorizationService } from '../document/document.service.authorization';
 import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
 import { AuthorizationPrivilege } from '@common/enums';
-import { POLICY_RULE_PLATFORM_DELETE } from '@common/constants';
+import {
+  CREDENTIAL_RULE_STORAGE_BUCKET_FILE_UPLOAD,
+  POLICY_RULE_PLATFORM_DELETE,
+} from '@common/constants';
 
 @Injectable()
 export class StorageBucketAuthorizationService {
@@ -73,7 +76,7 @@ export class StorageBucketAuthorizationService {
     const createPrivilege = new AuthorizationPolicyRulePrivilege(
       [AuthorizationPrivilege.FILE_UPLOAD],
       AuthorizationPrivilege.UPDATE,
-      'storagePrivilegeRuleUpload'
+      CREDENTIAL_RULE_STORAGE_BUCKET_FILE_UPLOAD
     );
     privilegeRules.push(createPrivilege);
 

--- a/src/domain/storage/storage-bucket/storage.bucket.service.authorization.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.authorization.ts
@@ -10,7 +10,7 @@ import { DocumentAuthorizationService } from '../document/document.service.autho
 import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
 import { AuthorizationPrivilege } from '@common/enums';
 import {
-  CREDENTIAL_RULE_STORAGE_BUCKET_FILE_UPLOAD,
+  POLICY_RULE_STORAGE_BUCKET_FILE_UPLOAD,
   POLICY_RULE_PLATFORM_DELETE,
 } from '@common/constants';
 
@@ -76,7 +76,7 @@ export class StorageBucketAuthorizationService {
     const createPrivilege = new AuthorizationPolicyRulePrivilege(
       [AuthorizationPrivilege.FILE_UPLOAD],
       AuthorizationPrivilege.UPDATE,
-      CREDENTIAL_RULE_STORAGE_BUCKET_FILE_UPLOAD
+      POLICY_RULE_STORAGE_BUCKET_FILE_UPLOAD
     );
     privilegeRules.push(createPrivilege);
 

--- a/src/domain/storage/storage-bucket/storage.bucket.service.authorization.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.authorization.ts
@@ -7,6 +7,9 @@ import { StorageBucketService } from './storage.bucket.service';
 import { IStorageBucket } from './storage.bucket.interface';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { DocumentAuthorizationService } from '../document/document.service.authorization';
+import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
+import { AuthorizationPrivilege } from '@common/enums';
+import { POLICY_RULE_PLATFORM_DELETE } from '@common/constants';
 
 @Injectable()
 export class StorageBucketAuthorizationService {
@@ -32,6 +35,10 @@ export class StorageBucketAuthorizationService {
         parentAuthorization
       );
 
+    storageBucket.authorization = this.appendPrivilegeRules(
+      storageBucket.authorization
+    );
+
     // Cascade down
     const storagePropagated = await this.propagateAuthorizationToChildEntities(
       storageBucket
@@ -56,5 +63,30 @@ export class StorageBucketAuthorizationService {
     }
 
     return storageBucket;
+  }
+
+  private appendPrivilegeRules(
+    authorization: IAuthorizationPolicy
+  ): IAuthorizationPolicy {
+    const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
+
+    const createPrivilege = new AuthorizationPolicyRulePrivilege(
+      [AuthorizationPrivilege.FILE_UPLOAD],
+      AuthorizationPrivilege.UPDATE,
+      'storagePrivilegeRuleUpload'
+    );
+    privilegeRules.push(createPrivilege);
+
+    const deletePrivilege = new AuthorizationPolicyRulePrivilege(
+      [AuthorizationPrivilege.FILE_DELETE],
+      AuthorizationPrivilege.DELETE,
+      POLICY_RULE_PLATFORM_DELETE
+    );
+    privilegeRules.push(deletePrivilege);
+
+    return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
+      authorization,
+      privilegeRules
+    );
   }
 }

--- a/src/library/library/library.service.authorization.ts
+++ b/src/library/library/library.service.authorization.ts
@@ -8,6 +8,13 @@ import { ILibrary } from './library.interface';
 import { InnovationPackAuthorizationService } from '@library/innovation-pack/innovation.pack.service.authorization';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { StorageBucketAuthorizationService } from '@domain/storage/storage-bucket/storage.bucket.service.authorization';
+import { EntityNotInitializedException } from '@common/exceptions';
+import {
+  AuthorizationCredential,
+  AuthorizationPrivilege,
+  LogContext,
+} from '@common/enums';
+import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential.interface';
 
 @Injectable()
 export class LibraryAuthorizationService {
@@ -61,7 +68,41 @@ export class LibraryAuthorizationService {
         library.storageBucket,
         library.authorization
       );
+    library.storageBucket.authorization = this.extendStorageAuthorizationPolicy(
+      library.storageBucket.authorization,
+      library
+    );
 
     return library;
+  }
+
+  private extendStorageAuthorizationPolicy(
+    storageAuthorization: IAuthorizationPolicy | undefined,
+    library: ILibrary
+  ): IAuthorizationPolicy {
+    if (!storageAuthorization)
+      throw new EntityNotInitializedException(
+        `Authorization definition not found for: ${library.id}`,
+        LogContext.LIBRARY
+      );
+
+    const newRules: IAuthorizationPolicyRuleCredential[] = [];
+
+    // Any member can upload
+    const registeredUsersCanUpload =
+      this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
+        [AuthorizationPrivilege.FILE_UPLOAD],
+        [AuthorizationCredential.GLOBAL_REGISTERED],
+        'credentialRuleLibraryStorageUpload'
+      );
+    registeredUsersCanUpload.cascade = false;
+    newRules.push(registeredUsersCanUpload);
+
+    this.authorizationPolicyService.appendCredentialAuthorizationRules(
+      storageAuthorization,
+      newRules
+    );
+
+    return storageAuthorization;
   }
 }

--- a/src/library/library/library.service.authorization.ts
+++ b/src/library/library/library.service.authorization.ts
@@ -15,6 +15,7 @@ import {
   LogContext,
 } from '@common/enums';
 import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential.interface';
+import { CREDENTIAL_RULE_TYPES_LIBRARY_FILE_UPLOAD_ANY_USER } from '@common/constants';
 
 @Injectable()
 export class LibraryAuthorizationService {
@@ -93,7 +94,7 @@ export class LibraryAuthorizationService {
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
         [AuthorizationPrivilege.FILE_UPLOAD],
         [AuthorizationCredential.GLOBAL_REGISTERED],
-        'credentialRuleLibraryStorageUpload'
+        CREDENTIAL_RULE_TYPES_LIBRARY_FILE_UPLOAD_ANY_USER
       );
     registeredUsersCanUpload.cascade = false;
     newRules.push(registeredUsersCanUpload);

--- a/src/platform/authorization/platform.authorization.policy.service.ts
+++ b/src/platform/authorization/platform.authorization.policy.service.ts
@@ -10,10 +10,9 @@ import {
   CREDENTIAL_RULE_TYPES_PLATFORM_GRANT_GLOBAL_ADMINS,
   CREDENTIAL_RULE_TYPES_PLATFORM_ADMINS,
   CREDENTIAL_RULE_TYPES_PLATFORM_READ_REGISTERED,
-  CREDENTIAL_RULE_TYPES_PLATFORM_CREATE_ORG_FILE_UPLOAD,
+  CREDENTIAL_RULE_TYPES_PLATFORM_CREATE_ORG_FILE_UPLOAD as CREDENTIAL_RULE_TYPES_PLATFORM_CREATE_ORG,
   CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN,
   POLICY_RULE_PLATFORM_CREATE,
-  POLICY_RULE_PLATFORM_DELETE,
 } from '@common/constants';
 
 @Injectable()
@@ -134,15 +133,12 @@ export class PlatformAuthorizationPolicyService {
 
     const createOrg =
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
-        [
-          AuthorizationPrivilege.CREATE_ORGANIZATION,
-          AuthorizationPrivilege.FILE_UPLOAD,
-        ],
+        [AuthorizationPrivilege.CREATE_ORGANIZATION],
         [
           AuthorizationCredential.SPACE_ADMIN,
           AuthorizationCredential.CHALLENGE_ADMIN,
         ],
-        CREDENTIAL_RULE_TYPES_PLATFORM_CREATE_ORG_FILE_UPLOAD
+        CREDENTIAL_RULE_TYPES_PLATFORM_CREATE_ORG
       );
     createOrg.cascade = false;
     credentialRules.push(createOrg);
@@ -174,19 +170,11 @@ export class PlatformAuthorizationPolicyService {
       [
         AuthorizationPrivilege.CREATE_SPACE,
         AuthorizationPrivilege.CREATE_ORGANIZATION,
-        AuthorizationPrivilege.FILE_UPLOAD,
       ],
       AuthorizationPrivilege.CREATE,
       POLICY_RULE_PLATFORM_CREATE
     );
     privilegeRules.push(createPrivilege);
-
-    const deletePrivilege = new AuthorizationPolicyRulePrivilege(
-      [AuthorizationPrivilege.FILE_DELETE],
-      AuthorizationPrivilege.DELETE,
-      POLICY_RULE_PLATFORM_DELETE
-    );
-    privilegeRules.push(deletePrivilege);
 
     return privilegeRules;
   }

--- a/src/platform/platfrom/platform.service.authorization.ts
+++ b/src/platform/platfrom/platform.service.authorization.ts
@@ -19,6 +19,7 @@ import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authoriz
 import { StorageBucketAuthorizationService } from '@domain/storage/storage-bucket/storage.bucket.service.authorization';
 import { InnovationHubService } from '@domain/innovation-hub';
 import { InnovationHubAuthorizationService } from '@domain/innovation-hub/innovation.hub.service.authorization';
+import { CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER } from '@common/constants';
 
 @Injectable()
 export class PlatformAuthorizationService {
@@ -150,7 +151,7 @@ export class PlatformAuthorizationService {
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
         [AuthorizationPrivilege.FILE_UPLOAD],
         [AuthorizationCredential.GLOBAL_REGISTERED],
-        'platformFileUploadRegistered'
+        CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER
       );
     registeredUserUpload.cascade = false;
     newRules.push(registeredUserUpload);


### PR DESCRIPTION
Locally extends the authorization definition for storage bucket from the containing entity. Note that the authorization policy cannot be extended within the authorization service as it does not have sufficient context to know what to assign. 

Draft as have not had a chance to run / test it - but hopefully shows what is needed. 

FILE_UPLOAD:
- space: assign if the user is a member
- challenge: assign if the user is allowed to contribute (member, or a member of the space if flag is set for space members to contribute)
- platform: assign if the user is registered
- org: assign based on the user being associated with the org
- library: assign if the user is registered

FILE_DELETE:
- removed from platform entity
- assigned if the user has a cascading DELETE privilege