### PR TITLE
Removed HOME_0 callout location. Moved recommendations to HOME_1

### DIFF
--- a/src/common/enums/callout.display.location.ts
+++ b/src/common/enums/callout.display.location.ts
@@ -1,7 +1,6 @@
 import { registerEnumType } from '@nestjs/graphql';
 
 export enum CalloutDisplayLocation {
-  HOME_TOP = 'HOME_0',
   HOME_LEFT = 'HOME_1',
   HOME_RIGHT = 'HOME_2',
   CONTRIBUTE_LEFT = 'CONTRIBUTE_1',

--- a/src/common/enums/common.display.location.ts
+++ b/src/common/enums/common.display.location.ts
@@ -1,5 +1,4 @@
 export enum CommonDisplayLocation {
-  HOME_TOP = 'HOME_0',
   HOME_LEFT = 'HOME_1',
   HOME_RIGHT = 'HOME_2',
   KNOWLEDGE = 'KNOWLEDGE',

--- a/src/domain/challenge/challenge/challenge.default.callouts.ts
+++ b/src/domain/challenge/challenge/challenge.default.callouts.ts
@@ -12,7 +12,7 @@ export const challengeDefaultCallouts: CreateCalloutInput[] = [
     nameID: 'getting-started',
     type: CalloutType.LINK_COLLECTION,
     state: CalloutState.CLOSED,
-    sortOrder: 3,
+    sortOrder: 1,
     profile: {
       displayName: 'Getting Started',
       description: '⬇️ Here are some quick links to help you get started',
@@ -46,7 +46,7 @@ export const challengeDefaultCallouts: CreateCalloutInput[] = [
     nameID: 'contributor-profiles',
     type: CalloutType.POST_COLLECTION,
     state: CalloutState.OPEN,
-    sortOrder: 1,
+    sortOrder: 2,
     profile: {
       displayName: '👥 This is us!',
       description:

--- a/src/domain/challenge/challenge/challenge.default.callouts.ts
+++ b/src/domain/challenge/challenge/challenge.default.callouts.ts
@@ -20,7 +20,7 @@ export const challengeDefaultCallouts: CreateCalloutInput[] = [
         {
           name: TagsetReservedName.CALLOUT_DISPLAY_LOCATION,
           type: TagsetType.SELECT_ONE,
-          tags: [CommonDisplayLocation.HOME_TOP],
+          tags: [CommonDisplayLocation.HOME_RIGHT],
         },
       ],
     },

--- a/src/domain/challenge/space/space.default.callouts.ts
+++ b/src/domain/challenge/space/space.default.callouts.ts
@@ -20,7 +20,7 @@ export const spaceDefaultCallouts: CreateCalloutInput[] = [
         {
           name: TagsetReservedName.CALLOUT_DISPLAY_LOCATION,
           type: TagsetType.SELECT_ONE,
-          tags: [CommonDisplayLocation.HOME_TOP],
+          tags: [CommonDisplayLocation.HOME_RIGHT],
         },
       ],
     },

--- a/src/domain/challenge/space/space.default.callouts.ts
+++ b/src/domain/challenge/space/space.default.callouts.ts
@@ -12,7 +12,7 @@ export const spaceDefaultCallouts: CreateCalloutInput[] = [
     nameID: 'getting-started',
     type: CalloutType.LINK_COLLECTION,
     state: CalloutState.CLOSED,
-    sortOrder: 3,
+    sortOrder: 1,
     profile: {
       displayName: 'Getting Started',
       description: '⬇️ Here are some quick links to help you get started',

--- a/src/domain/collaboration/opportunity/opportunity.default.callouts.ts
+++ b/src/domain/collaboration/opportunity/opportunity.default.callouts.ts
@@ -20,7 +20,7 @@ export const opportunityDefaultCallouts: CreateCalloutInput[] = [
         {
           name: TagsetReservedName.CALLOUT_DISPLAY_LOCATION,
           type: TagsetType.SELECT_ONE,
-          tags: [CommonDisplayLocation.HOME_TOP],
+          tags: [CommonDisplayLocation.HOME_RIGHT],
         },
       ],
     },

--- a/src/domain/collaboration/opportunity/opportunity.default.callouts.ts
+++ b/src/domain/collaboration/opportunity/opportunity.default.callouts.ts
@@ -12,7 +12,7 @@ export const opportunityDefaultCallouts: CreateCalloutInput[] = [
     nameID: 'getting-started',
     type: CalloutType.LINK_COLLECTION,
     state: CalloutState.CLOSED,
-    sortOrder: 3,
+    sortOrder: 1,
     profile: {
       displayName: 'Getting Started',
       description: '⬇️ Here are some quick links to help you get started',
@@ -46,7 +46,7 @@ export const opportunityDefaultCallouts: CreateCalloutInput[] = [
     nameID: 'tasks',
     type: CalloutType.POST_COLLECTION,
     state: CalloutState.OPEN,
-    sortOrder: 1,
+    sortOrder: 2,
     profile: {
       displayName: '💪 Jobs to be done...',
       description: '',
@@ -72,7 +72,7 @@ export const opportunityDefaultCallouts: CreateCalloutInput[] = [
     nameID: 'roles',
     type: CalloutType.POST,
     state: CalloutState.OPEN,
-    sortOrder: 2,
+    sortOrder: 3,
     profile: {
       displayName: '👋 Hi, this is us!',
       description:

--- a/src/migrations/1695296600518-calloutLocation.ts
+++ b/src/migrations/1695296600518-calloutLocation.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class calloutLocation1695296600518 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE tagset SET tags = 'HOME_1' WHERE tags = 'HOME_0'`
+    );
+    await queryRunner.query(
+      `UPDATE tagset_template SET defaultSelectedValue = 'HOME_1' WHERE defaultSelectedValue = 'HOME_0'`
+    );
+    const tagsetTemplates = await queryRunner.query(
+      `SELECT * FROM tagset_template`
+    );
+
+    for (const tagsetTemplate of tagsetTemplates) {
+      const tagsetTemplateArray = tagsetTemplate.allowedValues.split(',');
+
+      // Check if "HOME_1" is not in the array, replace "HOME_0" with "HOME_1"
+      if (!tagsetTemplateArray.includes('HOME_1')) {
+        const updatedArray = tagsetTemplateArray.map((value: string) =>
+          value === 'HOME_0' ? 'HOME_1' : value
+        );
+
+        const tagsetTemplateString = updatedArray.join(',');
+        console.log(tagsetTemplateString);
+
+        await queryRunner.query(
+          `UPDATE tagset_template SET allowedValues = ? WHERE id = ?`,
+          [tagsetTemplateString, tagsetTemplate.id]
+        );
+      } else {
+        // Remove "HOME_0" from the array
+        const updatedArray = tagsetTemplateArray.filter(
+          (value: string) => value !== 'HOME_0'
+        );
+
+        const tagsetTemplateString = updatedArray.join(',');
+        console.log(tagsetTemplateString);
+
+        await queryRunner.query(
+          `UPDATE tagset_template SET allowedValues = ? WHERE id = ?`,
+          [tagsetTemplateString, tagsetTemplate.id]
+        );
+      }
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/migrations/1695296600518-calloutLocation.ts
+++ b/src/migrations/1695296600518-calloutLocation.ts
@@ -43,6 +43,18 @@ export class calloutLocation1695296600518 implements MigrationInterface {
         );
       }
     }
+    await queryRunner.query(
+      `UPDATE callout SET sortOrder = 1 WHERE type = 'link-collection' AND nameID like '%getting-started%'`
+    );
+    await queryRunner.query(
+      `UPDATE callout SET sortOrder = 2 WHERE type = 'post-collection' AND nameID like '%contributor-profiles%'`
+    );
+    await queryRunner.query(
+      `UPDATE callout SET sortOrder = 2 WHERE type = 'post-collection' AND nameID like '%tasks%'`
+    );
+    await queryRunner.query(
+      `UPDATE callout SET sortOrder = 3 WHERE type = 'post' AND nameID like '%roles%'`
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {}


### PR DESCRIPTION
I have encountered multiple problems with this. I believe the requirement might be incorrect.

What is done:
- Removed HOME_0 ("HOME_TOP" / "Dashboard Recommendations" on the client)
- Replaced it with HOME_1 ("HOME_RIGHT" / "Dashboard Right" on the client)

This is one to one with AC.

Problems I have seen:
- There are default callouts created in Journeys in HOME_RIGHT that are not visualized (contributor-profiles)
- I believe HOME_RIGHT is actually the mid-right section on the page, not the top-right one. I don't believe we had anything for top-right section.

@techsmyth @SimoneZaza @larssondenise - the PR follows the AC but further changes may be needed as I feel the AC may not be what is actually needed.