### PR TITLE
smarter generation of nameIDs 

### DIFF
--- a/src/core/bootstrap/bootstrap.service.ts
+++ b/src/core/bootstrap/bootstrap.service.ts
@@ -178,10 +178,9 @@ export class BootstrapService {
           userData.email
         );
         if (!userExists) {
-          const nameID = this.userService.createUserNameID(
+          const nameID = await this.userService.createUserNameID(
             userData.firstName,
-            userData.lastName,
-            false
+            userData.lastName
           );
           let user = await this.userService.createUser({
             nameID: nameID,

--- a/src/domain/collaboration/callout-contribution/callout.contribution.move.module.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.move.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Callout } from '@domain/collaboration/callout';
 import { AuthorizationModule } from '@core/authorization/authorization.module';
-import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
 import { CalloutContribution } from './callout.contribution.entity';
 import { CalloutModule } from '../callout/callout.module';
 import { CalloutContributionMoveService } from './callout.contribution.move.service';
@@ -14,7 +13,6 @@ import { UrlGeneratorModule } from '@services/infrastructure/url-generator';
   imports: [
     CalloutModule,
     AuthorizationModule,
-    EntityResolverModule,
     CalloutContributionModule,
     UrlGeneratorModule,
     TypeOrmModule.forFeature([CalloutContribution, Callout]),

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -10,7 +10,6 @@ import { LogContext } from '@common/enums/logging.context';
 import { UUID_LENGTH } from '@common/constants/entity.field.length.constants';
 import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
 import { IWhiteboard } from '@domain/common/whiteboard/types';
-import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { PostService } from '../post/post.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IPost } from '../post';
@@ -28,7 +27,6 @@ export class CalloutContributionService {
     private postService: PostService,
     private whiteboardService: WhiteboardService,
     private linkService: LinkService,
-    private namingService: NamingService,
     @InjectRepository(CalloutContribution)
     private contributionRepository: Repository<CalloutContribution>
   ) {}
@@ -52,9 +50,6 @@ export class CalloutContributionService {
         contributionPolicy,
         CalloutContributionType.WHITEBOARD
       );
-      whiteboard.nameID = this.namingService.createNameID(
-        `${whiteboard.profileData.displayName}`
-      );
       contribution.whiteboard = await this.whiteboardService.createWhiteboard(
         whiteboard,
         storageAggregator,
@@ -67,9 +62,7 @@ export class CalloutContributionService {
         contributionPolicy,
         CalloutContributionType.POST
       );
-      post.nameID =
-        post.nameID ??
-        this.namingService.createNameID(`${post.profileData.displayName}`);
+
       contribution.post = await this.postService.createPost(
         post,
         storageAggregator,

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -74,24 +74,12 @@ export class CalloutFramingService {
     );
 
     if (whiteboard) {
-      whiteboard.nameID = this.namingService.createNameID(
-        `${whiteboard.profileData.displayName}`
-      );
-      calloutFraming.whiteboard = await this.whiteboardService.createWhiteboard(
-        whiteboard,
-        storageAggregator,
-        userID
-      );
-      await this.profileService.addVisualOnProfile(
-        calloutFraming.whiteboard.profile,
-        VisualType.BANNER
-      );
-    }
-
-    if (whiteboard) {
-      whiteboard.nameID = this.namingService.createNameID(
-        `${whiteboard.profileData.displayName}`
-      );
+      const reservedNameIDs: string[] = []; // no reserved nameIDs for framing
+      whiteboard.nameID =
+        this.namingService.createNameIdAvoidingReservedNameIDs(
+          `${whiteboard.profileData.displayName}`,
+          reservedNameIDs
+        );
       calloutFraming.whiteboard = await this.whiteboardService.createWhiteboard(
         whiteboard,
         storageAggregator,

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -383,21 +383,23 @@ export class CollaborationService {
         );
     }
 
+    const reservedNameIDs =
+      await this.namingService.getReservedNameIDsInCollaboration(
+        collaboration.id
+      );
     if (calloutData.nameID && calloutData.nameID.length > 0) {
-      const nameAvailable =
-        await this.namingService.isCalloutNameIdAvailableInCollaboration(
-          calloutData.nameID,
-          collaboration.id
-        );
-      if (!nameAvailable)
+      const nameIdAlreadyTaken = reservedNameIDs.includes(calloutData.nameID);
+      if (nameIdAlreadyTaken)
         throw new ValidationException(
           `Unable to create Callout: the provided nameID is already taken: ${calloutData.nameID}`,
           LogContext.SPACES
         );
     } else {
-      calloutData.nameID = this.namingService.createNameID(
-        `${calloutData.framing.profile.displayName}`
-      );
+      calloutData.nameID =
+        this.namingService.createNameIdAvoidingReservedNameIDs(
+          `${calloutData.framing.profile.displayName}`,
+          reservedNameIDs
+        );
     }
 
     const displayNameAvailable =

--- a/src/domain/communication/communication/communication.module.ts
+++ b/src/domain/communication/communication/communication.module.ts
@@ -27,6 +27,7 @@ import { StorageAggregatorResolverModule } from '@services/infrastructure/storag
     CommunicationAdapterModule,
     CommunicationAdapterModule,
     EntityResolverModule,
+    NamingModule,
     PlatformAuthorizationPolicyModule,
     StorageAggregatorResolverModule,
     NamingModule,

--- a/src/domain/communication/communication/communication.service.ts
+++ b/src/domain/communication/communication/communication.service.ts
@@ -27,6 +27,7 @@ import { COMMUNICATION_PLATFORM_SPACEID } from '@common/constants';
 import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
 import { DiscussionsOrderBy } from '@common/enums/discussions.orderBy';
 import { Discussion } from '../discussion/discussion.entity';
+import { NamingService } from '@services/infrastructure/naming/naming.service';
 
 @Injectable()
 export class CommunicationService {
@@ -35,6 +36,7 @@ export class CommunicationService {
     private roomService: RoomService,
     private communicationAdapter: CommunicationAdapter,
     private storageAggregatorResolverService: StorageAggregatorResolverService,
+    private namingService: NamingService,
     @InjectRepository(Communication)
     private communicationRepository: Repository<Communication>,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
@@ -100,6 +102,15 @@ export class CommunicationService {
     const storageAggregator =
       await this.storageAggregatorResolverService.getStorageAggregatorForCommunication(
         communication.id
+      );
+    const reservedNameIDs =
+      await this.namingService.getReservedNameIDsInCommunication(
+        communication.id
+      );
+    discussionData.nameID =
+      this.namingService.createNameIdAvoidingReservedNameIDs(
+        `${discussionData.profile.displayName}`,
+        reservedNameIDs
       );
     const discussion = await this.discussionService.createDiscussion(
       discussionData,

--- a/src/domain/communication/communication/dto/communication.dto.create.discussion.ts
+++ b/src/domain/communication/communication/dto/communication.dto.create.discussion.ts
@@ -29,4 +29,6 @@ export class CommunicationCreateDiscussionInput {
   @Field(() => [String], { nullable: true })
   @IsOptional()
   tags?: string[];
+
+  nameID?: string;
 }

--- a/src/domain/communication/discussion/discussion.module.ts
+++ b/src/domain/communication/discussion/discussion.module.ts
@@ -4,7 +4,6 @@ import { ProfileModule } from '@domain/common/profile/profile.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommunicationAdapterModule } from '@services/adapters/communication-adapter/communication-adapter.module';
-import { NamingModule } from '@services/infrastructure/naming/naming.module';
 import { RoomModule } from '../room/room.module';
 import { Discussion } from './discussion.entity';
 import { DiscussionResolverFields } from './discussion.resolver.fields';
@@ -21,7 +20,6 @@ import { NotificationAdapterModule } from '@services/adapters/notification-adapt
     AuthorizationModule,
     AuthorizationPolicyModule,
     ProfileModule,
-    NamingModule,
     NotificationAdapterModule,
   ],
   providers: [

--- a/src/domain/communication/discussion/discussion.service.ts
+++ b/src/domain/communication/discussion/discussion.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { FindOneOptions, FindOptionsRelations, Repository } from 'typeorm';
 import { EntityNotFoundException } from '@common/exceptions';
 import { LogContext, ProfileType } from '@common/enums';
@@ -10,9 +11,7 @@ import { DeleteDiscussionInput } from './dto/discussion.dto.delete';
 import { RoomService } from '../room/room.service';
 import { CommunicationCreateDiscussionInput } from '../communication/dto/communication.dto.create.discussion';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ProfileService } from '@domain/common/profile/profile.service';
-import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { UUID_LENGTH } from '@common/constants/entity.field.length.constants';
 import { IRoom } from '../room/room.interface';
 import { RoomType } from '@common/enums/room.type';
@@ -27,7 +26,6 @@ export class DiscussionService {
     private discussionRepository: Repository<Discussion>,
     private profileService: ProfileService,
     private roomService: RoomService,
-    private namingService: NamingService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
@@ -38,14 +36,7 @@ export class DiscussionService {
     roomType: RoomType,
     storageAggregator: IStorageAggregator
   ): Promise<IDiscussion> {
-    const discussionNameID = this.namingService.createNameID(
-      `${discussionData.profile.displayName}`
-    );
-    const discussionCreationData = {
-      ...discussionData,
-      nameID: discussionNameID,
-    };
-    const discussion: IDiscussion = Discussion.create(discussionCreationData);
+    const discussion: IDiscussion = Discussion.create(discussionData);
     discussion.profile = await this.profileService.createProfile(
       discussionData.profile,
       ProfileType.DISCUSSION,

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -301,8 +301,12 @@ export class UserService {
       agentInfo.avatarURL
     );
 
+    const nameID = await this.createUserNameID(
+      agentInfo.firstName,
+      agentInfo.lastName
+    );
     let user = await this.createUser({
-      nameID: this.createUserNameID(agentInfo.firstName, agentInfo.lastName),
+      nameID,
       email: email,
       firstName: agentInfo.firstName,
       lastName: agentInfo.lastName,
@@ -921,13 +925,17 @@ export class UserService {
     return directRooms;
   }
 
-  createUserNameID(
+  public async createUserNameID(
     firstName: string,
-    lastName: string,
-    useRandomSuffix = true
-  ): string {
+    lastName: string
+  ): Promise<string> {
     const base = `${firstName}-${lastName}`;
-    return this.namingService.createNameID(base, useRandomSuffix);
+    const reservedNameIDs =
+      await this.namingService.getReservedNameIDsInUsers(); // This will need to be smarter later
+    return this.namingService.createNameIdAvoidingReservedNameIDs(
+      base,
+      reservedNameIDs
+    );
   }
 
   async findProfilesByBatch(userIds: string[]): Promise<(IProfile | Error)[]> {

--- a/src/domain/innovation-hub/innovation.hub.service.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.ts
@@ -54,20 +54,20 @@ export class InnovationHubService {
         LogContext.INNOVATION_HUB
       );
 
+    const reservedNameIDs = await this.namingService.getReservedNameIDsInHubs();
     if (createData.nameID && createData.nameID.length > 0) {
-      const nameAvailable =
-        await this.namingService.isInnovationHubNameIdAvailable(
-          createData.nameID
-        );
-      if (!nameAvailable)
+      const nameTaken = reservedNameIDs.includes(createData.nameID);
+      if (nameTaken)
         throw new ValidationException(
           `Unable to create Innovation Hub: the provided nameID is already taken: ${createData.nameID}`,
           LogContext.INNOVATION_HUB
         );
     } else {
-      createData.nameID = this.namingService.createNameID(
-        `${createData.profileData.displayName}`
-      );
+      createData.nameID =
+        this.namingService.createNameIdAvoidingReservedNameIDs(
+          `${createData.profileData.displayName}`,
+          reservedNameIDs
+        );
     }
 
     const hub: IInnovationHub = InnovationHub.create(createData);
@@ -109,9 +109,10 @@ export class InnovationHubService {
 
     if (input.nameID) {
       if (input.nameID !== innovationHub.nameID) {
-        const updateAllowed =
-          await this.namingService.isInnovationHubNameIdAvailable(input.nameID);
-        if (!updateAllowed) {
+        const reservedNameIDs =
+          await this.namingService.getReservedNameIDsInHubs();
+        const nameTaken = reservedNameIDs.includes(input.nameID);
+        if (nameTaken) {
           throw new ValidationException(
             `Unable to update Innovation Hub nameID: the provided nameID '${input.nameID}' is already taken`,
             LogContext.INNOVATION_HUB

--- a/src/domain/space/account/account.module.ts
+++ b/src/domain/space/account/account.module.ts
@@ -17,6 +17,7 @@ import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platf
 import { NameReporterModule } from '@services/external/elasticsearch/name-reporter/name.reporter.module';
 import { InnovationFlowTemplateModule } from '@domain/template/innovation-flow-template/innovation.flow.template.module';
 import { AccountResolverQueries } from './account.resolver.queries';
+import { NamingModule } from '@services/infrastructure/naming/naming.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { AccountResolverQueries } from './account.resolver.queries';
     PlatformAuthorizationPolicyModule,
     InnovationFlowTemplateModule,
     LicenseModule,
+    NamingModule,
     NameReporterModule,
     TypeOrmModule.forFeature([Account]),
   ],

--- a/src/domain/timeline/calendar/calendar.service.ts
+++ b/src/domain/timeline/calendar/calendar.service.ts
@@ -113,20 +113,21 @@ export class CalendarService {
         `Calendar (${calendar}) not initialised`,
         LogContext.CALENDAR
       );
-
+    const reservedNameIDs =
+      await this.namingService.getReservedNameIDsInCalendar(calendar.id);
     if (calendarEventData.nameID && calendarEventData.nameID.length > 0) {
-      const eventWithNameID = calendar.events.find(
-        e => e.nameID === calendarEventData.nameID
-      );
-      if (eventWithNameID)
+      const nameTaken = reservedNameIDs.includes(calendarEventData.nameID);
+      if (nameTaken)
         throw new ValidationException(
           `Unable to create CalendarEvent: the provided nameID is already taken: ${calendarEventData.nameID}`,
           LogContext.CALENDAR
         );
     } else {
-      calendarEventData.nameID = this.namingService.createNameID(
-        `${calendarEventData.profileData?.displayName}`
-      );
+      calendarEventData.nameID =
+        this.namingService.createNameIdAvoidingReservedNameIDs(
+          `${calendarEventData.profileData?.displayName}`,
+          reservedNameIDs
+        );
     }
 
     const storageAggregator =

--- a/src/library/library/library.service.ts
+++ b/src/library/library/library.service.ts
@@ -86,19 +86,21 @@ export class LibraryService {
         LogContext.LIBRARY
       );
 
+    const reservedNameIDs =
+      await this.namingService.getReservedNameIDsInLibrary(library.id);
     if (innovationPackData.nameID && innovationPackData.nameID.length > 0) {
-      const nameAvailable = await this.innovationPackService.isNameIdAvailable(
-        innovationPackData.nameID
-      );
-      if (!nameAvailable)
+      const nameTaken = reservedNameIDs.includes(innovationPackData.nameID);
+      if (nameTaken)
         throw new ValidationException(
           `Unable to create InnovationPack: the provided nameID is already taken: ${innovationPackData.nameID}`,
           LogContext.LIBRARY
         );
     } else {
-      innovationPackData.nameID = this.namingService.createNameID(
-        `${innovationPackData.profileData.displayName}`
-      );
+      innovationPackData.nameID =
+        this.namingService.createNameIdAvoidingReservedNameIDs(
+          `${innovationPackData.profileData.displayName}`,
+          reservedNameIDs
+        );
     }
 
     const innovationPack =

--- a/src/services/api/conversion/conversion.module.ts
+++ b/src/services/api/conversion/conversion.module.ts
@@ -7,6 +7,7 @@ import { CommunityModule } from '@domain/community/community/community.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { CommunicationModule } from '@domain/communication/communication/communication.module';
 import { AccountModule } from '@domain/space/account/account.module';
+import { NamingModule } from '@services/infrastructure/naming/naming.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { AccountModule } from '@domain/space/account/account.module';
     CommunityModule,
     AuthorizationModule,
     AuthorizationPolicyModule,
+    NamingModule,
     CommunicationModule,
   ],
   providers: [ConversionService, ConversionResolverMutations],

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -24,11 +24,13 @@ import { CreateAccountInput } from '@domain/space/account/dto';
 import { AccountService } from '@domain/space/account/account.service';
 import { SpaceService } from '@domain/space/space/space.service';
 import { CreateSubspaceInput } from '@domain/space/space/dto/space.dto.create.subspace';
+import { NamingService } from '@services/infrastructure/naming/naming.service';
 
 export class ConversionService {
   constructor(
     private accountService: AccountService,
     private spaceService: SpaceService,
+    private namingService: NamingService,
     private communityService: CommunityService,
     private communicationService: CommunicationService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
@@ -263,11 +265,15 @@ export class ConversionService {
       );
     }
 
-    const subspaceNameID = `${subsubspace.nameID}c`;
-    await this.spaceService.validateSubspaceNameIdOrFail(
-      subspaceNameID,
-      spaceID
-    );
+    const reservedNameIDs =
+      await this.namingService.getReservedNameIDsInAccount(
+        subsubspace.account.id
+      );
+    const subspaceNameID =
+      this.namingService.createNameIdAvoidingReservedNameIDs(
+        `${subsubspace.nameID}`,
+        reservedNameIDs
+      );
 
     // TODO: need to check if the space has a default innovation flow template
     const innovationFlowTemplateID = innovationFlowTemplateIdInput;

--- a/src/services/infrastructure/naming/naming.module.ts
+++ b/src/services/infrastructure/naming/naming.module.ts
@@ -5,17 +5,13 @@ import { Callout } from '@domain/collaboration/callout/callout.entity';
 import { CalendarEvent } from '@domain/timeline/event';
 import { Discussion } from '@domain/communication/discussion/discussion.entity';
 import { InnovationHub } from '@domain/innovation-hub/innovation.hub.entity';
-import { CalloutContribution } from '@domain/collaboration/callout-contribution/callout.contribution.entity';
-import { Space } from '@domain/space/space/space.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Space]),
     TypeOrmModule.forFeature([Callout]),
     TypeOrmModule.forFeature([CalendarEvent]),
     TypeOrmModule.forFeature([Discussion]),
     TypeOrmModule.forFeature([InnovationHub]),
-    TypeOrmModule.forFeature([CalloutContribution]),
   ],
   providers: [NamingService],
   exports: [NamingService],


### PR DESCRIPTION
The generation of nameIDs now is smart in how it generates the nameID from a displayName:
- generate a candidate nameID from the displayName
- if it is already taken in a given context, add '-1" as suffix + try again, and if that is taken, increase the number + try again etc

Tried with subspaces with subsubspace both using the same title 'test':
http://localhost:3000/eco1/challenges/**test**/opportunities/**test-1**

Used everywhere we were generating nameIDs: user, discussion, callout, callout contributions, calendars. 

Note: pattern used has changed. It is the responsibility of the containing entity to check / create the nameID, not the child. E.g. a Collaboration should look after nameID for a Callout, not the Callout itself which should not know its context. 