### PR TITLE
privilege to allow access to settings on a user

### DIFF
--- a/src/common/constants/authorization/policy.rule.constants.ts
+++ b/src/common/constants/authorization/policy.rule.constants.ts
@@ -26,3 +26,5 @@ export const POLICY_RULE_STORAGE_BUCKET_CONTRIBUTOR_FILE_UPLOAD =
   'policyRule-storageBucketContributorFileUpload';
 export const PRIVILEGE_RULE_TYPES_INNOVATION_FLOW_UPDATE =
   'privilegeRuleTypes-innovationFlowUpdate';
+export const PRIVILEGE_RULE_READ_USER_SETTINGS =
+  'privilegeRule-readUserSettings';

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -33,6 +33,7 @@ export enum AuthorizationPrivilege {
   UPDATE_CALLOUT_PUBLISHER = 'update-callout-publisher',
   READ_USERS = 'read-users',
   READ_USER_PII = 'read-user-pii',
+  READ_USER_SETTINGS = 'read-user-settings',
   MOVE_POST = 'move-post',
   MOVE_CONTRIBUTION = 'move-contribution',
   ACCESS_INTERACTIVE_GUIDANCE = 'access-interactive-guidance',

--- a/src/domain/community/user/user.resolver.fields.ts
+++ b/src/domain/community/user/user.resolver.fields.ts
@@ -106,7 +106,7 @@ export class UserResolverFields {
       !(await this.isAccessGranted(
         user,
         agentInfo,
-        AuthorizationPrivilege.UPDATE
+        AuthorizationPrivilege.READ_USER_SETTINGS
       ))
     ) {
       return [];

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -25,8 +25,10 @@ import {
   CREDENTIAL_RULE_USER_READ_PII,
   CREDENTIAL_RULE_TYPES_USER_PLATFORM_ADMIN,
   CREDENTIAL_RULE_USER_READ,
+  PRIVILEGE_RULE_READ_USER_SETTINGS,
 } from '@common/constants';
 import { StorageAggregatorAuthorizationService } from '@domain/storage/storage-aggregator/storage.aggregator.service.authorization';
+import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
 
 @Injectable()
 export class UserAuthorizationService {
@@ -72,6 +74,9 @@ export class UserAuthorizationService {
       user.authorization,
       user
     );
+
+    user.authorization = this.appendPrivilegeRules(user.authorization);
+
     // NOTE: Clone the authorization policy to ensure the changes are local to profile
     const clonedAnonymousReadAccessAuthorization =
       this.authorizationPolicyService.cloneAuthorizationPolicy(
@@ -205,7 +210,10 @@ export class UserAuthorizationService {
 
     const communityReader =
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
-        [AuthorizationPrivilege.READ],
+        [
+          AuthorizationPrivilege.READ,
+          AuthorizationPrivilege.READ_USER_SETTINGS,
+        ],
         [
           AuthorizationCredential.GLOBAL_COMMUNITY_READ,
           AuthorizationCredential.GLOBAL_SUPPORT,
@@ -214,20 +222,6 @@ export class UserAuthorizationService {
       );
     communityReader.cascade = true;
     newRules.push(communityReader);
-
-    // TODO: Currently the UPDATE privilege is used to protect the user's preferences
-    // This rule can be removed once the privilege protecting user preferences is updated.
-    const communityReaderUpdate =
-      this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
-        [AuthorizationPrivilege.UPDATE],
-        [
-          AuthorizationCredential.GLOBAL_COMMUNITY_READ,
-          AuthorizationCredential.GLOBAL_SUPPORT,
-        ],
-        CREDENTIAL_RULE_USER_READ
-      );
-    communityReader.cascade = false;
-    newRules.push(communityReaderUpdate);
 
     // Determine who is able to see the PII designated fields for a User
     const { credentials } = await this.userService.getUserAndCredentials(
@@ -284,5 +278,23 @@ export class UserAuthorizationService {
     );
 
     return authorization;
+  }
+
+  private appendPrivilegeRules(
+    authorization: IAuthorizationPolicy
+  ): IAuthorizationPolicy {
+    const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
+
+    const readSettingsPrivilege = new AuthorizationPolicyRulePrivilege(
+      [AuthorizationPrivilege.READ_USER_SETTINGS],
+      AuthorizationPrivilege.UPDATE,
+      PRIVILEGE_RULE_READ_USER_SETTINGS
+    );
+    privilegeRules.push(readSettingsPrivilege);
+
+    return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
+      authorization,
+      privilegeRules
+    );
   }
 }


### PR DESCRIPTION
Removed usage of UPDATE privilege to access the preferences field on a User

Replaced by a new READ_SETTINGS privilege, that is assigned to community readers / support, as well as a privilege rule that is hooked onto the UPDATE privilege (so anyone that can update can see the settings)