### PR TITLE
VC privileges for Account Host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.78.8",
+  "version": "0.78.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.78.8",
+      "version": "0.78.9",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.78.8",
+  "version": "0.78.9",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -62,3 +62,5 @@ export const CREDENTIAL_RULE_DOCUMENT_CREATED_BY =
   'credentialRule-documentCreatedBy';
 export const CREDENTIAL_RULE_LIBRARY_INNOVATION_PACK_PROVIDER_ADMIN =
   'credentialRule-libraryInnovationPackProvider';
+export const CREDENTIAL_RULE_VIRTUAL_CONTRIBUTOR_CREATED_BY =
+  'credentialRule-virtualContributorCreatedBy';

--- a/src/domain/community/community/community.module.ts
+++ b/src/domain/community/community/community.module.ts
@@ -30,10 +30,12 @@ import { StorageAggregatorResolverModule } from '@services/infrastructure/storag
 import { CommunityGuidelinesModule } from '../community-guidelines/community.guidelines.module';
 import { VirtualContributorModule } from '../virtual-contributor/virtual.contributor.module';
 import { LicenseEngineModule } from '@core/license-engine/license.engine.module';
+import { AccountHostModule } from '@domain/space/account/account.host.module';
 
 @Module({
   imports: [
     ActivityAdapterModule,
+    AccountHostModule,
     NotificationAdapterModule,
     AuthorizationModule,
     AuthorizationPolicyModule,

--- a/src/domain/community/community/community.resolver.mutations.ts
+++ b/src/domain/community/community/community.resolver.mutations.ts
@@ -59,7 +59,7 @@ import {
   IngestSpace,
   SpaceIngestionPurpose,
 } from '@services/infrastructure/event-bus/commands';
-import { InvitationExternalService } from '../invitation.external/invitation.external.service';
+import { AccountHostService } from '@domain/space/account/account.host.service';
 
 const IAnyInvitation = createUnionType({
   name: 'AnyInvitation',
@@ -91,9 +91,9 @@ export class CommunityResolverMutations {
     private applicationAuthorizationService: ApplicationAuthorizationService,
     private invitationService: InvitationService,
     private invitationAuthorizationService: InvitationAuthorizationService,
-    private invitationExternalService: InvitationExternalService,
     private invitationExternalAuthorizationService: InvitationExternalAuthorizationService,
     private communityAuthorizationService: CommunityAuthorizationService,
+    private accountHostService: AccountHostService,
     private eventBus: EventBus
   ) {}
 
@@ -239,9 +239,12 @@ export class CommunityResolverMutations {
         }
       );
 
+    const host = await this.accountHostService.getHostOrFail(virtual.account);
+
     virtual =
       await this.virtualContributorAuthorizationService.applyAuthorizationPolicy(
         virtual,
+        host,
         virtual.account.authorization
       );
     virtual = await this.virtualContributorService.save(virtual);
@@ -362,9 +365,11 @@ export class CommunityResolverMutations {
           },
         }
       );
+    const host = await this.accountHostService.getHostOrFail(virtual.account);
     virtual =
       await this.virtualContributorAuthorizationService.applyAuthorizationPolicy(
         virtual,
+        host,
         virtual.account.authorization
       );
     return await this.virtualContributorService.save(virtual);

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -70,6 +70,11 @@ export class VirtualContributorAuthorizationService {
       virtual.id
     );
 
+    virtual.authorization = this.extendAuthorizationPolicy(
+      virtual.authorization,
+      host
+    );
+
     // NOTE: Clone the authorization policy to ensure the changes are local to profile
     const clonedVirtualAuthorizationAnonymousAccess =
       this.authorizationPolicyService.cloneAuthorizationPolicy(
@@ -92,11 +97,6 @@ export class VirtualContributorAuthorizationService {
     virtual.agent = this.agentAuthorizationService.applyAuthorizationPolicy(
       virtual.agent,
       virtual.authorization
-    );
-
-    virtual.authorization = this.extendAuthorizationPolicy(
-      virtual.authorization,
-      host
     );
 
     return virtual;
@@ -210,7 +210,7 @@ export class VirtualContributorAuthorizationService {
       hostSelfManagementCriterias,
       CREDENTIAL_RULE_VIRTUAL_CONTRIBUTOR_CREATED_BY
     );
-    selfManageVC.cascade = false;
+    selfManageVC.cascade = true;
     newRules.push(selfManageVC);
 
     this.authorizationPolicyService.appendCredentialAuthorizationRules(

--- a/src/domain/space/account/account.host.module.ts
+++ b/src/domain/space/account/account.host.module.ts
@@ -1,0 +1,10 @@
+import { ContributorModule } from '@domain/community/contributor/contributor.module';
+import { Module } from '@nestjs/common';
+import { AccountHostService } from './account.host.service';
+
+@Module({
+  imports: [ContributorModule],
+  providers: [AccountHostService],
+  exports: [AccountHostService],
+})
+export class AccountHostModule {}

--- a/src/domain/space/account/account.host.service.ts
+++ b/src/domain/space/account/account.host.service.ts
@@ -1,0 +1,52 @@
+import { AuthorizationCredential, LogContext } from '@common/enums';
+import { IContributor } from '@domain/community/contributor/contributor.interface';
+import { ContributorService } from '@domain/community/contributor/contributor.service';
+import { Injectable, Inject, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { IAccount } from './account.interface';
+import { EntityNotFoundException } from '@common/exceptions';
+
+@Injectable()
+export class AccountHostService {
+  constructor(
+    private contributorService: ContributorService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+  ) {}
+
+  async getHosts(account: IAccount): Promise<IContributor[]> {
+    const contributors =
+      await this.contributorService.contributorsWithCredentials({
+        type: AuthorizationCredential.ACCOUNT_HOST,
+        resourceID: account.id,
+      });
+    return contributors;
+  }
+
+  async getHost(account: IAccount): Promise<IContributor | null> {
+    const contributors =
+      await this.contributorService.contributorsWithCredentials({
+        type: AuthorizationCredential.ACCOUNT_HOST,
+        resourceID: account.id,
+      });
+    if (contributors.length === 1) {
+      return contributors[0];
+    } else if (contributors.length > 1) {
+      this.logger.error(
+        `Account with ID: ${account.id} has multiple hosts. This should not happen.`,
+        LogContext.ACCOUNT
+      );
+    }
+
+    return null;
+  }
+
+  async getHostOrFail(account: IAccount): Promise<IContributor> {
+    const host = await this.getHost(account);
+    if (!host)
+      throw new EntityNotFoundException(
+        `Unable to find Host for account with ID: ${account.id}`,
+        LogContext.COMMUNITY
+      );
+    return host;
+  }
+}

--- a/src/domain/space/account/account.module.ts
+++ b/src/domain/space/account/account.module.ts
@@ -20,9 +20,11 @@ import { ContributorModule } from '@domain/community/contributor/contributor.mod
 import { LicensingModule } from '@platform/licensing/licensing.module';
 import { VirtualContributorModule } from '@domain/community/virtual-contributor/virtual.contributor.module';
 import { LicenseIssuerModule } from '@platform/license-issuer/license.issuer.module';
+import { AccountHostModule } from './account.host.module';
 
 @Module({
   imports: [
+    AccountHostModule,
     AgentModule,
     AuthorizationModule,
     AuthorizationPolicyModule,

--- a/src/domain/space/account/account.resolver.fields.ts
+++ b/src/domain/space/account/account.resolver.fields.ts
@@ -33,11 +33,13 @@ import {
   IVirtualContributor,
   VirtualContributor,
 } from '@domain/community/virtual-contributor';
+import { AccountHostService } from './account.host.service';
 
 @Resolver(() => IAccount)
 export class AccountResolverFields {
   constructor(
     private accountService: AccountService,
+    private accountHostService: AccountHostService,
     private licensingService: LicensingService,
     private authorizationService: AuthorizationService
   ) {}
@@ -120,7 +122,7 @@ export class AccountResolverFields {
     description: 'The Account host.',
   })
   async host(@Parent() account: Account): Promise<IContributor> {
-    return await this.accountService.getHostOrFail(account);
+    return await this.accountHostService.getHostOrFail(account);
   }
 
   @ResolveField('spaceID', () => String, {

--- a/src/domain/space/account/account.resolver.mutations.ts
+++ b/src/domain/space/account/account.resolver.mutations.ts
@@ -36,11 +36,13 @@ import {
 } from '@services/infrastructure/event-bus/commands';
 import { CommunityContributorType } from '@common/enums/community.contributor.type';
 import { CommunityRole } from '@common/enums/community.role';
+import { AccountHostService } from './account.host.service';
 
 @Resolver()
 export class AccountResolverMutations {
   constructor(
     private accountService: AccountService,
+    private accountHostService: AccountHostService,
     private accountAuthorizationService: AccountAuthorizationService,
     private authorizationService: AuthorizationService,
     private platformAuthorizationService: PlatformAuthorizationPolicyService,
@@ -268,9 +270,11 @@ export class AccountResolverMutations {
       virtualContributorData
     );
 
+    const host = await this.accountHostService.getHostOrFail(account);
     virtual =
       await this.virtualContributorAuthorizationService.applyAuthorizationPolicy(
         virtual,
+        host,
         account.authorization
       );
 

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -34,6 +34,7 @@ import { IContributor } from '@domain/community/contributor/contributor.interfac
 import { Organization } from '@domain/community/organization';
 import { User } from '@domain/community/user/user.entity';
 import { ISpace } from '../space/space.interface';
+import { AccountHostService } from './account.host.service';
 
 @Injectable()
 export class AccountAuthorizationService {
@@ -45,7 +46,8 @@ export class AccountAuthorizationService {
     private platformAuthorizationService: PlatformAuthorizationPolicyService,
     private spaceAuthorizationService: SpaceAuthorizationService,
     private virtualContributorAuthorizationService: VirtualContributorAuthorizationService,
-    private accountService: AccountService
+    private accountService: AccountService,
+    private accountHostService: AccountHostService
   ) {}
 
   async applyAuthorizationPolicy(accountInput: IAccount): Promise<IAccount> {
@@ -78,7 +80,7 @@ export class AccountAuthorizationService {
         LogContext.ACCOUNT
       );
     }
-    const host = await this.accountService.getHostOrFail(account);
+    const host = await this.accountHostService.getHostOrFail(account);
 
     // Ensure always applying from a clean state
     account.authorization = this.authorizationPolicyService.reset(
@@ -133,6 +135,7 @@ export class AccountAuthorizationService {
       const udpatedVC =
         await this.virtualContributorAuthorizationService.applyAuthorizationPolicy(
           vc,
+          host,
           spaceAuthorization
         );
       updatedVCs.push(udpatedVC);


### PR DESCRIPTION
- Split Account and Account Host module because of circular dependencies
- Give READ, UPDATE, DELETE privileges to ACCOUNT_HOST

This is caused by the ACCOUNT --> SPACE --> ACCOUNT loop in inheriting the authorization policy. Because the VIRTUAL_CONTRIBUTOR needs the rules from SPACE_ADMIN, which is on SPACE level, and is not initialized at ACCOUNT creation time, no privileges are inherited from that rule.

I have added an explicit HOST rule on the VIRTUAL_CONTRIBUTOR, which fixes the problem, but the root cause is still there (the root cause also caused the patch needed yesterday). There is no easy fix, it's a design flaw.

@techsmyth this fixes the flow for now. Also, after auth reset GRANT and CREATE are added. To be consistent, we may add them, although they don't make any difference.

P.S. I have tried an extra .save just before applying authorization policy on VCs, but that didn't help (and will make things significantly slower as well).