### PR TITLE
ensure external invitation is saved after auth is reset before completing the mutation

### DIFF
--- a/src/domain/community/community/community.resolver.mutations.ts
+++ b/src/domain/community/community/community.resolver.mutations.ts
@@ -60,6 +60,7 @@ import {
   SpaceIngestionPurpose,
 } from '@services/infrastructure/event-bus/commands';
 import { AccountHostService } from '@domain/space/account/account.host.service';
+import { InvitationExternalService } from '../invitation.external/invitation.external.service';
 
 const IAnyInvitation = createUnionType({
   name: 'AnyInvitation',
@@ -91,6 +92,7 @@ export class CommunityResolverMutations {
     private applicationAuthorizationService: ApplicationAuthorizationService,
     private invitationService: InvitationService,
     private invitationAuthorizationService: InvitationAuthorizationService,
+    private invitationExternalService: InvitationExternalService,
     private invitationExternalAuthorizationService: InvitationExternalAuthorizationService,
     private communityAuthorizationService: CommunityAuthorizationService,
     private accountHostService: AccountHostService,
@@ -681,6 +683,9 @@ export class CommunityResolverMutations {
         externalInvitation,
         community.authorization
       );
+    externalInvitation = await this.invitationExternalService.save(
+      externalInvitation
+    );
 
     const notificationInput: NotificationInputCommunityInvitationExternal = {
       triggeredBy: agentInfo.userID,


### PR DESCRIPTION
basically the updated auth is no longer saved in the auth service, so parent needs to do so