### PR TITLE
Ensure avatars are stored on Alkemio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "cookie-parser": "^1.4.6",
         "cross-env": "^7.0.3",
         "dataloader": "^2.2.2",
-        "file-type": "^19.1.1",
+        "file-type": "^17.1.0",
         "graphql": "^16.9.0",
         "graphql-amqp-subscriptions": "^2.0.0",
         "graphql-subscriptions": "^2.0.0",
@@ -3536,11 +3536,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "node_modules/@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -7446,46 +7441,19 @@
       }
     },
     "node_modules/file-type": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.4.1.tgz",
-      "integrity": "sha512-RuWzwF2L9tCHS76KR/Mdh+DwJZcFCzrhrPXpOw6MlEfl/o31fjpTikzcKlYuyeV7e7ftdCGVJTNOCzkYD/aLbw==",
+      "version": "17.1.6",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.6.tgz",
+      "integrity": "sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==",
       "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^8.1.0",
-        "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0-alpha.9",
+        "token-types": "^5.0.0-alpha.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/file-type/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/file-type/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/filelist": {
@@ -11959,6 +11927,42 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -12987,12 +12991,12 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-8.1.0.tgz",
-      "integrity": "sha512-ExzDvHYPj6F6QkSNe/JxSlBxTh3OrI6wrAIz53ulxo1c4hBJ1bT9C/JrAthEKHWG9riVH3Xzg7B03Oxty6S2Lw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.1.1.tgz",
+      "integrity": "sha512-mKX8HA/cdBqMKUr0MMZAFssCkIGoZeSCMXgnt79yKxNFguMLVFgRe6wB+fsL0NmoHDbeyZXczy7vEPSoo3rkzg==",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.1.4"
+        "peek-readable": "^5.1.3"
       },
       "engines": {
         "node": ">=16"
@@ -13351,9 +13355,9 @@
       }
     },
     "node_modules/token-types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
-      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -13945,17 +13949,6 @@
       "integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
-      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/uint8arrays": {
@@ -16997,11 +16990,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
-    "@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
-    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -19887,30 +19875,13 @@
       }
     },
     "file-type": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.4.1.tgz",
-      "integrity": "sha512-RuWzwF2L9tCHS76KR/Mdh+DwJZcFCzrhrPXpOw6MlEfl/o31fjpTikzcKlYuyeV7e7ftdCGVJTNOCzkYD/aLbw==",
+      "version": "17.1.6",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.6.tgz",
+      "integrity": "sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==",
       "requires": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^8.1.0",
-        "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-          "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-          "requires": {
-            "@sec-ant/readable-stream": "^0.4.1",
-            "is-stream": "^4.0.1"
-          }
-        },
-        "is-stream": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-          "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
-        }
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0-alpha.9",
+        "token-types": "^5.0.0-alpha.2"
       }
     },
     "filelist": {
@@ -22955,6 +22926,34 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -23680,12 +23679,12 @@
       "dev": true
     },
     "strtok3": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-8.1.0.tgz",
-      "integrity": "sha512-ExzDvHYPj6F6QkSNe/JxSlBxTh3OrI6wrAIz53ulxo1c4hBJ1bT9C/JrAthEKHWG9riVH3Xzg7B03Oxty6S2Lw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.1.1.tgz",
+      "integrity": "sha512-mKX8HA/cdBqMKUr0MMZAFssCkIGoZeSCMXgnt79yKxNFguMLVFgRe6wB+fsL0NmoHDbeyZXczy7vEPSoo3rkzg==",
       "requires": {
         "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.1.4"
+        "peek-readable": "^5.1.3"
       }
     },
     "subscriptions-transport-ws": {
@@ -23924,9 +23923,9 @@
       "version": "1.0.1"
     },
     "token-types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
-      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -24255,11 +24254,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz",
       "integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ=="
-    },
-    "uint8array-extras": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
-      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ=="
     },
     "uint8arrays": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "cookie-parser": "^1.4.6",
     "cross-env": "^7.0.3",
     "dataloader": "^2.2.2",
-    "file-type": "^19.1.1",
     "graphql": "^16.9.0",
     "graphql-amqp-subscriptions": "^2.0.0",
     "graphql-subscriptions": "^2.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -80,6 +80,7 @@ import { AdminLicensingModule } from '@platform/admin/licensing/admin.licensing.
 import { PlatformRoleModule } from '@platform/platfrom.role/platform.role.module';
 import { LookupByNameModule } from '@services/api/lookup-by-name';
 import { PlatformHubModule } from '@platform/platfrom.hub/platform.hub.module';
+import { AdminContributorsModule } from '@platform/admin/avatars/admin.avatar.module';
 
 @Module({
   imports: [
@@ -239,6 +240,7 @@ import { PlatformHubModule } from '@platform/platfrom.hub/platform.hub.module';
     ActivityLogModule,
     RolesModule,
     KonfigModule,
+    AdminContributorsModule,
     AdminCommunicationModule,
     AdminSearchIngestModule,
     AdminLicensingModule,

--- a/src/domain/community/community-role/community.role.service.ts
+++ b/src/domain/community/community-role/community.role.service.ts
@@ -945,7 +945,7 @@ export class CommunityRoleService {
     );
     if (openApplication) {
       throw new CommunityMembershipException(
-        `An open application (ID: ${openApplication.id}) already exists for contributor ${openApplication.user?.id} on Community: ${community.id}.`,
+        `Application not possible: An open application (ID: ${openApplication.id}) already exists for contributor ${openApplication.user?.id} on Community: ${community.id}.`,
         LogContext.COMMUNITY
       );
     }
@@ -953,7 +953,7 @@ export class CommunityRoleService {
     const openInvitation = await this.findOpenInvitation(user.id, community.id);
     if (openInvitation) {
       throw new CommunityMembershipException(
-        `An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributor} (${openInvitation.contributorType}) on Community: ${community.id}.`,
+        `Application not possible: An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributor} (${openInvitation.contributorType}) on Community: ${community.id}.`,
         LogContext.COMMUNITY
       );
     }
@@ -962,7 +962,7 @@ export class CommunityRoleService {
     const isExistingMember = await this.isMember(agent, community);
     if (isExistingMember)
       throw new CommunityMembershipException(
-        `Contributor ${user.id} is already a member of the Community: ${community.id}.`,
+        `Application not possible: Contributor ${user.id} is already a member of the Community: ${community.id}.`,
         LogContext.COMMUNITY
       );
   }
@@ -978,7 +978,7 @@ export class CommunityRoleService {
     );
     if (openInvitation) {
       throw new CommunityMembershipException(
-        `An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributor} (${openInvitation.contributorType}) on Community: ${community.id}.`,
+        `Invitation not possible: An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributor} (${openInvitation.contributorType}) on Community: ${community.id}.`,
         LogContext.COMMUNITY
       );
     }
@@ -989,7 +989,7 @@ export class CommunityRoleService {
     );
     if (openApplication) {
       throw new CommunityMembershipException(
-        `An open application (ID: ${openApplication.id}) already exists for contributor ${openApplication.user?.id} on Community: ${community.id}.`,
+        `Invitation not possible: An open application (ID: ${openApplication.id}) already exists for contributor ${openApplication.user?.id} on Community: ${community.id}.`,
         LogContext.COMMUNITY
       );
     }
@@ -998,7 +998,7 @@ export class CommunityRoleService {
     const isExistingMember = await this.isMember(agent, community);
     if (isExistingMember)
       throw new CommunityMembershipException(
-        `Contributor ${contributor.id} is already a member of the Community: ${community.id}.`,
+        `Invitation not possible: Contributor ${contributor.id} is already a member of the Community: ${community.id}.`,
         LogContext.COMMUNITY
       );
   }

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -166,10 +166,10 @@ export class OrganizationService {
 
     organization = await this.save(organization);
 
-    // await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-    //   organization.profile,
-    //   organization.id
-    // );
+    await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
+      organization.profile,
+      organization.id
+    );
 
     return await this.getOrganizationOrFail(organization.id);
   }

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -166,9 +166,10 @@ export class OrganizationService {
 
     organization = await this.save(organization);
 
+    const userID = agentInfo ? agentInfo.userID : '';
     await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
       organization.profile,
-      organization.id
+      userID
     );
 
     return await this.getOrganizationOrFail(organization.id);

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -168,7 +168,7 @@ export class OrganizationService {
 
     const userID = agentInfo ? agentInfo.userID : '';
     await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-      organization.profile,
+      organization.profile.id,
       userID
     );
 

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -168,10 +168,10 @@ export class UserService {
 
     user = await this.save(user);
 
-    // await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-    //   user.profile,
-    //   user.id
-    // );
+    await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
+      user.profile,
+      user.id
+    );
     // Reload to ensure have the updated avatar URL
     user = await this.getUserOrFail(user.id);
 

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -169,7 +169,7 @@ export class UserService {
     user = await this.save(user);
 
     await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-      user.profile,
+      user.profile.id,
       user.id
     );
     // Reload to ensure have the updated avatar URL

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -64,7 +64,8 @@ export class VirtualContributorService {
 
   async createVirtualContributor(
     virtualContributorData: CreateVirtualContributorInput,
-    storageAggregator: IStorageAggregator
+    storageAggregator: IStorageAggregator,
+    agentInfo?: AgentInfo
   ): Promise<IVirtualContributor> {
     if (virtualContributorData.nameID) {
       // Convert nameID to lower case
@@ -127,9 +128,10 @@ export class VirtualContributorService {
 
     virtualContributor = await this.save(virtualContributor);
 
+    const userID = agentInfo ? agentInfo.userID : '';
     await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
       virtualContributor.profile,
-      virtualContributor.id
+      userID
     );
     // Reload to ensure have the updated avatar URL
     virtualContributor = await this.getVirtualContributorOrFail(

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -130,7 +130,7 @@ export class VirtualContributorService {
 
     const userID = agentInfo ? agentInfo.userID : '';
     await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-      virtualContributor.profile,
+      virtualContributor.profile.id,
       userID
     );
     // Reload to ensure have the updated avatar URL

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -127,10 +127,10 @@ export class VirtualContributorService {
 
     virtualContributor = await this.save(virtualContributor);
 
-    // await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-    //   virtualContributor.profile,
-    //   virtualContributor.id
-    // );
+    await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
+      virtualContributor.profile,
+      virtualContributor.id
+    );
     // Reload to ensure have the updated avatar URL
     virtualContributor = await this.getVirtualContributorOrFail(
       virtualContributor.id

--- a/src/domain/space/account/account.service.ts
+++ b/src/domain/space/account/account.service.ts
@@ -228,7 +228,8 @@ export class AccountService {
 
     const vc = await this.virtualContributorService.createVirtualContributor(
       vcData,
-      account.storageAggregator
+      account.storageAggregator,
+      agentInfo
     );
     vc.account = account;
     return await this.virtualContributorService.save(vc);

--- a/src/platform/admin/avatars/admin.avatar.module.ts
+++ b/src/platform/admin/avatars/admin.avatar.module.ts
@@ -3,9 +3,15 @@ import { ContributorModule } from '@domain/community/contributor/contributor.mod
 import { AdminSearchContributorsMutations } from './admin.avatarresolver.mutations';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
 
 @Module({
-  imports: [AuthorizationModule, AuthorizationPolicyModule, ContributorModule],
+  imports: [
+    AuthorizationModule,
+    AuthorizationPolicyModule,
+    PlatformAuthorizationPolicyModule,
+    ContributorModule,
+  ],
   providers: [AdminSearchContributorsMutations],
   exports: [],
 })

--- a/src/platform/admin/avatars/admin.avatar.module.ts
+++ b/src/platform/admin/avatars/admin.avatar.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ContributorModule } from '@domain/community/contributor/contributor.module';
 import { AdminSearchContributorsMutations } from './admin.avatarresolver.mutations';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { AuthorizationModule } from '@core/authorization/authorization.module';
 
 @Module({
-  imports: [ContributorModule],
+  imports: [AuthorizationModule, AuthorizationPolicyModule, ContributorModule],
   providers: [AdminSearchContributorsMutations],
   exports: [],
 })

--- a/src/platform/admin/avatars/admin.avatarresolver.mutations.ts
+++ b/src/platform/admin/avatars/admin.avatarresolver.mutations.ts
@@ -49,7 +49,7 @@ export class AdminSearchContributorsMutations {
       if (user.profile) {
         await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
           user.profile,
-          user.id
+          agentInfo.userID
         );
       }
     }
@@ -62,7 +62,7 @@ export class AdminSearchContributorsMutations {
       if (organization.profile) {
         await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
           organization.profile,
-          organization.id
+          agentInfo.userID
         );
       }
     }
@@ -79,7 +79,7 @@ export class AdminSearchContributorsMutations {
       if (virtualContributor.profile) {
         await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
           virtualContributor.profile,
-          virtualContributor.id
+          agentInfo.userID
         );
       }
     }

--- a/src/platform/admin/avatars/admin.avatarresolver.mutations.ts
+++ b/src/platform/admin/avatars/admin.avatarresolver.mutations.ts
@@ -1,18 +1,14 @@
 import { Inject, LoggerService, UseGuards } from '@nestjs/common';
-import { Mutation, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { CurrentUser } from '@src/common/decorators';
 import { GraphqlGuard } from '@core/authorization/graphql.guard';
-import { AuthorizationPrivilege, LogContext } from '@common/enums';
+import { AuthorizationPrivilege } from '@common/enums';
 import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ContributorService } from '@domain/community/contributor/contributor.service';
-import { InjectEntityManager } from '@nestjs/typeorm';
-import { EntityManager } from 'typeorm';
-import { User } from '@domain/community/user/user.entity';
-import { Organization } from '@domain/community/organization/organization.entity';
-import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
+import { UUID } from '@domain/common/scalars/scalar.uuid';
 
 @Resolver()
 export class AdminSearchContributorsMutations {
@@ -20,17 +16,18 @@ export class AdminSearchContributorsMutations {
     private authorizationService: AuthorizationService,
     private platformAuthorizationPolicyService: PlatformAuthorizationPolicyService,
     private contributorService: ContributorService,
-    @InjectEntityManager('default')
-    private entityManager: EntityManager,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private logger: LoggerService
   ) {}
 
   @UseGuards(GraphqlGuard)
   @Mutation(() => String, {
     description:
-      'Update all contributor avatars to be stored as Documents. This is an admin only operation to be run once.',
+      'Update the Avatar on the Profile with the spedified profileID to be stored as a Document.',
   })
-  async adminUpdateContributorAvatars(@CurrentUser() agentInfo: AgentInfo) {
+  async adminUpdateContributorAvatars(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('profileID', { type: () => UUID }) profileID: string
+  ) {
     const platformPolicy =
       await this.platformAuthorizationPolicyService.getPlatformAuthorizationPolicy();
     this.authorizationService.grantAccessOrFail(
@@ -40,53 +37,9 @@ export class AdminSearchContributorsMutations {
       `Update contributor avatars to be stored as Documents: ${agentInfo.email}`
     );
 
-    const users = await this.entityManager.find(User, {
-      relations: {
-        profile: true,
-      },
-    });
-    for (const user of users) {
-      if (user.profile) {
-        await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-          user.profile,
-          agentInfo.userID
-        );
-      }
-    }
-    const organizations = await this.entityManager.find(Organization, {
-      relations: {
-        profile: true,
-      },
-    });
-    for (const organization of organizations) {
-      if (organization.profile) {
-        await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-          organization.profile,
-          agentInfo.userID
-        );
-      }
-    }
-
-    const virtualContributors = await this.entityManager.find(
-      VirtualContributor,
-      {
-        relations: {
-          profile: true,
-        },
-      }
-    );
-    for (const virtualContributor of virtualContributors) {
-      if (virtualContributor.profile) {
-        await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-          virtualContributor.profile,
-          agentInfo.userID
-        );
-      }
-    }
-
-    this.logger.verbose?.(
-      'Completed updating all contributor avatars',
-      LogContext.COMMUNITY
+    await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
+      profileID,
+      agentInfo.userID
     );
   }
 }

--- a/src/services/external/avatar-creator/avatar.creator.service.ts
+++ b/src/services/external/avatar-creator/avatar.creator.service.ts
@@ -3,6 +3,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import axios, { AxiosResponse } from 'axios';
 import { LogContext } from '@common/enums';
 import replaceSpecialCharacters from 'replace-special-characters';
+import { MimeFileType } from '@common/enums/mime.file.type';
 
 @Injectable()
 export class AvatarCreatorService {
@@ -68,9 +69,17 @@ export class AvatarCreatorService {
   }
 
   public async getFileType(imageBuffer: Buffer): Promise<string | undefined> {
+    this.logger.verbose?.(
+      `Not determining file type from buffer: ${imageBuffer.byteLength}, using hard coded PNG response`,
+      LogContext.COMMUNITY
+    );
+    // TODO: implement proper file type detection based on the buffer contents.
+    // However the package 'file-type' is causing issues with the CS Common package setup
+    // https://github.com/alkem-io/server/issues/4459
     // Dynamic import required to avoid CS Common require issue
-    const { fileTypeFromBuffer } = await import('file-type');
-    const fileInfo = await fileTypeFromBuffer(imageBuffer);
-    return fileInfo?.mime;
+    // const { fileTypeFromBuffer } = await import('file-type');
+    // const fileInfo = await fileTypeFromBuffer(imageBuffer);
+    // return fileInfo?.mime;
+    return MimeFileType.PNG;
   }
 }


### PR DESCRIPTION
Please see https://github.com/alkem-io/server/pull/4412 for initial set of findings.

The code in that branch was merged to develop as was needed for other work, with the actual logic of ensuring avatars are stored on Alkemio being disabled. 

For now the mime type is hard coded to PNG as the widely used file-type package requires ESM to be used, which is a bigger change. Please see https://github.com/alkem-io/server/issues/4459.  The issue to ensure file types are automatically detected is https://github.com/alkem-io/server/issues/4460 which is then blocked. This PR can move ahead. 