### PR TITLE
Remove Authorization requirement for Space.collaboration

### DIFF
--- a/src/domain/challenge/space/space.resolver.fields.ts
+++ b/src/domain/challenge/space/space.resolver.fields.ts
@@ -92,7 +92,6 @@ export class SpaceResolverFields {
     return context;
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @UseGuards(GraphqlGuard)
   @ResolveField('collaboration', () => ICollaboration, {
     nullable: true,


### PR DESCRIPTION
This fixes #5158 (client) but I'm not fully sure if this is a proper fix or if it is dangerous in any way.

- I have realized that the resolver for `community` doesn't have `@AuthorizationAgentPrivilege` either.

- With this change I can request `authorization` without errors
```graphql
{
space(ID:"eco1") {
  collaboration{
    id
    authorization{
      myPrivileges
    }
  }
}}
```
![image](https://github.com/alkem-io/server/assets/16032487/bc952d78-3eba-4666-8afb-e744abeec132)

which is what I need, with `authorization.myPrivileges` I have enough.

And I have confirmed that the other fields: `relations`, `callouts`, `tagsetTemplates`, `timeline` throw an error and come set to `null` if I request them.

But I am concerned about that privilege `CREATE_RELATION`, having that permission may be a sign of another different bug.

