### PR TITLE
updated vc removal from community to extend auth policy with account host credentials in memory

### DIFF
--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -41,6 +41,8 @@ export const CREDENTIAL_RULE_COMMUNITY_USER_INVITATION =
   'credentialRule-communityUserInvitation';
 export const CREDENTIAL_RULE_COMMUNITY_SELF_REMOVAL =
   'credentialRule-communitySelfRemoval';
+export const CREDENTIAL_RULE_COMMUNITY_VIRTUAL_CONTRIBUTOR_REMOVAL =
+  'credentialRule-communityVirtualContributorRemoval';
 export const CREDENTIAL_RULE_COMMUNITY_ADD_MEMBER =
   'credentialRule-communityAddMember';
 export const CREDENTIAL_RULE_ORGANIZATION_VERIFICATION_ADMIN =

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -1,7 +1,7 @@
 export const CREDENTIAL_RULE_TYPES_ACCOUNT_AUTHORIZATION_RESET =
   'credentialRuleTypes-accountAuthorizationReset';
-export const CREDENTIAL_RULE_TYPES_ACCOUNT_DELETE =
-  'credentialRuleTypes-accountDelete';
+export const CREDENTIAL_RULE_TYPES_ACCOUNT_MANAGE =
+  'credentialRuleTypes-accountManage';
 export const CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES =
   'credentialRuleTypes-accountChildEntities';
 export const CREDENTIAL_RULE_TYPES_SPACE_GLOBAL_COMMUNITY_READ =
@@ -70,8 +70,6 @@ export const CREDENTIAL_RULE_TYPES_PLATFORM_ANY_ADMIN =
   'credentialRuleTypes-platformAnyAdmin';
 export const CREDENTIAL_RULE_PLATFORM_CREATE_ORGANIZATION =
   'credentialRuleTypes-platformCreateOrganization';
-export const CREDENTIAL_RULE_ACCOUNT_CREATE_VIRTUAL_CONTRIBUTOR =
-  'credentialRuleTypes-accountCreateVirtualContributor';
 export const CREDENTIAL_RULE_PLATFORM_CREATE_SPACE =
   'credentialRuleTypes-platformCreateSpace';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE =

--- a/src/common/constants/authorization/policy.rule.constants.ts
+++ b/src/common/constants/authorization/policy.rule.constants.ts
@@ -2,6 +2,7 @@ export const POLICY_RULE_SPACE_CREATE_SUBSPACE =
   'policyRule-spaceCreateSubspace';
 export const POLICY_RULE_WHITEBOARD_CONTENT_UPDATE =
   'policyRule-whiteboardContentUpdate';
+export const POLICY_RULE_ACCOUNT_CREATE_VC = 'policyRule-accountCreateVC';
 export const POLICY_RULE_VISUAL_UPDATE = 'policyRule-visualUpdate';
 export const POLICY_RULE_ROOM_CONTRIBUTE = 'policyRule-roomContribute';
 export const POLICY_RULE_ROOM_ADMINS = 'policyRule-roomAdminsCreate';

--- a/src/domain/communication/communication/communication.service.authorization.ts
+++ b/src/domain/communication/communication/communication.service.authorization.ts
@@ -2,13 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ICommunication } from '@domain/communication/communication';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
-import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { CommunicationService } from './communication.service';
-import { AuthorizationPolicyRulePrivilege } from '@core/authorization/authorization.policy.rule.privilege';
-import {
-  POLICY_RULE_FORUM_CONTRIBUTE,
-  POLICY_RULE_FORUM_CREATE,
-} from '@common/constants';
 import { RoomAuthorizationService } from '../room/room.service.authorization';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
 
@@ -49,10 +43,6 @@ export class CommunicationAuthorizationService {
         parentAuthorization
       );
 
-    communication.authorization = this.appendPrivilegeRules(
-      communication.authorization
-    );
-
     communication.updates =
       this.roomAuthorizationService.applyAuthorizationPolicy(
         communication.updates,
@@ -65,30 +55,5 @@ export class CommunicationAuthorizationService {
       );
 
     return communication;
-  }
-
-  private appendPrivilegeRules(
-    authorization: IAuthorizationPolicy
-  ): IAuthorizationPolicy {
-    const privilegeRules: AuthorizationPolicyRulePrivilege[] = [];
-
-    // Allow any contributor to this community to create discussions, and to send messages to the discussion
-    const contributePrivilege = new AuthorizationPolicyRulePrivilege(
-      [AuthorizationPrivilege.CREATE_DISCUSSION],
-      AuthorizationPrivilege.CONTRIBUTE,
-      POLICY_RULE_FORUM_CONTRIBUTE
-    );
-    privilegeRules.push(contributePrivilege);
-
-    const createPrivilege = new AuthorizationPolicyRulePrivilege(
-      [AuthorizationPrivilege.CREATE_DISCUSSION],
-      AuthorizationPrivilege.CREATE,
-      POLICY_RULE_FORUM_CREATE
-    );
-    privilegeRules.push(createPrivilege);
-    return this.authorizationPolicyService.appendPrivilegeAuthorizationRules(
-      authorization,
-      privilegeRules
-    );
   }
 }

--- a/src/domain/communication/communication/communication.service.authorization.ts
+++ b/src/domain/communication/communication/communication.service.authorization.ts
@@ -5,6 +5,7 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy/author
 import { CommunicationService } from './communication.service';
 import { RoomAuthorizationService } from '../room/room.service.authorization';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
+import { LogContext } from '@common/enums/logging.context';
 
 @Injectable()
 export class CommunicationAuthorizationService {

--- a/src/domain/community/community/community.resolver.mutations.ts
+++ b/src/domain/community/community/community.resolver.mutations.ts
@@ -314,9 +314,18 @@ export class CommunityResolverMutations {
       roleData.communityID
     );
 
+    // Extend the authorization policy with a credential rule to assign the GRANT privilege
+    // to the user with rights around the incoming virtual being removed.
+    //. Then if it is the user that is logged in then the user will have the GRANT privilege + so can carry out the mutation
+    const extendedAuthorization =
+      await this.communityAuthorizationService.extendAuthorizationPolicyForVirtualContributorRemoval(
+        community,
+        roleData.virtualContributorID
+      );
+
     await this.authorizationService.grantAccessOrFail(
       agentInfo,
-      community.authorization,
+      extendedAuthorization,
       AuthorizationPrivilege.GRANT,
       `remove virtual from community role: ${community.id}`
     );

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -125,6 +125,7 @@ export class VirtualContributorAuthorizationService {
       );
     newRules.push(globalCommunityRead);
 
+    // TODO: rule that for now allows global support ability to manage VCs, this to be removed later
     const globalSupportManage =
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
         [

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -38,6 +38,7 @@ import { IMessageAnswerToQuestion } from '@domain/communication/message.answer.t
 import { IAiPersona } from '../ai-persona';
 import { IContributor } from '../contributor/contributor.interface';
 import { AccountHostService } from '@domain/space/account.host/account.host.service';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 
 @Injectable()
 export class VirtualContributorService {
@@ -455,6 +456,26 @@ export class VirtualContributorService {
 
     const host = await this.accountHostService.getHostOrFail(account);
     return host;
+  }
+
+  public async getAccountHostCredentials(
+    virtualContributorID: string
+  ): Promise<ICredentialDefinition[]> {
+    const virtualContributorWithAccount =
+      await this.getVirtualContributorOrFail(virtualContributorID, {
+        relations: { account: true },
+      });
+    const account = virtualContributorWithAccount.account;
+    if (!account)
+      throw new EntityNotInitializedException(
+        `Virtual Contributor Account not initialized: ${virtualContributorID}`,
+        LogContext.AUTH
+      );
+
+    const hostCredentials = await this.accountHostService.getHostCredentials(
+      account
+    );
+    return hostCredentials;
   }
 
   async getAiPersonaOrFail(

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -261,17 +261,19 @@ export class AccountAuthorizationService {
       );
     accountChildEntitiesManage.push(...spaceAdminCriterias);
     if (accountChildEntitiesManage.length !== 0) {
-      const spaceAdmin = this.authorizationPolicyService.createCredentialRule(
-        [
-          AuthorizationPrivilege.CREATE,
-          AuthorizationPrivilege.READ,
-          AuthorizationPrivilege.UPDATE,
-          AuthorizationPrivilege.DELETE,
-        ],
-        accountChildEntitiesManage,
-        CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES
-      );
-      newRules.push(spaceAdmin);
+      const accountChildEntities =
+        this.authorizationPolicyService.createCredentialRule(
+          [
+            AuthorizationPrivilege.CREATE,
+            AuthorizationPrivilege.READ,
+            AuthorizationPrivilege.UPDATE,
+            AuthorizationPrivilege.DELETE,
+            AuthorizationPrivilege.GRANT,
+          ],
+          accountChildEntitiesManage,
+          CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES
+        );
+      newRules.push(accountChildEntities);
     }
     return this.authorizationPolicyService.appendCredentialAuthorizationRules(
       authorization,

--- a/src/platform/admin/licensing/admin.licensing.resolver.mutations.ts
+++ b/src/platform/admin/licensing/admin.licensing.resolver.mutations.ts
@@ -11,11 +11,13 @@ import { ILicensing } from '@platform/licensing/licensing.interface';
 import { AdminLicensingService } from './admin.licensing.service';
 import { IAccount } from '@domain/space/account/account.interface';
 import { RevokeLicensePlanFromAccount } from './dto/admin.licensing.dto.revoke.license.plan.from.account';
+import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
 
 @Resolver()
 export class AdminLicensingResolverMutations {
   constructor(
     private authorizationService: AuthorizationService,
+    private accountAuthorizationService: AccountAuthorizationService,
     private licensingService: LicensingService,
     private adminLicensingService: AdminLicensingService
   ) {}
@@ -45,9 +47,13 @@ export class AdminLicensingResolverMutations {
       `assign licensePlan on licensing: ${licensing.id}`
     );
 
-    return await this.adminLicensingService.assignLicensePlanToAccount(
+    const account = await this.adminLicensingService.assignLicensePlanToAccount(
       planData,
       licensing.id
+    );
+    // Need to trigger an authorization reset as some license credentials are used in auth policy e.g. VCs feature flag
+    return await this.accountAuthorizationService.applyAuthorizationPolicy(
+      account
     );
   }
 


### PR DESCRIPTION
This PR enables the mutation on the server to run,. key here is that the authorization policy has to be extended in memory, based on the information from the incoming request. This is similar to how user self removal works.

In addition the authorization policy around account / space has been tidied up, with the result that the VC provider will now have the GRANT privilege + so will see the button to leave. 

Other updates:
removed CREATE_DISCUSSION privilege assignment from community; 
trigger authorization reset after assign license plan to account; 
removed spaceIngest mutation that logically should not be there