### PR TITLE
Creation of challenge / opportunity using another challenge / opportunity as a template for callouts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "files.eol": "\n",
   "[yaml]": {

--- a/src/core/validation/handlers/base/base.handler.ts
+++ b/src/core/validation/handlers/base/base.handler.ts
@@ -27,7 +27,7 @@ import {
   CreateUserGroupInput,
   UpdateUserGroupInput,
 } from '@domain/community/user-group/dto';
-import { CreateChallengeOnSpaceInput } from '@domain/challenge/challenge/dto/challenge.dto.create.in.space';
+import { CreateChallengeOnSpaceInput } from '@domain/challenge/space/dto/space.dto.create.challenge';
 import { CreateChallengeOnChallengeInput } from '@domain/challenge/challenge/dto/challenge.dto.create.in.challenge';
 import { CreateActorInput, UpdateActorInput } from '@domain/context/actor';
 import { CommunityApplyInput } from '@domain/community/community/dto/community.dto.apply';

--- a/src/domain/challenge/challenge/challenge.resolver.mutations.ts
+++ b/src/domain/challenge/challenge/challenge.resolver.mutations.ts
@@ -86,6 +86,16 @@ export class ChallengeResolverMutations {
       AuthorizationPrivilege.CREATE_OPPORTUNITY,
       `opportunityCreate: ${challenge.nameID}`
     );
+
+    // For the creation based on the template from another challenge require platform admin privileges
+    if (opportunityData.collaborationTemplateOpportunityID) {
+      await this.authorizationService.grantAccessOrFail(
+        agentInfo,
+        challenge.authorization,
+        AuthorizationPrivilege.CREATE,
+        `opportunityCreate using challenge template: ${challenge.nameID} - ${opportunityData.collaborationTemplateOpportunityID}`
+      );
+    }
     const opportunity = await this.challengeService.createOpportunity(
       opportunityData,
       agentInfo

--- a/src/domain/challenge/challenge/dto/challenge.dto.create.ts
+++ b/src/domain/challenge/challenge/dto/challenge.dto.create.ts
@@ -19,6 +19,13 @@ export class CreateChallengeInput extends CreateBaseChallengeInput {
   })
   innovationFlowTemplateID?: string;
 
+  @Field(() => UUID, {
+    nullable: true,
+    description:
+      'The ID of the Challenge to use for setting up the collaboration the Challenge.',
+  })
+  collaborationTemplateChallengeID?: string;
+
   // Override
   @Field(() => NameID, {
     nullable: true,

--- a/src/domain/challenge/space/dto/space.dto.create.challenge.ts
+++ b/src/domain/challenge/space/dto/space.dto.create.challenge.ts
@@ -1,6 +1,6 @@
 import { UUID_NAMEID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
-import { CreateChallengeInput } from './challenge.dto.create';
+import { CreateChallengeInput } from '../../challenge/dto/challenge.dto.create';
 
 @InputType()
 export class CreateChallengeOnSpaceInput extends CreateChallengeInput {

--- a/src/domain/challenge/space/space.resolver.mutations.ts
+++ b/src/domain/challenge/space/space.resolver.mutations.ts
@@ -306,7 +306,7 @@ export class SpaceResolverMutations {
       await this.authorizationService.grantAccessOrFail(
         agentInfo,
         space.authorization,
-        AuthorizationPrivilege.PLATFORM_ADMIN,
+        AuthorizationPrivilege.CREATE,
         `challengeCreate using challenge template: ${space.nameID} - ${challengeData.collaborationTemplateChallengeID}`
       );
     }

--- a/src/domain/challenge/space/space.resolver.mutations.ts
+++ b/src/domain/challenge/space/space.resolver.mutations.ts
@@ -16,7 +16,7 @@ import { SpaceAuthorizationService } from './space.service.authorization';
 import { ChallengeAuthorizationService } from '@domain/challenge/challenge/challenge.service.authorization';
 import { ISpace } from './space.interface';
 import { SpaceAuthorizationResetInput } from './dto/space.dto.reset.authorization';
-import { CreateChallengeOnSpaceInput } from '../challenge/dto/challenge.dto.create.in.space';
+import { CreateChallengeOnSpaceInput } from './dto/space.dto.create.challenge';
 import { PreferenceService } from '@domain/common/preference/preference.service';
 import { IPreference } from '@domain/common/preference/preference.interface';
 import { PreferenceDefinitionSet } from '@common/enums/preference.definition.set';
@@ -300,6 +300,16 @@ export class SpaceResolverMutations {
       AuthorizationPrivilege.CREATE_CHALLENGE,
       `challengeCreate: ${space.nameID}`
     );
+
+    // For the creation based on the template from another challenge require platform admin privileges
+    if (challengeData.collaborationTemplateChallengeID) {
+      await this.authorizationService.grantAccessOrFail(
+        agentInfo,
+        space.authorization,
+        AuthorizationPrivilege.PLATFORM_ADMIN,
+        `challengeCreate using challenge template: ${space.nameID} - ${challengeData.collaborationTemplateChallengeID}`
+      );
+    }
     const challenge = await this.spaceService.createChallengeInSpace(
       challengeData,
       agentInfo

--- a/src/domain/challenge/space/space.service.ts
+++ b/src/domain/challenge/space/space.service.ts
@@ -40,7 +40,7 @@ import { Space } from './space.entity';
 import { ISpace } from './space.interface';
 import { AgentService } from '@domain/agent/agent/agent.service';
 import { UpdateSpaceInput } from './dto/space.dto.update';
-import { CreateChallengeOnSpaceInput } from '../challenge/dto/challenge.dto.create.in.space';
+import { CreateChallengeOnSpaceInput } from './dto/space.dto.create.challenge';
 import { CommunityService } from '@domain/community/community/community.service';
 import { CommunityType } from '@common/enums/community.type';
 import { AgentInfo } from '@src/core/authentication/agent-info';

--- a/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.ts
+++ b/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.ts
@@ -58,4 +58,17 @@ export class CalloutContributionDefaultsService {
     result.id = calloutContributionDefaultsID;
     return result;
   }
+
+  public createCalloutContributionDefaultsInputFromCalloutContributionDefaults(
+    calloutContributionDefaults?: ICalloutContributionDefaults
+  ): CreateCalloutContributionDefaultsInput | undefined {
+    if (!calloutContributionDefaults) {
+      return undefined;
+    }
+    const result: CreateCalloutContributionDefaultsInput = {
+      postDescription: calloutContributionDefaults.postDescription,
+      whiteboardContent: calloutContributionDefaults.whiteboardContent,
+    };
+    return result;
+  }
 }

--- a/src/domain/collaboration/callout-contribution-policy/callout.contribution.policy.service.ts
+++ b/src/domain/collaboration/callout-contribution-policy/callout.contribution.policy.service.ts
@@ -90,4 +90,14 @@ export class CalloutContributionPolicyService {
     result.id = calloutContributionPolicyID;
     return result;
   }
+
+  public createCalloutContributionPolicyInputFromCalloutContributionPolicy(
+    calloutContributionPolicy: ICalloutContributionPolicy
+  ): CreateCalloutContributionPolicyInput {
+    return {
+      state: calloutContributionPolicy.state,
+      allowedContributionTypes:
+        calloutContributionPolicy.allowedContributionTypes,
+    };
+  }
 }

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -259,6 +259,23 @@ export class CalloutFramingService {
     return calloutFraming.whiteboardRt;
   }
 
+  public createCalloutFramingInputFromCalloutFraming(
+    calloutFraming: ICalloutFraming
+  ): CreateCalloutFramingInput {
+    return {
+      profile: this.profileService.createProfileInputFromProfile(
+        calloutFraming.profile
+      ),
+      whiteboard: this.whiteboardService.createWhiteboardInputFromWhiteboard(
+        calloutFraming.whiteboard
+      ),
+      whiteboardRt:
+        this.whiteboardRtService.createWhiteboardRtInputFromWhiteboardRt(
+          calloutFraming.whiteboardRt
+        ),
+    };
+  }
+
   updateDisplayLocationTagsetValue(
     framing: ICalloutFraming,
     group: CalloutDisplayLocation

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -41,7 +41,6 @@ import { ICalloutContributionDefaults } from '../callout-contribution-defaults/c
 import { CalloutContributionFilterArgs } from '../callout-contribution/dto/callout.contribution.args.filter';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
-import { PostService } from '../post/post.service';
 
 @Injectable()
 export class CalloutService {
@@ -55,7 +54,6 @@ export class CalloutService {
     private contributionPolicyService: CalloutContributionPolicyService,
     private contributionService: CalloutContributionService,
     private storageAggregatorResolverService: StorageAggregatorResolverService,
-    private postService: PostService,
     @InjectRepository(Callout)
     private calloutRepository: Repository<Callout>
   ) {}
@@ -319,6 +317,27 @@ export class CalloutService {
     result.id = calloutID;
 
     return result;
+  }
+
+  public createCalloutInputFromCallout(callout: ICallout): CreateCalloutInput {
+    return {
+      nameID: callout.nameID,
+      type: callout.type,
+      visibility: callout.visibility,
+      framing:
+        this.calloutFramingService.createCalloutFramingInputFromCalloutFraming(
+          callout.framing
+        ),
+      contributionDefaults:
+        this.contributionDefaultsService.createCalloutContributionDefaultsInputFromCalloutContributionDefaults(
+          callout.contributionDefaults
+        ),
+      contributionPolicy:
+        this.contributionPolicyService.createCalloutContributionPolicyInputFromCalloutContributionPolicy(
+          callout.contributionPolicy
+        ),
+      sortOrder: callout.sortOrder,
+    };
   }
 
   public async getActivityCount(callout: ICallout): Promise<number> {

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -319,7 +319,28 @@ export class CalloutService {
     return result;
   }
 
-  public createCalloutInputFromCallout(callout: ICallout): CreateCalloutInput {
+  public async createCalloutInputFromCallout(
+    calloutInput: ICallout
+  ): Promise<CreateCalloutInput> {
+    const callout = await this.getCalloutOrFail(calloutInput.id, {
+      relations: {
+        contributionDefaults: true,
+        contributionPolicy: true,
+        framing: {
+          profile: {
+            references: true,
+            location: true,
+            tagsets: true,
+          },
+          whiteboard: {
+            profile: true,
+          },
+          whiteboardRt: {
+            profile: true,
+          },
+        },
+      },
+    });
     return {
       nameID: callout.nameID,
       type: callout.type,

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -130,7 +130,7 @@ export class CollaborationService {
 
     for (const sourceCallout of sourceCallouts) {
       const sourceCalloutInput =
-        this.calloutService.createCalloutInputFromCallout(sourceCallout);
+        await this.calloutService.createCalloutInputFromCallout(sourceCallout);
       calloutsData.push(sourceCalloutInput);
     }
     return calloutsData;

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -119,6 +119,23 @@ export class CollaborationService {
     return await this.save(collaboration);
   }
 
+  public async createCalloutInputsFromCollaboration(
+    collaborationSource: ICollaboration
+  ): Promise<CreateCalloutInput[]> {
+    const calloutsData: CreateCalloutInput[] = [];
+
+    const sourceCallouts = await this.getCalloutsOnCollaboration(
+      collaborationSource
+    );
+
+    for (const sourceCallout of sourceCallouts) {
+      const sourceCalloutInput =
+        this.calloutService.createCalloutInputFromCallout(sourceCallout);
+      calloutsData.push(sourceCalloutInput);
+    }
+    return calloutsData;
+  }
+
   async save(collaboration: ICollaboration): Promise<ICollaboration> {
     return await this.collaborationRepository.save(collaboration);
   }

--- a/src/domain/collaboration/opportunity/dto/opportunity.dto.create.ts
+++ b/src/domain/collaboration/opportunity/dto/opportunity.dto.create.ts
@@ -22,4 +22,11 @@ export class CreateOpportunityInput extends CreateBaseChallengeInput {
   nameID!: string;
 
   storageAggregatorParent!: IStorageAggregator;
+
+  @Field(() => UUID, {
+    nullable: true,
+    description:
+      'The ID of the Opportunity to use for setting up the collaboration of the Opportunity.',
+  })
+  collaborationTemplateOpportunityID?: string;
 }

--- a/src/domain/common/location/location.service.ts
+++ b/src/domain/common/location/location.service.ts
@@ -65,4 +65,18 @@ export class LocationService {
 
     return await this.locationRepository.save(location);
   }
+
+  public createLocationInputFromLocation(
+    location?: ILocation
+  ): CreateLocationInput | undefined {
+    if (!location) return undefined;
+    return {
+      city: location.city,
+      country: location.country,
+      addressLine1: location.addressLine1,
+      addressLine2: location.addressLine2,
+      postalCode: location.postalCode,
+      stateOrProvince: location.stateOrProvince,
+    };
+  }
 }

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -454,4 +454,21 @@ export class ProfileService {
     }
     return result;
   }
+
+  public createProfileInputFromProfile(profile: IProfile): CreateProfileInput {
+    return {
+      description: profile.description,
+      displayName: profile.displayName,
+      location: this.locationService.createLocationInputFromLocation(
+        profile.location
+      ),
+      referencesData: this.referenceService.createReferencesInputFromReferences(
+        profile.references
+      ),
+      tagline: profile.tagline,
+      tagsets: this.tagsetService.createTagsetsInputFromTagsets(
+        profile.tagsets
+      ),
+    };
+  }
 }

--- a/src/domain/common/reference/reference.service.ts
+++ b/src/domain/common/reference/reference.service.ts
@@ -122,4 +122,25 @@ export class ReferenceService {
   async saveReference(reference: IReference): Promise<IReference> {
     return await this.referenceRepository.save(reference);
   }
+
+  public createReferenceInputFromReference(
+    reference: IReference
+  ): CreateReferenceInput {
+    return {
+      name: reference.name,
+      uri: reference.uri,
+      description: reference.description,
+    };
+  }
+
+  public createReferencesInputFromReferences(
+    references?: IReference[]
+  ): CreateReferenceInput[] {
+    const result: CreateReferenceInput[] = [];
+    if (!references) return result;
+    for (const reference of references) {
+      result.push(this.createReferenceInputFromReference(reference));
+    }
+    return result;
+  }
 }

--- a/src/domain/common/tagset/tagset.service.ts
+++ b/src/domain/common/tagset/tagset.service.ts
@@ -251,4 +251,24 @@ export class TagsetService {
   async save(tagset: ITagset): Promise<ITagset> {
     return await this.tagsetRepository.save(tagset);
   }
+
+  public createTagsetInputFromTagset(tagset: ITagset): CreateTagsetInput {
+    return {
+      name: tagset.name,
+      tags: tagset.tags,
+      type: tagset.type,
+      tagsetTemplate: tagset.tagsetTemplate,
+    };
+  }
+
+  public createTagsetsInputFromTagsets(
+    tagsets?: ITagset[]
+  ): CreateTagsetInput[] {
+    const tagsetInputs: CreateTagsetInput[] = [];
+    if (!tagsets) return tagsetInputs;
+    for (const tagset of tagsets) {
+      tagsetInputs.push(this.createTagsetInputFromTagset(tagset));
+    }
+    return tagsetInputs;
+  }
 }

--- a/src/domain/common/whiteboard-rt/whiteboard.rt.service.ts
+++ b/src/domain/common/whiteboard-rt/whiteboard.rt.service.ts
@@ -257,4 +257,17 @@ export class WhiteboardRtService {
 
     return whiteboardContent;
   }
+
+  public createWhiteboardRtInputFromWhiteboardRt(
+    whiteboard?: IWhiteboardRt
+  ): CreateWhiteboardRtInput | undefined {
+    if (!whiteboard) return undefined;
+    return {
+      profileData: this.profileService.createProfileInputFromProfile(
+        whiteboard.profile
+      ),
+      content: whiteboard.content,
+      nameID: whiteboard.nameID,
+    };
+  }
 }

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -270,4 +270,17 @@ export class WhiteboardService {
 
     return whiteboardContent;
   }
+
+  public createWhiteboardInputFromWhiteboard(
+    whiteboard?: IWhiteboard
+  ): CreateWhiteboardInput | undefined {
+    if (!whiteboard) return undefined;
+    return {
+      profileData: this.profileService.createProfileInputFromProfile(
+        whiteboard.profile
+      ),
+      content: whiteboard.content,
+      nameID: whiteboard.nameID,
+    };
+  }
 }


### PR DESCRIPTION
createChallenge mutation DTO extended to allow specifying the ID of the challenge to use as the base for the callouts: 

![image](https://github.com/alkem-io/server/assets/30729240/f97e3c85-ead5-4728-8e0a-7e620e52276e)

Similarly createOpportunity DTO extended to allow specifying an opportunity to copy. 

Note: only available via graphql api for now. 