### PR TITLE
pick up the level zero space agent for authorization logic

### DIFF
--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -66,6 +66,7 @@ export class SpaceAuthorizationService {
             policy: true,
           },
         },
+        agent: true,
         authorization: true,
         community: {
           policy: true,

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -70,7 +70,6 @@ export class SpaceAuthorizationService {
         community: {
           policy: true,
         },
-        agent: true,
         collaboration: true,
         context: true,
         profile: true,
@@ -81,7 +80,6 @@ export class SpaceAuthorizationService {
       },
     });
     if (
-      !space.agent ||
       !space.authorization ||
       !space.community ||
       !space.community.policy ||
@@ -93,7 +91,10 @@ export class SpaceAuthorizationService {
       );
     }
 
-    const spaceAgent = space.agent;
+    // Get the root space agent for licensing related logic
+    const levelZeroSpaceAgent =
+      await this.spaceService.getLevelZeroSpaceAgent(space);
+
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
 
     const spaceVisibility = space.visibility;
@@ -205,7 +206,7 @@ export class SpaceAuthorizationService {
     // propagate authorization rules for child entities
     const childAuthorzations = await this.propagateAuthorizationToChildEntities(
       space,
-      spaceAgent,
+      levelZeroSpaceAgent,
       communityPolicy,
       spaceSettings,
       spaceMembershipAllowed

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -942,6 +942,21 @@ export class SpaceService {
     );
   }
 
+  public async getLevelZeroSpaceAgent(space: ISpace): Promise<IAgent> {
+    const levelZeroSpace = await this.getSpaceOrFail(space.levelZeroSpaceID, {
+      relations: {
+        agent: true,
+      },
+    });
+    if (!levelZeroSpace.agent) {
+      throw new RelationshipNotFoundException(
+        `Agent not initialised on Level Zero Space: ${levelZeroSpace.id}`,
+        LogContext.SPACES
+      );
+    }
+    return levelZeroSpace.agent;
+  }
+
   public async assignUserToRoles(space: ISpace, agentInfo: AgentInfo) {
     if (!space.community) {
       throw new EntityNotInitializedException(


### PR DESCRIPTION
Previous fix only helped level zero spaces; with this fix all subspaces now also pick up the correct licensing. 