### PR TITLE
Grant COMMUNITY_ADD_MEMBER to Support role

### DIFF
--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -175,7 +175,10 @@ export class CommunityAuthorizationService {
     const globalAdminAddMembers =
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
         [AuthorizationPrivilege.COMMUNITY_ADD_MEMBER],
-        [AuthorizationCredential.GLOBAL_ADMIN],
+        [
+          AuthorizationCredential.GLOBAL_ADMIN,
+          AuthorizationCredential.GLOBAL_SUPPORT,
+        ],
         CREDENTIAL_RULE_TYPES_COMMUNITY_ADD_MEMBERS
       );
     newRules.push(globalAdminAddMembers);


### PR DESCRIPTION
With this PR SUPPORT role should be able to add VCs outside of the Account.

Reset the Account that is being tested.