### PR TITLE
Activity feed service fix

### DIFF
--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -18,6 +18,7 @@ import {
   CredentialMap,
   groupCredentialsByEntity,
 } from '@services/api/roles/util/group.credentials.by.entity';
+import { ICollaboration } from '@domain/collaboration/collaboration';
 
 type ActivityFeedFilters = {
   types?: Array<ActivityEventType>;
@@ -163,6 +164,7 @@ export class ActivityFeedService {
       const collaboration = await this.spaceService.getCollaborationOrFail(
         spaceId
       );
+      let childCollaborations: ICollaboration[] = [];
       try {
         this.authorizationService.grantAccessOrFail(
           agentInfo,
@@ -178,11 +180,19 @@ export class ActivityFeedService {
         );
       }
 
-      // get all child collaborations
-      const childCollaborations =
-        await this.collaborationService.getChildCollaborationsOrFail(
-          collaboration.id
+      try {
+        // get all child collaborations
+        childCollaborations =
+          await this.collaborationService.getChildCollaborationsOrFail(
+            collaboration.id
+          );
+      } catch (error) {
+        this.logger?.warn(
+          `User ${agentInfo.userID} is not able to read childCollaborations for collaboration: ${collaboration.id}`,
+          LogContext.ACTIVITY_FEED
         );
+      }
+
       // filter the child collaborations by read access
       for (const childCollaboration of childCollaborations) {
         try {

--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -163,13 +163,21 @@ export class ActivityFeedService {
       const collaboration = await this.spaceService.getCollaborationOrFail(
         spaceId
       );
-      this.authorizationService.grantAccessOrFail(
-        agentInfo,
-        collaboration.authorization,
-        AuthorizationPrivilege.READ,
-        `Collaboration activity query: ${agentInfo.email}`
-      );
-      collaborationIds.push(collaboration.id);
+      try {
+        this.authorizationService.grantAccessOrFail(
+          agentInfo,
+          collaboration.authorization,
+          AuthorizationPrivilege.READ,
+          `Collaboration activity query: ${agentInfo.email}`
+        );
+        collaborationIds.push(collaboration.id);
+      } catch (error) {
+        this.logger?.warn(
+          `User ${agentInfo.userID} is not able to read collaboration ${collaboration.id}`,
+          LogContext.ACTIVITY_FEED
+        );
+      }
+
       // get all child collaborations
       const childCollaborations =
         await this.collaborationService.getChildCollaborationsOrFail(

--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -156,7 +156,7 @@ export class ActivityFeedService {
   private async getAllAuthorizedCollaborations(
     agentInfo: AgentInfo,
     spaceIds: string[]
-  ) {
+  ): Promise<string[]> {
     const collaborationIds: string[] = [];
     for (const spaceId of spaceIds) {
       // filter the collaborations by read access


### PR DESCRIPTION
The activity feed service `getAllAuthorizedCollaborations`'s implementation is expecting Promise<string[]> but the logic returned Promise<string[] | never>.

I have altered the logic to work as expected, based on standard notation we use, and standard contracts we use. If it is `getAllAuthorizedCollaborationsOrFail`, I'd expect the behaviour observed before the fix (- the handling of the childCollaborations).