### PR TITLE
Removed redundant code, blocking callout delete

### DIFF
--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -155,11 +155,6 @@ export class CalloutFramingService {
       );
     }
 
-    if (calloutFraming.whiteboard) {
-      await this.whiteboardService.deleteWhiteboard(
-        calloutFraming.whiteboard.id
-      );
-    }
     if (calloutFraming.authorization) {
       await this.authorizationPolicyService.delete(
         calloutFraming.authorization


### PR DESCRIPTION
Duplicated code left after the wb unification, causing failure when deleting a callout