### PR TITLE
Properly wire `aiPersonaServiceID`

### DIFF
--- a/src/domain/community/ai-persona/ai.persona.service.ts
+++ b/src/domain/community/ai-persona/ai.persona.service.ts
@@ -158,7 +158,7 @@ export class AiPersonaService {
 
     const input: AiServerAdapterAskQuestionInput = {
       question: personaQuestionInput.question,
-      personaServiceID: aiPersona.aiPersonaServiceID,
+      aiPersonaServiceID: aiPersona.aiPersonaServiceID,
     };
 
     return await this.aiServerAdapter.askQuestion(

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -347,7 +347,7 @@ export class VirtualContributorService {
       LogContext.VIRTUAL_CONTRIBUTOR_ENGINE
     );
     const aiServerAdapterQuestionInput: AiServerAdapterAskQuestionInput = {
-      personaServiceID: virtualContributor.aiPersona.aiPersonaServiceID,
+      aiPersonaServiceID: virtualContributor.aiPersona.aiPersonaServiceID,
       question: vcQuestionInput.question,
     };
 

--- a/src/services/adapters/ai-server-adapter/ai.server.adapter.ts
+++ b/src/services/adapters/ai-server-adapter/ai.server.adapter.ts
@@ -6,7 +6,6 @@ import { AiServerService } from '@services/ai-server/ai-server/ai.server.service
 import { CreateAiPersonaServiceInput } from '@services/ai-server/ai-persona-service/dto';
 import { IAiPersonaService } from '@services/ai-server/ai-persona-service';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
-import { AiPersonaServiceQuestionInput } from '@services/ai-server/ai-persona-service/dto/ai.persona.service.question.dto.input';
 import { SpaceIngestionPurpose } from '@services/infrastructure/event-bus/commands';
 
 @Injectable()
@@ -49,7 +48,7 @@ export class AiServerAdapter {
     contextSapceNameID: string
   ): Promise<IAiPersonaQuestionResult> {
     return this.aiServer.askQuestion(
-      questionInput as unknown as AiPersonaServiceQuestionInput,
+      questionInput,
       agentInfo,
       contextSapceNameID
     );

--- a/src/services/adapters/ai-server-adapter/dto/ai.server.adapter.dto.ask.question.ts
+++ b/src/services/adapters/ai-server-adapter/dto/ai.server.adapter.dto.ask.question.ts
@@ -1,4 +1,4 @@
 export class AiServerAdapterAskQuestionInput {
   question!: string;
-  personaServiceID!: string;
+  aiPersonaServiceID!: string;
 }


### PR DESCRIPTION
### Describe the background of your pull request
I left a stupid typecast to unknown, which wiped a required property. As a result, the first `aiPersonaService` was always loaded for the engine.

This PR fixes that.