### PR TITLE
tidy up of privileges around contributions

### DIFF
--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -25,7 +25,10 @@ export const CREDENTIAL_RULE_SPACE_FILE_UPLOAD =
   'credentialRule-spaceMemberFileUpload';
 export const CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY =
   'credentialRule-contributionCreatedBy';
+export const CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY_DELETE =
+  'credentialRule-contributionCreatedByDelete';
 export const CREDENTIAL_RULE_POST_CREATED_BY = 'credentialRule-postCreatedBy';
+export const CREDENTIAL_RULE_LINK_CREATED_BY = 'credentialRule-linkCreatedBy';
 export const CREDENTIAL_RULE_POST_ADMINS_MOVE = 'credentialRule-postAdminsMove';
 export const CREDENTIAL_RULE_CONTRIBUTION_ADMINS_MOVE =
   'credentialRule-contributionAdminsMove';

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
@@ -15,6 +15,7 @@ import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
 import {
   CREDENTIAL_RULE_CONTRIBUTION_ADMINS_MOVE,
   CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY,
+  CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY_DELETE,
 } from '@common/constants';
 import { LinkAuthorizationService } from '../link/link.service.authorization';
 
@@ -78,7 +79,8 @@ export class CalloutContributionAuthorizationService {
       contribution.link =
         await this.linkAuthorizationService.applyAuthorizationPolicy(
           contribution.link,
-          contribution.authorization
+          contribution.authorization,
+          contribution.createdBy
         );
     }
 
@@ -99,13 +101,12 @@ export class CalloutContributionAuthorizationService {
     const newRules: IAuthorizationPolicyRuleCredential[] = [];
 
     if (contribution.createdBy) {
-      const manageCreatedPostPolicy =
+      const manageContributionPolicy =
         this.authorizationPolicyService.createCredentialRule(
           [
             AuthorizationPrivilege.CREATE,
             AuthorizationPrivilege.READ,
             AuthorizationPrivilege.UPDATE,
-            AuthorizationPrivilege.DELETE,
           ],
           [
             {
@@ -115,7 +116,21 @@ export class CalloutContributionAuthorizationService {
           ],
           CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY
         );
-      newRules.push(manageCreatedPostPolicy);
+      newRules.push(manageContributionPolicy);
+
+      const manageContributionDeletePolicy =
+        this.authorizationPolicyService.createCredentialRule(
+          [AuthorizationPrivilege.DELETE],
+          [
+            {
+              type: AuthorizationCredential.USER_SELF_MANAGEMENT,
+              resourceID: contribution.createdBy,
+            },
+          ],
+          CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY_DELETE
+        );
+      manageContributionDeletePolicy.cascade = false; // do not cascade delete to children
+      newRules.push(manageContributionDeletePolicy);
     }
 
     // Allow space admins to move post

--- a/src/domain/collaboration/post/post.service.authorization.ts
+++ b/src/domain/collaboration/post/post.service.authorization.ts
@@ -94,12 +94,7 @@ export class PostAuthorizationService {
 
     const manageCreatedPostPolicy =
       this.authorizationPolicyService.createCredentialRule(
-        [
-          AuthorizationPrivilege.CREATE,
-          AuthorizationPrivilege.READ,
-          AuthorizationPrivilege.UPDATE,
-          AuthorizationPrivilege.DELETE,
-        ],
+        [AuthorizationPrivilege.DELETE],
         [
           {
             type: AuthorizationCredential.USER_SELF_MANAGEMENT,

--- a/src/domain/common/whiteboard-rt/whiteboard.rt.service.authorization.ts
+++ b/src/domain/common/whiteboard-rt/whiteboard.rt.service.authorization.ts
@@ -85,9 +85,6 @@ export class WhiteboardRtAuthorizationService {
       const manageWhiteboardCreatedByPolicy =
         this.authorizationPolicyService.createCredentialRule(
           [
-            AuthorizationPrivilege.CREATE,
-            AuthorizationPrivilege.READ,
-            AuthorizationPrivilege.UPDATE,
             AuthorizationPrivilege.UPDATE_CONTENT,
             AuthorizationPrivilege.CONTRIBUTE,
             AuthorizationPrivilege.DELETE,


### PR DESCRIPTION
Related to who created the contribution.

At Contribution level:
- privileges assigned cascading: C, R, U 
- privileges assigned NOT cascading: D

At link level:
- add in the D privilege before cascading to Profile

At Post level
- add in the D privilege *after* cascading to Comments but before cascading to Profile

At WhiteboardRt:
- removed C, R, U as that is now inherited from 