### PR TITLE
Allow for description on innovation flow state to be left undefined

### DIFF
--- a/src/domain/collaboration/innovation-flow-states/dto/innovation.flow.state.dto.create.ts
+++ b/src/domain/collaboration/innovation-flow-states/dto/innovation.flow.state.dto.create.ts
@@ -1,5 +1,5 @@
 export class CreateInnovationFlowStateInput {
   displayName!: string;
 
-  description!: string;
+  description?: string;
 }

--- a/src/domain/collaboration/innovation-flow-states/dto/innovation.flow.state.dto.update.ts
+++ b/src/domain/collaboration/innovation-flow-states/dto/innovation.flow.state.dto.update.ts
@@ -13,9 +13,9 @@ export class UpdateInnovationFlowStateInput {
   displayName!: string;
 
   @Field(() => Markdown, {
-    nullable: false,
+    nullable: true,
     description: 'The explation text to clarify the State.',
   })
   @MaxLength(LONG_TEXT_LENGTH)
-  description!: string;
+  description?: string;
 }

--- a/src/domain/collaboration/innovation-flow-states/innovaton.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-states/innovaton.flow.state.service.ts
@@ -3,6 +3,8 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { IInnovationFlowState } from './innovation.flow.state.interface';
 import { ValidationException } from '@common/exceptions';
 import { LogContext } from '@common/enums';
+import { CreateInnovationFlowStateInput } from './dto/innovation.flow.state.dto.create';
+import { UpdateInnovationFlowStateInput } from './dto/innovation.flow.state.dto.update';
 
 @Injectable()
 export class InnovationFlowStatesService {
@@ -28,7 +30,24 @@ export class InnovationFlowStatesService {
     return JSON.parse(statesStr);
   }
 
-  public validateDefinition(states: IInnovationFlowState[]) {
+  public convertInputsToStates(
+    statesInput:
+      | CreateInnovationFlowStateInput[]
+      | UpdateInnovationFlowStateInput[]
+  ): IInnovationFlowState[] {
+    const result: IInnovationFlowState[] = [];
+    for (const stateInput of statesInput) {
+      const state: IInnovationFlowState = {
+        displayName: stateInput.displayName,
+        description: stateInput.description || '',
+      };
+      result.push(state);
+    }
+    return result;
+  }
+  public validateDefinition(
+    states: CreateInnovationFlowStateInput[] | UpdateInnovationFlowStateInput[]
+  ) {
     if (states.length === 0) {
       throw new ValidationException(
         `At least one state must be defined: ${states}`,

--- a/src/domain/collaboration/innovation-flow/innovaton.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovaton.flow.service.ts
@@ -88,9 +88,12 @@ export class InnovationFlowService {
       VisualType.CARD
     );
 
-    innovationFlow.states = this.innovationFlowStatesService.serializeStates(
-      innovationFlowData.states
-    );
+    const convertedStates =
+      this.innovationFlowStatesService.convertInputsToStates(
+        innovationFlowData.states
+      );
+    innovationFlow.states =
+      this.innovationFlowStatesService.serializeStates(convertedStates);
 
     return await this.innovationFlowRepository.save(innovationFlow);
   }
@@ -126,10 +129,13 @@ export class InnovationFlowService {
       };
       await this.profileService.updateSelectTagsetDefinition(updateData);
 
+      const convertedStates =
+        this.innovationFlowStatesService.convertInputsToStates(
+          innovationFlowData.states
+        );
       // serialize the states
-      innovationFlow.states = this.innovationFlowStatesService.serializeStates(
-        innovationFlowData.states
-      );
+      innovationFlow.states =
+        this.innovationFlowStatesService.serializeStates(convertedStates);
     }
 
     if (innovationFlowData.profileData) {
@@ -250,7 +256,7 @@ export class InnovationFlowService {
     for (const state of states) {
       if (state.displayName === updateData.stateDisplayName) {
         state.displayName = updateData.stateUpdatedData.displayName;
-        state.description = updateData.stateUpdatedData.description;
+        state.description = updateData.stateUpdatedData.description || '';
       }
       newStates.push(state);
     }

--- a/src/domain/template/innovation-flow-template/innovation.flow.template.service.ts
+++ b/src/domain/template/innovation-flow-template/innovation.flow.template.service.ts
@@ -37,10 +37,13 @@ export class InnovationFlowTemplateService {
       storageAggregator
     );
 
-    innovationFlowTemplate.states =
-      this.innovationFlowStatesService.serializeStates(
+    const convertedStates =
+      this.innovationFlowStatesService.convertInputsToStates(
         innovationFlowTemplateData.states
       );
+
+    innovationFlowTemplate.states =
+      this.innovationFlowStatesService.serializeStates(convertedStates);
 
     return await this.innovationFlowTemplateRepository.save(
       innovationFlowTemplate
@@ -83,10 +86,12 @@ export class InnovationFlowTemplateService {
       this.innovationFlowStatesService.validateDefinition(
         innovationFlowTemplateData.states
       );
-      innovationFlowTemplate.states =
-        this.innovationFlowStatesService.serializeStates(
+      const convertedStates =
+        this.innovationFlowStatesService.convertInputsToStates(
           innovationFlowTemplateData.states
         );
+      innovationFlowTemplate.states =
+        this.innovationFlowStatesService.serializeStates(convertedStates);
     }
 
     return await this.innovationFlowTemplateRepository.save(


### PR DESCRIPTION
The api now allows for the description on an innovation flow state to not be specified.

The client may also need updating?