### PR TITLE
Revoke profile URL cache when moving callout contribution

### DIFF
--- a/src/domain/collaboration/callout-contribution/callout.contribution.move.module.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.move.module.ts
@@ -8,6 +8,7 @@ import { CalloutModule } from '../callout/callout.module';
 import { CalloutContributionMoveService } from './callout.contribution.move.service';
 import { CalloutContributionMoveResolverMutations } from './callout.contribution.move.resolver.mutations';
 import { CalloutContributionModule } from './callout.contribution.module';
+import { UrlGeneratorModule } from '@services/infrastructure/url-generator';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { CalloutContributionModule } from './callout.contribution.module';
     AuthorizationModule,
     EntityResolverModule,
     CalloutContributionModule,
+    UrlGeneratorModule,
     TypeOrmModule.forFeature([CalloutContribution, Callout]),
   ],
   providers: [

--- a/src/services/infrastructure/url-generator/url.generator.service.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.ts
@@ -65,6 +65,10 @@ export class UrlGeneratorService {
     );
   }
 
+  public async revokeUrlCache(entityId: string): Promise<void> {
+    await this.cacheManager.del(this.getUrlIdCacheKey(entityId));
+  }
+
   public async getUrlFromCache(entityId: string): Promise<string | undefined> {
     const url = await this.cacheManager.get<string>(
       this.getUrlIdCacheKey(entityId)


### PR DESCRIPTION
This is a server caching issue, as we cache the ProfileURLs. Before not all those were used, but since now they are used, if we don't revoke / update the cache on changing the underlying entity, the link URL - entity breaks.