### PR TITLE
Safely drop FK

### DIFF
--- a/src/migrations/1721649196399-innovationPacksAccount.ts
+++ b/src/migrations/1721649196399-innovationPacksAccount.ts
@@ -1,14 +1,19 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
+import { safelyDropFK } from './utils/safely-drop-foreignKey';
 
 export class InnovationPacksAccount1721649196399 implements MigrationInterface {
   name = 'InnovationPacksAccount1721649196399';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE \`innovation_pack\` DROP FOREIGN KEY \`FK_77777450cf75dc486700ca034c6\``
+    await safelyDropFK(
+      queryRunner,
+      'innovation_pack',
+      'FK_77777450cf75dc486700ca034c6'
     );
-    await queryRunner.query(
-      `ALTER TABLE \`library\` DROP FOREIGN KEY \`FK_6664d59c0b805c9c1ecb0070e16\``
+    await safelyDropFK(
+      queryRunner,
+      'library',
+      'FK_6664d59c0b805c9c1ecb0070e16'
     );
 
     await queryRunner.query(

--- a/src/migrations/utils/safely-drop-foreignKey.ts
+++ b/src/migrations/utils/safely-drop-foreignKey.ts
@@ -1,0 +1,24 @@
+import { QueryRunner } from 'typeorm';
+
+export const safelyDropFK = async (
+  queryRunner: QueryRunner,
+  tableName: string,
+  foreignKey: string
+) => {
+  const result = await queryRunner.query(
+    `
+    SELECT CONSTRAINT_NAME
+    FROM information_schema.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = ?
+    AND CONSTRAINT_NAME = ?
+    `,
+    [tableName, foreignKey]
+  );
+
+  if (result && result.length && result.length > 0) {
+    await queryRunner.query(
+      `ALTER TABLE \`${tableName}\` DROP FOREIGN KEY \`${foreignKey}\``
+    );
+  }
+};


### PR DESCRIPTION
- added utility method that checks if a FK exists before dropping it
- added it to a failing migration