### PR TITLE
Notification for Virtual Contributor invitation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@alkemio/notifications-lib": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
-      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.5.tgz",
+      "integrity": "sha512-8QnTL5NZuToWirLAqzrTCW45xLuK8OlmNZLzrJd6t/vxzHJ89b0FYQpZ/U2xLkr0JBtoqTKbN2tI7vLvYnO7XQ==",
       "engines": {
         "node": ">=16.15.0",
         "npm": ">=8.5.5"
@@ -12802,9 +12802,9 @@
       "version": "0.3.6"
     },
     "@alkemio/notifications-lib": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
-      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA=="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.5.tgz",
+      "integrity": "sha512-8QnTL5NZuToWirLAqzrTCW45xLuK8OlmNZLzrJd6t/vxzHJ89b0FYQpZ/U2xLkr0JBtoqTKbN2tI7vLvYnO7XQ=="
     },
     "@ampproject/remapping": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.3.6",
-        "@alkemio/notifications-lib": "^0.8.3",
+        "@alkemio/notifications-lib": "^0.8.5",
         "@apollo/server": "^4.10.2",
         "@elastic/elasticsearch": "^8.4.0",
         "@golevelup/nestjs-rabbitmq": "^5.3.0",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@alkemio/notifications-lib": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.3.tgz",
-      "integrity": "sha512-NTLt09X57gbSe0OOlwEKGbHcwtz/d1qVVuNvnlsv6yJJhZk+82FBPC6/KAzEaD/zclyVJQXcdg20NeHoEEc9Bw==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
+      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA==",
       "engines": {
         "node": ">=16.15.0",
         "npm": ">=8.5.5"
@@ -12802,9 +12802,9 @@
       "version": "0.3.6"
     },
     "@alkemio/notifications-lib": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.3.tgz",
-      "integrity": "sha512-NTLt09X57gbSe0OOlwEKGbHcwtz/d1qVVuNvnlsv6yJJhZk+82FBPC6/KAzEaD/zclyVJQXcdg20NeHoEEc9Bw=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.8.4.tgz",
+      "integrity": "sha512-Vx0YWBqf0ptsL/cZwTTiyAcRoZleOBvuovj6BYXt8TbfQDdmGKfZz2tCg7+HvHOdbD1d8NPzIo+tooQo4nxQOA=="
     },
     "@ampproject/remapping": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@alkemio/matrix-adapter-lib": "^0.3.6",
     "@apollo/server": "^4.10.2",
-    "@alkemio/notifications-lib": "^0.8.3",
+    "@alkemio/notifications-lib": "^0.8.5",
     "@elastic/elasticsearch": "^8.4.0",
     "@nestjs/apollo": "^12.1.0",
     "@nestjs/axios": "^3.0.2",

--- a/src/common/enums/user.preference.type.ts
+++ b/src/common/enums/user.preference.type.ts
@@ -29,7 +29,6 @@ export enum UserPreferenceType {
   NOTIFICATION_FORUM_DISCUSSION_CREATED = 'NotificationForumDiscussionCreated',
   NOTIFICATION_FORUM_DISCUSSION_COMMENT = 'NotificationForumDiscussionComment',
   NOTIFICATION_COMMENT_REPLY = 'NotificationCommentReply',
-  NOTIFICATION_VIRTUAL_CONTRIBUTOR_INVITATION_HOST = 'NotificationVirtualContributorInvitationHost',
 }
 
 registerEnumType(UserPreferenceType, {

--- a/src/common/enums/user.preference.type.ts
+++ b/src/common/enums/user.preference.type.ts
@@ -29,6 +29,7 @@ export enum UserPreferenceType {
   NOTIFICATION_FORUM_DISCUSSION_CREATED = 'NotificationForumDiscussionCreated',
   NOTIFICATION_FORUM_DISCUSSION_COMMENT = 'NotificationForumDiscussionComment',
   NOTIFICATION_COMMENT_REPLY = 'NotificationCommentReply',
+  NOTIFICATION_VIRTUAL_CONTRIBUTOR_INVITATION_HOST = 'NotificationVirtualContributorInvitationHost',
 }
 
 registerEnumType(UserPreferenceType, {

--- a/src/services/adapters/notification-adapter/dto/notification.dto.input.community.vc.invitation.ts
+++ b/src/services/adapters/notification-adapter/dto/notification.dto.input.community.vc.invitation.ts
@@ -1,0 +1,10 @@
+import { ICommunity } from '@domain/community/community/community.interface';
+import { NotificationInputBase } from './notification.dto.input.base';
+import { IAccount } from '@domain/space/account/account.interface';
+
+export interface NotificationInputCommunityVirtualContributorInvitation
+  extends NotificationInputBase {
+  community: ICommunity;
+  account: IAccount;
+  virtualContributorID: string;
+}

--- a/src/services/adapters/notification-adapter/notification.adapter.module.ts
+++ b/src/services/adapters/notification-adapter/notification.adapter.module.ts
@@ -8,6 +8,8 @@ import { ActivityModule } from '@src/platform/activity/activity.module';
 import { NotificationAdapter } from './notification.adapter';
 import { NotificationPayloadBuilder } from './notification.payload.builder';
 import { UrlGeneratorModule } from '@services/infrastructure/url-generator/url.generator.module';
+import { AccountHostModule } from '@domain/space/account/account.host.module';
+import { VirtualContributorModule } from '@domain/community/virtual-contributor/virtual.contributor.module';
 
 @Module({
   imports: [
@@ -15,6 +17,8 @@ import { UrlGeneratorModule } from '@services/infrastructure/url-generator/url.g
     EntityResolverModule,
     UrlGeneratorModule,
     TypeOrmModule.forFeature([Post, Whiteboard, Community]),
+    AccountHostModule,
+    VirtualContributorModule,
   ],
   providers: [NotificationAdapter, NotificationPayloadBuilder],
   exports: [NotificationAdapter],

--- a/src/services/adapters/notification-adapter/notification.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.adapter.ts
@@ -29,6 +29,7 @@ import { NotificationInputCommunityInvitation } from './dto/notification.dto.inp
 import { NotificationInputCommentReply } from './dto/notification.dto.input.comment.reply';
 import { NotificationInputCommunityInvitationExternal } from './dto/notification.dto.input.community.invitation.external';
 import { NotificationInputPlatformGlobalRoleChange } from './dto/notification.dto.input.platform.global.role.change';
+import { NotificationInputCommunityVirtualContributorInvitation } from './dto/notification.dto.input.community.vc.invitation';
 
 @Injectable()
 export class NotificationAdapter {
@@ -315,6 +316,23 @@ export class NotificationAdapter {
         eventData.invitedUser,
         eventData.community,
         eventData.welcomeMessage
+      );
+
+    this.notificationsClient.emit<number>(event, payload);
+  }
+
+  public async invitationVirtualContributorCreated(
+    eventData: NotificationInputCommunityVirtualContributorInvitation
+  ): Promise<void> {
+    const event = NotificationEventType.COMMUNITY_INVITATION_CREATED_VC;
+    this.logEventTriggered(eventData, event);
+
+    const payload =
+      await this.notificationPayloadBuilder.buildInvitationVirtualContributorCreatedNotificationPayload(
+        eventData.triggeredBy,
+        eventData.virtualContributorID,
+        eventData.account,
+        eventData.community
       );
 
     this.notificationsClient.emit<number>(event, payload);

--- a/src/services/adapters/notification-adapter/notification.payload.builder.ts
+++ b/src/services/adapters/notification-adapter/notification.payload.builder.ts
@@ -134,20 +134,20 @@ export class NotificationPayloadBuilder {
     const hostPayload = await this.getContributorPayloadOrFail(host.id);
     const virtualContributor =
       await this.virtualContributorService.getVirtualContributorOrFail(
-        virtualContributorID
+        virtualContributorID,
+        { relations: { profile: true } }
       );
-    const payload: VirtualContributorInvitationCreatedEventPayload = {
+
+    return {
       host: hostPayload,
       virtualContributor: {
-        name: virtualContributor.nameID,
+        name: virtualContributor.profile.displayName,
         url: this.urlGeneratorService.generateUrlForVC(
           virtualContributor.nameID
         ),
       },
       ...spacePayload,
-    } as any;
-
-    return payload;
+    };
   }
 
   async buildExternalInvitationCreatedNotificationPayload(

--- a/src/services/adapters/notification-adapter/notification.payload.builder.ts
+++ b/src/services/adapters/notification-adapter/notification.payload.builder.ts
@@ -54,6 +54,10 @@ import { IDiscussion } from '@platform/forum-discussion/discussion.interface';
 import { IContributor } from '@domain/community/contributor/contributor.interface';
 import { UUID_LENGTH } from '@common/constants/entity.field.length.constants';
 import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
+import { AccountHostService } from '@domain/space/account/account.host.service';
+import { IAccount } from '@domain/space/account/account.interface';
+import { VirtualContributorService } from '@domain/community/virtual-contributor/virtual.contributor.service';
+import { VirtualContributorInvitationCreatedEventPayload } from '@alkemio/notifications-lib/dist/dto/virtual.contributor.invitation.created.event.payload';
 
 @Injectable()
 export class NotificationPayloadBuilder {
@@ -69,7 +73,9 @@ export class NotificationPayloadBuilder {
     private readonly logger: LoggerService,
     private configService: ConfigService,
     private contributionResolverService: ContributionResolverService,
-    private urlGeneratorService: UrlGeneratorService
+    private urlGeneratorService: UrlGeneratorService,
+    private accountHostService: AccountHostService,
+    private virtualContributorService: VirtualContributorService
   ) {}
 
   async buildApplicationCreatedNotificationPayload(
@@ -110,6 +116,36 @@ export class NotificationPayloadBuilder {
       welcomeMessage,
       ...spacePayload,
     };
+
+    return payload;
+  }
+
+  async buildInvitationVirtualContributorCreatedNotificationPayload(
+    invitationCreatorID: string,
+    virtualContributorID: string,
+    account: IAccount,
+    community: ICommunity
+  ): Promise<VirtualContributorInvitationCreatedEventPayload> {
+    const spacePayload = await this.buildSpacePayload(
+      community,
+      invitationCreatorID
+    );
+    const host = await this.accountHostService.getHostOrFail(account);
+    const hostPayload = await this.getContributorPayloadOrFail(host.id);
+    const virtualContributor =
+      await this.virtualContributorService.getVirtualContributorOrFail(
+        virtualContributorID
+      );
+    const payload: VirtualContributorInvitationCreatedEventPayload = {
+      host: hostPayload,
+      virtualContributor: {
+        name: virtualContributor.nameID,
+        url: this.urlGeneratorService.generateUrlForVC(
+          virtualContributor.nameID
+        ),
+      },
+      ...spacePayload,
+    } as any;
 
     return payload;
   }

--- a/src/services/infrastructure/url-generator/url.generator.service.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.ts
@@ -149,6 +149,10 @@ export class UrlGeneratorService {
     return url;
   }
 
+  public generateUrlForVC(nameID: string): string {
+    return `${this.endpoint_cluster}/vc/${nameID}`;
+  }
+
   async createJourneyAdminCommunityURL(space: ISpace): Promise<string> {
     const spaceNameID = space.nameID;
     const baseURL = `${this.endpoint_cluster}/admin/spaces/${spaceNameID}`;


### PR DESCRIPTION
Send email to host when a virtual contributor is invited to a communityл Payload will need a section for AccountHost from the account where the VC is provided from, with the following information: hostID
Recipients are:
- users with USER_SELF_MANAGEMENT credential, with the hostID specified
- users with ORGANIZATION_OWNER or ORGANIZATION_ADMIN credential with the hostID specified
Use the following preference: NOTIFICATION_COMMUNITY_INVITATION_USER