### PR TITLE
allow creation of all contributor types without specifying the nameID

### DIFF
--- a/src/domain/community/contributor/dto/contributor.dto.create.ts
+++ b/src/domain/community/contributor/dto/contributor.dto.create.ts
@@ -1,5 +1,13 @@
-import { InputType } from '@nestjs/graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { CreateNameableInput } from '@domain/common/entity/nameable-entity/dto/nameable.dto.create';
+import { NameID } from '@domain/common/scalars/scalar.nameid';
 
 @InputType()
-export class CreateContributorInput extends CreateNameableInput {}
+export class CreateContributorInput extends CreateNameableInput {
+  // Override to allow contributors to have a nameID generated that is unique
+  @Field(() => NameID, {
+    nullable: true,
+    description: 'A readable identifier, unique within the containing scope.',
+  })
+  nameID!: string;
+}

--- a/src/domain/community/virtual-contributor/virtual.contributor.module.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.module.ts
@@ -14,6 +14,7 @@ import { StorageAggregatorModule } from '@domain/storage/storage-aggregator/stor
 import { VirtualContributor } from './virtual.contributor.entity';
 import { CommunicationAdapterModule } from '@services/adapters/communication-adapter/communication-adapter.module';
 import { VirtualPersonaModule } from '@platform/virtual-persona/virtual.persona.module';
+import { NamingModule } from '@services/infrastructure/naming/naming.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { VirtualPersonaModule } from '@platform/virtual-persona/virtual.persona.
     AuthorizationPolicyModule,
     AuthorizationModule,
     ProfileModule,
+    NamingModule,
     StorageAggregatorModule,
     VirtualPersonaModule,
     CommunicationAdapterModule,

--- a/src/services/infrastructure/naming/naming.service.ts
+++ b/src/services/infrastructure/naming/naming.service.ts
@@ -22,6 +22,8 @@ import { ISpaceSettings } from '@domain/space/space.settings/space.settings.inte
 import { SpaceLevel } from '@common/enums/space.level';
 import { User } from '@domain/community/user/user.entity';
 import { InnovationPack } from '@library/innovation-pack/innovation.pack.entity';
+import { VirtualContributor } from '@domain/community/virtual-contributor';
+import { Organization } from '@domain/community/organization';
 
 export class NamingService {
   replaceSpecialCharacters = require('replace-special-characters');
@@ -141,6 +143,26 @@ export class NamingService {
       },
     });
     const nameIDs = users.map(user => user.nameID);
+    return nameIDs;
+  }
+
+  public async getReservedNameIDsInVirtualContributors(): Promise<string[]> {
+    const vcs = await this.entityManager.find(VirtualContributor, {
+      select: {
+        nameID: true,
+      },
+    });
+    const nameIDs = vcs.map(vc => vc.nameID);
+    return nameIDs;
+  }
+
+  public async getReservedNameIDsInOrganizations(): Promise<string[]> {
+    const organizations = await this.entityManager.find(Organization, {
+      select: {
+        nameID: true,
+      },
+    });
+    const nameIDs = organizations.map(organization => organization.nameID);
     return nameIDs;
   }
 


### PR DESCRIPTION
nameID parameter is now optional on all contributor creations

if not specified, the server will take care of creating a suitable nameID based on the provided displayName