### PR TITLE
rolesUser to only show child challenge + opportunities for spaces with READ access

### DIFF
--- a/src/services/api/roles/roles.resolver.fields.ts
+++ b/src/services/api/roles/roles.resolver.fields.ts
@@ -35,12 +35,16 @@ export class RolesResolverFields {
   @UseGuards(GraphqlGuard)
   @ResolveField('spaces', () => [RolesResultSpace], {
     description:
-      'Details of Spaces the User or Organization is a member of, with child memberships',
+      'Details of Spaces the User or Organization is a member of, with child memberships - if Space is accessible for the current user.',
   })
   public async spaces(
+    @CurrentUser() agentInfo: AgentInfo,
     @Parent() roles: ContributorRoles
   ): Promise<RolesResultSpace[]> {
-    return await this.rolesService.getJourneyRolesForContributor(roles);
+    return await this.rolesService.getJourneyRolesForContributor(
+      roles,
+      agentInfo
+    );
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -6,7 +6,7 @@ import { MockOrganizationService } from '@test/mocks/organization.service.mock';
 import { MockUserService } from '@test/mocks/user.service.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { MockSpaceFilterService } from '@test/mocks/space.filter.service.mock';
-import { EntityManagerProvider } from '@test/mocks';
+import { EntityManagerProvider, MockAuthorizationService } from '@test/mocks';
 import { Test } from '@nestjs/testing';
 import { RolesService } from './roles.service';
 import { UserService } from '@domain/community/user/user.service';
@@ -21,7 +21,6 @@ import * as getJourneyRolesForContributorEntityData from './util/get.journey.rol
 import * as getOrganizationRolesForUserEntityData from './util/get.organization.roles.for.user.entity.data';
 import { MockInvitationService } from '@test/mocks/invitation.service.mock';
 import { MockCommunityResolverService } from '@test/mocks/community.resolver.service.mock';
-import { AgentInfo } from '@core/authentication/agent-info';
 
 describe('RolesService', () => {
   let rolesService: RolesService;
@@ -43,6 +42,7 @@ describe('RolesService', () => {
         MockSpaceFilterService,
         MockOrganizationService,
         MockCommunityResolverService,
+        MockAuthorizationService,
         MockWinstonProvider,
         EntityManagerProvider,
         RolesService,
@@ -108,11 +108,9 @@ describe('RolesService', () => {
       const organizationRoles = await rolesService.getOrganizationRolesForUser(
         roles
       );
-      const agentInfo = new AgentInfo();
-      // TODO: will this work?
       const journeyRoles = await rolesService.getJourneyRolesForContributor(
         roles,
-        agentInfo
+        testData.agentInfo
       );
 
       expect(organizationRoles).toEqual(
@@ -180,11 +178,9 @@ describe('RolesService', () => {
         organizationID: testData.organization.id,
       });
 
-      const agentInfo = new AgentInfo();
-      // TODO: will this work?
       const spaces = await rolesService.getJourneyRolesForContributor(
         roles,
-        agentInfo
+        testData.agentInfo
       );
 
       expect(spaces).toEqual(

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -21,6 +21,7 @@ import * as getJourneyRolesForContributorEntityData from './util/get.journey.rol
 import * as getOrganizationRolesForUserEntityData from './util/get.organization.roles.for.user.entity.data';
 import { MockInvitationService } from '@test/mocks/invitation.service.mock';
 import { MockCommunityResolverService } from '@test/mocks/community.resolver.service.mock';
+import { AgentInfo } from '@core/authentication/agent-info';
 
 describe('RolesService', () => {
   let rolesService: RolesService;
@@ -107,8 +108,11 @@ describe('RolesService', () => {
       const organizationRoles = await rolesService.getOrganizationRolesForUser(
         roles
       );
+      const agentInfo = new AgentInfo();
+      // TODO: will this work?
       const journeyRoles = await rolesService.getJourneyRolesForContributor(
-        roles
+        roles,
+        agentInfo
       );
 
       expect(organizationRoles).toEqual(

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -180,7 +180,12 @@ describe('RolesService', () => {
         organizationID: testData.organization.id,
       });
 
-      const spaces = await rolesService.getJourneyRolesForContributor(roles);
+      const agentInfo = new AgentInfo();
+      // TODO: will this work?
+      const spaces = await rolesService.getJourneyRolesForContributor(
+        roles,
+        agentInfo
+      );
 
       expect(spaces).toEqual(
         expect.arrayContaining([

--- a/src/services/api/roles/roles.service.ts
+++ b/src/services/api/roles/roles.service.ts
@@ -25,6 +25,8 @@ import { CommunityResolverService } from '@services/infrastructure/entity-resolv
 import { RolesResultOrganization } from './dto/roles.dto.result.organization';
 import { mapOrganizationCredentialsToRoles } from './util/map.organization.credentials.to.roles';
 import { RolesResultSpace } from './dto/roles.dto.result.space';
+import { AgentInfo } from '@core/authentication';
+import { AuthorizationService } from '@core/authorization/authorization.service';
 
 export class RolesService {
   constructor(
@@ -37,6 +39,7 @@ export class RolesService {
     private opportunityService: OpportunityService,
     private spaceFilterService: SpaceFilterService,
     private communityResolverService: CommunityResolverService,
+    private authorizationService: AuthorizationService,
     private organizationService: OrganizationService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
@@ -80,7 +83,8 @@ export class RolesService {
   }
 
   public async getJourneyRolesForContributor(
-    roles: ContributorRoles
+    roles: ContributorRoles,
+    agentInfo: AgentInfo
   ): Promise<RolesResultSpace[]> {
     const allowedVisibilities = this.spaceFilterService.getAllowedVisibilities(
       roles.filter
@@ -89,7 +93,9 @@ export class RolesService {
     return await mapJourneyCredentialsToRoles(
       this.entityManager,
       roles.credentials,
-      allowedVisibilities
+      allowedVisibilities,
+      agentInfo,
+      this.authorizationService
     );
   }
 

--- a/src/services/api/roles/util/get.journey.roles.for.contributor.query.result.ts
+++ b/src/services/api/roles/util/get.journey.roles.for.contributor.query.result.ts
@@ -4,12 +4,18 @@ import { Opportunity } from '@domain/collaboration/opportunity';
 import { RolesResultSpace } from '../dto/roles.dto.result.space';
 import { RolesResultCommunity } from '../dto/roles.dto.result.community';
 import { CredentialMap } from './group.credentials.by.entity';
+import { AgentInfo } from '@core/authentication/agent-info';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { RelationshipNotFoundException } from '@common/exceptions';
+import { AuthorizationPrivilege, LogContext } from '@common/enums';
 
 export const getJourneyRolesForContributorQueryResult = (
   map: CredentialMap,
   spaces: Space[],
   challenges: Challenge[],
-  opportunities: Opportunity[]
+  opportunities: Opportunity[],
+  agentInfo: AgentInfo,
+  authorizationService: AuthorizationService
 ): RolesResultSpace[] => {
   return spaces.map(space => {
     const spaceResult = new RolesResultSpace(space);
@@ -17,31 +23,47 @@ export const getJourneyRolesForContributorQueryResult = (
     spaceResult.userGroups = [];
     spaceResult.roles = map.get('spaces')?.get(space.id) ?? [];
 
-    spaceResult.challenges = challenges
-      .filter(challenge => challenge.spaceID === space.id)
-      .map(x => {
-        const challengeResult = new RolesResultCommunity(
-          x.nameID,
-          x.id,
-          x.profile.displayName
-        );
-        challengeResult.userGroups = [];
-        challengeResult.roles = map.get('challenges')?.get(x.id) ?? [];
-        return challengeResult;
-      });
+    // Only return children of spaces that the current user has READ access to
+    if (!space.authorization) {
+      throw new RelationshipNotFoundException(
+        `Unable to load authorization on Space in roles user: ${space.nameID}`,
+        LogContext.ROLES
+      );
+    }
+    const readAccessSpace = authorizationService.isAccessGranted(
+      agentInfo,
+      space.authorization,
+      AuthorizationPrivilege.READ
+    );
 
-    spaceResult.opportunities = opportunities
-      .filter(opp => opp.spaceID === space.id)
-      .map(x => {
-        const oppResult = new RolesResultCommunity(
-          x.nameID,
-          x.id,
-          x.profile.displayName
-        );
-        oppResult.userGroups = [];
-        oppResult.roles = map.get('opportunities')?.get(x.id) ?? [];
-        return oppResult;
-      });
+    if (readAccessSpace) {
+      spaceResult.challenges = challenges
+        .filter(challenge => challenge.spaceID === space.id)
+        .map(x => {
+          const challengeResult = new RolesResultCommunity(
+            x.nameID,
+            x.id,
+            x.profile.displayName
+          );
+          challengeResult.userGroups = [];
+          challengeResult.roles = map.get('challenges')?.get(x.id) ?? [];
+          return challengeResult;
+        });
+
+      // TODO: also filter out opportunities in private challenges, for later...
+      spaceResult.opportunities = opportunities
+        .filter(opp => opp.spaceID === space.id)
+        .map(x => {
+          const oppResult = new RolesResultCommunity(
+            x.nameID,
+            x.id,
+            x.profile.displayName
+          );
+          oppResult.userGroups = [];
+          oppResult.roles = map.get('opportunities')?.get(x.id) ?? [];
+          return oppResult;
+        });
+    }
     return spaceResult;
   });
 };

--- a/src/services/api/roles/util/map.journey.credentials.to.roles.ts
+++ b/src/services/api/roles/util/map.journey.credentials.to.roles.ts
@@ -4,11 +4,15 @@ import { SpaceVisibility } from '@common/enums/space.visibility';
 import { groupCredentialsByEntity } from './group.credentials.by.entity';
 import { getJourneyRolesForContributorEntityData } from './get.journey.roles.for.contributor.entity.data';
 import { getJourneyRolesForContributorQueryResult } from './get.journey.roles.for.contributor.query.result';
+import { AgentInfo } from '@core/authentication/agent-info';
+import { AuthorizationService } from '@core/authorization/authorization.service';
 
 export const mapJourneyCredentialsToRoles = async (
   entityManager: EntityManager,
   credentials: ICredential[],
-  allowedVisibilities: SpaceVisibility[]
+  allowedVisibilities: SpaceVisibility[],
+  agentInfo: AgentInfo,
+  authorizationService: AuthorizationService
 ) => {
   const credentialMap = groupCredentialsByEntity(credentials);
 
@@ -31,6 +35,8 @@ export const mapJourneyCredentialsToRoles = async (
     credentialMap,
     spaces,
     challenges,
-    opportunities
+    opportunities,
+    agentInfo,
+    authorizationService
   );
 };

--- a/test/data/agentInfo.json
+++ b/test/data/agentInfo.json
@@ -1,0 +1,20 @@
+{
+  "agentInfo": {
+    "userID": "91b7e044-61ff-468b-a705-1672b0bda510",
+    "email": "admin@alkem.io",
+    "emailVerified": true,
+    "firstName": "Valentin Admin",
+    "lastName": "Yanakiev",
+    "credentials": [
+      {
+        "id": "7be2b579-b47c-494f-8bd7-5d86edf37eaf",
+        "resourceID": "",
+        "type": "global-admin"
+      }
+    ],
+    "verifiedCredentials": [],
+    "communicationID": "@admin=alkem.io:matrix.alkem.io",
+    "agentID": "66000b15-ae7f-448e-aade-3b4ae1fd4c33",
+    "avatarURL": ""
+  }
+}

--- a/test/mocks/authorization.service.mock.ts
+++ b/test/mocks/authorization.service.mock.ts
@@ -8,5 +8,6 @@ export const MockAuthorizationService: ValueProvider<
   provide: AuthorizationService,
   useValue: {
     grantAccessOrFail: jest.fn(),
+    isAccessGranted: jest.fn(),
   },
 };

--- a/test/utils/test-data.ts
+++ b/test/utils/test-data.ts
@@ -6,6 +6,7 @@ import * as opportunity from '@test/data/opportunity.json';
 import * as applications from '@test/data/applications.json';
 import * as userRoles from '@test/data/roles-user.json';
 import * as challenge from '@test/data/challenge.json';
+import * as agentInfo from '@test/data/agentInfo.json';
 
 export const testData = {
   ...space,
@@ -16,4 +17,5 @@ export const testData = {
   ...applications,
   ...userRoles,
   ...challenge,
+  ...agentInfo,
 };


### PR DESCRIPTION
Updated the rolesUser service to not show memberships of challenges + opportunities that are inside of Spaces that the user does not have access to. 

Note: there is a second case that we can consider, whereby there are opportunities inside of private challenges - but that should be picked up separately. This PR will address the bulk of the current production errors. 