### PR TITLE
Support for readonly and update modes for users in Whiteboard RT

### DIFF
--- a/src/core/authorization/authorization.service.ts
+++ b/src/core/authorization/authorization.service.ts
@@ -32,8 +32,7 @@ export class AuthorizationService {
 
     const errorMsg = `Authorization: unable to grant '${privilegeRequired}' privilege: ${msg} user: ${agentInfo.userID}`;
     this.logCredentialCheckFailDetails(errorMsg, agentInfo, auth);
-
-    // If get to here then no match was found
+    // If you get to here then no match was found
     throw new ForbiddenAuthorizationPolicyException(
       errorMsg,
       privilegeRequired,

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -171,6 +171,11 @@ export class ExcalidrawServer {
     );
 
     this.wsServer.on(CONNECTION, async socket => {
+      // first authorize
+      // attach session handlers
+      // attach error handlers
+      // attach socket handlers conditional on authorization
+
       // drop connection on invalid or expired session
       socket.prependAny(() => checkSession(socket));
       socket.use((_, next) => checkSessionMiddleware(socket, next));
@@ -317,7 +322,7 @@ export class ExcalidrawServer {
     }
     // get only sockets which can save
     const sockets = (await this.wsServer.in(roomId).fetchSockets()).filter(
-      socket => !socket.data.readonly
+      socket => socket.data.update
     );
     // return if no eligible sockets
     if (!sockets.length) {

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -17,13 +17,13 @@ import { WhiteboardRtService } from '@domain/common/whiteboard-rt';
 import { ContributionReporterService } from '@services/external/elasticsearch/contribution-reporter';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import {
+  checkSession,
   closeConnection,
   disconnectEventHandler,
   disconnectingEventHandler,
-  joinRoomEventHandler,
   serverBroadcastEventHandler,
+  authorizeWithRoomAndJoinHandler,
   serverVolatileBroadcastEventHandler,
-  checkSession,
 } from './utils';
 import {
   CONNECTION,
@@ -171,14 +171,29 @@ export class ExcalidrawServer {
     );
 
     this.wsServer.on(CONNECTION, async socket => {
-      // first authorize
+      this.logger?.verbose?.(
+        `User '${socket.data.agentInfo.userID}' established connection`,
+        LogContext.EXCALIDRAW_SERVER
+      );
+      this.wsServer.to(socket.id).emit(INIT_ROOM);
+      // first authorize the user with the room
+      socket.on(
+        JOIN_ROOM,
+        async (roomID: string) =>
+          await authorizeWithRoomAndJoinHandler(
+            roomID,
+            socket,
+            this.wsServer,
+            this.whiteboardRtService,
+            this.authorizationService,
+            this.logger
+          )
+      );
       // attach session handlers
-      // attach error handlers
-      // attach socket handlers conditional on authorization
-
       // drop connection on invalid or expired session
       socket.prependAny(() => checkSession(socket));
       socket.use((_, next) => checkSessionMiddleware(socket, next));
+      // attach error handlers
       socket.on('error', err => {
         if (!err) {
           return;
@@ -190,43 +205,27 @@ export class ExcalidrawServer {
           closeConnection(socket, err.message);
         }
       });
-
-      this.logger?.verbose?.(
-        `User '${socket.data.agentInfo.userID}' established connection`,
-        LogContext.EXCALIDRAW_SERVER
-      );
-
-      this.wsServer.to(socket.id).emit(INIT_ROOM);
+      // attach socket handlers conditionally on authorization
       // client events ONLY
-      socket.on(
-        JOIN_ROOM,
-        async (roomID: string) =>
-          await joinRoomEventHandler(
-            roomID,
-            socket,
-            this.wsServer,
-            this.whiteboardRtService,
-            this.authorizationService,
-            this.logger
-          )
-      );
-
-      socket.on(SERVER_BROADCAST, (roomID: string, data: ArrayBuffer) =>
-        serverBroadcastEventHandler(roomID, data, socket)
-      );
-
+      // user can broadcast presence
       socket.on(
         SERVER_VOLATILE_BROADCAST,
         (roomID: string, data: ArrayBuffer) =>
           serverVolatileBroadcastEventHandler(roomID, data, socket)
       );
 
+      if (socket.data.update) {
+        // user can broadcast content change events
+        socket.on(SERVER_BROADCAST, (roomID: string, data: ArrayBuffer) =>
+          serverBroadcastEventHandler(roomID, data, socket)
+        );
+      }
+
       socket.on(
         DISCONNECTING,
         async () =>
           await disconnectingEventHandler(this.wsServer, socket, this.logger)
       );
-
       socket.on(DISCONNECT, () => disconnectEventHandler(socket));
     });
   }

--- a/src/services/external/excalidraw-backend/types/socket.data.ts
+++ b/src/services/external/excalidraw-backend/types/socket.data.ts
@@ -12,10 +12,13 @@ export type SocketData = {
    */
   lastContributed: number;
   /***
-   * True if the user can only read the content and see the interactions of others users
-   * but is not able to contribute
+   * True if the user can read the content and see the interactions of others users
    */
-  readonly: boolean;
+  read: boolean;
+  /***
+   * If the user can update the content o the whiteboard
+   */
+  update: boolean;
   /***
    * The session of the user connected with the socket
    */

--- a/src/services/external/excalidraw-backend/types/socket.data.ts
+++ b/src/services/external/excalidraw-backend/types/socket.data.ts
@@ -16,7 +16,7 @@ export type SocketData = {
    */
   read: boolean;
   /***
-   * If the user can update the content o the whiteboard
+   * If the user can update the content of the whiteboard
    */
   update: boolean;
   /***

--- a/src/services/external/excalidraw-backend/utils/util.ts
+++ b/src/services/external/excalidraw-backend/utils/util.ts
@@ -52,11 +52,28 @@ export const getUserInfo = async (
     return undefined;
   }
 };
-export const isUserReadonly = async (
+export const canUserRead = (
   authorizationService: AuthorizationService,
   agentInfo: AgentInfo,
   wbRtAuthorization?: IAuthorizationPolicy
-): Promise<boolean> => {
+): boolean => {
+  try {
+    authorizationService.grantAccessOrFail(
+      agentInfo,
+      wbRtAuthorization,
+      AuthorizationPrivilege.READ,
+      'access whiteboardRt'
+    );
+    return false;
+  } catch (e) {
+    return true;
+  }
+};
+export const canUserUpdate = (
+  authorizationService: AuthorizationService,
+  agentInfo: AgentInfo,
+  wbRtAuthorization?: IAuthorizationPolicy
+): boolean => {
   try {
     authorizationService.grantAccessOrFail(
       agentInfo,
@@ -65,7 +82,7 @@ export const isUserReadonly = async (
       'access whiteboardRt'
     );
     return false;
-  } catch (e: any) {
+  } catch (e) {
     return true;
   }
 };

--- a/src/services/external/excalidraw-backend/utils/util.ts
+++ b/src/services/external/excalidraw-backend/utils/util.ts
@@ -64,10 +64,11 @@ export const canUserRead = (
       AuthorizationPrivilege.READ,
       'access whiteboardRt'
     );
-    return false;
   } catch (e) {
-    return true;
+    return false;
   }
+
+  return true;
 };
 export const canUserUpdate = (
   authorizationService: AuthorizationService,


### PR DESCRIPTION
- User is authorized based on the READ privilege.
- Server broadcasts content mutation events only if the user has the UPDATE_CONTENT privilege.
- Server broadcast presencing events (mouse move, clicks, etc.) if is authorized with the Whiteboard