### PR TITLE
VC creation - removed the check for unique displayName

### DIFF
--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -73,9 +73,6 @@ export class VirtualContributorService {
         virtualContributorData.profileData?.displayName || ''
       );
     }
-    await this.checkDisplayNameOrFail(
-      virtualContributorData.profileData?.displayName
-    );
 
     let virtualContributor: IVirtualContributor = VirtualContributor.create(
       virtualContributorData


### PR DESCRIPTION
As part of the VC creation flow, we'd like users to have a seamless experience.
All entities should be created without redundant errors. 

As the VC display name is added on the first step and the actual creation is done further in the flow, we need to:
1. either have a VC name check early in the flow (implement endpoint);
2. or remove the check for a unique name. 

We're doing the simpler option 2, as the uniqueness of the nameID is enough. 
(discussed with @techsmyth)