### PR TITLE
Secure elastic connection based on self-signed ssl cert

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -358,6 +358,7 @@ integrations:
       namings: ${ELASTIC_INDEX_NAMINGS_NAME}:namings
       guidance_usage: ${ELASTIC_INDEX_GUIDANCE_USAGE_NAME}:guidance-usage
     tls:
+      ca_cert_path: ${ELASTIC_TLS_CA_CERT_PATH}:none
       rejectUnauthorized: ${ELASTIC_TLS_REJECT_UNAUTHORIZED}:false
     policies:
       space_name_enrich_policy: ${ELASTIC_POLICY_SPACE_NAME_ENRICH}:space_name_enrich_policy

--- a/src/services/external/elasticsearch/elasticsearch-client/elasticsearch.client.factory.ts
+++ b/src/services/external/elasticsearch/elasticsearch-client/elasticsearch.client.factory.ts
@@ -28,7 +28,7 @@ export const elasticSearchClientFactory = async (
     }
     const cert = fs.readFileSync(certPath);
     tlsOptions = {
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
       ca: cert,
     };
   }

--- a/src/services/external/elasticsearch/elasticsearch-client/elasticsearch.client.factory.ts
+++ b/src/services/external/elasticsearch/elasticsearch-client/elasticsearch.client.factory.ts
@@ -2,17 +2,36 @@ import { LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Client } from '@elastic/elasticsearch';
 import { ConfigurationTypes } from '@common/enums';
+import fs from 'fs';
 
-export const elasticSearchClientFactory = (
+export const elasticSearchClientFactory = async (
   logger: LoggerService,
   configService: ConfigService
-): Client | undefined => {
+): Promise<Client | undefined> => {
   const elasticsearch = configService.get(
     ConfigurationTypes.INTEGRATIONS
   )?.elasticsearch;
 
   const { host, retries, timeout, api_key, tls } = elasticsearch;
   const rejectUnauthorized = tls.rejectUnauthorized ?? false;
+  let tlsOptions;
+
+  // Ensure the path to the certificate inside the container is correct
+  if (tls.ca_cert_path === 'none') {
+    tlsOptions = { rejectUnauthorized };
+  } else {
+    // This should match the mountPath in your Kubernetes deployment YAML
+    const certPath = tls.ca_cert_path;
+    if (!fs.existsSync(certPath)) {
+      logger.error(`Certificate not found at path: ${certPath}`);
+      return undefined;
+    }
+    const cert = fs.readFileSync(certPath);
+    tlsOptions = {
+      rejectUnauthorized: false,
+      ca: cert,
+    };
+  }
 
   if (!host) {
     logger.warn('Elasticsearch host URL not provided!');
@@ -30,6 +49,6 @@ export const elasticSearchClientFactory = (
     requestTimeout: timeout,
     resurrectStrategy: 'ping',
     auth: { apiKey: api_key },
-    tls: { rejectUnauthorized },
+    tls: tlsOptions,
   });
 };


### PR DESCRIPTION
Added the option to establish secure transport to elasticsearch. Uses self-signed SSL cert. To test:

Select `k8s-elastic` or `k8s-sandbox-elastic` as k8s context and run the following command:

```bash
kubectl get secret "elasticsearch-es-http-certs-public" -o go-template='{{index .data "tls.crt" | base64decode }}' > tls.crt
```

This will give you `tls.crt` --> the self-signed certificate used to connect.
Save it to a location, and then configure it in .env via `ELASTIC_TLS_CA_CERT_PATH` env var.

The code is backwards-compatible. If the cert is provided, `rejectUnauthorized` is set to `true`.

I have used this in the elastic factory to test:

```typescript
  const client = new Client({
    node: host,
    maxRetries: retries,
    requestTimeout: timeout,
    resurrectStrategy: 'ping',
    auth: { apiKey: api_key },
    tls: tlsOptions,
  });

  // Test the connection
  client
    .info()
    .then(response => {
      console.log('Successfully connected to Elasticsearch');
      console.log(response);
    })
    .catch(error => {
      console.error('Error connecting to Elasticsearch:', error);
    });
```