### PR TITLE
Update the deps and steps for running the server

### DIFF
--- a/docs/Running.md
+++ b/docs/Running.md
@@ -8,17 +8,18 @@ To simplify setting up the Server development environment, a pre-configured dock
 
 - Docker and docker-compose installed on x86 architecture (so not an ARM-based architecture like Raspberry pi or MacBook with M1 processor)
 - ports available on localhost:
-   - 4000 (alkemio server),
-   - 3306 (MySQL database)
-   - 8888 (traefik dashobard)
-   - 3000 (alkemio client)
-   - 8008 (synapse server)
-   - 5001 (ipfs server)
-   - 4436 (mailslurper UI)
-   - 4437 (mailslurper API)
-   - 5672 (rabbitMQ amqp)
-   - 15672 (rabbitMQ management UI)
+  - 4000 (alkemio server),
+  - 3306 (MySQL database)
+  - 8888 (traefik dashobard)
+  - 3000 (alkemio client)
+  - 8008 (synapse server)
+  - 5001 (ipfs server)
+  - 4436 (mailslurper UI)
+  - 4437 (mailslurper API)
+  - 5672 (rabbitMQ amqp)
+  - 15672 (rabbitMQ management UI)
 - Register an alkemio profile for notifications and configure it via SERVICE_ACCOUNT_USERNAME & SERVICE_ACCOUNT_PASSWORD env variables in .env.docker. The profile needs to be Global Community Admin.
+- Make sure you're using npm @8.5.5. node v16.15 is recommended (but it should work with v <21)
 
 ## Steps:
 
@@ -28,13 +29,19 @@ To simplify setting up the Server development environment, a pre-configured dock
 npm run start:services
 ```
 
-2. Start alkemio-server
+2. Run the migrations
+
+```bash
+npm run migration:run
+```
+
+3. Start alkemio-server
 
 ```bash
 npm start
 ```
 
-3. Validate that the server is running by visiting the [graphql endpoint](http://localhost:3000/graphql).
+4. Validate that the server is running by visiting the [graphql endpoint](http://localhost:3000/graphql).
 
 ## Notes
 

--- a/docs/Running.md
+++ b/docs/Running.md
@@ -13,7 +13,6 @@ To simplify setting up the Server development environment, a pre-configured dock
   - 8888 (traefik dashobard)
   - 3000 (alkemio client)
   - 8008 (synapse server)
-  - 5001 (ipfs server)
   - 4436 (mailslurper UI)
   - 4437 (mailslurper API)
   - 5672 (rabbitMQ amqp)


### PR DESCRIPTION
Updates to the documentation for Running the server were added:

- `npm` specific version was added to the prerequisites;
- additional step in the process - `npm run migration:run` - added before starting the server;

 
