### PR TITLE
added ability to lookup authorization policy by iD, protected by platform admin privilege

### DIFF
--- a/src/services/api/lookup/lookup.module.ts
+++ b/src/services/api/lookup/lookup.module.ts
@@ -24,10 +24,13 @@ import { CalloutTemplateModule } from '@domain/template/callout-template/callout
 import { WhiteboardRtModule } from '@domain/common/whiteboard-rt';
 import { DocumentModule } from '@domain/storage/document/document.module';
 import { StorageAggregatorModule } from '@domain/storage/storage-aggregator/storage.aggregator.module';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
 
 @Module({
   imports: [
     AuthorizationModule,
+    AuthorizationPolicyModule,
     CommunityModule,
     CollaborationModule,
     ContextModule,
@@ -49,6 +52,7 @@ import { StorageAggregatorModule } from '@domain/storage/storage-aggregator/stor
     OpportunityModule,
     DocumentModule,
     StorageAggregatorModule,
+    PlatformAuthorizationPolicyModule,
   ],
   providers: [LookupService, LookupResolverQueries, LookupResolverFields],
   exports: [LookupService],

--- a/src/services/api/lookup/lookup.resolver.fields.ts
+++ b/src/services/api/lookup/lookup.resolver.fields.ts
@@ -52,6 +52,7 @@ import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.a
 import { StorageAggregatorService } from '@domain/storage/storage-aggregator/storage.aggregator.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 
 @Resolver(() => LookupQueryResults)
 export class LookupResolverFields {
@@ -103,14 +104,14 @@ export class LookupResolverFields {
   }
 
   @UseGuards(GraphqlGuard)
-  @ResolveField(() => IStorageAggregator, {
+  @ResolveField(() => IAuthorizationPolicy, {
     nullable: true,
     description: 'Lookup the specified Authorization Policy',
   })
   async authorizationPolicy(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('ID', { type: () => UUID }) id: string
-  ): Promise<IStorageAggregator> {
+  ): Promise<IAuthorizationPolicy> {
     // Note: this is a special case, mostly to track down issues related to authorization policies, so restrict access to platform admins
     const authorizationPolicy =
       await this.authorizationPolicyService.getAuthorizationPolicyOrFail(id);

--- a/src/services/api/lookup/lookup.resolver.fields.ts
+++ b/src/services/api/lookup/lookup.resolver.fields.ts
@@ -50,11 +50,15 @@ import { DocumentService } from '@domain/storage/document/document.service';
 import { IDocument } from '@domain/storage/document';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { StorageAggregatorService } from '@domain/storage/storage-aggregator/storage.aggregator.service';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
 
 @Resolver(() => LookupQueryResults)
 export class LookupResolverFields {
   constructor(
     private authorizationService: AuthorizationService,
+    private authorizationPolicyService: AuthorizationPolicyService,
+    private platformAuthorizationService: PlatformAuthorizationPolicyService,
     private communityService: CommunityService,
     private applicationService: ApplicationService,
     private invitationService: InvitationService,
@@ -96,6 +100,30 @@ export class LookupResolverFields {
     );
 
     return document;
+  }
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField(() => IStorageAggregator, {
+    nullable: true,
+    description: 'Lookup the specified Authorization Policy',
+  })
+  async authorizationPolicy(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('ID', { type: () => UUID }) id: string
+  ): Promise<IStorageAggregator> {
+    // Note: this is a special case, mostly to track down issues related to authorization policies, so restrict access to platform admins
+    const authorizationPolicy =
+      await this.authorizationPolicyService.getAuthorizationPolicyOrFail(id);
+    const platformAuthorization =
+      this.platformAuthorizationService.getPlatformAuthorizationPolicy();
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      platformAuthorization,
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      `lookup AuthorizationPolicy: ${authorizationPolicy.id}`
+    );
+
+    return authorizationPolicy;
   }
 
   @UseGuards(GraphqlGuard)


### PR DESCRIPTION
This allows looking up on production the details of the authorization policy where e.g. a privilege was not provided. 