### PR TITLE
Changed the order of execution on user reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.63.3",
+  "version": "0.63.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.63.3",
+      "version": "0.63.4",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.63.3",
+  "version": "0.63.4",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/domain/community/user/user.resolver.mutations.ts
+++ b/src/domain/community/user/user.resolver.mutations.ts
@@ -50,7 +50,7 @@ export class UserResolverMutations {
   ): Promise<IUser> {
     const authorization =
       await this.platformAuthorizationService.getPlatformAuthorizationPolicy();
-    await this.authorizationService.grantAccessOrFail(
+    this.authorizationService.grantAccessOrFail(
       agentInfo,
       authorization,
       AuthorizationPrivilege.CREATE,

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -57,14 +57,6 @@ export class UserAuthorizationService {
         `Unable to load agent or profile or preferences or storage for User ${user.id} `,
         LogContext.COMMUNITY
       );
-    // NOTE: Clone the authorization policy to ensure the changes are local to profile
-    const clonedAnonymousReadAccessAuthorization =
-      this.authorizationPolicyService.cloneAuthorizationPolicy(
-        user.authorization
-      );
-    // To ensure that profile + context on a space are always publicly visible, even for private spaces
-    clonedAnonymousReadAccessAuthorization.anonymousReadAccess = true;
-
     // Ensure always applying from a clean state
     user.authorization = this.authorizationPolicyService.reset(
       user.authorization
@@ -78,6 +70,13 @@ export class UserAuthorizationService {
       user.authorization,
       user
     );
+    // NOTE: Clone the authorization policy to ensure the changes are local to profile
+    const clonedAnonymousReadAccessAuthorization =
+      this.authorizationPolicyService.cloneAuthorizationPolicy(
+        user.authorization
+      );
+    // To ensure that profile + context on a space are always publicly visible, even for private spaces
+    clonedAnonymousReadAccessAuthorization.anonymousReadAccess = true;
 
     // cascade
     user.profile =


### PR DESCRIPTION
`clonedAnonymousReadAccessAuthorization` was cloned before the auth is reset and then `clonedAnonymousReadAccessAuthorization` is compared against.