### PR TITLE
Magic number fix

### DIFF
--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -65,7 +65,7 @@ export class MeService {
   ): Promise<MyJourneyResults[]> {
     const rawActivities = await this.activityService.getMyJourneysActivity(
       agentInfo.userID,
-      limit * 2
+      limit * 2 //magic number, should not be needed. toDo Fix in https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/gh/alkem-io/server/3626
     );
 
     const myJourneyResults: MyJourneyResults[] = [];

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -65,7 +65,7 @@ export class MeService {
   ): Promise<MyJourneyResults[]> {
     const rawActivities = await this.activityService.getMyJourneysActivity(
       agentInfo.userID,
-      limit
+      limit * 2
     );
 
     const myJourneyResults: MyJourneyResults[] = [];
@@ -87,6 +87,6 @@ export class MeService {
       });
     }
 
-    return myJourneyResults;
+    return myJourneyResults.slice(0, limit);
   }
 }


### PR DESCRIPTION
This is not a trivial problem as:
- the issue arises when data needed to construct an activity is missing
- the search for N latest algorithm is optimized for N `RAW` activities
- to construct an activity that can be visualized from a raw data, you need data integrity + more data queried
- this data is sometimes missing (e.g. a `Callout` was deleted

There is no way to both optimize the algorithm and fetch the right amount of data. I have added a magic number fetching twice as much data and then slicing second time, but even that is not 100% guaranteed to work. It is a tradeoff stability vs performance, which should be ok for most cases...