### PR TITLE
Fixed ordering of journeys per latest activity

### DIFF
--- a/src/platform/activity/activity.service.ts
+++ b/src/platform/activity/activity.service.ts
@@ -189,19 +189,26 @@ export class ActivityService {
     );
 
     // Create a map of collaboration IDs to latest activities
-    const latestActivityMap = new Map();
+    const latestActivityPerCollaborationMap = new Map();
     for (const activity of filteredActivities) {
-      const existingActivity = latestActivityMap.get(activity.collaborationID);
+      const existingActivity = latestActivityPerCollaborationMap.get(
+        activity.collaborationID
+      );
       if (
         !existingActivity ||
         activity.createdDate > existingActivity.createdDate
       ) {
-        latestActivityMap.set(activity.collaborationID, activity);
+        latestActivityPerCollaborationMap.set(
+          activity.collaborationID,
+          activity
+        );
       }
     }
 
     // Convert the map values to an array and limit the results
-    const activityData = Array.from(latestActivityMap.values()).slice(0, limit);
+    const activityData = Array.from(
+      latestActivityPerCollaborationMap.values()
+    ).slice(0, limit);
 
     return activityData;
   }


### PR DESCRIPTION
Group by + order by together on sql level didn't work. It was grouping first, ordering later, and it should have been the other way round.

This seems to be working now and is performant. It took 67 ms for me with real dataset.