### PR TITLE
Serving finalized invitations

### DIFF
--- a/src/services/api/roles/roles.service.ts
+++ b/src/services/api/roles/roles.service.ts
@@ -197,11 +197,6 @@ export class RolesService {
     if (!invitations) return [];
 
     for (const invitation of invitations) {
-      // skip any finalized invitations; only want to return pending invitations
-      const isFinalized = await this.invitationService.isFinalizedInvitation(
-        invitation.id
-      );
-      if (isFinalized) continue;
       const community = invitation.community;
       const state = await this.invitationService.getInvitationState(
         invitation.id


### PR DESCRIPTION
Some other functionality may be affected, needs to be tested.
From the point of the API and the client, this is a fix: applications with state = 'approved' and invitations with state = 'rejected' couldn't be requested even if such states were specified.