### PR TITLE
Fix CREATE_SPACE permission for VC Campaign and Beta testers

### DIFF
--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -74,6 +74,8 @@ export const CREDENTIAL_RULE_PLATFORM_CREATE_ORGANIZATION =
   'credentialRuleTypes-platformCreateOrganization';
 export const CREDENTIAL_RULE_PLATFORM_CREATE_SPACE =
   'credentialRuleTypes-platformCreateSpace';
+export const CREDENTIAL_RULE_PLATFORM_CREATE_VC =
+  'credentialRuleTypes-platformCreateVC';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE =
   'credentialRuleTypes-platformAccessGuidance';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_DASHBOARD =

--- a/src/common/constants/authorization/policy.rule.constants.ts
+++ b/src/common/constants/authorization/policy.rule.constants.ts
@@ -2,7 +2,6 @@ export const POLICY_RULE_SPACE_CREATE_SUBSPACE =
   'policyRule-spaceCreateSubspace';
 export const POLICY_RULE_WHITEBOARD_CONTENT_UPDATE =
   'policyRule-whiteboardContentUpdate';
-export const POLICY_RULE_ACCOUNT_CREATE_VC = 'policyRule-accountCreateVC';
 export const POLICY_RULE_VISUAL_UPDATE = 'policyRule-visualUpdate';
 export const POLICY_RULE_ROOM_CONTRIBUTE = 'policyRule-roomContribute';
 export const POLICY_RULE_ROOM_ADMINS = 'policyRule-roomAdminsCreate';

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -17,6 +17,7 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy/author
 import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential.interface';
 import {
   CREDENTIAL_RULE_PLATFORM_CREATE_SPACE,
+  CREDENTIAL_RULE_PLATFORM_CREATE_VC,
   CREDENTIAL_RULE_TYPES_ACCOUNT_AUTHORIZATION_RESET,
   CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES,
   CREDENTIAL_RULE_TYPES_ACCOUNT_MANAGE,
@@ -90,7 +91,11 @@ export class AccountAuthorizationService {
       account.authorization,
       hostCredentials
     );
-    account.authorization = this.appendPrivilegeRules(account.authorization);
+
+    // TODO: Removed for now the privilege to create a space and a VC.
+    // Only users in Beta Testers and VC Campaigns can create spaces
+    // account.authorization = this.appendPrivilegeRules(account.authorization);
+
     account.authorization = await this.authorizationPolicyService.save(
       account.authorization
     );
@@ -264,7 +269,7 @@ export class AccountAuthorizationService {
 
     const createSpace =
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
-        [AuthorizationPrivilege.CREATE],
+        [AuthorizationPrivilege.CREATE_SPACE],
         [
           AuthorizationCredential.GLOBAL_ADMIN,
           AuthorizationCredential.BETA_TESTER,
@@ -274,6 +279,19 @@ export class AccountAuthorizationService {
       );
     createSpace.cascade = false;
     newRules.push(createSpace);
+
+    const createVC =
+      this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
+        [AuthorizationPrivilege.CREATE_VIRTUAL_CONTRIBUTOR],
+        [
+          AuthorizationCredential.GLOBAL_ADMIN,
+          AuthorizationCredential.BETA_TESTER,
+          AuthorizationCredential.VC_CAMPAIGN,
+        ],
+        CREDENTIAL_RULE_PLATFORM_CREATE_VC
+      );
+    createVC.cascade = false;
+    newRules.push(createVC);
 
     return this.authorizationPolicyService.appendCredentialAuthorizationRules(
       authorization,


### PR DESCRIPTION
The only real "fix" is this:
![image](https://github.com/user-attachments/assets/941c32db-1051-4461-8cac-8a187b357a8d)

Before this change, all users with Admin, VCCampaign and BetaTester creds were getting the `CREATE` privilege was is already there.  Note that `CREATE` is not `CREATE_SPACE`.
Then, everybody was getting `CREATE_SPACE` and `CREATE_VIRTUAL_CONTRIBUTOR` in the function at the end `appendPrivilegeRules`.
I have commented the call to `appendPrivilegeRules` for now and have added CREATE_VIRTUAL_CONTRIBUTOR privilege to the users with those credentials