### PR TITLE
Updated me query + applications / invitations via field resolvers on rolesUser

### DIFF
--- a/src/services/api/me/me.module.ts
+++ b/src/services/api/me/me.module.ts
@@ -7,6 +7,7 @@ import { MeService } from './me.service';
 import { MeResolverQueries } from './me.resolver.queries';
 import { MeResolverFields } from './me.resolver.fields';
 import { SpaceModule } from '@domain/challenge/space/space.module';
+import { RolesModule } from '../roles/roles.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { SpaceModule } from '@domain/challenge/space/space.module';
     InvitationModule,
     UserModule,
     SpaceModule,
+    RolesModule,
   ],
   providers: [MeService, MeResolverQueries, MeResolverFields],
   exports: [MeService],

--- a/src/services/api/me/me.resolver.fields.ts
+++ b/src/services/api/me/me.resolver.fields.ts
@@ -51,7 +51,7 @@ export class MeResolverFields {
     })
     states: string[]
   ): Promise<InvitationForRoleResult[]> {
-    return await this.meService.getUserInvitations(agentInfo.userID, states);
+    return this.meService.getUserInvitations(agentInfo.userID, states);
   }
 
   @UseGuards(GraphqlGuard)
@@ -69,7 +69,7 @@ export class MeResolverFields {
     })
     states: string[]
   ): Promise<ApplicationForRoleResult[]> {
-    return await this.meService.getUserApplications(agentInfo.userID, states);
+    return this.meService.getUserApplications(agentInfo.userID, states);
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/services/api/me/me.resolver.fields.ts
+++ b/src/services/api/me/me.resolver.fields.ts
@@ -5,14 +5,14 @@ import { CurrentUser, Profiling } from '@src/common/decorators';
 import { Args, ResolveField } from '@nestjs/graphql';
 import { AgentInfo } from '@core/authentication/agent-info';
 import { MeQueryResults } from '@services/api/me/dto';
-import { IInvitation } from '@domain/community/invitation';
-import { IApplication } from '@domain/community/application';
 import { IUser } from '@domain/community/user';
 import { AuthenticationException } from '@common/exceptions';
 import { UserService } from '@domain/community/user/user.service';
 import { ISpace } from '@domain/challenge/space/space.interface';
 import { SpaceVisibility } from '@common/enums/space.visibility';
 import { MeService } from './me.service';
+import { ApplicationForRoleResult } from '../roles/dto/roles.dto.result.application';
+import { InvitationForRoleResult } from '../roles/dto/roles.dto.result.invitation';
 
 @Resolver(() => MeQueryResults)
 export class MeResolverFields {
@@ -37,11 +37,11 @@ export class MeResolverFields {
   }
 
   @UseGuards(GraphqlGuard)
-  @ResolveField(() => [IInvitation], {
+  @ResolveField(() => [InvitationForRoleResult], {
     description: 'The invitations of the current authenticated user',
   })
   @Profiling.api
-  public invitations(
+  public async invitations(
     @CurrentUser() agentInfo: AgentInfo,
     @Args({
       name: 'states',
@@ -50,16 +50,16 @@ export class MeResolverFields {
       description: 'The state names you want to filter on',
     })
     states: string[]
-  ): Promise<IInvitation[]> {
-    return this.meService.getUserInvitations(agentInfo.userID, states);
+  ): Promise<InvitationForRoleResult[]> {
+    return await this.meService.getUserInvitations(agentInfo.userID, states);
   }
 
   @UseGuards(GraphqlGuard)
-  @ResolveField(() => [IApplication], {
+  @ResolveField(() => [ApplicationForRoleResult], {
     description: 'The applications of the current authenticated user',
   })
   @Profiling.api
-  public applications(
+  public async applications(
     @CurrentUser() agentInfo: AgentInfo,
     @Args({
       name: 'states',
@@ -68,8 +68,8 @@ export class MeResolverFields {
       description: 'The state names you want to filter on',
     })
     states: string[]
-  ): Promise<IApplication[]> {
-    return this.meService.getUserApplications(agentInfo.userID, states);
+  ): Promise<ApplicationForRoleResult[]> {
+    return await this.meService.getUserApplications(agentInfo.userID, states);
   }
 
   @UseGuards(GraphqlGuard)
@@ -86,7 +86,7 @@ export class MeResolverFields {
       description: 'The Space visibilities you want to filter on',
     })
     visibilities: SpaceVisibility[]
-  ): Promise<IApplication[]> {
+  ): Promise<ISpace[]> {
     return this.meService.getSpaceMemberships(
       agentInfo.credentials,
       visibilities

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -1,41 +1,38 @@
 import { Injectable } from '@nestjs/common';
-import { UserService } from '@domain/community/user/user.service';
-import { ApplicationService } from '@domain/community/application/application.service';
-import { InvitationService } from '@domain/community/invitation/invitation.service';
-import { IInvitation } from '@domain/community/invitation';
-import { IApplication } from '@domain/community/application';
 import { ICredential } from '@src/domain';
 import { SpaceVisibility } from '@common/enums/space.visibility';
 import { groupCredentialsByEntity } from '@services/api/roles/util/group.credentials.by.entity';
 import { SpaceService } from '@domain/challenge/space/space.service';
+import { RolesService } from '../roles/roles.service';
+import { ApplicationForRoleResult } from '../roles/dto/roles.dto.result.application';
+import { InvitationForRoleResult } from '../roles/dto/roles.dto.result.invitation';
+import { ISpace } from '@domain/challenge/space/space.interface';
 
 @Injectable()
 export class MeService {
   constructor(
-    private userService: UserService,
-    private applicationService: ApplicationService,
-    private invitationService: InvitationService,
-    private spaceService: SpaceService
+    private spaceService: SpaceService,
+    private rolesService: RolesService
   ) {}
 
-  public getUserInvitations(
+  public async getUserInvitations(
     userId: string,
     states?: string[]
-  ): Promise<IInvitation[]> {
-    return this.invitationService.findInvitationsForUser(userId, states);
+  ): Promise<InvitationForRoleResult[]> {
+    return await this.rolesService.getUserInvitations(userId, states);
   }
 
-  public getUserApplications(
+  public async getUserApplications(
     userId: string,
     states?: string[]
-  ): Promise<IApplication[]> {
-    return this.applicationService.findApplicationsForUser(userId, states);
+  ): Promise<ApplicationForRoleResult[]> {
+    return await this.rolesService.getUserApplications(userId, states);
   }
 
   public getSpaceMemberships(
     credentials: ICredential[],
     visibilities: SpaceVisibility[] = []
-  ) {
+  ): Promise<ISpace[]> {
     const credentialMap = groupCredentialsByEntity(credentials);
     const spaceIds = Array.from(credentialMap.get('spaces')?.keys() ?? []);
 

--- a/src/services/api/roles/roles.module.ts
+++ b/src/services/api/roles/roles.module.ts
@@ -18,6 +18,7 @@ import { PlatformAuthorizationPolicyModule } from '@src/platform/authorization/p
 import { SpaceFilterModule } from '@services/infrastructure/space-filter/space.filter.module';
 import { InvitationModule } from '@domain/community/invitation/invitation.module';
 import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
+import { RolesResolverFields } from './roles.resolver.fields';
 
 @Module({
   imports: [
@@ -38,7 +39,7 @@ import { EntityResolverModule } from '@services/infrastructure/entity-resolver/e
     TypeOrmModule.forFeature([Challenge]),
     TypeOrmModule.forFeature([Opportunity]),
   ],
-  providers: [RolesService, RolesResolverQueries],
+  providers: [RolesService, RolesResolverQueries, RolesResolverFields],
   exports: [RolesService],
 })
 export class RolesModule {}

--- a/src/services/api/roles/roles.resolver.fields.ts
+++ b/src/services/api/roles/roles.resolver.fields.ts
@@ -1,0 +1,73 @@
+import { Resolver } from '@nestjs/graphql';
+import { GraphqlGuard } from '@core/authorization';
+import { UseGuards } from '@nestjs/common';
+import { CurrentUser } from '@src/common/decorators';
+import { Args, ResolveField } from '@nestjs/graphql';
+import { AgentInfo } from '@core/authentication/agent-info';
+import { InvitationForRoleResult } from './dto/roles.dto.result.invitation';
+import { RolesService } from './roles.service';
+import { ContributorRoles } from './dto/roles.dto.result.contributor';
+import { ApplicationForRoleResult } from './dto/roles.dto.result.application';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import { AuthorizationPrivilege } from '@common/enums';
+
+@Resolver(() => ContributorRoles)
+export class RolesResolverFields {
+  constructor(
+    private rolesService: RolesService,
+    private authorizationService: AuthorizationService,
+    private platformAuthorizationService: PlatformAuthorizationPolicyService
+  ) {}
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField(() => [InvitationForRoleResult], {
+    description:
+      'The invitations for the specified user; only accessible for platform admins',
+  })
+  public async invitations(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args({
+      name: 'states',
+      nullable: true,
+      type: () => [String],
+      description: 'The state names you want to filter on',
+    })
+    states: string[]
+  ): Promise<InvitationForRoleResult[]> {
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      `roles user query: ${agentInfo.email}`
+    );
+    return await this.rolesService.getUserInvitations(agentInfo.userID, states);
+  }
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField(() => [ApplicationForRoleResult], {
+    description:
+      'The applications for the specified user; only accessible for platform admins',
+  })
+  public async applications(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args({
+      name: 'states',
+      nullable: true,
+      type: () => [String],
+      description: 'The state names you want to filter on',
+    })
+    states: string[]
+  ): Promise<ApplicationForRoleResult[]> {
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      `roles user query: ${agentInfo.email}`
+    );
+    return await this.rolesService.getUserApplications(
+      agentInfo.userID,
+      states
+    );
+  }
+}

--- a/src/services/api/roles/roles.resolver.queries.ts
+++ b/src/services/api/roles/roles.resolver.queries.ts
@@ -1,6 +1,6 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Resolver, Query } from '@nestjs/graphql';
-import { CurrentUser, Profiling } from '@src/common/decorators';
+import { CurrentUser } from '@src/common/decorators';
 import { GraphqlGuard } from '@core/authorization';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AgentInfo } from '@core/authentication';
@@ -24,7 +24,6 @@ export class RolesResolverQueries {
     nullable: false,
     description: 'The roles that that the specified User has.',
   })
-  @Profiling.api
   async rolesUser(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('rolesData') rolesData: RolesUserInput
@@ -42,7 +41,6 @@ export class RolesResolverQueries {
   @Query(() => ContributorRoles, {
     description: 'The roles that the specified Organization has.',
   })
-  @Profiling.api
   async rolesOrganization(
     @Args('rolesData') rolesData: RolesOrganizationInput
   ): Promise<ContributorRoles> {

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -94,15 +94,6 @@ describe('RolesService', () => {
         userID: testData.user.id,
       });
 
-      expect(res.applications).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            communityID: testData.rolesUser.applications[0].communityID,
-            spaceID: testData.rolesUser.applications[0].spaceID,
-          }),
-        ])
-      );
-
       expect(res.organizations).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -120,15 +111,26 @@ describe('RolesService', () => {
       );
     });
 
+    it('Should get user applications', async () => {
+      const res = await rolesService.getUserApplications(testData.user.id);
+
+      expect(res).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            communityID: testData.rolesUser.applications[0].communityID,
+            spaceID: testData.rolesUser.applications[0].spaceID,
+          }),
+        ])
+      );
+    });
+
     it('Should throw exception when community parent is not found', async () => {
       jest
         .spyOn(communityService, 'isSpaceCommunity')
         .mockResolvedValueOnce(false);
 
       await asyncToThrow(
-        rolesService.getUserRoles({
-          userID: testData.user.id,
-        }),
+        rolesService.getUserApplications(testData.user.id),
         RelationshipNotFoundException
       );
     });

--- a/src/services/api/roles/roles.service.ts
+++ b/src/services/api/roles/roles.service.ts
@@ -9,7 +9,6 @@ import { LogContext } from '@common/enums';
 import { ICommunity } from '@domain/community/community';
 import { OpportunityService } from '@domain/collaboration/opportunity/opportunity.service';
 import { ApplicationService } from '@domain/community/application/application.service';
-import { IUser } from '@domain/community/user/user.interface';
 import { CommunityService } from '@domain/community/community/community.service';
 import { RelationshipNotFoundException } from '@common/exceptions';
 import { ICredential } from '@domain/agent/credential/credential.interface';
@@ -56,9 +55,6 @@ export class RolesService {
       allowedVisibilities
     );
 
-    contributorRoles.applications = await this.getUserApplications(user);
-    contributorRoles.invitations = await this.getUserInvitations(user);
-
     return contributorRoles;
   }
 
@@ -99,12 +95,14 @@ export class RolesService {
     return membership;
   }
 
-  private async getUserApplications(
-    user: IUser
+  public async getUserApplications(
+    userID: string,
+    states?: string[]
   ): Promise<ApplicationForRoleResult[]> {
     const applicationResults: ApplicationForRoleResult[] = [];
     const applications = await this.applicationService.findApplicationsForUser(
-      user.id
+      userID,
+      states
     );
     for (const application of applications) {
       // skip any finalized applications; only want to return pending applications
@@ -182,12 +180,14 @@ export class RolesService {
     return applicationResult;
   }
 
-  private async getUserInvitations(
-    user: IUser
+  public async getUserInvitations(
+    userID: string,
+    states?: string[]
   ): Promise<InvitationForRoleResult[]> {
     const invitationResults: InvitationForRoleResult[] = [];
     const invitations = await this.invitationService.findInvitationsForUser(
-      user.id
+      userID,
+      states
     );
 
     if (!invitations) return [];


### PR DESCRIPTION


me query updated to return the same results for invitations / applications as in rolesUser. The full entity is not useful as do not know the community for it.

added field resolver for the invitations / applications fields on rolesUser to only allow it for platform admins. Only a significant optimization