### PR TITLE
Alternative redirects post registration for oidc / password flows

### DIFF
--- a/.build/ory/kratos/kratos.yml
+++ b/.build/ory/kratos/kratos.yml
@@ -65,7 +65,7 @@ selfservice:
       enabled: true
       ui_url: http://localhost:3000/verify
       after:
-        default_browser_return_url: http://localhost:3000/verify/success
+        default_browser_return_url: http://localhost:3000/login
 
     logout:
       after:
@@ -87,6 +87,7 @@ selfservice:
         password:
           default_browser_return_url: http://localhost:3000/registration/success
         oidc:
+          default_browser_return_url: http://localhost:3000
           hooks:
             - hook: session
 


### PR DESCRIPTION
- stay on main dashboard if registered via OIDC
- go to login screen if verified with Password flow
- goes with `infra-ops-765` client branch