### PR TITLE
Allow assigning / removing of license plans

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -76,6 +76,7 @@ import { EventBusModule } from '@services/infrastructure/event-bus/event.bus.mod
 import { WhiteboardIntegrationModule } from '@services/whiteboard-integration/whiteboard.integration.module';
 import { PlatformSettingsModule } from '@platform/settings/platform.settings.module';
 import { FileIntegrationModule } from '@services/file-integration';
+import { AdminLicensingModule } from '@platform/admin/licensing/admin.licensing.module';
 
 @Module({
   imports: [
@@ -239,6 +240,7 @@ import { FileIntegrationModule } from '@services/file-integration';
     KonfigModule,
     AdminCommunicationModule,
     AdminSearchIngestModule,
+    AdminLicensingModule,
     AgentModule,
     MessageModule,
     MessageReactionModule,

--- a/src/domain/space/account/account.module.ts
+++ b/src/domain/space/account/account.module.ts
@@ -19,6 +19,7 @@ import { AccountResolverQueries } from './account.resolver.queries';
 import { ContributorModule } from '@domain/community/contributor/contributor.module';
 import { LicensingModule } from '@platform/licensing/licensing.module';
 import { VirtualContributorModule } from '@domain/community/virtual-contributor/virtual.contributor.module';
+import { LicenseIssuerModule } from '@platform/license-issuer/license.issuer.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { VirtualContributorModule } from '@domain/community/virtual-contributor/
     InnovationFlowTemplateModule,
     LicenseModule,
     LicensingModule,
+    LicenseIssuerModule,
     NameReporterModule,
     TypeOrmModule.forFeature([Account]),
   ],

--- a/src/platform/admin/licensing/admin.licensing.module.ts
+++ b/src/platform/admin/licensing/admin.licensing.module.ts
@@ -1,0 +1,19 @@
+import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { Module } from '@nestjs/common';
+import { AdminLicensingResolverMutations } from './admin.licensing.resolver.mutations';
+import { AdminLicensingService } from './admin.licensing.service';
+import { AccountModule } from '@domain/space/account/account.module';
+import { LicensingModule } from '@platform/licensing/licensing.module';
+
+@Module({
+  imports: [
+    AccountModule,
+    LicensingModule,
+    AuthorizationModule,
+    AuthorizationPolicyModule,
+  ],
+  providers: [AdminLicensingResolverMutations, AdminLicensingService],
+  exports: [],
+})
+export class AdminLicensingModule {}

--- a/src/platform/admin/licensing/admin.licensing.module.ts
+++ b/src/platform/admin/licensing/admin.licensing.module.ts
@@ -5,11 +5,13 @@ import { AdminLicensingResolverMutations } from './admin.licensing.resolver.muta
 import { AdminLicensingService } from './admin.licensing.service';
 import { AccountModule } from '@domain/space/account/account.module';
 import { LicensingModule } from '@platform/licensing/licensing.module';
+import { LicenseIssuerModule } from '@platform/license-issuer/license.issuer.module';
 
 @Module({
   imports: [
     AccountModule,
     LicensingModule,
+    LicenseIssuerModule,
     AuthorizationModule,
     AuthorizationPolicyModule,
   ],

--- a/src/platform/admin/licensing/admin.licensing.resolver.mutations.ts
+++ b/src/platform/admin/licensing/admin.licensing.resolver.mutations.ts
@@ -1,0 +1,52 @@
+import { UseGuards } from '@nestjs/common';
+import { Resolver, Mutation, Args } from '@nestjs/graphql';
+import { CurrentUser, Profiling } from '@src/common/decorators';
+import { GraphqlGuard } from '@core/authorization';
+import { AgentInfo } from '@core/authentication.agent.info/agent.info';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { ILicensePlan } from '@platform/license-plan/license.plan.interface';
+import { AssignLicensePlanToAccount } from './dto/admin.licensing.dto.assign.license.plan.to.account';
+import { LicensingService } from '@platform/licensing/licensing.service';
+import { ILicensing } from '@platform/licensing/licensing.interface';
+import { AdminLicensingService } from './admin.licensing.service';
+
+@Resolver()
+export class AdminLicensingResolverMutations {
+  constructor(
+    private authorizationService: AuthorizationService,
+    private licensingService: LicensingService,
+    private adminLicensingService: AdminLicensingService
+  ) {}
+
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => ILicensePlan, {
+    description: 'Assign the specified LicensePlan to an Account.',
+  })
+  @Profiling.api
+  async assignLicensePlanToAccount(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('planData') planData: AssignLicensePlanToAccount
+  ): Promise<ILicensePlan> {
+    let licensing: ILicensing | undefined;
+    if (planData.licensingID) {
+      licensing = await this.licensingService.getLicensingOrFail(
+        planData.licensingID
+      );
+    } else {
+      licensing = await this.licensingService.getDefaultLicensingOrFail();
+    }
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      licensing.authorization,
+      AuthorizationPrivilege.GRANT,
+      `assign licensePlan on licensing: ${licensing.id}`
+    );
+
+    return await this.adminLicensingService.assignLicensePlanToAccount(
+      planData,
+      licensing.id
+    );
+  }
+}

--- a/src/platform/admin/licensing/admin.licensing.service.ts
+++ b/src/platform/admin/licensing/admin.licensing.service.ts
@@ -1,0 +1,59 @@
+import { LogContext } from '@common/enums/logging.context';
+import { EntityNotInitializedException } from '@common/exceptions/entity.not.initialized.exception';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { ILicensePlan } from '@platform/license-plan/license.plan.interface';
+import { AssignLicensePlanToAccount } from './dto/admin.licensing.dto.assign.license.plan.to.account';
+import { AccountService } from '@domain/space/account/account.service';
+import { LicenseNotFoundException } from '@common/exceptions/license.not.found.exception';
+import { LicensingService } from '@platform/licensing/licensing.service';
+
+@Injectable()
+export class AdminLicensingService {
+  constructor(
+    private licensingService: LicensingService,
+    private accountService: AccountService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  public async assignLicensePlanToAccount(
+    licensePlanData: AssignLicensePlanToAccount,
+    licensingID: string
+  ): Promise<ILicensePlan> {
+    const licensing = await this.licensingService.getLicensingOrFail(
+      licensingID,
+      {
+        relations: {
+          plans: true,
+        },
+      }
+    );
+    if (!licensing.plans) {
+      throw new EntityNotInitializedException(
+        `Licensing (${licensing}) not initialised`,
+        LogContext.LICENSE
+      );
+    }
+
+    const licensePlan = licensing.plans.find(
+      plan => plan.id === licensePlanData.licensePlanID
+    );
+    if (!licensePlan) {
+      throw new LicenseNotFoundException(
+        `Licensing (${licensing}) does not contain the requested plan: ${licensePlanData.licensePlanID}`,
+        LogContext.LICENSE
+      );
+    }
+
+    // Todo: assign the actual credential for the license plan
+    const account = await this.accountService.getAccountOrFail(
+      licensePlanData.accountID
+    );
+    this.logger.verbose?.(
+      `Assigning license plan ${licensePlan.id} to account ${account.id}`,
+      LogContext.LICENSE
+    );
+
+    return licensePlan;
+  }
+}

--- a/src/platform/admin/licensing/dto/admin.licensing.dto.assign.license.plan.to.account.ts
+++ b/src/platform/admin/licensing/dto/admin.licensing.dto.assign.license.plan.to.account.ts
@@ -1,0 +1,23 @@
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class AssignLicensePlanToAccount {
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'The ID of the LicensePlan to assign.',
+  })
+  licensePlanID!: string;
+
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'The ID of the Account to assign the LicensePlan to.',
+  })
+  accountID!: string;
+
+  @Field(() => UUID, {
+    nullable: true,
+    description: 'The ID of the Licensing to use.',
+  })
+  licensingID?: string;
+}

--- a/src/platform/admin/licensing/dto/admin.licensing.dto.revoke.license.plan.from.account.ts
+++ b/src/platform/admin/licensing/dto/admin.licensing.dto.revoke.license.plan.from.account.ts
@@ -2,7 +2,7 @@ import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { Field, InputType } from '@nestjs/graphql';
 
 @InputType()
-export class AssignLicensePlanToAccount {
+export class RevokeLicensePlanFromAccount {
   @Field(() => UUID, {
     nullable: false,
     description: 'The ID of the LicensePlan to assign.',

--- a/src/platform/admin/licensing/dto/admin.licensing.dto.revoke.license.plan.on.account.ts
+++ b/src/platform/admin/licensing/dto/admin.licensing.dto.revoke.license.plan.on.account.ts
@@ -1,0 +1,23 @@
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class AssignLicensePlanToAccount {
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'The ID of the LicensePlan to assign.',
+  })
+  licensePlanID!: string;
+
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'The ID of the Account to assign the LicensePlan to.',
+  })
+  accountID!: string;
+
+  @Field(() => UUID, {
+    nullable: true,
+    description: 'The ID of the Licensing to use.',
+  })
+  licensingID?: string;
+}

--- a/src/platform/license-issuer/license.issuer.module.ts
+++ b/src/platform/license-issuer/license.issuer.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LicenseIssuerService } from './license.issuer.service';
+import { AgentModule } from '@domain/agent/agent/agent.module';
+
+@Module({
+  imports: [AgentModule],
+  providers: [LicenseIssuerService],
+  exports: [LicenseIssuerService],
+})
+export class LicenseIssuerModule {}

--- a/src/platform/license-issuer/license.issuer.service.ts
+++ b/src/platform/license-issuer/license.issuer.service.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { ILicensePlan } from '@platform/license-plan/license.plan.interface';
+import { IAgent } from '@domain/agent/agent/agent.interface';
+import { AgentService } from '@domain/agent/agent/agent.service';
+
+@Injectable()
+export class LicenseIssuerService {
+  constructor(
+    private agentService: AgentService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  public async assignLicensePlan(
+    agent: IAgent,
+    licensePlan: ILicensePlan,
+    resourceID: string
+  ): Promise<IAgent> {
+    let expires: Date | undefined = undefined;
+    if (licensePlan.trialEnabled) {
+      const now = new Date();
+      const oneMonthFromNow = new Date(
+        now.getFullYear(),
+        now.getMonth() + 1,
+        now.getDate(),
+        0,
+        0,
+        0
+      );
+      expires = oneMonthFromNow;
+    }
+    const updatedAgent = await this.agentService.grantCredential({
+      agentID: agent.id,
+      type: licensePlan.licenseCredential,
+      resourceID: resourceID,
+      expires: expires,
+    });
+    return updatedAgent;
+  }
+
+  public async revokeLicensePlan(
+    agent: IAgent,
+    licensePlan: ILicensePlan,
+    resourceID: string
+  ): Promise<IAgent> {
+    const updatedAgent = await this.agentService.revokeCredential({
+      agentID: agent.id,
+      type: licensePlan.licenseCredential,
+      resourceID: resourceID,
+    });
+    return updatedAgent;
+  }
+}

--- a/src/platform/licensing/licensing.service.authorization.ts
+++ b/src/platform/licensing/licensing.service.authorization.ts
@@ -61,7 +61,7 @@ export class LicensingAuthorizationService {
 
     // Cascade down
     licensing.licensePolicy =
-      await this.licensePolicyAuthorizationService.applyAuthorizationPolicy(
+      this.licensePolicyAuthorizationService.applyAuthorizationPolicy(
         licensing.licensePolicy,
         licensing.authorization
       );
@@ -87,6 +87,7 @@ export class LicensingAuthorizationService {
           AuthorizationPrivilege.READ,
           AuthorizationPrivilege.UPDATE,
           AuthorizationPrivilege.DELETE,
+          AuthorizationPrivilege.GRANT,
         ],
         [AuthorizationCredential.GLOBAL_LICENSE_MANAGER],
         CREDENTIAL_RULE_LICENSE_MANAGER


### PR DESCRIPTION
New module for admin of license plans
New module for the actual assignment / revoking of license related credentials (resolves what is otherwise a circular dependency)

Logic updated to use the new license issuer module in the account service to ensure one way to assign license plans