### PR TITLE
InnovationFlow: update single state + keep existing callouts, validation

### DIFF
--- a/src/common/enums/logging.context.ts
+++ b/src/common/enums/logging.context.ts
@@ -55,4 +55,5 @@ export enum LogContext {
   TASKS = 'tasks',
   LICENSE = 'license',
   LOCAL_STORAGE = 'local-storage',
+  INNOVATION_FLOW = 'innovation-flow',
 }

--- a/src/core/validation/handlers/base/base.handler.ts
+++ b/src/core/validation/handlers/base/base.handler.ts
@@ -63,7 +63,7 @@ import {
 import { VisualUploadImageInput } from '@domain/common/visual/dto/visual.dto.upload.image';
 import { CreateInvitationExistingUserOnCommunityInput } from '@domain/community/community/dto/community.dto.invite.existing.user';
 import { CreateInvitationExternalUserOnCommunityInput } from '@domain/community/community/dto/community.dto.invite.external.user';
-import { UpdateInnovationFlowInput } from '@domain/collaboration/innovation-flow';
+import { UpdateInnovationFlowInput } from '@domain/collaboration/innovation-flow/dto';
 import {
   CreateCalloutFramingInput,
   UpdateCalloutFramingInput,

--- a/src/domain/challenge/challenge/dto/challenge.dto.update.ts
+++ b/src/domain/challenge/challenge/dto/challenge.dto.update.ts
@@ -1,6 +1,6 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { UpdateBaseChallengeInput } from '@domain/challenge/base-challenge/base.challenge.dto.update';
-import { UpdateInnovationFlowInput } from '@domain/collaboration/innovation-flow';
+import { UpdateInnovationFlowInput } from '@domain/collaboration/innovation-flow/dto';
 import { IsOptional, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 

--- a/src/domain/challenge/space.defaults/space.defaults.service.ts
+++ b/src/domain/challenge/space.defaults/space.defaults.service.ts
@@ -14,7 +14,7 @@ import { InnovationFlowTemplateService } from '@domain/template/innovation-flow-
 import { ITemplatesSet } from '@domain/template/templates-set';
 import { TemplatesSetService } from '@domain/template/templates-set/templates.set.service';
 import { IInnovationFlowTemplate } from '@domain/template/innovation-flow-template/innovation.flow.template.interface';
-import { CreateInnovationFlowInput } from '@domain/collaboration/innovation-flow';
+import { CreateInnovationFlowInput } from '@domain/collaboration/innovation-flow/dto';
 import { templatesSetDefaults } from './definitions/space.defaults.templates';
 import { innovationFlowStatesDefault } from './definitions/space.defaults.innovation.flow';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';

--- a/src/domain/collaboration/innovation-flow-states/innovaton.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-states/innovaton.flow.state.service.ts
@@ -31,7 +31,7 @@ export class InnovationFlowStatesService {
   public validateDefinition(states: IInnovationFlowState[]) {
     if (states.length === 0) {
       throw new ValidationException(
-        `At least one state must be definede: ${states}`,
+        `At least one state must be defined: ${states}`,
         LogContext.INNOVATION_FLOW
       );
     }

--- a/src/domain/collaboration/innovation-flow-states/innovaton.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-states/innovaton.flow.state.service.ts
@@ -1,6 +1,8 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { IInnovationFlowState } from './innovation.flow.state.interface';
+import { ValidationException } from '@common/exceptions';
+import { LogContext } from '@common/enums';
 
 @Injectable()
 export class InnovationFlowStatesService {
@@ -24,5 +26,22 @@ export class InnovationFlowStatesService {
 
   private deserializeStates(statesStr: string): IInnovationFlowState[] {
     return JSON.parse(statesStr);
+  }
+
+  public validateDefinition(states: IInnovationFlowState[]) {
+    if (states.length === 0) {
+      throw new ValidationException(
+        `At least one state must be definede: ${states}`,
+        LogContext.INNOVATION_FLOW
+      );
+    }
+    const stateNames = states.map(state => state.displayName);
+    const uniqueStateNames = new Set(stateNames);
+    if (uniqueStateNames.size !== stateNames.length) {
+      throw new ValidationException(
+        `State names must be unique: ${stateNames}`,
+        LogContext.INNOVATION_FLOW
+      );
+    }
   }
 }

--- a/src/domain/collaboration/innovation-flow/dto/index.ts
+++ b/src/domain/collaboration/innovation-flow/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './innovation.flow.dto.update';
+export * from './innovation.flow.dto.create';

--- a/src/domain/collaboration/innovation-flow/dto/innovation.flow.dto.update.single.state.ts
+++ b/src/domain/collaboration/innovation-flow/dto/innovation.flow.dto.update.single.state.ts
@@ -1,0 +1,27 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { MaxLength, ValidateNested } from 'class-validator';
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { Type } from 'class-transformer';
+import { SMALL_TEXT_LENGTH } from '@common/constants';
+import { UpdateInnovationFlowStateInput } from '@domain/collaboration/innovation-flow-states/dto/innovation.flow.state.dto.update';
+
+@InputType()
+export class UpdateInnovationFlowSingleStateInput {
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'ID of the Innovation Flow',
+  })
+  innovationFlowID!: string;
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'The name of the Innovation Flow State to be updated',
+  })
+  @MaxLength(SMALL_TEXT_LENGTH)
+  stateDisplayName!: string;
+
+  @Field(() => UpdateInnovationFlowStateInput, { nullable: false })
+  @ValidateNested({ each: true })
+  @Type(() => UpdateInnovationFlowStateInput)
+  stateUpdatedData!: UpdateInnovationFlowStateInput;
+}

--- a/src/domain/collaboration/innovation-flow/index.ts
+++ b/src/domain/collaboration/innovation-flow/index.ts
@@ -1,2 +1,0 @@
-export * from './dto/innovation.flow.dto.update';
-export * from './dto/innovation.flow.dto.create';

--- a/src/domain/collaboration/innovation-flow/innovaton.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovaton.flow.service.ts
@@ -110,6 +110,9 @@ export class InnovationFlowService {
     );
 
     if (innovationFlowData.states) {
+      this.innovationFlowStatesService.validateDefinition(
+        innovationFlowData.states
+      );
       const newStateNames = innovationFlowData.states.map(
         state => state.displayName
       );
@@ -251,6 +254,9 @@ export class InnovationFlowService {
       }
       newStates.push(state);
     }
+    // Check that the new states setup is valid
+    this.innovationFlowStatesService.validateDefinition(newStates);
+
     innovationFlow.states =
       this.innovationFlowStatesService.serializeStates(newStates);
 

--- a/src/domain/collaboration/innovation-flow/innovaton.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovaton.flow.service.ts
@@ -254,6 +254,9 @@ export class InnovationFlowService {
     innovationFlow.states =
       this.innovationFlowStatesService.serializeStates(newStates);
 
+    // Save with new states before updating selected values
+    await this.innovationFlowRepository.save(innovationFlow);
+
     // Now update the selected state
 
     const statesTagset = await this.profileService.getTagset(

--- a/src/domain/common/profile/dto/profile.dto.update.select.tagset.definition.ts
+++ b/src/domain/common/profile/dto/profile.dto.update.select.tagset.definition.ts
@@ -6,4 +6,8 @@ export class UpdateProfileSelectTagsetDefinitionInput {
   defaultSelectedValue?: string;
 
   allowedValues!: string[];
+
+  // To allow for updating from one value to a new one
+  oldSelectedValue?: string;
+  newSelectedValue?: string;
 }

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -407,6 +407,8 @@ export class ProfileService {
       {
         allowedValues: updateData.allowedValues,
         defaultSelectedValue: updateData.defaultSelectedValue,
+        newSelectedValue: updateData.newSelectedValue,
+        oldSelectedValue: updateData.oldSelectedValue,
       }
     );
 

--- a/src/domain/common/tagset-template/dto/tagset.template.dto.update.ts
+++ b/src/domain/common/tagset-template/dto/tagset.template.dto.update.ts
@@ -2,4 +2,7 @@ export class UpdateTagsetTemplateDefinitionInput {
   allowedValues!: string[];
 
   defaultSelectedValue?: string;
+
+  oldSelectedValue?: string;
+  newSelectedValue?: string;
 }

--- a/src/domain/template/innovation-flow-template/innovation.flow.template.service.ts
+++ b/src/domain/template/innovation-flow-template/innovation.flow.template.service.ts
@@ -25,6 +25,9 @@ export class InnovationFlowTemplateService {
     innovationFlowTemplateData: CreateInnovationFlowTemplateInput,
     storageAggregator: IStorageAggregator
   ): Promise<IInnovationFlowTemplate> {
+    this.innovationFlowStatesService.validateDefinition(
+      innovationFlowTemplateData.states
+    );
     const innovationFlowTemplate: IInnovationFlowTemplate =
       new InnovationFlowTemplate();
     await this.templateBaseService.initialise(
@@ -77,6 +80,9 @@ export class InnovationFlowTemplateService {
       innovationFlowTemplateData
     );
     if (innovationFlowTemplateData.states) {
+      this.innovationFlowStatesService.validateDefinition(
+        innovationFlowTemplateData.states
+      );
       innovationFlowTemplate.states =
         this.innovationFlowStatesService.serializeStates(
           innovationFlowTemplateData.states


### PR DESCRIPTION
New mutation to allow updating a single state in an innovation flow, and importantly not resetting all existing callouts in that state to the default state.

Added validation to check the set of state names is unique, and test for this when updating the set of state defintions, single state, template etc. 