### PR TITLE
Fix storage query

### DIFF
--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -286,15 +286,13 @@ export class StorageBucketService {
   public async size(storage: IStorageBucket): Promise<number> {
     const documentsSize = await this.documentRepository
       .createQueryBuilder('document')
-      .select([])
       .where('document.storageBucketId = :storageBucketId', {
         storageBucketId: storage.id,
       })
-      .addSelect('SUM(size)', 'totalSize')
-      .getRawOne();
+      .select('SUM(size)', 'totalSize')
+      .getRawOne<{ totalSize: number }>();
 
-    if (!documentsSize || !documentsSize.totalSize) return 0;
-    return documentsSize.totalSize;
+    return documentsSize?.totalSize ?? 0;
   }
 
   public async getFilteredDocuments(

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -286,6 +286,7 @@ export class StorageBucketService {
   public async size(storage: IStorageBucket): Promise<number> {
     const documentsSize = await this.documentRepository
       .createQueryBuilder('document')
+      .select([])
       .where('document.storageBucketId = :storageBucketId', {
         storageBucketId: storage.id,
       })


### PR DESCRIPTION
This typeorm query:
![image](https://github.com/alkem-io/server/assets/16032487/bec93366-a344-44b5-ad50-579f7cf2d260)
was turned into this:
 
![image](https://github.com/alkem-io/server/assets/16032487/64a08335-de69-4542-a5e2-4263d1d205a0)


I have just removed the useless selected columns to retrieve only the `SUM(size)`.
![image](https://github.com/alkem-io/server/assets/16032487/47478f37-fc0b-40f1-96f1-f885ad706e2b)

----

Has been difficult to reproduce in localhost, because we don't have `ONLY_FULL_GROUP_BY` enabled in our local mysql container.

I have tried to enable it with this command: 
```
SET session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
```
but that was not enough - not sure why - `SELECT @@sql_mode;` was still the same.
- I have added a volume  to  quickstart-services.yml:  `      - ./mysql-custom-config:/etc/mysql/conf.d` 
- Created a file my.conf in `server/mysql-custom-config`
- Added this lines: 
```
[mysqld]
sql_mode = "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY"
```

The other values `STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION` are the default ones for our local mysql server, but I would like to run `SELECT @@sql_mode;` on all the environments and make sure that we configure all the environments the same way including local.