### PR TITLE
Release: Authorization Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.62.0",
+      "version": "0.62.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/common/constants/authorization/policy.rule.constants.ts
+++ b/src/common/constants/authorization/policy.rule.constants.ts
@@ -21,6 +21,8 @@ export const POLICY_RULE_COLLABORATION_CREATE =
   'policyRule-collaborationCreate';
 export const POLICY_RULE_COLLABORATION_WHITEBOARD_RT_CREATE =
   'policyRule-collaborationWhiteboardRtCreate';
+export const POLICY_RULE_COLLABORATION_WHITEBOARD_RT_CONTRIBUTORS_CREATE =
+  'policyRule-collaborationWhiteboardRtContributorsCreate';
 export const POLICY_RULE_COMMUNITY_INVITE = 'policyRule-communityInvite';
 export const POLICY_RULE_STORAGE_BUCKET_UPDATER_FILE_UPLOAD =
   'policyRule-storageBucketUpdaterFileUpload';

--- a/src/domain/collaboration/collaboration/collaboration.service.authorization.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.authorization.ts
@@ -23,6 +23,7 @@ import {
   POLICY_RULE_COLLABORATION_CREATE,
   POLICY_RULE_CALLOUT_CONTRIBUTE,
   POLICY_RULE_COLLABORATION_WHITEBOARD_RT_CREATE,
+  POLICY_RULE_COLLABORATION_WHITEBOARD_RT_CONTRIBUTORS_CREATE,
 } from '@common/constants';
 import { CommunityRole } from '@common/enums/community.role';
 import { TimelineAuthorizationService } from '@domain/timeline/timeline/timeline.service.authorization';
@@ -261,6 +262,16 @@ export class CollaborationAuthorizationService {
         POLICY_RULE_CALLOUT_CONTRIBUTE
       );
       privilegeRules.push(createCalloutPrivilege);
+
+      if (whiteboardRtEnabled) {
+        const createWhiteboardRtContributePrivilege =
+          new AuthorizationPolicyRulePrivilege(
+            [AuthorizationPrivilege.CREATE_WHITEBOARD_RT],
+            AuthorizationPrivilege.CONTRIBUTE,
+            POLICY_RULE_COLLABORATION_WHITEBOARD_RT_CONTRIBUTORS_CREATE
+          );
+        privilegeRules.push(createWhiteboardRtContributePrivilege);
+      }
     }
 
     return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(

--- a/src/domain/common/whiteboard-rt/whiteboard.rt.service.authorization.ts
+++ b/src/domain/common/whiteboard-rt/whiteboard.rt.service.authorization.ts
@@ -74,6 +74,7 @@ export class WhiteboardRtAuthorizationService {
             AuthorizationPrivilege.READ,
             AuthorizationPrivilege.UPDATE,
             AuthorizationPrivilege.UPDATE_CONTENT,
+            AuthorizationPrivilege.CONTRIBUTE,
             AuthorizationPrivilege.DELETE,
           ],
           [

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -201,6 +201,22 @@ export class UserAuthorizationService {
     const readUserPiiCredentials: ICredentialDefinition[] = [
       userSelfManagementCredential,
     ];
+
+    // Ensure global admins can see PII
+    readUserPiiCredentials.push({
+      type: AuthorizationCredential.GLOBAL_ADMIN,
+      resourceID: '',
+    });
+    readUserPiiCredentials.push({
+      type: AuthorizationCredential.GLOBAL_ADMIN_SPACES,
+      resourceID: '',
+    });
+    readUserPiiCredentials.push({
+      type: AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
+      resourceID: '',
+    });
+
+    // Give visibility to admins of communities / orgs
     for (const credential of credentials) {
       // Grant read access to Space Admins for spaces the user is a member of
       if (credential.type === AuthorizationCredential.SPACE_MEMBER) {


### PR DESCRIPTION
## Authorization Fixes
 - `Global Admin`, `Global Community Admin`, `Global Admin Spaces` now can see PII
 - Contributors to a `Journey` can now contribute to a `WHITEBOARD_RT` on it
 - Owners of a `Whiteboard` can `CONTRIBUTE` to a `WHITEBOARD` they have created even if the `CommunityPolicy` doesn't allow so