### PR TITLE
Fix 4251: Get my created spaces in a proper way

### DIFF
--- a/src/domain/community/contributor/contributor.service.ts
+++ b/src/domain/community/contributor/contributor.service.ts
@@ -124,7 +124,8 @@ export class ContributorService {
   }
 
   public async getAccountsHostedByContributor(
-    contributor: IContributor
+    contributor: IContributor,
+    includeSpace = false
   ): Promise<IAccount[]> {
     let agent = contributor.agent;
     if (!agent) {
@@ -148,6 +149,9 @@ export class ContributorService {
     const accounts = await this.entityManager.find(Account, {
       where: {
         id: In(accountIDs),
+      },
+      relations: {
+        space: includeSpace,
       },
     });
 

--- a/src/domain/space/account/account.interface.ts
+++ b/src/domain/space/account/account.interface.ts
@@ -17,4 +17,5 @@ export class IAccount extends IAuthorizable {
   license?: ILicense;
   virtualContributors!: IVirtualContributor[];
   storageAggregator?: IStorageAggregator;
+  createdDate?: Date;
 }

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1173,7 +1173,7 @@ export class SpaceService {
 
   public async getSpaceForAccountOrFail(accountId: string): Promise<ISpace> {
     const space = await this.spaceRepository.findOne({
-      where: { account: { id: accountId } },
+      where: { level: 0, account: { id: accountId } },
       relations: {
         account: true,
       },

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1171,6 +1171,24 @@ export class SpaceService {
     return space.account;
   }
 
+  public async getSpaceForAccountOrFail(accountId: string): Promise<ISpace> {
+    const space = await this.spaceRepository.findOne({
+      where: { account: { id: accountId } },
+      relations: {
+        account: true,
+      },
+    });
+
+    if (!space) {
+      throw new EntityNotFoundException(
+        `Unable to find base subspace with accountID: ${accountId}`,
+        LogContext.SPACES
+      );
+    }
+
+    return space;
+  }
+
   public async getCommunity(spaceId: string): Promise<ICommunity> {
     const subspaceWithCommunity = await this.getSpaceOrFail(spaceId, {
       relations: { community: true },

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1171,24 +1171,6 @@ export class SpaceService {
     return space.account;
   }
 
-  public async getSpaceForAccountOrFail(accountId: string): Promise<ISpace> {
-    const space = await this.spaceRepository.findOne({
-      where: { level: 0, account: { id: accountId } },
-      relations: {
-        account: true,
-      },
-    });
-
-    if (!space) {
-      throw new EntityNotFoundException(
-        `Unable to find base subspace with accountID: ${accountId}`,
-        LogContext.SPACES
-      );
-    }
-
-    return space;
-  }
-
   public async getCommunity(spaceId: string): Promise<ICommunity> {
     const subspaceWithCommunity = await this.getSpaceOrFail(spaceId, {
       relations: { community: true },

--- a/src/services/api/me/me.module.ts
+++ b/src/services/api/me/me.module.ts
@@ -12,6 +12,7 @@ import { ActivityLogModule } from '../activity-log/activity.log.module';
 import { ActivityModule } from '@platform/activity/activity.module';
 import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
 import { CommunityRoleModule } from '@domain/community/community-role/community.role.module';
+import { ContributorModule } from '@domain/community/contributor/contributor.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { CommunityRoleModule } from '@domain/community/community-role/community.
     ApplicationModule,
     InvitationModule,
     UserModule,
+    ContributorModule,
     SpaceModule,
     RolesModule,
     ActivityLogModule,

--- a/src/services/api/me/me.resolver.fields.ts
+++ b/src/services/api/me/me.resolver.fields.ts
@@ -132,15 +132,19 @@ export class MeResolverFields {
         'The number of Journeys to return; if omitted return latest 20 active Journeys.',
       nullable: true,
     })
-    limit: number,
-    @Args('showOnlyMyCreatedSpaces', { type: () => Boolean, nullable: true })
-    showOnlyMyCreatedSpaces: boolean
+    limit: number
   ): Promise<MySpaceResults[]> {
-    return this.meService.getMySpaces(
-      agentInfo,
-      limit,
-      showOnlyMyCreatedSpaces
-    );
+    return this.meService.getMySpaces(agentInfo, limit);
+  }
+
+  @UseGuards(GraphqlGuard)
+  @ResolveField(() => [ISpace], {
+    description: 'The Spaces I have created',
+  })
+  public myCreatedSpaces(
+    @CurrentUser() agentInfo: AgentInfo
+  ): Promise<ISpace[]> {
+    return this.meService.getMyCreatedSpaces(agentInfo);
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/services/api/me/me.resolver.fields.ts
+++ b/src/services/api/me/me.resolver.fields.ts
@@ -142,9 +142,17 @@ export class MeResolverFields {
     description: 'The Spaces I have created',
   })
   public myCreatedSpaces(
-    @CurrentUser() agentInfo: AgentInfo
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args({
+      name: 'limit',
+      type: () => Float,
+      description:
+        'The number of Spaces to return; if omitted return latest 20 created spaces.',
+      nullable: true,
+    })
+    limit: number
   ): Promise<ISpace[]> {
-    return this.meService.getMyCreatedSpaces(agentInfo);
+    return this.meService.getMyCreatedSpaces(agentInfo, limit);
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -19,6 +19,7 @@ import { CommunityApplicationResult } from './dto/me.application.result';
 import { CommunityRoleService } from '@domain/community/community-role/community.role.service';
 import { ContributorService } from '@domain/community/contributor/contributor.service';
 import { UserService } from '@domain/community/user/user.service';
+import { compact } from 'lodash';
 
 @Injectable()
 export class MeService {
@@ -165,7 +166,7 @@ export class MeService {
       );
     }
     const accounts = (
-      await this.contributorService.getAccountsHostedByContributor(user)
+      await this.contributorService.getAccountsHostedByContributor(user, true)
     )
       .sort((a, b) =>
         a.createdDate && b.createdDate
@@ -174,11 +175,11 @@ export class MeService {
       )
       .slice(0, limit);
 
-    return await Promise.all(
-      accounts.map(account =>
-        this.spaceService.getSpaceForAccountOrFail(account.id)
-      )
-    );
+    if (!accounts || accounts.length === 0) {
+      return [];
+    }
+
+    return compact(accounts.map(account => account.space));
   }
 
   public async canCreateFreeSpace(agentInfo: AgentInfo): Promise<boolean> {

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -12,17 +12,20 @@ import { ActivityService } from '@platform/activity/activity.service';
 import { AuthorizationCredential, LogContext } from '@common/enums';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { sortSpacesByActivity } from '@domain/space/space/sort.spaces.by.activity';
-import { CommunityRole } from '@common/enums/community.role';
 import { CommunityInvitationResult } from './dto/me.invitation.result';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { EntityNotFoundException } from '@common/exceptions';
 import { CommunityApplicationResult } from './dto/me.application.result';
 import { CommunityRoleService } from '@domain/community/community-role/community.role.service';
+import { ContributorService } from '@domain/community/contributor/contributor.service';
+import { UserService } from '@domain/community/user/user.service';
 
 @Injectable()
 export class MeService {
   constructor(
     private spaceService: SpaceService,
+    private contributorService: ContributorService,
+    private userService: UserService,
     private rolesService: RolesService,
     private activityLogService: ActivityLogService,
     private activityService: ActivityService,
@@ -121,8 +124,7 @@ export class MeService {
 
   public async getMySpaces(
     agentInfo: AgentInfo,
-    limit = 20,
-    showOnlyMyCreatedSpaces = false
+    limit = 20
   ): Promise<MySpaceResults[]> {
     const rawActivities = await this.activityService.getMySpacesActivity(
       agentInfo.userID,
@@ -142,38 +144,31 @@ export class MeService {
         );
         continue;
       }
-      if (!showOnlyMyCreatedSpaces) {
-        mySpaceResults.push({
-          space: activityLog.space,
-          latestActivity: activityLog,
-        });
-      } else {
-        if (activityLog?.space) {
-          if (!activityLog?.space.community) {
-            this.logger.warn(
-              `Unable to process space entry ${activityLog?.space.id} because it does not have a community.`,
-              LogContext.ACTIVITY
-            );
-            continue;
-          }
-          const myRoles = await this.communityRoleService.getCommunityRoles(
-            agentInfo,
-            activityLog.space.community
-          );
-          if (
-            myRoles.includes(CommunityRole.ADMIN) &&
-            activityLog.space.level === 0
-          ) {
-            mySpaceResults.push({
-              space: activityLog.space,
-              latestActivity: activityLog,
-            });
-          }
-        }
-      }
+      mySpaceResults.push({
+        space: activityLog.space,
+        latestActivity: activityLog,
+      });
     }
 
     return mySpaceResults.slice(0, limit);
+  }
+
+  public async getMyCreatedSpaces(agentInfo: AgentInfo): Promise<ISpace[]> {
+    const user = await this.userService.getUserOrFail(agentInfo.userID);
+    if (!user) {
+      throw new EntityNotFoundException(
+        `User not found ${agentInfo.userID}`,
+        LogContext.COMMUNITY
+      );
+    }
+    const accounts =
+      await this.contributorService.getAccountsHostedByContributor(user);
+
+    return await Promise.all(
+      accounts.map(account =>
+        this.spaceService.getSpaceForAccountOrFail(account.id)
+      )
+    );
   }
 
   public async canCreateFreeSpace(agentInfo: AgentInfo): Promise<boolean> {

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -153,7 +153,10 @@ export class MeService {
     return mySpaceResults.slice(0, limit);
   }
 
-  public async getMyCreatedSpaces(agentInfo: AgentInfo): Promise<ISpace[]> {
+  public async getMyCreatedSpaces(
+    agentInfo: AgentInfo,
+    limit = 20
+  ): Promise<ISpace[]> {
     const user = await this.userService.getUserOrFail(agentInfo.userID);
     if (!user) {
       throw new EntityNotFoundException(
@@ -161,8 +164,15 @@ export class MeService {
         LogContext.COMMUNITY
       );
     }
-    const accounts =
-      await this.contributorService.getAccountsHostedByContributor(user);
+    const accounts = (
+      await this.contributorService.getAccountsHostedByContributor(user)
+    )
+      .sort((a, b) =>
+        a.createdDate && b.createdDate
+          ? b.createdDate.getTime() - a.createdDate.getTime() // Sort descending, so latest is the first
+          : 0
+      )
+      .slice(0, limit);
 
     return await Promise.all(
       accounts.map(account =>


### PR DESCRIPTION
I've just removed the param `showOnlyMyCreatedSpaces` and have added a field to the `me` query that returns directly my created spaces instead of passing through activities.

