### PR TITLE
Fixed issue updating image to org.

### DIFF
--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -55,6 +55,11 @@ http:
         servers:
           - url: 'http://synapse-admin:80/'
 
+    ipfs-api:
+      loadBalancer:
+        servers:
+          - url: 'http://ipfs:5001'
+
   middlewares:
     strip-api-private-non-interactive-prefix:
       stripPrefix:
@@ -226,6 +231,12 @@ http:
       service: 'rabbitmq-management'
       entryPoints:
         - 'rabbitmq-management'
+
+    ipfs-api:
+        rule: 'PathPrefix(`/`)'
+        service: 'ipfs-api'
+        entryPoints:
+          - 'ipfs-api'
 
 tcp:
   services:

--- a/src/domain/community/organization/organization.resolver.mutations.ts
+++ b/src/domain/community/organization/organization.resolver.mutations.ts
@@ -150,7 +150,10 @@ export class OrganizationResolverMutations {
     authorizationResetData: OrganizationAuthorizationResetInput
   ): Promise<IOrganization> {
     const organization = await this.organizationService.getOrganizationOrFail(
-      authorizationResetData.organizationID
+      authorizationResetData.organizationID,
+      {
+        relations: ['profile', 'profile.storageBucket'],
+      }
     );
     await this.authorizationService.grantAccessOrFail(
       agentInfo,


### PR DESCRIPTION
- Went a bit overboard cleaning /ipfs of the server - reverted some configuration as it is actually needed for the internal iPFS API
- This code needs auth reset. Actually the issue was that the profile of the organization was not loaded on a reset, hence nothing was being propagated down the dependency tree. Potentially fixed other bugs there...