### PR TITLE
Timers deleted on room globally deleted 

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -370,8 +370,6 @@ collaboration:
     save_interval: ${WHITEBOARD_AUTOSAVE_INTERVAL}:15
     # SECONDS to wait after the request is saved, before it fails
     save_timeout: ${WHITEBOARD_AUTOSAVE_TIMEOUT}:10
-    # max retries before the autosave fails
-    save_max_retries: ${WHITEBOARD_AUTOSAVE_MAX_RETRIES}:5
     # MILLISECONDS to wait before the socket data has been initialized
     socket_data_init_delay: ${WHITEBOARD_SOCKET_DATA_INIT_DELAY}:700
 

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -158,7 +158,15 @@ export class ExcalidrawServer {
         }`,
         LogContext.EXCALIDRAW_SERVER
       );
+
       if (!isRoomId(roomId)) {
+        return;
+      }
+
+      if ((await this.wsServer.in(roomId).fetchSockets()).length > 0) {
+        // if there are sockets already connected
+        // this room was deleted, but it's still active on the other instances
+        // so do nothing here
         return;
       }
 

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -162,10 +162,11 @@ export class ExcalidrawServer {
         return;
       }
 
-      this.wsServer.serverSideEmit(SERVER_SIDE_ROOM_DELETED, [
+      this.wsServer.serverSideEmit(
+        SERVER_SIDE_ROOM_DELETED,
         this.appId,
-        roomId,
-      ]);
+        roomId
+      );
 
       this.logger.verbose?.(
         `Room deleted: '${roomId}`,

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -324,7 +324,7 @@ export class ExcalidrawServer {
       });
 
       if (saved === undefined) {
-        this.logger.warn?.(
+        this.logger.verbose?.(
           `No eligible sockets found to save '${roomId}'.`,
           LogContext.EXCALIDRAW_SERVER
         );

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -65,7 +65,6 @@ export class ExcalidrawServer {
   private readonly contributionWindowMs: number;
   private readonly saveIntervalMs: number;
   private readonly saveTimeoutMs: number;
-  private readonly saveMaxRetries: number;
   private readonly socketDataInitDelayMs: number;
 
   constructor(
@@ -321,7 +320,6 @@ export class ExcalidrawServer {
   private startSaveTimer(roomId: string) {
     return setInterval(async () => {
       const saved = await this.sendSaveMessage(roomId, {
-        maxRetries: this.saveMaxRetries,
         timeout: this.saveTimeoutMs,
       });
 

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -147,13 +147,6 @@ export class ExcalidrawServer {
       }
     });
     adapter.on(DELETE_ROOM, async (roomId: string) => {
-      this.logger.verbose?.(
-        `roomId: '${roomId}', sockets: ${
-          (await this.wsServer.in(roomId).fetchSockets()).length
-        }`,
-        LogContext.EXCALIDRAW_SERVER
-      );
-
       if (!isRoomId(roomId)) {
         return;
       }
@@ -340,10 +333,7 @@ export class ExcalidrawServer {
           LogContext.EXCALIDRAW_SERVER
         );
       }
-
-      // timer.refresh();
     }, this.saveIntervalMs);
-    // return timer;
   }
 
   /***

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -55,7 +55,7 @@ const defaultContributionInterval = 600;
 const defaultSaveInterval = 15;
 const defaultSaveTimeout = 10;
 const defaultMaxRetries = 5;
-const defaultTimeoutBeforeRetryMs = 3000;
+// const defaultTimeoutBeforeRetryMs = 3000;
 const defaultSocketDataInitDelay = 700;
 
 @Injectable()
@@ -298,7 +298,7 @@ export class ExcalidrawServer {
   }
 
   private startSaveTimer(roomId: string) {
-    const timer = setTimeout(async () => {
+    return setInterval(async () => {
       const saved = await this.sendSaveMessage(roomId, {
         maxRetries: this.saveMaxRetries,
         timeout: this.saveTimeoutMs,
@@ -322,9 +322,9 @@ export class ExcalidrawServer {
         );
       }
 
-      timer.refresh();
+      // timer.refresh();
     }, this.saveIntervalMs);
-    return timer;
+    // return timer;
   }
 
   /***
@@ -374,16 +374,16 @@ export class ExcalidrawServer {
       // log the response
       this.logResponse(response, randomSocket, roomId);
       // if failed - repeat
-      if (!response.success) {
-        // workaround for timers/promises not working
-        return new Promise(res =>
-          setTimeout(
-            async () =>
-              res(await this._sendSaveMessage(roomId, ++retries, opts)),
-            defaultTimeoutBeforeRetryMs
-          )
-        );
-      }
+      // if (!response.success) {
+      //   // workaround for timers/promises not working
+      //   return new Promise(res =>
+      //     setTimeout(
+      //       async () =>
+      //         res(await this._sendSaveMessage(roomId, ++retries, opts)),
+      //       defaultTimeoutBeforeRetryMs
+      //     )
+      //   );
+      // }
       // if successful - stop and return
       return true;
     } catch (e) {
@@ -391,8 +391,9 @@ export class ExcalidrawServer {
         `User '${randomSocket.data.agentInfo.userID}' did not respond to '${SERVER_SAVE_REQUEST}' event after ${timeout}ms`,
         LogContext.EXCALIDRAW_SERVER
       );
-      //retry if timed out
-      return await this._sendSaveMessage(roomId, ++retries, opts);
+      // retry if timed out
+      // return await this._sendSaveMessage(roomId, ++retries, opts);
+      return false;
     }
   }
 

--- a/src/services/external/excalidraw-backend/excalidraw.server.ts
+++ b/src/services/external/excalidraw-backend/excalidraw.server.ts
@@ -48,7 +48,7 @@ import {
 } from './middlewares';
 
 type SaveMessageOpts = { maxRetries: number; timeout: number };
-type RoomTimers = Map<string, NodeJS.Timer | NodeJS.Timeout>;
+type RoomTimers = Map<string, NodeJS.Timer>;
 type SaveResponse = { success: boolean; errors?: string[] };
 
 const defaultContributionInterval = 600;
@@ -150,6 +150,12 @@ export class ExcalidrawServer {
       }
     });
     adapter.on(DELETE_ROOM, async (roomId: string) => {
+      this.logger.verbose?.(
+        `roomId: '${roomId}', sockets: ${
+          (await this.wsServer.in(roomId).fetchSockets()).length
+        }`,
+        LogContext.EXCALIDRAW_SERVER
+      );
       if (!isRoomId(roomId)) {
         return;
       }

--- a/src/services/external/excalidraw-backend/types/event.names.ts
+++ b/src/services/external/excalidraw-backend/types/event.names.ts
@@ -15,3 +15,4 @@ export const CLIENT_BROADCAST = 'client-broadcast';
 export const CONNECTION_CLOSED = 'connection-closed';
 
 export const SERVER_SAVE_REQUEST = 'save-request';
+export const SERVER_SIDE_ROOM_DELETED = 'server-side-room-deleted';


### PR DESCRIPTION
- removed the retry logic - introduced complexity and potential bugs
- timeout converted to interval, managed in a central place
- more verbose logging added
- each server sends an event to inform the others in the cluster that the last socket from a room is disconnected, so the room is deleted globally. This is needed in the case where no sockets are connected locally to an instance, but the room still exists globally (on the other instances), so the timers are there to handle saving and contributions.

## Please squash on merge