### PR TITLE
addressing assignment / removal of subspace admin implicit role

### DIFF
--- a/src/domain/community/community/community.resolver.fields.ts
+++ b/src/domain/community/community/community.resolver.fields.ts
@@ -28,6 +28,7 @@ import { IInvitationExternal } from '../invitation.external';
 import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { ICommunityGuidelines } from '../community-guidelines/community.guidelines.interface';
 import { IVirtualContributor } from '../virtual-contributor';
+import { CommunityRoleImplicit } from '@common/enums/community.role.implicit';
 
 @Resolver(() => ICommunity)
 export class CommunityResolverFields {
@@ -314,6 +315,22 @@ export class CommunityResolverFields {
     @Parent() community: ICommunity
   ): Promise<CommunityRole[]> {
     return this.communityService.getCommunityRoles(agentInfo, community);
+  }
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField('myRolesImplicit', () => [CommunityRoleImplicit], {
+    nullable: false,
+    description:
+      'The implicit roles on this community for the currently logged in user.',
+  })
+  async myRolesImplicit(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Parent() community: ICommunity
+  ): Promise<CommunityRoleImplicit[]> {
+    return this.communityService.getCommunityImplicitRoles(
+      agentInfo,
+      community
+    );
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -395,6 +395,26 @@ export class CommunityService {
         result.push(role);
       }
     }
+
+    return result;
+  }
+
+  async getCommunityImplicitRoles(
+    agentInfo: AgentInfo,
+    community: ICommunity
+  ): Promise<CommunityRoleImplicit[]> {
+    const result: CommunityRoleImplicit[] = [];
+    const agent = await this.agentService.getAgentOrFail(agentInfo.agentID);
+
+    const rolesImplicit: CommunityRoleImplicit[] = Object.values(
+      CommunityRoleImplicit
+    ) as CommunityRoleImplicit[];
+    for (const role of rolesImplicit) {
+      const hasAgentRole = await this.isInRoleImplicit(agent, community, role);
+      if (hasAgentRole) {
+        result.push(role);
+      }
+    }
     return result;
   }
 
@@ -752,7 +772,7 @@ export class CommunityService {
 
     const parentCommunity = await this.getParentCommunity(community);
     if (role === CommunityRole.ADMIN && parentCommunity) {
-      // TODO: check if an admin anywhere else in the community
+      // Check if an admin anywhere else in the community
       const peerCommunities = await this.getPeerCommunites(
         parentCommunity,
         community
@@ -1077,6 +1097,26 @@ export class CommunityService {
     role: CommunityRole
   ): Promise<boolean> {
     const membershipCredential = this.getCredentialDefinitionForRole(
+      community,
+      role
+    );
+
+    const validCredential = await this.agentService.hasValidCredential(
+      agent.id,
+      {
+        type: membershipCredential.type,
+        resourceID: membershipCredential.resourceID,
+      }
+    );
+    return validCredential;
+  }
+
+  async isInRoleImplicit(
+    agent: IAgent,
+    community: ICommunity,
+    role: CommunityRoleImplicit
+  ): Promise<boolean> {
+    const membershipCredential = this.getCredentialForImplicitRole(
       community,
       role
     );

--- a/src/domain/community/community/community.service.ts
+++ b/src/domain/community/community/community.service.ts
@@ -550,11 +550,19 @@ export class CommunityService {
     );
     if (role === CommunityRole.ADMIN && parentCommunity) {
       // also assign as subspace admin in parent community if there is a parent community
-      await this.assignContributorToImplicitRole(
+      const credential = this.getCredentialForImplicitRole(
         parentCommunity,
-        agent,
         CommunityRoleImplicit.SUBSPACE_ADMIN
       );
+      const alreadyHasSubspaceAdmin =
+        await this.agentService.hasValidCredential(agent.id, credential);
+      if (!alreadyHasSubspaceAdmin) {
+        await this.assignContributorToImplicitRole(
+          parentCommunity,
+          agent,
+          CommunityRoleImplicit.SUBSPACE_ADMIN
+        );
+      }
     }
 
     if (role === CommunityRole.MEMBER) {
@@ -744,11 +752,22 @@ export class CommunityService {
 
     const parentCommunity = await this.getParentCommunity(community);
     if (role === CommunityRole.ADMIN && parentCommunity) {
-      await this.removeContributorToImplicitRole(
+      // TODO: check if an admin anywhere else in the community
+      const peerCommunities = await this.getPeerCommunites(
         parentCommunity,
-        agent,
-        CommunityRoleImplicit.SUBSPACE_ADMIN
+        community
       );
+      const hasAnotherAdminRole = peerCommunities.some(pc =>
+        this.isInRole(agent, pc, CommunityRole.ADMIN)
+      );
+
+      if (!hasAnotherAdminRole) {
+        await this.removeContributorToImplicitRole(
+          parentCommunity,
+          agent,
+          CommunityRoleImplicit.SUBSPACE_ADMIN
+        );
+      }
     }
 
     if (role === CommunityRole.MEMBER) {
@@ -765,6 +784,22 @@ export class CommunityService {
     }
 
     return user;
+  }
+
+  private async getPeerCommunites(
+    parentCommunity: ICommunity,
+    childCommunity: ICommunity
+  ): Promise<ICommunity[]> {
+    const peerCommunities = await this.communityRepository.find({
+      where: {
+        parentCommunity: {
+          id: parentCommunity.id,
+        },
+      },
+    });
+    return peerCommunities.filter(
+      community => community.id !== childCommunity.id
+    );
   }
 
   async removeOrganizationFromRole(


### PR DESCRIPTION
To test
- ensure you are an admin that is a member of the root space
- create two subspaces
- remove one subspace, check your roles on the space:
```
query {
  spaces {
    community {
      myRoles
      myRolesImplicit
    }
    subspaces {
      community {
        myRoles
        myRolesImplicit
      }
    }
  }
}
```
- remove the last subspace
- check your roles using the above query again