### PR TITLE
add auth reset privilege to global admins on platform

### DIFF
--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -40,6 +40,8 @@ export const CREDENTIAL_RULE_TYPES_PLATFORM_GRANT_GLOBAL_ADMINS =
   'credentialRuleTypes-platformGrantGlobalAdmins';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ADMINS =
   'credentialRuleTypes-platformPlatformAdmins';
+export const CREDENTIAL_RULE_TYPES_PLATFORM_AUTH_RESET =
+  'credentialRuleTypes-platformPlatformAuthReset';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_READ_REGISTERED =
   'credentialRuleTypes-platformReadRegistered';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_CREATE_ORG_FILE_UPLOAD =

--- a/src/platform/platfrom/platform.service.authorization.ts
+++ b/src/platform/platfrom/platform.service.authorization.ts
@@ -23,6 +23,7 @@ import {
   CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE,
   CREDENTIAL_RULE_TYPES_PLATFORM_ADMINS,
   CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN,
+  CREDENTIAL_RULE_TYPES_PLATFORM_AUTH_RESET,
   CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER,
   CREDENTIAL_RULE_TYPES_PLATFORM_GRANT_GLOBAL_ADMINS,
   CREDENTIAL_RULE_TYPES_PLATFORM_READ_REGISTERED,
@@ -294,6 +295,19 @@ export class PlatformAuthorizationService {
     platformAdmin.cascade = false;
     credentialRules.push(platformAdmin);
 
+    // Allow global admin Spaces to reset auth
+    const platformResetAuth =
+      this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
+        [AuthorizationPrivilege.AUTHORIZATION_RESET],
+        [
+          AuthorizationCredential.GLOBAL_ADMIN,
+          AuthorizationCredential.GLOBAL_ADMIN_SPACES,
+        ],
+        CREDENTIAL_RULE_TYPES_PLATFORM_AUTH_RESET
+      );
+    platformAdmin.cascade = false;
+    credentialRules.push(platformResetAuth);
+
     // Allow all registered users to query non-protected user information
     const userNotInherited =
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
@@ -309,7 +323,7 @@ export class PlatformAuthorizationService {
         [AuthorizationPrivilege.CREATE_ORGANIZATION],
         [
           AuthorizationCredential.SPACE_ADMIN,
-          AuthorizationCredential.CHALLENGE_ADMIN,
+          AuthorizationCredential.SUBSPACE_ADMIN,
         ],
         CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN
       );
@@ -324,8 +338,8 @@ export class PlatformAuthorizationService {
           AuthorizationCredential.GLOBAL_ADMIN_SPACES,
           AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
           AuthorizationCredential.SPACE_ADMIN,
-          AuthorizationCredential.CHALLENGE_ADMIN,
-          AuthorizationCredential.OPPORTUNITY_ADMIN,
+          AuthorizationCredential.SUBSPACE_ADMIN,
+          AuthorizationCredential.SUBSPACE_ADMIN,
           AuthorizationCredential.ORGANIZATION_ADMIN,
         ],
         CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN

--- a/src/platform/platfrom/platform.service.authorization.ts
+++ b/src/platform/platfrom/platform.service.authorization.ts
@@ -323,7 +323,7 @@ export class PlatformAuthorizationService {
         [AuthorizationPrivilege.CREATE_ORGANIZATION],
         [
           AuthorizationCredential.SPACE_ADMIN,
-          AuthorizationCredential.SUBSPACE_ADMIN,
+          AuthorizationCredential.CHALLENGE_ADMIN,
         ],
         CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN
       );
@@ -338,8 +338,8 @@ export class PlatformAuthorizationService {
           AuthorizationCredential.GLOBAL_ADMIN_SPACES,
           AuthorizationCredential.GLOBAL_ADMIN_COMMUNITY,
           AuthorizationCredential.SPACE_ADMIN,
-          AuthorizationCredential.SUBSPACE_ADMIN,
-          AuthorizationCredential.SUBSPACE_ADMIN,
+          AuthorizationCredential.OPPORTUNITY_ADMIN,
+          AuthorizationCredential.CHALLENGE_ADMIN,
           AuthorizationCredential.ORGANIZATION_ADMIN,
         ],
         CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN


### PR DESCRIPTION
The privilege checked was recently fixed to be AUTHORIZATION_RESET (from PLATFORM_ADMIN), but this privilege was not granted:

![image](https://github.com/alkem-io/server/assets/30729240/c08de90b-0ece-433b-bc55-6e0237b3babe)
