### PR TITLE
Release: Guidance Engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.64.3",
+  "version": "0.65.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.64.3",
+      "version": "0.65.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.64.3",
+  "version": "0.65.0",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -310,7 +310,7 @@ services:
   guidance_engine:
     container_name: alkemio_dev_guidance_engine
     hostname: guidance-engine
-    image: alkemio/guidance-engine:v0.5.2
+    image: alkemio/guidance-engine:v0.6.0
     restart: always
     volumes:
        - /dev/shm:/dev/shm

--- a/src/domain/communication/room/room.resolver.mutations.ts
+++ b/src/domain/communication/room/room.resolver.mutations.ts
@@ -104,12 +104,14 @@ export class RoomResolverMutations {
           message,
           agentInfo
         );
-        this.roomServiceEvents.processNotificationPostComment(
-          post,
-          room,
-          message,
-          agentInfo
-        );
+        if (post.createdBy !== agentInfo.userID) {
+          this.roomServiceEvents.processNotificationPostComment(
+            post,
+            room,
+            message,
+            agentInfo
+          );
+        }
         this.roomServiceEvents.processActivityPostComment(
           post,
           room,

--- a/src/services/adapters/chat-guidance-adapter/guidance.engine.adapter.ts
+++ b/src/services/adapters/chat-guidance-adapter/guidance.engine.adapter.ts
@@ -58,8 +58,7 @@ export class GuidanceEngineAdapter {
       formattedString = message
         .replace(/\\\\n/g, ' ')
         .replace(/\\\\"/g, '')
-        .replace(/<\|im_end\|>/g, '')
-        .replace(/content=(['"])(.*?)\1/g, '$2');
+        .replace(/<\|im_end\|>/g, '');
     }
 
     try {

--- a/src/services/api/chat-guidance/chat.guidance.service.ts
+++ b/src/services/api/chat-guidance/chat.guidance.service.ts
@@ -24,8 +24,6 @@ export class ChatGuidanceService {
       language: chatData.language ?? 'EN',
     });
 
-    this.guidanceEngineAdapter.sendReset({ userId: agentInfo.userID });
-
     return response;
   }
 

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -24,6 +24,7 @@ import {
   authorizeWithRoomAndJoinHandler,
   serverVolatileBroadcastEventHandler,
   checkSessionHandler,
+  requestBroadcastEventHandler,
 } from './utils';
 import {
   CONNECTION,
@@ -36,6 +37,7 @@ import {
   SERVER_SAVE_REQUEST,
   SocketIoServer,
   RemoteSocketIoSocket,
+  SERVER_REQUEST_BROADCAST,
 } from './types';
 import { CREATE_ROOM, DELETE_ROOM } from './adapters/adapter.event.names';
 import {
@@ -220,6 +222,12 @@ export class ExcalidrawServer {
         SERVER_VOLATILE_BROADCAST,
         (roomID: string, data: ArrayBuffer) =>
           serverVolatileBroadcastEventHandler(roomID, data, socket)
+      );
+      // A channel where all viewers of the whiteboard can broadcast messages.
+      // Currently used to send requests for missing data, to pull from other whiteboard collaborators.
+      // This channel is needed because not all viewers has 'write' privilege, so they can't use the channel where updates are broadcast.
+      socket.on(SERVER_REQUEST_BROADCAST, (roomID: string, data: ArrayBuffer) =>
+        requestBroadcastEventHandler(roomID, data, socket)
       );
       // to avoid this problem we can extend the server impl to have a build in
       // auth and handlers to be attached when the socket has been authenticated

--- a/src/services/external/excalidraw-backend/types/event.names.ts
+++ b/src/services/external/excalidraw-backend/types/event.names.ts
@@ -5,6 +5,7 @@ export const FIRST_IN_ROOM = 'first-in-room';
 export const NEW_USER = 'new-user';
 export const ROOM_USER_CHANGE = 'room-user-change';
 export const SERVER_BROADCAST = 'server-broadcast';
+export const SERVER_REQUEST_BROADCAST = 'server-request-broadcast';
 export const SERVER_VOLATILE_BROADCAST = 'server-volatile-broadcast';
 export const DISCONNECTING = 'disconnecting';
 export const DISCONNECT = 'disconnect';

--- a/src/services/external/excalidraw-backend/utils/handlers.ts
+++ b/src/services/external/excalidraw-backend/utils/handlers.ts
@@ -109,6 +109,14 @@ export const serverVolatileBroadcastEventHandler = (
 ) => {
   socket.volatile.broadcast.to(roomID).emit(CLIENT_BROADCAST, data);
 };
+// broadcasts requests from socket to all other sockets
+export const requestBroadcastEventHandler = (
+  roomID: string,
+  data: ArrayBuffer,
+  socket: SocketIoSocket
+) => {
+  socket.broadcast.to(roomID).emit(CLIENT_BROADCAST, data);
+};
 /* Built-in event for handling socket disconnects */
 export const disconnectingEventHandler = async (
   wsServer: SocketIoServer,


### PR DESCRIPTION
## Guidance Engine
  - Now `sendQuery` doesn't reset the conversation
  - Updated `guidance-engine` dependency
  - Removed `.content` parsing from the `ChatGuidanceResponse` payload