### PR TITLE
Account license support; account type

### DIFF
--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -420,58 +420,58 @@ services:
       - AI_MODEL_TEMPERATURE
       - LOG_LEVEL=DEBUG
       - AZURE_OPENAI_ENDPOINT=https://alkemio-gpt.openai.azure.com
-      - AZURE_OPENAI_API_KEY
+      - AZURE_OPENAI_API_KEY=4b262af068ff4546a69b996bea9e41cb
       - LLM_DEPLOYMENT_NAME=deploy-gpt-35-turbo
       - EMBEDDINGS_DEPLOYMENT_NAME=embedding
       - LANGCHAIN_TRACING_V2
       - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY
+      - LANGCHAIN_API_KEY = ls__1b4c37c4102e4c7fa015c56595526fac
       - LANGCHAIN_PROJECT=virtual-contributor-engine-expert
       - VECTOR_DB_PORT
       - VECTOR_DB_HOST
 
-  virtual_contributor_ingest_space:
-    # the space-ingest service needs to download files from the server running on the host
-    # for that to work the container needs to run in network_mode: host and refer to other
-    # services trough localhost
-    network_mode: host
-    extra_hosts:
-      - 'host.docker.internal:host-gateway'
-    container_name: alkemio_dev_virtual-contributor-ingest-space
-    hostname: virtual-contributor-ingest-space
-    image: alkemio/virtual-contributor-ingest-space:v0.8.1
-    platform: linux/x86_64
-    restart: always
-    volumes:
-       - /dev/shm:/dev/shm
-       - ~/alkemio/data:${AI_LOCAL_PATH:-/home/alkemio/data}
-    depends_on:
-      rabbitmq:
-        condition: "service_healthy"
-    environment:
-      - RABBITMQ_HOST=localhost
-      - RABBITMQ_USER
-      - RABBITMQ_PASSWORD
-      - RABBITMQ_PORT
-      - RABBITMQ_QUEUE=virtual-contributor-ingest-space
-      - ENVIRONMENT=dev
-      - LOG_LEVEL=debug
-      - EMBEDDINGS_DEPLOYMENT_NAME
-      - AZURE_OPENAI_API_KEY
-      - AZURE_OPENAI_ENDPOINT
-      - OPENAI_API_VERSION
-      - AI_MODEL_TEMPERATURE
-      - AI_LOCAL_PATH
-      - LLM_DEPLOYMENT_NAME
-      - LANGCHAIN_TRACING_V2
-      - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY
-      - LANGCHAIN_PROJECT=virtual-contributor-ingest-space
-      - VECTOR_DB_HOST=localhost
-      - VECTOR_DB_PORT=8765
-      - AUTH_ADMIN_EMAIL
-      - AUTH_ADMIN_PASSWORD
-      - API_ENDPOINT_PRIVATE_GRAPHQL=http://localhost:3000/api/private/non-interactive/graphql
-      - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/ory/kratos/public
-      - CHUNK_SIZE=1000
-      - CHUNK_OVERLAP=100
+  # virtual_contributor_ingest_space:
+  #   # the space-ingest service needs to download files from the server running on the host
+  #   # for that to work the container needs to run in network_mode: host and refer to other
+  #   # services trough localhost
+  #   network_mode: host
+  #   extra_hosts:
+  #     - 'host.docker.internal:host-gateway'
+  #   container_name: alkemio_dev_virtual-contributor-ingest-space
+  #   hostname: virtual-contributor-ingest-space
+  #   image: alkemio/virtual-contributor-ingest-space:v0.8.1
+  #   platform: linux/x86_64
+  #   restart: always
+  #   volumes:
+  #      - /dev/shm:/dev/shm
+  #      - ~/alkemio/data:${AI_LOCAL_PATH:-/home/alkemio/data}
+  #   depends_on:
+  #     rabbitmq:
+  #       condition: "service_healthy"
+  #   environment:
+  #     - RABBITMQ_HOST=localhost
+  #     - RABBITMQ_USER
+  #     - RABBITMQ_PASSWORD
+  #     - RABBITMQ_PORT
+  #     - RABBITMQ_QUEUE=virtual-contributor-ingest-space
+  #     - ENVIRONMENT=dev
+  #     - LOG_LEVEL=debug
+  #     - EMBEDDINGS_DEPLOYMENT_NAME
+  #     - AZURE_OPENAI_API_KEY=4b262af068ff4546a69b996bea9e41cb
+  #     - AZURE_OPENAI_ENDPOINT
+  #     - OPENAI_API_VERSION
+  #     - AI_MODEL_TEMPERATURE
+  #     - AI_LOCAL_PATH
+  #     - LLM_DEPLOYMENT_NAME
+  #     - LANGCHAIN_TRACING_V2
+  #     - LANGCHAIN_ENDPOINT
+  #     - LANGCHAIN_API_KEY=ls__1b4c37c4102e4c7fa015c56595526fac
+  #     - LANGCHAIN_PROJECT=virtual-contributor-ingest-space
+  #     - VECTOR_DB_HOST=localhost
+  #     - VECTOR_DB_PORT=8765
+  #     - AUTH_ADMIN_EMAIL
+  #     - AUTH_ADMIN_PASSWORD
+  #     - API_ENDPOINT_PRIVATE_GRAPHQL=http://localhost:3000/api/private/non-interactive/graphql
+  #     - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/ory/kratos/public
+  #     - CHUNK_SIZE=1000
+  #     - CHUNK_OVERLAP=100

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -420,58 +420,58 @@ services:
       - AI_MODEL_TEMPERATURE
       - LOG_LEVEL=DEBUG
       - AZURE_OPENAI_ENDPOINT=https://alkemio-gpt.openai.azure.com
-      - AZURE_OPENAI_API_KEY=4b262af068ff4546a69b996bea9e41cb
+      - AZURE_OPENAI_API_KEY
       - LLM_DEPLOYMENT_NAME=deploy-gpt-35-turbo
       - EMBEDDINGS_DEPLOYMENT_NAME=embedding
       - LANGCHAIN_TRACING_V2
       - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY = ls__1b4c37c4102e4c7fa015c56595526fac
+      - LANGCHAIN_API_KEY
       - LANGCHAIN_PROJECT=virtual-contributor-engine-expert
       - VECTOR_DB_PORT
       - VECTOR_DB_HOST
 
-  # virtual_contributor_ingest_space:
-  #   # the space-ingest service needs to download files from the server running on the host
-  #   # for that to work the container needs to run in network_mode: host and refer to other
-  #   # services trough localhost
-  #   network_mode: host
-  #   extra_hosts:
-  #     - 'host.docker.internal:host-gateway'
-  #   container_name: alkemio_dev_virtual-contributor-ingest-space
-  #   hostname: virtual-contributor-ingest-space
-  #   image: alkemio/virtual-contributor-ingest-space:v0.8.1
-  #   platform: linux/x86_64
-  #   restart: always
-  #   volumes:
-  #      - /dev/shm:/dev/shm
-  #      - ~/alkemio/data:${AI_LOCAL_PATH:-/home/alkemio/data}
-  #   depends_on:
-  #     rabbitmq:
-  #       condition: "service_healthy"
-  #   environment:
-  #     - RABBITMQ_HOST=localhost
-  #     - RABBITMQ_USER
-  #     - RABBITMQ_PASSWORD
-  #     - RABBITMQ_PORT
-  #     - RABBITMQ_QUEUE=virtual-contributor-ingest-space
-  #     - ENVIRONMENT=dev
-  #     - LOG_LEVEL=debug
-  #     - EMBEDDINGS_DEPLOYMENT_NAME
-  #     - AZURE_OPENAI_API_KEY=4b262af068ff4546a69b996bea9e41cb
-  #     - AZURE_OPENAI_ENDPOINT
-  #     - OPENAI_API_VERSION
-  #     - AI_MODEL_TEMPERATURE
-  #     - AI_LOCAL_PATH
-  #     - LLM_DEPLOYMENT_NAME
-  #     - LANGCHAIN_TRACING_V2
-  #     - LANGCHAIN_ENDPOINT
-  #     - LANGCHAIN_API_KEY=ls__1b4c37c4102e4c7fa015c56595526fac
-  #     - LANGCHAIN_PROJECT=virtual-contributor-ingest-space
-  #     - VECTOR_DB_HOST=localhost
-  #     - VECTOR_DB_PORT=8765
-  #     - AUTH_ADMIN_EMAIL
-  #     - AUTH_ADMIN_PASSWORD
-  #     - API_ENDPOINT_PRIVATE_GRAPHQL=http://localhost:3000/api/private/non-interactive/graphql
-  #     - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/ory/kratos/public
-  #     - CHUNK_SIZE=1000
-  #     - CHUNK_OVERLAP=100
+  virtual_contributor_ingest_space:
+    # the space-ingest service needs to download files from the server running on the host
+    # for that to work the container needs to run in network_mode: host and refer to other
+    # services trough localhost
+    network_mode: host
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    container_name: alkemio_dev_virtual-contributor-ingest-space
+    hostname: virtual-contributor-ingest-space
+    image: alkemio/virtual-contributor-ingest-space:v0.8.1
+    platform: linux/x86_64
+    restart: always
+    volumes:
+       - /dev/shm:/dev/shm
+       - ~/alkemio/data:${AI_LOCAL_PATH:-/home/alkemio/data}
+    depends_on:
+      rabbitmq:
+        condition: "service_healthy"
+    environment:
+      - RABBITMQ_HOST=localhost
+      - RABBITMQ_USER
+      - RABBITMQ_PASSWORD
+      - RABBITMQ_PORT
+      - RABBITMQ_QUEUE=virtual-contributor-ingest-space
+      - ENVIRONMENT=dev
+      - LOG_LEVEL=debug
+      - EMBEDDINGS_DEPLOYMENT_NAME
+      - AZURE_OPENAI_API_KEY
+      - AZURE_OPENAI_ENDPOINT
+      - OPENAI_API_VERSION
+      - AI_MODEL_TEMPERATURE
+      - AI_LOCAL_PATH
+      - LLM_DEPLOYMENT_NAME
+      - LANGCHAIN_TRACING_V2
+      - LANGCHAIN_ENDPOINT
+      - LANGCHAIN_API_KEY
+      - LANGCHAIN_PROJECT=virtual-contributor-ingest-space
+      - VECTOR_DB_HOST=localhost
+      - VECTOR_DB_PORT=8765
+      - AUTH_ADMIN_EMAIL
+      - AUTH_ADMIN_PASSWORD
+      - API_ENDPOINT_PRIVATE_GRAPHQL=http://localhost:3000/api/private/non-interactive/graphql
+      - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/ory/kratos/public
+      - CHUNK_SIZE=1000
+      - CHUNK_OVERLAP=100

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -4,8 +4,6 @@ export const CREDENTIAL_RULE_TYPES_ACCOUNT_MANAGE =
   'credentialRuleTypes-accountManage';
 export const CREDENTIAL_RULE_TYPES_ACCOUNT_RESOURCES_MANAGE =
   'credentialRuleTypes-accountResourcesManage';
-export const CREDENTIAL_RULE_TYPES_ACCOUNT_RESOURCES_CREATE =
-  'credentialRuleTypes-accountResourcesCreate';
 export const CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES =
   'credentialRuleTypes-accountChildEntities';
 export const CREDENTIAL_RULE_TYPES_SPACE_GLOBAL_COMMUNITY_READ =

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -1,9 +1,11 @@
-export const CREDENTIAL_RULE_TYPES_ACCOUNT_AUTHORIZATION_RESET =
-  'credentialRuleTypes-accountAuthorizationReset';
+export const CREDENTIAL_RULE_TYPES_ACCOUNT_MANAGE_GLOBAL_ROLES =
+  'credentialRuleTypes-accountManageGlobalRoles';
 export const CREDENTIAL_RULE_TYPES_ACCOUNT_MANAGE =
   'credentialRuleTypes-accountManage';
 export const CREDENTIAL_RULE_TYPES_ACCOUNT_RESOURCES_MANAGE =
   'credentialRuleTypes-accountResourcesManage';
+export const CREDENTIAL_RULE_TYPES_ACCOUNT_RESOURCES_CREATE =
+  'credentialRuleTypes-accountResourcesCreate';
 export const CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES =
   'credentialRuleTypes-accountChildEntities';
 export const CREDENTIAL_RULE_TYPES_SPACE_GLOBAL_COMMUNITY_READ =
@@ -76,6 +78,8 @@ export const CREDENTIAL_RULE_PLATFORM_CREATE_SPACE =
   'credentialRuleTypes-platformCreateSpace';
 export const CREDENTIAL_RULE_PLATFORM_CREATE_VC =
   'credentialRuleTypes-platformCreateVC';
+export const CREDENTIAL_RULE_PLATFORM_CREATE_INNOVATION_PACK =
+  'credentialRuleTypes-platformCreateInnovationPack';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE =
   'credentialRuleTypes-platformAccessGuidance';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_DASHBOARD =

--- a/src/common/enums/account.type.ts
+++ b/src/common/enums/account.type.ts
@@ -1,0 +1,10 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum AccountType {
+  USER = 'user',
+  ORGANIZATION = 'organization',
+}
+
+registerEnumType(AccountType, {
+  name: 'AccountType',
+});

--- a/src/common/enums/license.credential.ts
+++ b/src/common/enums/license.credential.ts
@@ -5,6 +5,7 @@ export enum LicenseCredential {
   SPACE_LICENSE_FREE = 'space-license-free',
   SPACE_LICENSE_PLUS = 'space-license-plus',
   SPACE_LICENSE_PREMIUM = 'space-license-premium',
+  SPACE_LICENSE_ENTERPRISE = 'space-license-enterprise', // todo: remove for space
   SPACE_FEATURE_SAVE_AS_TEMPLATE = 'space-feature-save-as-template',
   SPACE_FEATURE_VIRTUAL_CONTRIBUTORS = 'space-feature-virtual-contributors',
   SPACE_FEATURE_WHITEBOARD_MULTI_USER = 'space-feature-whiteboard-multi-user',

--- a/src/common/enums/license.credential.ts
+++ b/src/common/enums/license.credential.ts
@@ -2,13 +2,13 @@ import { registerEnumType } from '@nestjs/graphql';
 
 // Credentials to be added later:
 export enum LicenseCredential {
-  LICENSE_SPACE_FREE = 'license-space-free',
-  LICENSE_SPACE_PLUS = 'license-space-plus',
-  LICENSE_SPACE_PREMIUM = 'license-space-premium',
-  LICENSE_SPACE_ENTERPRISE = 'license-space-enterprise',
-  FEATURE_CALLOUT_TO_CALLOUT_TEMPLATE = 'feature-callout-to-callout-template',
-  FEATURE_VIRTUAL_CONTRIBUTORS = 'feature-virtual-contributors',
-  FEATURE_WHITEBOARD_MULTI_USER = 'feature-whiteboard-multi-user',
+  SPACE_LICENSE_FREE = 'space-license-free',
+  SPACE_LICENSE_PLUS = 'space-license-plus',
+  SPACE_LICENSE_PREMIUM = 'space-license-space-premium',
+  SPACE_FEATURE_SAVE_AS_TEMPLATE = 'space-feature-save-as-template',
+  SPACE_FEATURE_VIRTUAL_CONTRIBUTORS = 'space-feature-virtual-contributors',
+  SPACE_FEATURE_WHITEBOARD_MULTI_USER = 'space-feature-whiteboard-multi-user',
+  ACCOUNT_LICENSE_PLUS = 'account-license-plus',
 }
 
 registerEnumType(LicenseCredential, {

--- a/src/common/enums/license.credential.ts
+++ b/src/common/enums/license.credential.ts
@@ -4,7 +4,7 @@ import { registerEnumType } from '@nestjs/graphql';
 export enum LicenseCredential {
   SPACE_LICENSE_FREE = 'space-license-free',
   SPACE_LICENSE_PLUS = 'space-license-plus',
-  SPACE_LICENSE_PREMIUM = 'space-license-space-premium',
+  SPACE_LICENSE_PREMIUM = 'space-license-premium',
   SPACE_FEATURE_SAVE_AS_TEMPLATE = 'space-feature-save-as-template',
   SPACE_FEATURE_VIRTUAL_CONTRIBUTORS = 'space-feature-virtual-contributors',
   SPACE_FEATURE_WHITEBOARD_MULTI_USER = 'space-feature-whiteboard-multi-user',

--- a/src/common/enums/license.plan.type.ts
+++ b/src/common/enums/license.plan.type.ts
@@ -1,6 +1,8 @@
 import { registerEnumType } from '@nestjs/graphql';
 
 export enum LicensePlanType {
+  ACCOUNT_FEATURE_FLAG = 'account-feature-flag',
+  ACCOUNT_PLAN = 'account-plan',
   SPACE_PLAN = 'space-plan',
   SPACE_FEATURE_FLAG = 'space-feature-flag',
 }

--- a/src/common/enums/license.privilege.ts
+++ b/src/common/enums/license.privilege.ts
@@ -1,9 +1,13 @@
 import { registerEnumType } from '@nestjs/graphql';
 
 export enum LicensePrivilege {
-  VIRTUAL_CONTRIBUTOR_ACCESS = 'virtual-contributor-access',
-  WHITEBOARD_MULTI_USER = 'whiteboard-multi-user',
-  CALLOUT_SAVE_AS_TEMPLATE = 'callout-save-as-template',
+  SPACE_VIRTUAL_CONTRIBUTOR_ACCESS = 'space-virtual-contributor-access',
+  SPACE_WHITEBOARD_MULTI_USER = 'space-whiteboard-multi-user',
+  SPACE_SAVE_AS_TEMPLATE = 'space-save-as-template',
+
+  ACCOUNT_CREATE_SPACE = 'account-create-space',
+  ACCOUNT_CREATE_VIRTUAL_CONTRIBUTOR = 'account-create-virtual-contributor',
+  ACCOUNT_CREATE_INNOVATION_PACK = 'account-create-innovation-pack',
 }
 
 registerEnumType(LicensePrivilege, {

--- a/src/domain/collaboration/collaboration/collaboration.service.authorization.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.authorization.ts
@@ -215,7 +215,7 @@ export class CollaborationAuthorizationService {
 
     const saveAsTemplateEnabled =
       await this.licenseEngineService.isAccessGranted(
-        LicensePrivilege.CALLOUT_SAVE_AS_TEMPLATE,
+        LicensePrivilege.SPACE_SAVE_AS_TEMPLATE,
         spaceAgent
       );
     if (saveAsTemplateEnabled) {
@@ -291,7 +291,7 @@ export class CollaborationAuthorizationService {
     privilegeRules.push(createPrivilege);
 
     const whiteboardRtEnabled = await this.licenseEngineService.isAccessGranted(
-      LicensePrivilege.WHITEBOARD_MULTI_USER,
+      LicensePrivilege.SPACE_WHITEBOARD_MULTI_USER,
       spaceAgent
     );
     if (whiteboardRtEnabled) {

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -254,7 +254,7 @@ export class WhiteboardService {
       );
 
     const enabled = await this.licenseEngineService.isAccessGranted(
-      LicensePrivilege.WHITEBOARD_MULTI_USER,
+      LicensePrivilege.SPACE_WHITEBOARD_MULTI_USER,
       license
     );
 

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -65,7 +65,7 @@ export class CommunityAuthorizationService {
   async applyAuthorizationPolicy(
     communityInput: ICommunity,
     parentAuthorization: IAuthorizationPolicy,
-    spaceAgent: IAgent,
+    levelZeroSpaceAgent: IAgent,
     communityPolicy: ICommunityPolicy,
     spaceSettings: ISpaceSettings,
     spaceMembershipAllowed: boolean,
@@ -118,7 +118,7 @@ export class CommunityAuthorizationService {
     community.authorization = await this.extendAuthorizationPolicy(
       community.authorization,
       parentAuthorization?.anonymousReadAccess,
-      spaceAgent,
+      levelZeroSpaceAgent,
       communityPolicy,
       spaceSettings
     );
@@ -265,7 +265,7 @@ export class CommunityAuthorizationService {
   private async extendAuthorizationPolicy(
     authorization: IAuthorizationPolicy | undefined,
     allowGlobalRegisteredReadAccess: boolean | undefined,
-    spaceAgent: IAgent,
+    levelZeroSpaceAgent: IAgent,
     policy: ICommunityPolicy,
     spaceSettings: ISpaceSettings
   ): Promise<IAuthorizationPolicy> {
@@ -323,8 +323,8 @@ export class CommunityAuthorizationService {
 
     const accessVirtualContributors =
       await this.licenseEngineService.isAccessGranted(
-        LicensePrivilege.VIRTUAL_CONTRIBUTOR_ACCESS,
-        spaceAgent
+        LicensePrivilege.SPACE_VIRTUAL_CONTRIBUTOR_ACCESS,
+        levelZeroSpaceAgent
       );
     if (accessVirtualContributors) {
       const criterias: ICredentialDefinition[] =

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -59,6 +59,7 @@ import { StorageAggregatorType } from '@common/enums/storage.aggregator.type';
 import { AgentType } from '@common/enums/agent.type';
 import { ContributorService } from '../contributor/contributor.service';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { AccountType } from '@common/enums/account.type';
 
 @Injectable()
 export class OrganizationService {
@@ -161,7 +162,9 @@ export class OrganizationService {
         this.createPreferenceDefaults()
       );
 
-    const account = await this.accountHostService.createAccount();
+    const account = await this.accountHostService.createAccount(
+      AccountType.ORGANIZATION
+    );
     organization.accountID = account.id;
 
     organization = await this.save(organization);

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -63,6 +63,7 @@ import { StorageAggregatorType } from '@common/enums/storage.aggregator.type';
 import { AgentType } from '@common/enums/agent.type';
 import { ContributorService } from '../contributor/contributor.service';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { AccountType } from '@common/enums/account.type';
 
 @Injectable()
 export class UserService {
@@ -163,7 +164,9 @@ export class UserService {
       this.createPreferenceDefaults()
     );
 
-    const account = await this.accountHostService.createAccount();
+    const account = await this.accountHostService.createAccount(
+      AccountType.USER
+    );
     user.accountID = account.id;
 
     user = await this.save(user);

--- a/src/domain/space/account/account.entity.ts
+++ b/src/domain/space/account/account.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
 import { IAccount } from '@domain/space/account/account.interface';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { Space } from '../space/space.entity';
@@ -7,8 +7,12 @@ import { VirtualContributor } from '@domain/community/virtual-contributor/virtua
 import { StorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.entity';
 import { InnovationHub } from '@domain/innovation-hub/innovation.hub.entity';
 import { InnovationPack } from '@library/innovation-pack/innovation.pack.entity';
+import { AccountType } from '@common/enums/account.type';
 @Entity()
 export class Account extends AuthorizableEntity implements IAccount {
+  @Column('varchar', { length: 128, nullable: true })
+  type!: AccountType;
+
   @OneToMany(() => Space, space => space.account, {
     eager: false,
     cascade: false, // important: each space looks after saving itself! Same as space.subspaces field

--- a/src/domain/space/account/account.interface.ts
+++ b/src/domain/space/account/account.interface.ts
@@ -1,4 +1,4 @@
-import { ObjectType } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { IAuthorizable } from '@domain/common/entity/authorizable-entity';
 import { ISpace } from '../space/space.interface';
 import { IAgent } from '@domain/agent/agent/agent.interface';
@@ -6,9 +6,16 @@ import { IVirtualContributor } from '@domain/community/virtual-contributor/virtu
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { IInnovationHub } from '@domain/innovation-hub/innovation.hub.interface';
 import { IInnovationPack } from '@library/innovation-pack/innovation.pack.interface';
+import { AccountType } from '@common/enums/account.type';
 
 @ObjectType('Account')
 export class IAccount extends IAuthorizable {
+  @Field(() => AccountType, {
+    nullable: true,
+    description: 'A type of entity that this Account is being used with.',
+  })
+  type!: AccountType;
+
   agent?: IAgent;
   spaces!: ISpace[];
   virtualContributors!: IVirtualContributor[];

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -224,6 +224,7 @@ export class AccountAuthorizationService {
           AuthorizationPrivilege.CREATE_SPACE,
           AuthorizationPrivilege.CREATE_INNOVATION_HUB,
           AuthorizationPrivilege.CREATE_INNOVATION_PACK,
+          AuthorizationPrivilege.CREATE_VIRTUAL_CONTRIBUTOR,
         ],
         [
           AuthorizationCredential.GLOBAL_ADMIN,

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -21,7 +21,6 @@ import {
   CREDENTIAL_RULE_TYPES_ACCOUNT_MANAGE_GLOBAL_ROLES,
   CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES,
   CREDENTIAL_RULE_TYPES_ACCOUNT_MANAGE,
-  CREDENTIAL_RULE_TYPES_ACCOUNT_RESOURCES_CREATE,
   CREDENTIAL_RULE_TYPES_ACCOUNT_RESOURCES_MANAGE,
   CREDENTIAL_RULE_TYPES_GLOBAL_SPACE_READ,
   CREDENTIAL_RULE_PLATFORM_CREATE_INNOVATION_PACK,
@@ -269,19 +268,6 @@ export class AccountAuthorizationService {
       );
     accountHostManage.cascade = true;
     newRules.push(accountHostManage);
-
-    const accountHostCreate =
-      this.authorizationPolicyService.createCredentialRule(
-        [
-          AuthorizationPrivilege.CREATE_SPACE,
-          AuthorizationPrivilege.CREATE_INNOVATION_PACK,
-          AuthorizationPrivilege.CREATE_VIRTUAL_CONTRIBUTOR,
-        ],
-        [...hostCredentials],
-        CREDENTIAL_RULE_TYPES_ACCOUNT_RESOURCES_CREATE
-      );
-    accountHostCreate.cascade = false;
-    newRules.push(accountHostCreate);
 
     const createSpace = await this.licenseEngineService.isAccessGranted(
       LicensePrivilege.ACCOUNT_CREATE_SPACE,

--- a/src/domain/space/account/account.service.ts
+++ b/src/domain/space/account/account.service.ts
@@ -32,6 +32,7 @@ import { InnovationPackAuthorizationService } from '@library/innovation-pack/inn
 import { InnovationHubAuthorizationService } from '@domain/innovation-hub/innovation.hub.service.authorization';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { AccountHostService } from '../account.host/account.host.service';
+import { IAgent } from '@domain/agent/agent/agent.interface';
 
 @Injectable()
 export class AccountService {
@@ -68,8 +69,6 @@ export class AccountService {
         LogContext.ACCOUNT
       );
     }
-    const accountProvider =
-      await this.accountHostService.getHostOrFail(account);
 
     const reservedNameIDs =
       await this.namingService.getReservedNameIDsLevelZeroSpaces();
@@ -110,7 +109,7 @@ export class AccountService {
     });
     await this.accountHostService.assignLicensePlansToSpace(
       spaceWithAgent,
-      accountProvider
+      account.type
     );
     return await this.spaceService.getSpaceOrFail(space.id, {
       relations: {
@@ -308,5 +307,22 @@ export class AccountService {
         LogContext.ACCOUNT
       );
     return storageAggregator;
+  }
+
+  public async getAgent(accountID: string): Promise<IAgent> {
+    const account = await this.getAccountOrFail(accountID, {
+      relations: {
+        agent: true,
+      },
+    });
+
+    if (!account.agent) {
+      throw new RelationshipNotFoundException(
+        `Unable to retrieve Agent for Account: ${account.id}`,
+        LogContext.PLATFORM
+      );
+    }
+
+    return account.agent;
   }
 }

--- a/src/domain/space/space/sort.spaces.by.activity.spec.ts
+++ b/src/domain/space/space/sort.spaces.by.activity.spec.ts
@@ -6,6 +6,7 @@ import { sortSpacesByActivity } from './sort.spaces.by.activity';
 import { SpaceType } from '@common/enums/space.type';
 import { SpaceVisibility } from '@common/enums/space.visibility';
 import { ProfileType } from '@common/enums';
+import { AccountType } from '@common/enums/account.type';
 
 const createTestActivity = (createdDate: Date): IActivity => {
   return {
@@ -42,6 +43,7 @@ const createTestSpace = (id: string): ISpace => {
       innovationHubs: [],
       innovationPacks: [],
       spaces: [],
+      type: AccountType.ORGANIZATION,
     },
     type: SpaceType.SPACE,
     level: 0,

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -241,7 +241,7 @@ export class SpaceAuthorizationService {
 
   public async propagateAuthorizationToChildEntities(
     space: ISpace,
-    spaceAgent: IAgent,
+    levelZeroSpaceAgent: IAgent,
     communityPolicy: ICommunityPolicy,
     spaceSettings: ISpaceSettings,
     spaceMembershipAllowed: boolean
@@ -270,7 +270,7 @@ export class SpaceAuthorizationService {
       await this.communityAuthorizationService.applyAuthorizationPolicy(
         space.community,
         space.authorization,
-        spaceAgent,
+        levelZeroSpaceAgent,
         communityPolicy,
         spaceSettings,
         spaceMembershipAllowed,
@@ -284,7 +284,7 @@ export class SpaceAuthorizationService {
         space.authorization,
         communityPolicy,
         spaceSettings,
-        spaceAgent
+        levelZeroSpaceAgent
       );
     updatedAuthorizations.push(...collaborationAuthorizations);
 

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -17,6 +17,7 @@ import { Account } from '../account/account.entity';
 import { SpaceType } from '@common/enums/space.type';
 import { SpaceLevel } from '@common/enums/space.level';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { AccountType } from '@common/enums/account.type';
 
 const moduleMocker = new ModuleMocker(global);
 
@@ -101,6 +102,7 @@ const getSubspacesMock = (
         innovationHubs: [],
         innovationPacks: [],
         spaces: [],
+        type: AccountType.ORGANIZATION,
         ...getEntityMock<Account>(),
       },
       type: SpaceType.CHALLENGE,
@@ -195,6 +197,7 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
         innovationHubs: [],
         innovationPacks: [],
         spaces: [],
+        type: AccountType.ORGANIZATION,
         ...getEntityMock<Account>(),
       },
       type: SpaceType.OPPORTUNITY,
@@ -306,6 +309,7 @@ const getSpaceMock = ({
       innovationHubs: [],
       innovationPacks: [],
       spaces: [],
+      type: AccountType.ORGANIZATION,
       ...getEntityMock<Account>(),
     },
     authorization: getAuthorizationPolicyMock(

--- a/src/migrations/1724751579592-accountType.ts
+++ b/src/migrations/1724751579592-accountType.ts
@@ -23,7 +23,7 @@ export class AccountType1724751579592 implements MigrationInterface {
         `UPDATE \`credential\` SET type = '${credentialUpdate.newCredentialName}' WHERE type = '${credentialUpdate.oldCredentialName}'`
       );
       await queryRunner.query(
-        `UPDATE \`license_plan\` SET licenseCredential = '${credentialUpdate.newCredentialName}', name='${credentialUpdate.newPlanName}' WHERE type = '${credentialUpdate.oldCredentialName}'`
+        `UPDATE \`license_plan\` SET licenseCredential = '${credentialUpdate.newCredentialName}', name='${credentialUpdate.newPlanName}' WHERE licenseCredential = '${credentialUpdate.oldCredentialName}'`
       );
     }
 

--- a/src/migrations/1724751579592-accountType.ts
+++ b/src/migrations/1724751579592-accountType.ts
@@ -1,0 +1,282 @@
+import { randomUUID } from 'crypto';
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AccountType1724751579592 implements MigrationInterface {
+  name = 'AccountType1724751579592';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add the type column to the storage aggregator table
+    await queryRunner.query(
+      'ALTER TABLE `account` ADD `type` varchar(128) NULL'
+    );
+
+    await this.updateAccountTypeForEntity(queryRunner, 'user', 'user');
+    await this.updateAccountTypeForEntity(
+      queryRunner,
+      'organization',
+      'organization'
+    );
+
+    // Update all license related credentials and plans
+    for (const credentialUpdate of credentialUpdates) {
+      await queryRunner.query(
+        `UPDATE \`credential\` SET type = '${credentialUpdate.newCredentialName}' WHERE type = '${credentialUpdate.oldCredentialName}'`
+      );
+      await queryRunner.query(
+        `UPDATE \`license_plan\` SET licenseCredential = '${credentialUpdate.newCredentialName}', name='${credentialUpdate.newPlanName}' WHERE type = '${credentialUpdate.oldCredentialName}'`
+      );
+    }
+
+    // Create new license plans for accounts
+    // Create a new plan for each of the planDefinitions
+    const [platform]: {
+      id: string;
+      licensingId: string;
+    }[] = await queryRunner.query(`SELECT id, licensingId FROM platform`);
+    const licensingId = platform.licensingId;
+
+    const [licensing]: {
+      id: string;
+      licensePolicyId: string;
+    }[] = await queryRunner.query(
+      `SELECT id, licensePolicyId FROM licensing WHERE id = '${licensingId}'`
+    );
+
+    for (const plan of plans) {
+      const planID = randomUUID();
+      await queryRunner.query(
+        `INSERT INTO \`license_plan\`
+          ( \`id\`,
+            \`version\`,
+            \`name\`,
+            \`enabled\`,
+            \`licensingId\`,
+            \`sortOrder\`,
+            \`pricePerMonth\`,
+            \`isFree\`,
+            \`trialEnabled\`,
+            \`requiresPaymentMethod\`,
+            \`requiresContactSupport\`,
+            \`licenseCredential\`,
+            \`assignToNewOrganizationAccounts\`,
+            \`assignToNewUserAccounts\`)
+          VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        `,
+        [
+          planID, // id
+          1, // version
+          plan.name, // name
+          plan.enabled, // enabled
+          platform.licensingId, // licensingId
+          plan.sortOrder, // sortOrder
+          plan.pricePerMonth, // pricePerMonth
+          plan.isFree, // isFree
+          plan.trialEnabled, // trialEnabled
+          plan.requiresPaymentMethod, // requiresPaymentMethod
+          plan.requiresContactSupport, // requiresContactSupport
+          plan.credential,
+          plan.assignToNewOrganizationAccounts,
+          plan.assignToNewUserAccounts,
+        ]
+      );
+    }
+
+    // Update the credential rules in the license policy
+    await queryRunner.query(
+      `UPDATE \`license_policy\` SET rules = '${JSON.stringify(licenseCredentialRules)}' WHERE id = '${licensing.licensePolicyId}'`
+    );
+
+    // Update all accounts associated with users that are a) beta testers or b) part of the VC campaign and assign the appropriate license plan
+    await this.assignUserBetaTestersAccountLicense(queryRunner);
+  }
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+
+  private async updateAccountTypeForEntity(
+    queryRunner: QueryRunner,
+    entityType: string,
+    accountType: string
+  ) {
+    const entities: {
+      id: string;
+      accountID: string;
+    }[] = await queryRunner.query(
+      `SELECT id, accountID FROM \`${entityType}\``
+    );
+    for (const entity of entities) {
+      const [account]: {
+        id: string;
+      }[] = await queryRunner.query(
+        `SELECT id FROM account WHERE id = '${entity.accountID}'`
+      );
+      if (account) {
+        await queryRunner.query(
+          `UPDATE \`account\` SET type = '${accountType}' WHERE id = '${account.id}'`
+        );
+      } else {
+        console.log(`No account found for ${entityType}: ${entity.id}`);
+      }
+    }
+  }
+
+  private async assignUserBetaTestersAccountLicense(queryRunner: QueryRunner) {
+    const users: {
+      id: string;
+      agentId: string;
+      accountID: string;
+    }[] = await queryRunner.query(
+      `SELECT id, agentId, accountID FROM \`user\``
+    );
+    for (const user of users) {
+      const credentials: {
+        id: string;
+        type: string;
+      }[] = await queryRunner.query(
+        `SELECT id, type FROM \`credential\` where agentId = '${user.agentId}'`
+      );
+      const matchingCredential = credentials.find(
+        credential =>
+          credential.type === 'beta-tester' || credential.type === 'vc-campaign'
+      );
+      if (matchingCredential) {
+        const [account]: {
+          id: string;
+          agentId: string;
+        }[] = await queryRunner.query(
+          `SELECT id, agentId FROM account WHERE id = '${user.accountID}'`
+        );
+        if (account) {
+          /// Create a new credential for the agent
+          const credentialID = randomUUID();
+          await queryRunner.query(
+            `INSERT INTO \`credential\`
+              ( \`id\`,
+                \`version\`,
+                \`type\`,
+                \`resourceID\`,
+                \`agentId\`)
+              VALUES
+              (?, ?, ?, ?, ?);
+            `,
+            [
+              credentialID, // id
+              1, // version
+              'account-license-plus', // type
+              account.id, // resource
+              account.agentId, // agentId
+            ]
+          );
+        } else {
+          console.log(`No account found for user: ${user.id}`);
+        }
+      }
+    }
+  }
+}
+
+const credentialUpdates: CredentialUpdate[] = [
+  {
+    oldCredentialName: 'license-space-free',
+    newCredentialName: 'space-license-free',
+    newPlanName: 'SPACE_LICENSE_FREE',
+  },
+  {
+    oldCredentialName: 'license-space-plus',
+    newCredentialName: 'space-license-plus',
+    newPlanName: 'SPACE_LICENSE_PLUS',
+  },
+  {
+    oldCredentialName: 'license-space-enterprise',
+    newCredentialName: 'space-license-enterprise',
+    newPlanName: 'SPACE_LICENSE_ENTERPRISE',
+  },
+  {
+    oldCredentialName: 'license-space-premium',
+    newCredentialName: 'space-license-premium',
+    newPlanName: 'SPACE_LICENSE_PREMIUM',
+  },
+  {
+    oldCredentialName: 'feature-callout-to-callout-template',
+    newCredentialName: 'space-feature-create-template',
+    newPlanName: 'SPACE_FEATURE_CREATE_TEMPLATE',
+  },
+  {
+    oldCredentialName: 'feature-whiteboard-multi-user',
+    newCredentialName: 'space-feature-whiteboard-multi-user',
+    newPlanName: 'SPACE_FEATURE_WHITEBOARD_MULTI_USER',
+  },
+  {
+    oldCredentialName: 'feature-virtual-contributors',
+    newCredentialName: 'space-feature-virtual-contributors',
+    newPlanName: 'SPACE_FEATURE_VIRTUAL_CONTIBUTORS',
+  },
+];
+
+export enum LicenseCredential {
+  ACCOUNT_LICENSE_PLUS = 'account-license-plus',
+}
+
+const plans = [
+  {
+    name: 'ACCOUNT_LICENSE_PLUS',
+    credential: LicenseCredential.ACCOUNT_LICENSE_PLUS,
+    enabled: true,
+    sortOrder: 50,
+    pricePerMonth: 0,
+    isFree: false,
+    trialEnabled: false,
+    requiresPaymentMethod: false,
+    requiresContactSupport: true,
+    assignToNewOrganizationAccounts: false,
+    assignToNewUserAccounts: false,
+  },
+];
+
+export type CredentialUpdate = {
+  oldCredentialName: string;
+  newCredentialName: string;
+  newPlanName: string;
+};
+
+const licenseCredentialRules = [
+  {
+    credentialType: 'space-feature-virtual-contributors',
+    grantedPrivileges: ['space-virtual-contributor-access'],
+    name: 'Space Virtual Contributors',
+  },
+  {
+    credentialType: 'space-feature-whiteboard-multi-user',
+    grantedPrivileges: ['space-whiteboard-multi-user'],
+    name: 'Space Multi-user whiteboards',
+  },
+  {
+    credentialType: 'space-feature-save-as-template',
+    grantedPrivileges: ['space-save-as-template'],
+    name: 'Space Save As Templatet',
+  },
+  {
+    credentialType: 'space-license-plus',
+    grantedPrivileges: [
+      'space-whiteboard-multi-user',
+      'space-save-as-template',
+    ],
+    name: 'Space License Plus',
+  },
+  {
+    credentialType: 'space-license-premium',
+    grantedPrivileges: [
+      'space-whiteboard-multi-user',
+      'space-save-as-template',
+    ],
+    name: 'Space License Premium',
+  },
+  {
+    credentialType: 'account-license-plus',
+    grantedPrivileges: [
+      'account-create-space',
+      'account-create-virtual-contributor',
+      'account-create-innovation-pack',
+    ],
+    name: 'Account License Plus',
+  },
+];

--- a/src/migrations/1724751579592-accountType.ts
+++ b/src/migrations/1724751579592-accountType.ts
@@ -198,8 +198,8 @@ const credentialUpdates: CredentialUpdate[] = [
   },
   {
     oldCredentialName: 'feature-callout-to-callout-template',
-    newCredentialName: 'space-feature-create-template',
-    newPlanName: 'SPACE_FEATURE_CREATE_TEMPLATE',
+    newCredentialName: 'space-feature-save-as-template',
+    newPlanName: 'SPACE_FEATURE_SAVE_AS_TEMPLATE',
   },
   {
     oldCredentialName: 'feature-whiteboard-multi-user',

--- a/src/migrations/1724751579592-accountType.ts
+++ b/src/migrations/1724751579592-accountType.ts
@@ -61,7 +61,7 @@ export class AccountType1724751579592 implements MigrationInterface {
             \`assignToNewUserAccounts\`,
             \`type\`)
           VALUES
-          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         `,
         [
           planID, // id

--- a/src/migrations/1724751579592-accountType.ts
+++ b/src/migrations/1724751579592-accountType.ts
@@ -28,7 +28,6 @@ export class AccountType1724751579592 implements MigrationInterface {
     }
 
     // Create new license plans for accounts
-    // Create a new plan for each of the planDefinitions
     const [platform]: {
       id: string;
       licensingId: string;
@@ -84,7 +83,7 @@ export class AccountType1724751579592 implements MigrationInterface {
 
     // Update the credential rules in the license policy
     await queryRunner.query(
-      `UPDATE \`license_policy\` SET rules = '${JSON.stringify(licenseCredentialRules)}' WHERE id = '${licensing.licensePolicyId}'`
+      `UPDATE \`license_policy\` SET credentialRulesStr = '${JSON.stringify(licenseCredentialRules)}' WHERE id = '${licensing.licensePolicyId}'`
     );
 
     // Update all accounts associated with users that are a) beta testers or b) part of the VC campaign and assign the appropriate license plan

--- a/src/migrations/1724751579592-accountType.ts
+++ b/src/migrations/1724751579592-accountType.ts
@@ -61,7 +61,7 @@ export class AccountType1724751579592 implements MigrationInterface {
             \`assignToNewUserAccounts\`,
             \`type\`)
           VALUES
-          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         `,
         [
           planID, // id

--- a/src/migrations/1724751579592-accountType.ts
+++ b/src/migrations/1724751579592-accountType.ts
@@ -58,7 +58,8 @@ export class AccountType1724751579592 implements MigrationInterface {
             \`requiresContactSupport\`,
             \`licenseCredential\`,
             \`assignToNewOrganizationAccounts\`,
-            \`assignToNewUserAccounts\`)
+            \`assignToNewUserAccounts\`,
+            \`type\`)
           VALUES
           (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         `,
@@ -77,6 +78,7 @@ export class AccountType1724751579592 implements MigrationInterface {
           plan.credential,
           plan.assignToNewOrganizationAccounts,
           plan.assignToNewUserAccounts,
+          plan.type,
         ]
       );
     }
@@ -228,6 +230,7 @@ const plans = [
     requiresContactSupport: true,
     assignToNewOrganizationAccounts: false,
     assignToNewUserAccounts: false,
+    type: 'account-plan',
   },
 ];
 

--- a/src/platform/platfrom.role/platform.role.module.ts
+++ b/src/platform/platfrom.role/platform.role.module.ts
@@ -10,11 +10,13 @@ import { UserModule } from '@domain/community/user/user.module';
 import { AgentModule } from '@domain/agent/agent/agent.module';
 import { PlatformInvitationModule } from '@platform/invitation/platform.invitation.module';
 import { AccountModule } from '@domain/space/account/account.module';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 
 @Module({
   imports: [
     AccountModule,
     AuthorizationModule,
+    AuthorizationPolicyModule,
     PlatformModule,
     PlatformAuthorizationPolicyModule,
     PlatformInvitationModule,

--- a/src/platform/platfrom.role/platform.role.module.ts
+++ b/src/platform/platfrom.role/platform.role.module.ts
@@ -9,9 +9,11 @@ import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { UserModule } from '@domain/community/user/user.module';
 import { AgentModule } from '@domain/agent/agent/agent.module';
 import { PlatformInvitationModule } from '@platform/invitation/platform.invitation.module';
+import { AccountModule } from '@domain/space/account/account.module';
 
 @Module({
   imports: [
+    AccountModule,
     AuthorizationModule,
     PlatformModule,
     PlatformAuthorizationPolicyModule,

--- a/src/platform/platfrom.role/platform.role.service.ts
+++ b/src/platform/platfrom.role/platform.role.service.ts
@@ -17,11 +17,15 @@ import { PlatformInvitationService } from '@platform/invitation/platform.invitat
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { IAgent } from '@domain/agent/agent/agent.interface';
 import { PlatformService } from '@platform/platfrom/platform.service';
+import { RelationshipNotFoundException } from '@common/exceptions';
+import { AccountService } from '@domain/space/account/account.service';
+import { LicenseCredential } from '@common/enums/license.credential';
 
 @Injectable()
 export class PlatformRoleService {
   constructor(
     private userService: UserService,
+    private accountService: AccountService,
     private agentService: AgentService,
     private platformService: PlatformService,
     private platformInvitationService: PlatformInvitationService,
@@ -66,15 +70,42 @@ export class PlatformRoleService {
   public async assignPlatformRoleToUser(
     assignData: AssignPlatformRoleToUserInput
   ): Promise<IUser> {
-    const agent = await this.userService.getAgent(assignData.userID);
+    const user = await this.userService.getUserOrFail(assignData.userID, {
+      relations: {
+        agent: true,
+      },
+    });
+
+    if (!user.agent) {
+      throw new RelationshipNotFoundException(
+        `Unable to retrieve Agent for User: ${user.id}`,
+        LogContext.PLATFORM
+      );
+    }
 
     const credential = this.getCredentialForRole(assignData.role);
 
     // assign the credential
     await this.agentService.grantCredential({
-      agentID: agent.id,
+      agentID: user.agent.id,
       ...credential,
     });
+
+    if (
+      assignData.role === PlatformRole.BETA_TESTER ||
+      assignData.role === PlatformRole.VC_CAMPAIGN
+    ) {
+      // Also assign the user account a license plan
+      const accountAgent = await this.accountService.getAgent(user.accountID);
+      const accountLicenseCredential: ICredentialDefinition = {
+        type: LicenseCredential.ACCOUNT_LICENSE_PLUS,
+        resourceID: user.accountID,
+      };
+      await this.agentService.grantCredential({
+        agentID: accountAgent.id,
+        ...accountLicenseCredential,
+      });
+    }
 
     return await this.userService.getUserWithAgent(assignData.userID);
   }
@@ -82,7 +113,18 @@ export class PlatformRoleService {
   public async removePlatformRoleFromUser(
     removeData: RemovePlatformRoleFromUserInput
   ): Promise<IUser> {
-    const agent = await this.userService.getAgent(removeData.userID);
+    const user = await this.userService.getUserOrFail(removeData.userID, {
+      relations: {
+        agent: true,
+      },
+    });
+
+    if (!user.agent) {
+      throw new RelationshipNotFoundException(
+        `Unable to retrieve Agent for User: ${user.id}`,
+        LogContext.PLATFORM
+      );
+    }
 
     // Validation logic
     if (removeData.role === PlatformRole.GLOBAL_ADMIN) {
@@ -93,9 +135,25 @@ export class PlatformRoleService {
     const credential = this.getCredentialForRole(removeData.role);
 
     await this.agentService.revokeCredential({
-      agentID: agent.id,
+      agentID: user.agent.id,
       ...credential,
     });
+
+    if (
+      removeData.role === PlatformRole.BETA_TESTER ||
+      removeData.role === PlatformRole.VC_CAMPAIGN
+    ) {
+      // Also assign the user account a license plan
+      const accountAgent = await this.accountService.getAgent(user.accountID);
+      const accountLicenseCredential: ICredentialDefinition = {
+        type: LicenseCredential.ACCOUNT_LICENSE_PLUS,
+        resourceID: user.accountID,
+      };
+      await this.agentService.grantCredential({
+        agentID: accountAgent.id,
+        ...accountLicenseCredential,
+      });
+    }
 
     return await this.userService.getUserWithAgent(removeData.userID);
   }

--- a/src/platform/platfrom.role/platform.role.service.ts
+++ b/src/platform/platfrom.role/platform.role.service.ts
@@ -97,6 +97,7 @@ export class PlatformRoleService {
     ) {
       // Also assign the user account a license plan
       const accountAgent = await this.accountService.getAgent(user.accountID);
+
       const accountLicenseCredential: ICredentialDefinition = {
         type: LicenseCredential.ACCOUNT_LICENSE_PLUS,
         resourceID: user.accountID,
@@ -149,7 +150,7 @@ export class PlatformRoleService {
         type: LicenseCredential.ACCOUNT_LICENSE_PLUS,
         resourceID: user.accountID,
       };
-      await this.agentService.grantCredential({
+      await this.agentService.revokeCredential({
         agentID: accountAgent.id,
         ...accountLicenseCredential,
       });

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -34,6 +34,7 @@ import { MockUserLookupService } from '@test/mocks/user.lookup.service.mock';
 import { MockVirtualContributorService } from '@test/mocks/virtual.contributor.service.mock';
 import { IUser } from '@domain/community/user/user.interface';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
+import { AccountType } from '@common/enums/account.type';
 
 describe('RolesService', () => {
   let rolesService: RolesService;
@@ -263,6 +264,7 @@ const getSpaceRoleResultMock = ({
         innovationHubs: [],
         innovationPacks: [],
         spaces: [],
+        type: AccountType.ORGANIZATION,
       },
       ...getEntityMock<Space>(),
     },


### PR DESCRIPTION
1. Add type to account so can see whether for a user or an org
2. Updated licensing framework to add additional license credentials, privileges and rules to work with the credentials
3. Added an additional license plan for plus license on Account, temporary license plan
4. Assigned this plan to all user accounts with beta tester or vc campaign membership
5. Updated logic for assigning platform roles to assign the license plan to the associated user account.
6. Global roles now have Create VC/Space/Pack/Hub privileges;

Testing that has been done:
- assigning user / removing user from beta tester / vc campaign results in the assignment of the credential to the account and the right privileges showing up on the account authorization
```
query {
  accounts {
    id
    agent {
      credentials {
        type
      }
    }
    authorization {
      myPrivileges
    }
  }
}
```
![image](https://github.com/user-attachments/assets/17209bc5-a565-4725-a45e-2f38eec4f41d)

**Note:** 
- [x] client codegen changes - https://github.com/alkem-io/client-web/pull/6827
- [x] tests* need to be run against this branch;

**Later:** 
- need to look at how to assign this license credential to organizations, that is still an issue. 
- client to filter out the account licenses from the space licenses;
- Further implement mechanism for assigning license to account;
