### PR TITLE
Fix 6625 - StorageBucket not initialized when uploading a document to Space context

### DIFF
--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -152,7 +152,9 @@ export class StorageBucketService {
     userID: string,
     anonymousReadAccess = false
   ): Promise<IDocument | never> {
-    const storage = await this.getStorageBucketOrFail(storageBucketId);
+    const storage = await this.getStorageBucketOrFail(storageBucketId, {
+      relations: {},
+    });
 
     this.validateMimeTypes(storage, mimeType);
 

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -152,14 +152,7 @@ export class StorageBucketService {
     userID: string,
     anonymousReadAccess = false
   ): Promise<IDocument | never> {
-    const storage = await this.getStorageBucketOrFail(storageBucketId, {
-      relations: {},
-    });
-    if (!storage.documents)
-      throw new EntityNotInitializedException(
-        `StorageBucket (${storage}) not initialised`,
-        LogContext.STORAGE_BUCKET
-      );
+    const storage = await this.getStorageBucketOrFail(storageBucketId);
 
     this.validateMimeTypes(storage, mimeType);
 


### PR DESCRIPTION
Tried with adding the `relations: { documents: true }` and it worked, 
but `documents` is not needed at all, so removed the check completely.