### PR TITLE
Fix recentJourneys error when there are no activities.

### DIFF
--- a/src/platform/activity/activity.service.ts
+++ b/src/platform/activity/activity.service.ts
@@ -177,7 +177,7 @@ export class ActivityService {
     const collaborations: Collaboration[] = await collaborationRepository
       .createQueryBuilder('collaboration')
       .select()
-      .where('collaboration.id IN (:...ids)', { ids: collaborationIDs })
+      .where({ id: In(collaborationIDs) })
       .getMany();
 
     // Create a map of collaboration IDs to collaborations


### PR DESCRIPTION
When no activities are found the recentJourneys query throws an sql syntax error.

It is trying to use `IN ()`.