### PR TITLE
(almost) atomic profile creation

### DIFF
--- a/src/domain/common/location/location.service.ts
+++ b/src/domain/common/location/location.service.ts
@@ -14,9 +14,8 @@ export class LocationService {
     private locationRepository: Repository<Location>
   ) {}
 
-  async createLocation(locationData?: CreateLocationInput): Promise<ILocation> {
-    const location = Location.create({ ...locationData });
-    return await this.locationRepository.save(location);
+  public createLocation(locationData?: CreateLocationInput): ILocation {
+    return Location.create({ ...locationData });
   }
   async removeLocation(location: ILocation): Promise<ILocation> {
     return await this.locationRepository.remove(location as Location);

--- a/src/domain/common/reference/reference.service.ts
+++ b/src/domain/common/reference/reference.service.ts
@@ -21,16 +21,14 @@ export class ReferenceService {
     private referenceRepository: Repository<Reference>
   ) {}
 
-  async createReference(
-    referenceInput: CreateReferenceInput
-  ): Promise<IReference> {
+  public createReference(referenceInput: CreateReferenceInput): IReference {
     const reference = new Reference(
       referenceInput.name,
       referenceInput.uri || '',
       referenceInput.description
     );
     reference.authorization = new AuthorizationPolicy();
-    await this.referenceRepository.save(reference);
+
     return reference;
   }
 

--- a/src/domain/common/tagset/tagset.service.ts
+++ b/src/domain/common/tagset/tagset.service.ts
@@ -1,3 +1,4 @@
+import { some } from 'lodash';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -233,10 +234,10 @@ export class TagsetService {
     return tagset;
   }
 
-  async createTagsetWithName(
+  public createTagsetWithName(
     existingTagsets: ITagset[],
     tagsetData: CreateTagsetInput
-  ): Promise<ITagset> {
+  ): ITagset {
     // Check if the group already exists, if so log a warning
     if (this.hasTagsetWithName(existingTagsets, tagsetData.name)) {
       throw new ValidationException(
@@ -245,7 +246,7 @@ export class TagsetService {
       );
     }
 
-    return await this.createTagset(tagsetData);
+    return Tagset.create({ ...tagsetData });
   }
 
   async save(tagset: ITagset): Promise<ITagset> {

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -51,7 +51,7 @@ export class StorageBucketService {
     private profileRepository: Repository<Profile>
   ) {}
 
-  public async createStorageBucket(
+  public createStorageBucket(
     storageBucketData: CreateStorageBucketInput
   ): Promise<IStorageBucket> {
     const storage: IStorageBucket = new StorageBucket();
@@ -63,7 +63,7 @@ export class StorageBucketService {
       storageBucketData?.maxFileSize || this.DEFAULT_MAX_ALLOWED_FILE_SIZE;
     storage.storageAggregator = storageBucketData.storageAggregator;
 
-    return await this.storageBucketRepository.save(storage);
+    return this.storageBucketRepository.save(storage);
   }
 
   async deleteStorageBucket(storageID: string): Promise<IStorageBucket> {
@@ -188,9 +188,8 @@ export class StorageBucketService {
       /* just consume */
     }
 
-    const document = await this.documentService.createDocument(
-      createDocumentInput
-    );
+    const document =
+      await this.documentService.createDocument(createDocumentInput);
     document.storageBucket = storage;
 
     this.logger.verbose?.(
@@ -215,9 +214,8 @@ export class StorageBucketService {
         LogContext.DOCUMENT
       );
 
-    const documentForReference = await this.documentService.getDocumentFromURL(
-      uri
-    );
+    const documentForReference =
+      await this.documentService.getDocumentFromURL(uri);
 
     try {
       const newDocument = await this.uploadFileAsDocument(


### PR DESCRIPTION
## Start here

Only the creation of the storage bucket is still independant, because it introduces a cyclic issue for the typeorm for `StorageBucket`, which I have chosen to leave in to address other problems faster.
- I have ran `callouts`, `journey`, `organization` test suits.

**It is important that the reviewer is the same all across the epic to not loose context. It is a change with high risk overall.**