### PR TITLE
Add limit and order to innovationPacks query

### DIFF
--- a/src/common/enums/innovation.packs.orderBy.ts
+++ b/src/common/enums/innovation.packs.orderBy.ts
@@ -1,0 +1,11 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum InnovationPacksOrderBy {
+  RANDOM = 'random',
+  NUMBER_OF_TEMPLATES_ASC = 'innovationPacks.numberOfTemplates_ASC',
+  NUMBER_OF_TEMPLATES_DESC = 'innovationPacks.numberOfTemplates_DESC',
+}
+
+registerEnumType(InnovationPacksOrderBy, {
+  name: 'InnovationPacksOrderBy',
+});

--- a/src/domain/template/templates-set/templates.set.resolver.fields.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.fields.ts
@@ -1,5 +1,5 @@
 import { Profiling } from '@common/decorators';
-import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, Float, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common/decorators/core/use-guards.decorator';
 import { GraphqlGuard } from '@core/authorization/graphql.guard';
 import { UUID } from '@domain/common/scalars';
@@ -41,6 +41,18 @@ export class TemplatesSetResolverFields {
   }
 
   @UseGuards(GraphqlGuard)
+  @ResolveField('postTemplatesCount', () => Float, {
+    nullable: false,
+    description: 'The total number of PostTemplates in this TemplatesSet.',
+  })
+  @Profiling.api
+  async postTemplatesCount(
+    @Parent() templatesSet: ITemplatesSet
+  ): Promise<number> {
+    return this.templatesSetService.getPostTemplatesCount(templatesSet.id);
+  }
+
+  @UseGuards(GraphqlGuard)
   @ResolveField('postTemplate', () => IPostTemplate, {
     nullable: true,
     description: 'A single PostTemplate',
@@ -72,6 +84,21 @@ export class TemplatesSetResolverFields {
   }
 
   @UseGuards(GraphqlGuard)
+  @ResolveField('whiteboardTemplatesCount', () => Float, {
+    nullable: false,
+    description:
+      'The total number of WhiteboardTemplates in this TemplatesSet.',
+  })
+  @Profiling.api
+  async whiteboardTemplatesCount(
+    @Parent() templatesSet: ITemplatesSet
+  ): Promise<number> {
+    return this.templatesSetService.getWhiteboardTemplatesCount(
+      templatesSet.id
+    );
+  }
+
+  @UseGuards(GraphqlGuard)
   @ResolveField('whiteboardTemplate', () => IWhiteboardTemplate, {
     nullable: true,
     description: 'A single WhiteboardTemplate',
@@ -100,6 +127,21 @@ export class TemplatesSetResolverFields {
     @Parent() templatesSet: ITemplatesSet
   ): Promise<IInnovationFlowTemplate[]> {
     return this.templatesSetService.getInnovationFlowTemplates(templatesSet);
+  }
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField('innovationFlowTemplatesCount', () => Float, {
+    nullable: false,
+    description:
+      'The total number of InnovationFlowTemplates in this TemplatesSet.',
+  })
+  @Profiling.api
+  async innovationFlowTemplatesCount(
+    @Parent() templatesSet: ITemplatesSet
+  ): Promise<number> {
+    return this.templatesSetService.getInnovationFlowTemplatesCount(
+      templatesSet.id
+    );
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/domain/template/templates-set/templates.set.service.ts
+++ b/src/domain/template/templates-set/templates.set.service.ts
@@ -408,18 +408,32 @@ export class TemplatesSetService {
   }
 
   async getTemplatesCount(templatesSetID: string): Promise<number> {
-    const whiteboardTemplatesCount =
-      await this.whiteboardTemplateService.getCountInTemplatesSet(
-        templatesSetID
-      );
+    const whiteboardTemplatesCount = await this.getWhiteboardTemplatesCount(
+      templatesSetID
+    );
 
-    const postTemplatesCount =
-      await this.postTemplateService.getCountInTemplatesSet(templatesSetID);
+    const postTemplatesCount = await this.getPostTemplatesCount(templatesSetID);
 
-    const innovationFlowsCount =
-      await this.innovationFlowTemplateService.getCountInTemplatesSet(
-        templatesSetID
-      );
+    const innovationFlowsCount = await this.getInnovationFlowTemplatesCount(
+      templatesSetID
+    );
+
     return whiteboardTemplatesCount + postTemplatesCount + innovationFlowsCount;
+  }
+
+  getWhiteboardTemplatesCount(templatesSetID: string): Promise<number> {
+    return this.whiteboardTemplateService.getCountInTemplatesSet(
+      templatesSetID
+    );
+  }
+
+  getPostTemplatesCount(templatesSetID: string): Promise<number> {
+    return this.postTemplateService.getCountInTemplatesSet(templatesSetID);
+  }
+
+  getInnovationFlowTemplatesCount(templatesSetID: string): Promise<number> {
+    return this.innovationFlowTemplateService.getCountInTemplatesSet(
+      templatesSetID
+    );
   }
 }

--- a/src/library/library/dto/library.dto.innovationPacks.input.ts
+++ b/src/library/library/dto/library.dto.innovationPacks.input.ts
@@ -1,0 +1,19 @@
+import { Field, Float, InputType } from '@nestjs/graphql';
+import { InnovationPacksOrderBy } from '@common/enums/innovation.packs.orderBy';
+
+@InputType()
+export class InnovationPacksInput {
+  @Field(() => Float, {
+    nullable: true,
+    description:
+      'The number of Discussion entries to return; if omitted return all InnovationPacks.',
+  })
+  limit?: number;
+
+  @Field(() => InnovationPacksOrderBy, {
+    description:
+      'The sort order of the InnovationPacks to return. Defaults to number of templates ASC',
+    nullable: true,
+  })
+  orderBy?: InnovationPacksOrderBy;
+}

--- a/src/library/library/dto/library.dto.innovationPacks.input.ts
+++ b/src/library/library/dto/library.dto.innovationPacks.input.ts
@@ -12,7 +12,7 @@ export class InnovationPacksInput {
 
   @Field(() => InnovationPacksOrderBy, {
     description:
-      'The sort order of the InnovationPacks to return. Defaults to number of templates ASC',
+      'The sort order of the InnovationPacks to return. Defaults to number of templates Descending.',
     nullable: true,
   })
   orderBy?: InnovationPacksOrderBy;

--- a/src/library/library/library.resolver.fields.ts
+++ b/src/library/library/library.resolver.fields.ts
@@ -9,6 +9,7 @@ import { InnovationPackService } from '@library/innovation-pack/innovaton.pack.s
 import { IInnovationPack } from '@library/innovation-pack/innovation.pack.interface';
 import { LibraryService } from './library.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
+import { InnovationPacksInput } from './dto/library.dto.innovationPacks.input';
 
 @Resolver(() => ILibrary)
 export class LibraryResolverFields {
@@ -54,8 +55,14 @@ export class LibraryResolverFields {
   })
   @UseGuards(GraphqlGuard)
   async innovationPacks(
-    @Parent() library: ILibrary
+    @Parent() library: ILibrary,
+    @Args('queryData', { type: () => InnovationPacksInput, nullable: true })
+    queryData?: InnovationPacksInput
   ): Promise<IInnovationPack[]> {
-    return await this.libraryService.getInnovationPacks(library);
+    return await this.libraryService.getInnovationPacks(
+      library,
+      queryData?.limit,
+      queryData?.orderBy
+    );
   }
 }

--- a/src/library/library/library.service.ts
+++ b/src/library/library/library.service.ts
@@ -13,6 +13,7 @@ import { CreateInnovationPackOnLibraryInput } from './dto/library.dto.create.inn
 import { Library } from './library.entity';
 import { ILibrary } from './library.interface';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
+import { InnovationPacksOrderBy } from '@common/enums/innovation.packs.orderBy';
 
 @Injectable()
 export class LibraryService {
@@ -37,7 +38,9 @@ export class LibraryService {
   }
 
   public async getInnovationPacks(
-    library: ILibrary
+    library: ILibrary,
+    limit?: number,
+    orderBy: InnovationPacksOrderBy = InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_ASC
   ): Promise<IInnovationPack[]> {
     const innovationPacks = library.innovationPacks;
     if (!innovationPacks)
@@ -55,11 +58,18 @@ export class LibraryService {
       })
     );
 
-    const sortedPacks = innovationPacksWithCounts.sort((a, b) =>
-      a.templatesCount < b.templatesCount ? 1 : -1
-    );
-
-    return sortedPacks;
+    const sortedPacks = innovationPacksWithCounts.sort((a, b) => {
+      switch (orderBy) {
+        case InnovationPacksOrderBy.RANDOM:
+          return 0.5 - Math.random();
+        case InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_ASC:
+          return a.templatesCount < b.templatesCount ? 1 : -1;
+        case InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_DESC:
+          return a.templatesCount < b.templatesCount ? -1 : 1;
+      }
+      return 0;
+    });
+    return limit && limit > 0 ? sortedPacks.slice(0, limit) : sortedPacks;
   }
 
   public async createInnovationPack(

--- a/src/library/library/library.service.ts
+++ b/src/library/library/library.service.ts
@@ -40,7 +40,7 @@ export class LibraryService {
   public async getInnovationPacks(
     library: ILibrary,
     limit?: number,
-    orderBy: InnovationPacksOrderBy = InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_ASC
+    orderBy: InnovationPacksOrderBy = InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_DESC
   ): Promise<IInnovationPack[]> {
     const innovationPacks = library.innovationPacks;
     if (!innovationPacks)
@@ -63,9 +63,9 @@ export class LibraryService {
         case InnovationPacksOrderBy.RANDOM:
           return 0.5 - Math.random();
         case InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_ASC:
-          return a.templatesCount < b.templatesCount ? 1 : -1;
-        case InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_DESC:
           return a.templatesCount < b.templatesCount ? -1 : 1;
+        case InnovationPacksOrderBy.NUMBER_OF_TEMPLATES_DESC:
+          return a.templatesCount < b.templatesCount ? 1 : -1;
       }
       return 0;
     });


### PR DESCRIPTION
- Adds `queryData: { limit, orderBy }` to innovationPacks query
- Exposes Post/Wb/IF template counts as a field of templateSet