### PR TITLE
ExcalidrawServer sends BROADCAST_READY when socket is set up

### DIFF
--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -36,6 +36,7 @@ import {
   SERVER_SAVE_REQUEST,
   SocketIoServer,
   RemoteSocketIoSocket,
+  BROADCAST_READY,
 } from './types';
 import { CREATE_ROOM, DELETE_ROOM } from './adapters/adapter.event.names';
 import {
@@ -231,6 +232,7 @@ export class ExcalidrawServer {
           socket.on(SERVER_BROADCAST, (roomID: string, data: ArrayBuffer) =>
             serverBroadcastEventHandler(roomID, data, socket)
           );
+          this.wsServer.to(socket.id).emit(BROADCAST_READY);
         }
         this.logger.verbose?.(
           `User '${socket.data.agentInfo.userID}' update flag is '${socket.data.update}'`,

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -223,9 +223,9 @@ export class ExcalidrawServer {
         (roomID: string, data: ArrayBuffer) =>
           serverVolatileBroadcastEventHandler(roomID, data, socket)
       );
-      // separate channel for sending requests between sockets; available to all authorized sockets, in all modes
-      // socket is sending a request to the server, so the server broadcasts it to all other sockets
-      // the separate channel is required, because not all sockets can broadcast through SERVER_BROADCAST
+      // A channel where all viewers of the whiteboard can broadcast messages.
+      // Currently used to send requests for missing data, to pull from other whiteboard collaborators.
+      // This channel is needed because not all viewers has 'write' privilege, so they can't use the channel where updates are broadcast.
       socket.on(SERVER_REQUEST_BROADCAST, (roomID: string, data: ArrayBuffer) =>
         requestBroadcastEventHandler(roomID, data, socket)
       );

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -223,7 +223,7 @@ export class ExcalidrawServer {
         (roomID: string, data: ArrayBuffer) =>
           serverVolatileBroadcastEventHandler(roomID, data, socket)
       );
-      // separate channel for sending requests between sockets; available to all sockets, no matter the privileges
+      // separate channel for sending requests between sockets; available to all authorized sockets, in all modes
       // socket is sending a request to the server, so the server broadcasts it to all other sockets
       // the separate channel is required, because not all sockets can broadcast through SERVER_BROADCAST
       socket.on(SERVER_REQUEST_BROADCAST, (roomID: string, data: ArrayBuffer) =>

--- a/src/services/external/excalidraw-backend/types/event.names.ts
+++ b/src/services/external/excalidraw-backend/types/event.names.ts
@@ -1,11 +1,11 @@
 export const CONNECTION = 'connection';
 export const INIT_ROOM = 'init-room';
 export const JOIN_ROOM = 'join-room';
-export const BROADCAST_READY = 'broadcast-ready';
 export const FIRST_IN_ROOM = 'first-in-room';
 export const NEW_USER = 'new-user';
 export const ROOM_USER_CHANGE = 'room-user-change';
 export const SERVER_BROADCAST = 'server-broadcast';
+export const SERVER_REQUEST_BROADCAST = 'server-request-broadcast';
 export const SERVER_VOLATILE_BROADCAST = 'server-volatile-broadcast';
 export const DISCONNECTING = 'disconnecting';
 export const DISCONNECT = 'disconnect';

--- a/src/services/external/excalidraw-backend/types/event.names.ts
+++ b/src/services/external/excalidraw-backend/types/event.names.ts
@@ -1,6 +1,7 @@
 export const CONNECTION = 'connection';
 export const INIT_ROOM = 'init-room';
 export const JOIN_ROOM = 'join-room';
+export const BROADCAST_READY = 'broadcast-ready';
 export const FIRST_IN_ROOM = 'first-in-room';
 export const NEW_USER = 'new-user';
 export const ROOM_USER_CHANGE = 'room-user-change';

--- a/src/services/external/excalidraw-backend/utils/handlers.ts
+++ b/src/services/external/excalidraw-backend/utils/handlers.ts
@@ -109,6 +109,14 @@ export const serverVolatileBroadcastEventHandler = (
 ) => {
   socket.volatile.broadcast.to(roomID).emit(CLIENT_BROADCAST, data);
 };
+// broadcasts requests from socket to all other sockets
+export const requestBroadcastEventHandler = (
+  roomID: string,
+  data: ArrayBuffer,
+  socket: SocketIoSocket
+) => {
+  socket.broadcast.to(roomID).emit(CLIENT_BROADCAST, data);
+};
 /* Built-in event for handling socket disconnects */
 export const disconnectingEventHandler = async (
   wsServer: SocketIoServer,


### PR DESCRIPTION
![image](https://github.com/alkem-io/server/assets/7901834/7446af08-b25a-41f4-be44-d39a111a23aa)

1. A socket(client) sends a request message to the server
 to request files from other sockets(clients)
2. Sockets(clients) respond with files
3. Server relays the response from (2) to the other sockets(clients)
4. Client handles the response message if needed