### PR TITLE
fix assignment of flow-state template to tagset on subspace creation

### DIFF
--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -231,6 +231,17 @@ export class SpaceService {
       parentDisplayID: `${space.nameID}`,
     });
 
+    const flowStateTemplate =
+      space.collaboration.tagsetTemplateSet?.tagsetTemplates.find(
+        t => t.name === TagsetReservedName.FLOW_STATE
+      );
+    if (space.collaboration.innovationFlow?.profile.tagsets) {
+      for (const tagset of space.collaboration.innovationFlow?.profile
+        ?.tagsets) {
+        tagset.tagsetTemplate = flowStateTemplate;
+      }
+    }
+
     await this.save(space);
 
     if (spaceData.level === SpaceLevel.SPACE) {


### PR DESCRIPTION
- fix assignment of flow-state template to tagset on subspace creation
- this shouldn't be needed but by all means looks like a typeorm problem to me. The problem is the following - with the atomic creation, the subspace, collaboration, innovation flow, tagset templates and tagsets are created at one go. The creation should be managed by typeorm and only the root level entity in the hierarchy should be saved (in theory). The problem is, with the creation of the collaboration, innovation flow etc, when the flow reached the tagsets, it passes all fields BUT id to the tagsetTemplate on tagset. So when the entity was saved, in space.collaboration.tagsetTemplateSet.tagsetTemplates we have a generated tagsetTemplate with id and all fields, but in space.collaboration.innovationFlow.profile.tagsets.tagsetTemplate - we had all but id (and that should be handled by the ORM).
Given the entity is already created, I have simply associated the correct values, which, again in theory, should be redundant, but it is not.

I didn't find anything in the code that explains this behavior, so I believe it is a framework problem...