### PR TITLE
VC / VP Fixes

### DIFF
--- a/src/common/enums/virtual.contributor.engine.ts
+++ b/src/common/enums/virtual.contributor.engine.ts
@@ -3,6 +3,7 @@ import { registerEnumType } from '@nestjs/graphql';
 export enum VirtualContributorEngine {
   GUIDANCE = 'guidance',
   EXPERT = 'expert',
+  COMMUNITY_MANAGER = 'community-manager',
 }
 
 registerEnumType(VirtualContributorEngine, {

--- a/src/domain/community/virtual-contributor/dto/virtual.contributor.dto.create.ts
+++ b/src/domain/community/virtual-contributor/dto/virtual.contributor.dto.create.ts
@@ -5,8 +5,8 @@ import { BodyOfKnowledgeType } from '@common/enums/virtual.contributor.body.of.k
 
 @InputType()
 export class CreateVirtualContributorInput extends CreateContributorInput {
-  @Field(() => UUID, { nullable: false })
-  virtualPersonaID!: string;
+  @Field(() => UUID, { nullable: true })
+  virtualPersonaID?: string;
 
   @Field(() => BodyOfKnowledgeType, { nullable: false })
   bodyOfKnowledgeType!: BodyOfKnowledgeType;

--- a/src/domain/community/virtual-contributor/virtual.contributor.interface.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.interface.ts
@@ -4,6 +4,7 @@ import { IAccount } from '@domain/space/account/account.interface';
 import { BodyOfKnowledgeType } from '@common/enums/virtual.contributor.body.of.knowledge.type';
 import { IContributor } from '../contributor/contributor.interface';
 import { IVirtualPersona } from '@platform/virtual-persona/virtual.persona.interface';
+import { UUID } from '@domain/common/scalars';
 
 @ObjectType('VirtualContributor', {
   implements: () => [IContributor],
@@ -28,5 +29,10 @@ export class IVirtualContributor
     description: 'The body of knowledge type used for the Virtual Contributor',
   })
   bodyOfKnowledgeType!: BodyOfKnowledgeType;
+
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'The body of knowledge ID used for the Virtual Contributor',
+  })
   bodyOfKnowledgeID!: string;
 }

--- a/src/domain/community/virtual-contributor/virtual.contributor.interface.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.interface.ts
@@ -20,6 +20,7 @@ export class IVirtualContributor
 
   communicationID!: string;
   @Field(() => IAccount, {
+    nullable: true,
     description: 'The account under which the virtual contributor was created',
   })
   account!: IAccount;

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -79,6 +79,7 @@ export class VirtualContributorService {
         virtualContributorData.virtualPersonaID
       );
     } else {
+      //toDo fix this: https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/gh/alkem-io/server/4010
       virtualPersona =
         await this.virtualPersonaService.getVirtualPersonaByEngineOrFail(
           VirtualContributorEngine.EXPERT

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -32,6 +32,8 @@ import {
   SpaceIngestionPurpose,
 } from '@services/infrastructure/event-bus/commands';
 import { VirtualPersonaService } from '@platform/virtual-persona/virtual.persona.service';
+import { IVirtualPersona } from '@platform/virtual-persona';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
 
 @Injectable()
 export class VirtualContributorService {
@@ -71,10 +73,18 @@ export class VirtualContributorService {
       virtualContributor.communicationID = communicationID;
     }
 
-    const virtualPersona =
-      await this.virtualPersonaService.getVirtualPersonaOrFail(
+    let virtualPersona: IVirtualPersona;
+    if (virtualContributorData.virtualPersonaID) {
+      virtualPersona = await this.virtualPersonaService.getVirtualPersonaOrFail(
         virtualContributorData.virtualPersonaID
       );
+    } else {
+      virtualPersona =
+        await this.virtualPersonaService.getVirtualPersonaByEngineOrFail(
+          VirtualContributorEngine.EXPERT
+        );
+    }
+
     virtualContributor.virtualPersona = virtualPersona;
 
     virtualContributor.storageAggregator =

--- a/src/migrations/1716199897459-updateVirtualPersona.ts
+++ b/src/migrations/1716199897459-updateVirtualPersona.ts
@@ -11,9 +11,6 @@ export class updateVirtualPersona11716199897459 implements MigrationInterface {
       `DROP INDEX \`REL_a6a9c0a62d17b6737eeb90b790\` ON \`virtual_persona\``
     );
     await queryRunner.query(
-      `ALTER TABLE \`virtual_persona\` DROP COLUMN \`prompt\``
-    );
-    await queryRunner.query(
       `ALTER TABLE \`virtual_persona\` DROP COLUMN \`storageAggregatorId\``
     );
     await queryRunner.query(
@@ -50,9 +47,6 @@ export class updateVirtualPersona11716199897459 implements MigrationInterface {
     );
     await queryRunner.query(
       `ALTER TABLE \`virtual_persona\` ADD \`storageAggregatorId\` char(36) NULL`
-    );
-    await queryRunner.query(
-      `ALTER TABLE \`virtual_persona\` ADD \`prompt\` text NOT NULL`
     );
     await queryRunner.query(
       `CREATE UNIQUE INDEX \`REL_a6a9c0a62d17b6737eeb90b790\` ON \`virtual_persona\` (\`storageAggregatorId\`)`

--- a/src/migrations/1717058223813-revertVirtualPersonaPrompt.ts
+++ b/src/migrations/1717058223813-revertVirtualPersonaPrompt.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class revertVirtualPersonaPrompt1717058223813
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('virtual_persona');
+    const isPromptColumnExist = table?.findColumnByName('prompt');
+
+    if (!isPromptColumnExist) {
+      await queryRunner.query(
+        `ALTER TABLE \`virtual_persona\` ADD \`prompt\` text NOT NULL`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('virtual_persona');
+    const isPromptColumnExist = table?.findColumnByName('prompt');
+
+    if (isPromptColumnExist) {
+      await queryRunner.query(
+        `ALTER TABLE \`virtual_persona\` DROP COLUMN \`prompt\``
+      );
+    }
+  }
+}

--- a/src/platform/platfrom/platform.resolver.mutations.ts
+++ b/src/platform/platfrom/platform.resolver.mutations.ts
@@ -140,10 +140,15 @@ export class PlatformResolverMutations {
       virtualPersonaData
     );
 
-    return await this.virtualPersonaAuthorizationService.applyAuthorizationPolicy(
-      virtual,
-      platformPolicy
-    );
+    const virtualWithAuth =
+      await this.virtualPersonaAuthorizationService.applyAuthorizationPolicy(
+        virtual,
+        platformPolicy
+      );
+
+    await this.virtualPersonaService.save(virtualWithAuth);
+
+    return virtualWithAuth;
   }
 
   private async notifyPlatformGlobalRoleChange(

--- a/src/platform/virtual-persona/dto/virtual.persona.dto.create.ts
+++ b/src/platform/virtual-persona/dto/virtual.persona.dto.create.ts
@@ -11,7 +11,7 @@ export class CreateVirtualPersonaInput extends CreateNameableInput {
   @MaxLength(SMALL_TEXT_LENGTH)
   engine!: VirtualContributorEngine;
 
-  @Field(() => JSON, { nullable: false })
+  @Field(() => JSON, { nullable: true })
   @MaxLength(LONG_TEXT_LENGTH)
   prompt!: string;
 }

--- a/src/platform/virtual-persona/dto/virtual.persona.dto.create.ts
+++ b/src/platform/virtual-persona/dto/virtual.persona.dto.create.ts
@@ -1,16 +1,11 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { MaxLength } from 'class-validator';
-import { LONG_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@src/common/constants';
-import JSON from 'graphql-type-json';
+import { SMALL_TEXT_LENGTH } from '@src/common/constants';
 import { CreateNameableInput } from '@domain/common/entity/nameable-entity';
 import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
 
 @InputType()
 export class CreateVirtualPersonaInput extends CreateNameableInput {
-  @Field(() => JSON, { nullable: false })
-  @MaxLength(LONG_TEXT_LENGTH)
-  prompt!: string;
-
   @Field(() => VirtualContributorEngine, { nullable: false })
   @MaxLength(SMALL_TEXT_LENGTH)
   engine!: VirtualContributorEngine;

--- a/src/platform/virtual-persona/dto/virtual.persona.dto.create.ts
+++ b/src/platform/virtual-persona/dto/virtual.persona.dto.create.ts
@@ -1,12 +1,17 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { MaxLength } from 'class-validator';
-import { SMALL_TEXT_LENGTH } from '@src/common/constants';
+import { LONG_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@src/common/constants';
 import { CreateNameableInput } from '@domain/common/entity/nameable-entity';
-import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
+import JSON from 'graphql-type-json';
 
 @InputType()
 export class CreateVirtualPersonaInput extends CreateNameableInput {
   @Field(() => VirtualContributorEngine, { nullable: false })
   @MaxLength(SMALL_TEXT_LENGTH)
   engine!: VirtualContributorEngine;
+
+  @Field(() => JSON, { nullable: false })
+  @MaxLength(LONG_TEXT_LENGTH)
+  prompt!: string;
 }

--- a/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
+++ b/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
@@ -2,7 +2,8 @@ import { Field, InputType } from '@nestjs/graphql';
 import { MaxLength } from 'class-validator';
 import { LONG_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@src/common/constants';
 import { UpdateNameableInput } from '@domain/common/entity/nameable-entity';
-import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
+import JSON from 'graphql-type-json';
 
 @InputType()
 export class UpdateVirtualPersonaInput extends UpdateNameableInput {

--- a/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
+++ b/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
@@ -1,16 +1,11 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { MaxLength } from 'class-validator';
-import { LONG_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@src/common/constants';
-import JSON from 'graphql-type-json';
+import { SMALL_TEXT_LENGTH } from '@src/common/constants';
 import { UpdateNameableInput } from '@domain/common/entity/nameable-entity';
 import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
 
 @InputType()
 export class UpdateVirtualPersonaInput extends UpdateNameableInput {
-  @Field(() => JSON, { nullable: false })
-  @MaxLength(LONG_TEXT_LENGTH)
-  prompt!: string;
-
   @Field(() => VirtualContributorEngine, { nullable: false })
   @MaxLength(SMALL_TEXT_LENGTH)
   engine!: VirtualContributorEngine;

--- a/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
+++ b/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
@@ -1,6 +1,6 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { MaxLength } from 'class-validator';
-import { SMALL_TEXT_LENGTH } from '@src/common/constants';
+import { LONG_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@src/common/constants';
 import { UpdateNameableInput } from '@domain/common/entity/nameable-entity';
 import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
 
@@ -9,4 +9,8 @@ export class UpdateVirtualPersonaInput extends UpdateNameableInput {
   @Field(() => VirtualContributorEngine, { nullable: false })
   @MaxLength(SMALL_TEXT_LENGTH)
   engine!: VirtualContributorEngine;
+
+  @Field(() => JSON, { nullable: false })
+  @MaxLength(LONG_TEXT_LENGTH)
+  prompt!: string;
 }

--- a/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
+++ b/src/platform/virtual-persona/dto/virtual.persona.dto.update.ts
@@ -11,7 +11,7 @@ export class UpdateVirtualPersonaInput extends UpdateNameableInput {
   @MaxLength(SMALL_TEXT_LENGTH)
   engine!: VirtualContributorEngine;
 
-  @Field(() => JSON, { nullable: false })
+  @Field(() => JSON, { nullable: true })
   @MaxLength(LONG_TEXT_LENGTH)
   prompt!: string;
 }

--- a/src/platform/virtual-persona/virtual.persona.entity.ts
+++ b/src/platform/virtual-persona/virtual.persona.entity.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { IVirtualPersona } from './virtual.persona.interface';
-import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
 import { Platform } from '@platform/platfrom/platform.entity';
 import { VirtualPersonaAccessMode } from '@common/enums/virtual.persona.access.mode';
 import { NameableEntity } from '@domain/common/entity/nameable-entity/nameable.entity';

--- a/src/platform/virtual-persona/virtual.persona.entity.ts
+++ b/src/platform/virtual-persona/virtual.persona.entity.ts
@@ -16,6 +16,9 @@ export class VirtualPersona extends NameableEntity implements IVirtualPersona {
   @Column({ length: 128, nullable: false })
   engine!: VirtualContributorEngine;
 
+  @Column('text', { nullable: false })
+  prompt!: string;
+
   @Column({
     length: 64,
     nullable: false,

--- a/src/platform/virtual-persona/virtual.persona.interface.ts
+++ b/src/platform/virtual-persona/virtual.persona.interface.ts
@@ -1,5 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
 import { VirtualPersonaAccessMode } from '@common/enums/virtual.persona.access.mode';
 import { INameable } from '@domain/common/entity/nameable-entity';
 

--- a/src/platform/virtual-persona/virtual.persona.interface.ts
+++ b/src/platform/virtual-persona/virtual.persona.interface.ts
@@ -12,6 +12,12 @@ export class IVirtualPersona extends INameable {
   })
   engine!: VirtualContributorEngine;
 
+  @Field(() => String, {
+    nullable: false,
+    description: 'The prompt used by this Virtual Persona',
+  })
+  prompt!: string;
+
   @Field(() => VirtualPersonaAccessMode, {
     nullable: false,
     description: 'The required data access by the Virtual Persona',

--- a/src/platform/virtual-persona/virtual.persona.module.ts
+++ b/src/platform/virtual-persona/virtual.persona.module.ts
@@ -9,12 +9,16 @@ import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/a
 import { VirtualPersona } from './virtual.persona.entity';
 import { VirtualPersonaResolverFields } from './virtual.persona.resolver.fields';
 import { VirtualPersonaEngineAdapterModule } from '@services/adapters/virtual-persona-engine-adapter/virtual.persona.engine.adapter.module';
+import { ProfileModule } from '@domain/common/profile/profile.module';
+import { StorageAggregatorModule } from '@domain/storage/storage-aggregator/storage.aggregator.module';
 
 @Module({
   imports: [
     AuthorizationPolicyModule,
     AuthorizationModule,
     VirtualPersonaEngineAdapterModule,
+    ProfileModule,
+    StorageAggregatorModule,
     TypeOrmModule.forFeature([VirtualPersona]),
   ],
   providers: [

--- a/src/platform/virtual-persona/virtual.persona.service.ts
+++ b/src/platform/virtual-persona/virtual.persona.service.ts
@@ -38,6 +38,7 @@ export class VirtualPersonaService {
   async createVirtualPersona(
     virtualPersonaData: CreateVirtualPersonaInput
   ): Promise<IVirtualPersona> {
+    if (virtualPersonaData.prompt === undefined) virtualPersonaData.prompt = '';
     const virtual: IVirtualPersona = VirtualPersona.create(virtualPersonaData);
     virtual.authorization = new AuthorizationPolicy();
 

--- a/src/platform/virtual-persona/virtual.persona.service.ts
+++ b/src/platform/virtual-persona/virtual.persona.service.ts
@@ -90,7 +90,15 @@ export class VirtualPersonaService {
       {}
     );
 
-    return virtualPersona;
+    if (virtualPersonaData.prompt !== undefined) {
+      virtualPersona.prompt = virtualPersonaData.prompt;
+    }
+
+    if (virtualPersonaData.engine !== undefined) {
+      virtualPersona.engine = virtualPersonaData.engine;
+    }
+
+    return await this.virtualPersonaRepository.save(virtualPersona);
   }
 
   async deleteVirtualPersona(
@@ -164,7 +172,7 @@ export class VirtualPersonaService {
 
     const input: VirtualPersonaEngineAdapterQueryInput = {
       engine: virtualPersona.engine,
-      prompt: '',
+      prompt: virtualPersona.prompt,
       userId: agentInfo.userID,
       question: personaQuestionInput.question,
       knowledgeSpaceNameID,

--- a/src/platform/virtual-persona/virtual.persona.service.ts
+++ b/src/platform/virtual-persona/virtual.persona.service.ts
@@ -87,7 +87,7 @@ export class VirtualPersonaService {
   ): Promise<IVirtualPersona> {
     const virtualPersona = await this.getVirtualPersonaOrFail(
       virtualPersonaData.ID,
-      {}
+      { relations: { profile: true } }
     );
 
     if (virtualPersonaData.prompt !== undefined) {
@@ -96,6 +96,13 @@ export class VirtualPersonaService {
 
     if (virtualPersonaData.engine !== undefined) {
       virtualPersona.engine = virtualPersonaData.engine;
+    }
+
+    if (virtualPersonaData.profileData) {
+      virtualPersona.profile = await this.profileService.updateProfile(
+        virtualPersona.profile,
+        virtualPersonaData.profileData
+      );
     }
 
     return await this.virtualPersonaRepository.save(virtualPersona);

--- a/src/platform/virtual-persona/virtual.persona.service.ts
+++ b/src/platform/virtual-persona/virtual.persona.service.ts
@@ -15,13 +15,13 @@ import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { LogContext } from '@common/enums/logging.context';
 import { VirtualPersonaEngineAdapterQueryInput } from '@services/adapters/virtual-persona-engine-adapter/dto/virtual.persona.engine.adapter.dto.question.input';
 import { VirtualPersonaEngineAdapter } from '@services/adapters/virtual-persona-engine-adapter/virtual.persona.engine.adapter';
-import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { ProfileType } from '@common/enums';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { VisualType } from '@common/enums/visual.type';
 import { ProfileService } from '@domain/common/profile/profile.service';
 import { StorageAggregatorService } from '@domain/storage/storage-aggregator/storage.aggregator.service';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
 
 @Injectable()
 export class VirtualPersonaService {

--- a/src/platform/virtual-persona/virtual.persona.service.ts
+++ b/src/platform/virtual-persona/virtual.persona.service.ts
@@ -74,13 +74,13 @@ export class VirtualPersonaService {
       avatarURL
     );
 
-    const savedVC = await this.virtualPersonaRepository.save(virtual);
+    const savedVP = await this.virtualPersonaRepository.save(virtual);
     this.logger.verbose?.(
       `Created new virtual persona with id ${virtual.id}`,
       LogContext.COMMUNITY
     );
 
-    return savedVC;
+    return savedVP;
   }
 
   async updateVirtualPersona(

--- a/src/platform/virtual-persona/virtual.persona.service.ts
+++ b/src/platform/virtual-persona/virtual.persona.service.ts
@@ -77,7 +77,7 @@ export class VirtualPersonaService {
     const savedVP = await this.virtualPersonaRepository.save(virtual);
     this.logger.verbose?.(
       `Created new virtual persona with id ${virtual.id}`,
-      LogContext.COMMUNITY
+      LogContext.PLATFORM
     );
 
     return savedVP;
@@ -122,7 +122,7 @@ export class VirtualPersonaService {
     if (!virtualPersona.authorization) {
       throw new EntityNotFoundException(
         `Unable to find all fields on Virtual Persona with ID: ${deleteData.ID}`,
-        LogContext.COMMUNITY
+        LogContext.PLATFORM
       );
     }
     await this.authorizationPolicyService.delete(virtualPersona.authorization);
@@ -153,7 +153,7 @@ export class VirtualPersonaService {
     if (!virtualPersona)
       throw new EntityNotFoundException(
         `Unable to find Virtual Persona with ID: ${virtualID}`,
-        LogContext.COMMUNITY
+        LogContext.PLATFORM
       );
     return virtualPersona;
   }
@@ -165,12 +165,12 @@ export class VirtualPersonaService {
     const virtualPersona = await this.virtualPersonaRepository.findOne({
       ...options,
       where: { ...options?.where, engine },
-      order: { createdDate: 'DESC' },
+      order: { createdDate: 'ASC' },
     });
     if (!virtualPersona)
       throw new EntityNotFoundException(
         `Unable to find Virtual Persona with engine: ${engine}`,
-        LogContext.COMMUNITY
+        LogContext.PLATFORM
       );
     return virtualPersona;
   }

--- a/src/platform/virtual-persona/virtual.persona.service.ts
+++ b/src/platform/virtual-persona/virtual.persona.service.ts
@@ -132,7 +132,7 @@ export class VirtualPersonaService {
     return result;
   }
 
-  async getVirtualPersona(
+  public async getVirtualPersona(
     virtualPersonaID: string,
     options?: FindOneOptions<VirtualPersona>
   ): Promise<IVirtualPersona | null> {
@@ -144,7 +144,7 @@ export class VirtualPersonaService {
     return virtualPersona;
   }
 
-  async getVirtualPersonaOrFail(
+  public async getVirtualPersonaOrFail(
     virtualID: string,
     options?: FindOneOptions<VirtualPersona>
   ): Promise<IVirtualPersona | never> {
@@ -152,6 +152,23 @@ export class VirtualPersonaService {
     if (!virtualPersona)
       throw new EntityNotFoundException(
         `Unable to find Virtual Persona with ID: ${virtualID}`,
+        LogContext.COMMUNITY
+      );
+    return virtualPersona;
+  }
+
+  public async getVirtualPersonaByEngineOrFail(
+    engine: VirtualContributorEngine,
+    options?: FindOneOptions<VirtualPersona>
+  ): Promise<IVirtualPersona | never> {
+    const virtualPersona = await this.virtualPersonaRepository.findOne({
+      ...options,
+      where: { ...options?.where, engine },
+      order: { createdDate: 'DESC' },
+    });
+    if (!virtualPersona)
+      throw new EntityNotFoundException(
+        `Unable to find Virtual Persona with engine: ${engine}`,
         LogContext.COMMUNITY
       );
     return virtualPersona;

--- a/src/services/adapters/virtual-persona-engine-adapter/dto/virtual.persona.engine.adapter.dto.base.ts
+++ b/src/services/adapters/virtual-persona-engine-adapter/dto/virtual.persona.engine.adapter.dto.base.ts
@@ -1,4 +1,4 @@
-import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
 
 export interface VirtualPersonaEngineAdapterInputBase {
   userId: string;

--- a/src/services/adapters/virtual-persona-engine-adapter/virtual.persona.engine.adapter.ts
+++ b/src/services/adapters/virtual-persona-engine-adapter/virtual.persona.engine.adapter.ts
@@ -13,9 +13,9 @@ import { VirtualPersonaEngineAdapterQueryResponse } from './dto/virtual.persona.
 import { LogContext } from '@common/enums/logging.context';
 import { VirtualPersonaEngineAdapterInputBase } from './dto/virtual.persona.engine.adapter.dto.base';
 import { VirtualPersonaEngineAdapterBaseResponse } from './dto/virtual.persona.engine.adapter.dto.base.response';
-import { VirtualContributorEngine } from '@common/enums/virtual.persona.engine';
 import { ChatGuidanceInput } from '@services/api/chat-guidance/dto/chat.guidance.dto.input';
 import { IVirtualPersonaQuestionResult } from '@platform/virtual-persona/dto/virtual.persona.question.dto.result';
+import { VirtualContributorEngine } from '@common/enums/virtual.contributor.engine';
 
 enum VirtualPersonaEventType {
   QUERY = 'query',
@@ -46,6 +46,14 @@ export class VirtualPersonaEngineAdapter {
 
     try {
       switch (eventData.engine) {
+        case VirtualContributorEngine.COMMUNITY_MANAGER:
+          const responseCommunityManager =
+            this.virtualPersonaEngineCommunityManager.send<
+              VirtualPersonaEngineAdapterQueryResponse,
+              VirtualPersonaEngineAdapterQueryInput
+            >({ cmd: VirtualPersonaEventType.QUERY }, eventData);
+          responseData = await firstValueFrom(responseCommunityManager);
+          break;
         case VirtualContributorEngine.EXPERT:
           const responseAlkemioDigileefomgeving =
             this.virtualPersonaEngineAlkemioDigileefomgeving.send<


### PR DESCRIPTION
Fixes #4008 

- Re-added `Profile` on VP
- Re-added `prompt` on VP
- Made `Virtual Persona` optional on `Virtual Contributor` creation flow. If it is not provided, the `Virtual Persona` that was most recently created with EXPERT engine is selected
- For `VirtualContributor` queries added `Account` field resolver, that returns `null` if the `Account` is `null`. Useful for `VirtualContributors` query
- Re-added `COMMUNITY_MANAGER` engine
