### PR TITLE
Optimization of data loading on auth reset

### DIFF
--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
@@ -68,10 +68,12 @@ export class CalloutContributionAuthorizationService {
           },
           select: {
             id: true,
+            createdBy: true,
             authorization:
               this.authorizationPolicyService.authorizationSelectOptions,
             post: {
               id: true,
+              createdBy: true,
               authorization:
                 this.authorizationPolicyService.authorizationSelectOptions,
               profile: {
@@ -87,6 +89,7 @@ export class CalloutContributionAuthorizationService {
             },
             whiteboard: {
               id: true,
+              createdBy: true,
               authorization:
                 this.authorizationPolicyService.authorizationSelectOptions,
               profile: {

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
@@ -46,18 +46,24 @@ export class CalloutContributionAuthorizationService {
             authorization: true,
             post: {
               authorization: true,
-              profile: true,
+              profile: {
+                authorization: true,
+              },
               comments: {
                 authorization: true,
               },
             },
             whiteboard: {
               authorization: true,
-              profile: true,
+              profile: {
+                authorization: true,
+              },
             },
             link: {
               authorization: true,
-              profile: true,
+              profile: {
+                authorization: true,
+              },
             },
           },
           select: {
@@ -70,6 +76,13 @@ export class CalloutContributionAuthorizationService {
                 this.authorizationPolicyService.authorizationSelectOptions,
               profile: {
                 id: true,
+                authorization:
+                  this.authorizationPolicyService.authorizationSelectOptions,
+              },
+              comments: {
+                id: true,
+                authorization:
+                  this.authorizationPolicyService.authorizationSelectOptions,
               },
             },
             whiteboard: {
@@ -78,6 +91,8 @@ export class CalloutContributionAuthorizationService {
                 this.authorizationPolicyService.authorizationSelectOptions,
               profile: {
                 id: true,
+                authorization:
+                  this.authorizationPolicyService.authorizationSelectOptions,
               },
             },
             link: {
@@ -86,6 +101,8 @@ export class CalloutContributionAuthorizationService {
                 this.authorizationPolicyService.authorizationSelectOptions,
               profile: {
                 id: true,
+                authorization:
+                  this.authorizationPolicyService.authorizationSelectOptions,
               },
             },
           },

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
@@ -64,29 +64,29 @@ export class CalloutContributionAuthorizationService {
             id: true,
             authorization:
               this.authorizationPolicyService.authorizationSelectOptions,
-            whiteboard: {
-              id: true,
-              profile: {
-                id: true,
-              },
-              authorization:
-                this.authorizationPolicyService.authorizationSelectOptions,
-            },
             post: {
               id: true,
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
               profile: {
                 id: true,
               },
+            },
+            whiteboard: {
+              id: true,
               authorization:
                 this.authorizationPolicyService.authorizationSelectOptions,
+              profile: {
+                id: true,
+              },
             },
             link: {
               id: true,
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
               profile: {
                 id: true,
               },
-              authorization:
-                this.authorizationPolicyService.authorizationSelectOptions,
             },
           },
         }

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.authorization.ts
@@ -32,27 +32,61 @@ export class CalloutContributionAuthorizationService {
   ) {}
 
   public async applyAuthorizationPolicy(
-    contributionInput: ICalloutContribution,
+    contributionID: string,
     parentAuthorization: IAuthorizationPolicy | undefined,
     communityPolicy: ICommunityPolicy,
     spaceSettings: ISpaceSettings
   ): Promise<IAuthorizationPolicy[]> {
     const contribution =
       await this.contributionService.getCalloutContributionOrFail(
-        contributionInput.id,
+        contributionID,
         {
+          loadEagerRelations: false,
           relations: {
+            authorization: true,
             post: {
+              authorization: true,
               profile: true,
               comments: {
                 authorization: true,
               },
             },
             whiteboard: {
+              authorization: true,
               profile: true,
             },
             link: {
+              authorization: true,
               profile: true,
+            },
+          },
+          select: {
+            id: true,
+            authorization:
+              this.authorizationPolicyService.authorizationSelectOptions,
+            whiteboard: {
+              id: true,
+              profile: {
+                id: true,
+              },
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
+            },
+            post: {
+              id: true,
+              profile: {
+                id: true,
+              },
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
+            },
+            link: {
+              id: true,
+              profile: {
+                id: true,
+              },
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
             },
           },
         }

--- a/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
@@ -51,7 +51,7 @@ export class CalloutFramingAuthorizationService {
 
     const framingAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        calloutFraming.profile,
+        calloutFraming.profile.id,
         calloutFraming.authorization
       );
     updatedAuthorizations.push(...framingAuthorizations);

--- a/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
@@ -28,11 +28,11 @@ export class CalloutFramingAuthorizationService {
           loadEagerRelations: false,
           relations: {
             authorization: true,
+            profile: true,
             whiteboard: {
               authorization: true,
               profile: true,
             },
-            profile: true,
           },
           select: {
             id: true,

--- a/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
@@ -25,19 +25,28 @@ export class CalloutFramingAuthorizationService {
       await this.calloutFramingService.getCalloutFramingOrFail(
         calloutFramingInput.id,
         {
+          loadEagerRelations: false,
           relations: {
+            authorization: true,
             whiteboard: {
+              authorization: true,
               profile: true,
             },
             profile: true,
           },
           select: {
             id: true,
+            authorization:
+              this.authorizationPolicyService.authorizationSelectOptions,
             profile: {
               id: true,
-              authorization: {
-                id: true,
-              },
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
+            },
+            whiteboard: {
+              id: true,
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
             },
           },
         }

--- a/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
@@ -28,9 +28,7 @@ export class CalloutFramingAuthorizationService {
           loadEagerRelations: false,
           relations: {
             authorization: true,
-            profile: {
-              authorization: true,
-            },
+            profile: true,
             whiteboard: {
               authorization: true,
               profile: {
@@ -42,13 +40,10 @@ export class CalloutFramingAuthorizationService {
             id: true,
             authorization:
               this.authorizationPolicyService.authorizationSelectOptions,
-            profile: {
-              id: true,
-              authorization:
-                this.authorizationPolicyService.authorizationSelectOptions,
-            },
+            profile: { id: true },
             whiteboard: {
               id: true,
+              createdBy: true,
               authorization:
                 this.authorizationPolicyService.authorizationSelectOptions,
               profile: {

--- a/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
@@ -31,6 +31,15 @@ export class CalloutFramingAuthorizationService {
             },
             profile: true,
           },
+          select: {
+            id: true,
+            profile: {
+              id: true,
+              authorization: {
+                id: true,
+              },
+            },
+          },
         }
       );
 

--- a/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
@@ -28,10 +28,14 @@ export class CalloutFramingAuthorizationService {
           loadEagerRelations: false,
           relations: {
             authorization: true,
-            profile: true,
+            profile: {
+              authorization: true,
+            },
             whiteboard: {
               authorization: true,
-              profile: true,
+              profile: {
+                authorization: true,
+              },
             },
           },
           select: {
@@ -47,6 +51,11 @@ export class CalloutFramingAuthorizationService {
               id: true,
               authorization:
                 this.authorizationPolicyService.authorizationSelectOptions,
+              profile: {
+                id: true,
+                authorization:
+                  this.authorizationPolicyService.authorizationSelectOptions,
+              },
             },
           },
         }

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -235,7 +235,7 @@ export class CalloutResolverMutations {
     // Ensure settings are available
     const updatedAuthorizations =
       await this.contributionAuthorizationService.applyAuthorizationPolicy(
-        contribution,
+        contribution.id,
         callout.authorization,
         communityPolicy,
         spaceSettings

--- a/src/domain/collaboration/callout/callout.service.authorization.ts
+++ b/src/domain/collaboration/callout/callout.service.authorization.ts
@@ -88,7 +88,7 @@ export class CalloutAuthorizationService {
     for (const contribution of callout.contributions) {
       const updatedContributionAuthorizations =
         await this.contributionAuthorizationService.applyAuthorizationPolicy(
-          contribution,
+          contribution.id,
           callout.authorization,
           communityPolicy,
           spaceSettings

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.authorization.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.authorization.ts
@@ -48,7 +48,7 @@ export class InnovationFlowAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        innovationFlow.profile,
+        innovationFlow.profile.id,
         innovationFlow.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/collaboration/link/link.service.authorization.ts
+++ b/src/domain/collaboration/link/link.service.authorization.ts
@@ -40,7 +40,7 @@ export class LinkAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        link.profile,
+        link.profile.id,
         link.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/collaboration/post/post.service.authorization.ts
+++ b/src/domain/collaboration/post/post.service.authorization.ts
@@ -80,7 +80,7 @@ export class PostAuthorizationService {
     // cascade
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        post.profile,
+        post.profile.id,
         post.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindOptionsSelect, Repository } from 'typeorm';
 import {
   EntityNotFoundException,
   ForbiddenException,
@@ -36,7 +36,7 @@ export class AuthorizationPolicyService {
     private readonly logger: LoggerService
   ) {}
 
-  public authorizationSelectOptions = {
+  public authorizationSelectOptions: FindOptionsSelect<AuthorizationPolicy> = {
     id: true,
     anonymousReadAccess: true,
     credentialRules: true,

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -36,6 +36,14 @@ export class AuthorizationPolicyService {
     private readonly logger: LoggerService
   ) {}
 
+  public authorizationSelectOptions = {
+    id: true,
+    anonymousReadAccess: true,
+    credentialRules: true,
+    privilegeRules: true,
+    verifiedCredentialRules: true,
+  };
+
   createCredentialRule(
     grantedPrivileges: AuthorizationPrivilege[],
     criterias: ICredentialDefinition[],

--- a/src/domain/common/profile/profile.service.authorization.ts
+++ b/src/domain/common/profile/profile.service.authorization.ts
@@ -22,46 +22,6 @@ export class ProfileAuthorizationService {
   ): Promise<IAuthorizationPolicy[]> {
     const profile = await this.profileService.getProfileOrFail(profileID, {
       loadEagerRelations: false,
-      select: {
-        id: true,
-        displayName: false,
-        tagline: false,
-        description: false,
-        references: {
-          id: true,
-          uri: false,
-          description: false,
-          authorization:
-            this.authorizationPolicyService.authorizationSelectOptions,
-        },
-        tagsets: {
-          id: true,
-          tags: false,
-          authorization:
-            this.authorizationPolicyService.authorizationSelectOptions,
-        },
-        visuals: {
-          id: true,
-          uri: false,
-          authorization:
-            this.authorizationPolicyService.authorizationSelectOptions,
-        },
-        storageBucket: {
-          id: true,
-          authorization:
-            this.authorizationPolicyService.authorizationSelectOptions,
-          documents: {
-            id: true,
-            authorization:
-              this.authorizationPolicyService.authorizationSelectOptions,
-            tagset: {
-              id: true,
-              authorization:
-                this.authorizationPolicyService.authorizationSelectOptions,
-            },
-          },
-        },
-      },
       relations: {
         authorization: true,
         tagsets: {
@@ -79,6 +39,39 @@ export class ProfileAuthorizationService {
             authorization: true,
             tagset: {
               authorization: true,
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        tagsets: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
+        },
+        references: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
+        },
+        visuals: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
+        },
+        storageBucket: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
+          documents: {
+            id: true,
+            authorization:
+              this.authorizationPolicyService.authorizationSelectOptions,
+            tagset: {
+              id: true,
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
             },
           },
         },

--- a/src/domain/common/profile/profile.service.authorization.ts
+++ b/src/domain/common/profile/profile.service.authorization.ts
@@ -24,8 +24,8 @@ export class ProfileAuthorizationService {
       loadEagerRelations: false,
       relations: {
         authorization: true,
-        tagsets: { authorization: true },
         references: { authorization: true },
+        tagsets: { authorization: true },
         visuals: { authorization: true },
         storageBucket: {
           authorization: true,
@@ -39,12 +39,12 @@ export class ProfileAuthorizationService {
         id: true,
         authorization:
           this.authorizationPolicyService.authorizationSelectOptions,
-        tagsets: {
+        references: {
           id: true,
           authorization:
             this.authorizationPolicyService.authorizationSelectOptions,
         },
-        references: {
+        tagsets: {
           id: true,
           authorization:
             this.authorizationPolicyService.authorizationSelectOptions,

--- a/src/domain/common/profile/profile.service.authorization.ts
+++ b/src/domain/common/profile/profile.service.authorization.ts
@@ -24,27 +24,21 @@ export class ProfileAuthorizationService {
       loadEagerRelations: false,
       relations: {
         authorization: true,
-        tagsets: {
-          authorization: true,
-        },
-        references: {
-          authorization: true,
-        },
-        visuals: {
-          authorization: true,
-        },
+        tagsets: { authorization: true },
+        references: { authorization: true },
+        visuals: { authorization: true },
         storageBucket: {
           authorization: true,
           documents: {
             authorization: true,
-            tagset: {
-              authorization: true,
-            },
+            tagset: { authorization: true },
           },
         },
       },
       select: {
         id: true,
+        authorization:
+          this.authorizationPolicyService.authorizationSelectOptions,
         tagsets: {
           id: true,
           authorization:

--- a/src/domain/common/profile/profile.service.authorization.ts
+++ b/src/domain/common/profile/profile.service.authorization.ts
@@ -7,13 +7,6 @@ import { StorageBucketAuthorizationService } from '@domain/storage/storage-bucke
 import { LogContext } from '@common/enums/logging.context';
 import { RelationshipNotFoundException } from '@common/exceptions';
 
-const authorizationSelectOptions = {
-  id: true, // ?
-  anonymousReadAccess: true,
-  credentialRules: true,
-  privilegeRules: true,
-  verifiedCredentialRules: true,
-};
 @Injectable()
 export class ProfileAuthorizationService {
   constructor(
@@ -38,27 +31,33 @@ export class ProfileAuthorizationService {
           id: true,
           uri: false,
           description: false,
-          authorization: authorizationSelectOptions,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
         },
         tagsets: {
           id: true,
           tags: false,
-          authorization: authorizationSelectOptions,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
         },
         visuals: {
           id: true,
           uri: false,
-          authorization: authorizationSelectOptions,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
         },
         storageBucket: {
           id: true,
-          authorization: authorizationSelectOptions,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
           documents: {
             id: true,
-            authorization: authorizationSelectOptions,
+            authorization:
+              this.authorizationPolicyService.authorizationSelectOptions,
             tagset: {
               id: true,
-              authorization: authorizationSelectOptions,
+              authorization:
+                this.authorizationPolicyService.authorizationSelectOptions,
             },
           },
         },

--- a/src/domain/common/whiteboard/whiteboard.service.authorization.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.authorization.ts
@@ -51,7 +51,7 @@ export class WhiteboardAuthorizationService {
 
     const profileAuthoriations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        whiteboard.profile,
+        whiteboard.profile.id,
         whiteboard.authorization
       );
     updatedAuthorizations.push(...profileAuthoriations);

--- a/src/domain/common/whiteboard/whiteboard.service.authorization.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.authorization.ts
@@ -26,35 +26,37 @@ export class WhiteboardAuthorizationService {
   ) {}
 
   async applyAuthorizationPolicy(
-    whiteboard: IWhiteboard,
+    whiteboardWithProfile: IWhiteboard,
     parentAuthorization: IAuthorizationPolicy | undefined
   ): Promise<IAuthorizationPolicy[]> {
-    if (!whiteboard.profile) {
+    if (!whiteboardWithProfile.profile) {
       throw new RelationshipNotFoundException(
-        `Unable to load entities on whiteboard reset auth:  ${whiteboard.id} `,
+        `Unable to load entities on whiteboard reset auth:  ${whiteboardWithProfile.id} `,
         LogContext.COLLABORATION
       );
     }
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
-    whiteboard.authorization =
+    whiteboardWithProfile.authorization =
       this.authorizationPolicyService.inheritParentAuthorization(
-        whiteboard.authorization,
+        whiteboardWithProfile.authorization,
         parentAuthorization
       );
 
-    whiteboard.authorization = this.appendCredentialRules(whiteboard);
-    whiteboard.authorization = this.appendPrivilegeRules(
-      whiteboard.authorization,
-      whiteboard
+    whiteboardWithProfile.authorization = this.appendCredentialRules(
+      whiteboardWithProfile
     );
-    updatedAuthorizations.push(whiteboard.authorization);
+    whiteboardWithProfile.authorization = this.appendPrivilegeRules(
+      whiteboardWithProfile.authorization,
+      whiteboardWithProfile
+    );
+    updatedAuthorizations.push(whiteboardWithProfile.authorization);
 
-    const profileAuthoriations =
+    const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        whiteboard.profile.id,
-        whiteboard.authorization
+        whiteboardWithProfile.profile.id,
+        whiteboardWithProfile.authorization
       );
-    updatedAuthorizations.push(...profileAuthoriations);
+    updatedAuthorizations.push(...profileAuthorizations);
 
     return updatedAuthorizations;
   }

--- a/src/domain/community/community-guidelines/community.guidelines.service.authorization.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.authorization.ts
@@ -32,7 +32,7 @@ export class CommunityGuidelinesAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        communityGuidelines.profile,
+        communityGuidelines.profile.id,
         communityGuidelines.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -98,7 +98,7 @@ export class OrganizationAuthorizationService {
     clonedOrganizationAuthorizationAnonymousAccess.anonymousReadAccess = true;
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        organization.profile,
+        organization.profile.id,
         clonedOrganizationAuthorizationAnonymousAccess
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/community/user-group/user-group.service.authorization.ts
+++ b/src/domain/community/user-group/user-group.service.authorization.ts
@@ -46,7 +46,7 @@ export class UserGroupAuthorizationService {
 
     const profileAuthoriations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        userGroup.profile,
+        userGroup.profile.id,
         userGroup.authorization
       );
     updatedAuthorizations.push(...profileAuthoriations);

--- a/src/domain/community/user/user.resolver.mutations.ts
+++ b/src/domain/community/user/user.resolver.mutations.ts
@@ -19,7 +19,6 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { UpdateUserPlatformSettingsInput } from './dto/user.dto.update.platform.settings';
 import { UpdateUserInput } from './dto';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
-import { LogContext } from '@common/enums';
 
 @Resolver(() => IUser)
 export class UserResolverMutations {
@@ -120,8 +119,6 @@ export class UserResolverMutations {
     @Args('authorizationResetData')
     authorizationResetData: UserAuthorizationResetInput
   ): Promise<IUser> {
-    const start = performance.now();
-
     const user = await this.userService.getUserOrFail(
       authorizationResetData.userID
     );
@@ -134,11 +131,7 @@ export class UserResolverMutations {
     const updatedAuthorizations =
       await this.userAuthorizationService.applyAuthorizationPolicy(user);
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
-    const elapsed = (performance.now() - start).toFixed(3);
-    this.logger.verbose?.(
-      `authorizationPolicyResetOnUser took ${elapsed}ms`,
-      LogContext.COMMUNITY
-    );
+
     return await this.userService.getUserOrFail(user.id);
   }
 

--- a/src/domain/community/user/user.resolver.mutations.ts
+++ b/src/domain/community/user/user.resolver.mutations.ts
@@ -19,6 +19,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { UpdateUserPlatformSettingsInput } from './dto/user.dto.update.platform.settings';
 import { UpdateUserInput } from './dto';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { LogContext } from '@common/enums';
 
 @Resolver(() => IUser)
 export class UserResolverMutations {
@@ -119,6 +120,8 @@ export class UserResolverMutations {
     @Args('authorizationResetData')
     authorizationResetData: UserAuthorizationResetInput
   ): Promise<IUser> {
+    const start = performance.now();
+
     const user = await this.userService.getUserOrFail(
       authorizationResetData.userID
     );
@@ -131,6 +134,11 @@ export class UserResolverMutations {
     const updatedAuthorizations =
       await this.userAuthorizationService.applyAuthorizationPolicy(user);
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
+    const elapsed = (performance.now() - start).toFixed(3);
+    this.logger.verbose?.(
+      `authorizationPolicyResetOnUser took ${elapsed}ms`,
+      LogContext.COMMUNITY
+    );
     return await this.userService.getUserOrFail(user.id);
   }
 

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -99,7 +99,7 @@ export class UserAuthorizationService {
     // cascade
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        user.profile,
+        user.profile.id,
         clonedAnonymousReadAccessAuthorization // Key that this is publicly visible
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -49,31 +49,51 @@ export class UserAuthorizationService {
   ): Promise<IAuthorizationPolicy[]> {
     const user = await this.userService.getUserOrFail(userInput.id, {
       loadEagerRelations: false,
-      select: {
-        id: true,
-        profile: {
-          id: true,
-          authorization: {
-            id: true,
-          },
-        },
-      },
       relations: {
         authorization: true,
-        agent: {
-          authorization: true,
-        },
-        profile: true,
+        agent: { authorization: true },
+        profile: { authorization: true },
         preferenceSet: {
           authorization: true,
-          preferences: {
-            authorization: true,
-          },
+          preferences: { authorization: true },
         },
         storageAggregator: {
           authorization: true,
+          directStorage: { authorization: true },
+        },
+      },
+      select: {
+        id: true,
+        authorization:
+          this.authorizationPolicyService.authorizationSelectOptions,
+        agent: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
+        },
+        profile: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
+        },
+        preferenceSet: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
+          preferences: {
+            id: true,
+            authorization:
+              this.authorizationPolicyService.authorizationSelectOptions,
+          },
+        },
+        storageAggregator: {
+          id: true,
+          authorization:
+            this.authorizationPolicyService.authorizationSelectOptions,
           directStorage: {
-            authorization: true,
+            id: true,
+            authorization:
+              this.authorizationPolicyService.authorizationSelectOptions,
           },
         },
       },

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -48,13 +48,34 @@ export class UserAuthorizationService {
     userInput: IUser
   ): Promise<IAuthorizationPolicy[]> {
     const user = await this.userService.getUserOrFail(userInput.id, {
+      loadEagerRelations: false,
+      select: {
+        id: true,
+        profile: {
+          id: true,
+          authorization: {
+            id: true,
+          },
+        },
+      },
       relations: {
-        agent: true,
+        authorization: true,
+        agent: {
+          authorization: true,
+        },
         profile: true,
         preferenceSet: {
-          preferences: true,
+          authorization: true,
+          preferences: {
+            authorization: true,
+          },
         },
-        storageAggregator: true,
+        storageAggregator: {
+          authorization: true,
+          directStorage: {
+            authorization: true,
+          },
+        },
       },
     });
     if (

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -73,7 +73,7 @@ export class VirtualContributorAuthorizationService {
     clonedVirtualAuthorizationAnonymousAccess.anonymousReadAccess = true;
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        virtual.profile,
+        virtual.profile.id,
         clonedVirtualAuthorizationAnonymousAccess
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/innovation-hub/innovation.hub.service.authorization.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.authorization.ts
@@ -59,7 +59,7 @@ export class InnovationHubAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        hub.profile,
+        hub.profile.id,
         hub.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -337,7 +337,7 @@ export class SpaceAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        space.profile,
+        space.profile.id,
         clonedAuthorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/template/callout-template/callout.template.service.authorization.ts
+++ b/src/domain/template/callout-template/callout.template.service.authorization.ts
@@ -49,7 +49,7 @@ export class CalloutTemplateAuthorizationService {
     // Cascade
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        calloutTemplate.profile,
+        calloutTemplate.profile.id,
         calloutTemplate.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/template/community-guidelines-template/community.guidelines.template.service.authorization.ts
+++ b/src/domain/template/community-guidelines-template/community.guidelines.template.service.authorization.ts
@@ -30,7 +30,7 @@ export class CommunityGuidelinesTemplateAuthorizationService {
     // Cascade
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        communityGuidelinesTemplate.profile,
+        communityGuidelinesTemplate.profile.id,
         communityGuidelinesTemplate.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/template/innovation-flow-template/innovation.flow.template.service.authorization.ts
+++ b/src/domain/template/innovation-flow-template/innovation.flow.template.service.authorization.ts
@@ -26,7 +26,7 @@ export class InnovationFlowTemplateAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        innovationFlowTemplate.profile,
+        innovationFlowTemplate.profile.id,
         innovationFlowTemplate.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/template/post-template/post.template.service.authorization.ts
+++ b/src/domain/template/post-template/post.template.service.authorization.ts
@@ -28,7 +28,7 @@ export class PostTemplateAuthorizationService {
     // Cascade
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        postTemplate.profile,
+        postTemplate.profile.id,
         postTemplate.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/template/whiteboard-template/whiteboard.template.service.authorization.ts
+++ b/src/domain/template/whiteboard-template/whiteboard.template.service.authorization.ts
@@ -26,7 +26,7 @@ export class WhiteboardTemplateAuthorizationService {
     updatedAuthorizations.push(whiteboardTemplate.authorization);
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        whiteboardTemplate.profile,
+        whiteboardTemplate.profile.id,
         whiteboardTemplate.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/domain/timeline/event/event.service.authorization.ts
+++ b/src/domain/timeline/event/event.service.authorization.ts
@@ -77,7 +77,7 @@ export class CalendarEventAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        calendarEvent.profile,
+        calendarEvent.profile.id,
         calendarEvent.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/library/innovation-pack/innovation.pack.service.authorization.ts
+++ b/src/library/innovation-pack/innovation.pack.service.authorization.ts
@@ -57,7 +57,7 @@ export class InnovationPackAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        innovationPack.profile,
+        innovationPack.profile.id,
         innovationPack.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);

--- a/src/platform/forum-discussion/discussion.service.authorization.ts
+++ b/src/platform/forum-discussion/discussion.service.authorization.ts
@@ -78,7 +78,7 @@ export class DiscussionAuthorizationService {
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
-        discussion.profile,
+        discussion.profile.id,
         discussion.authorization
       );
     updatedAuthorizations.push(...profileAuthorizations);


### PR DESCRIPTION
Optimizes the data that is loaded around Profiles.

Also done for CalloutFraming, CalloutContribution and User entity. 

Further optimization possible but this relatively small set of changes is showing some good results. On my local machine: 
- simple account with one space: auth reset went from 4.1s to 1.7s
- simple user: auth reset went from 380ms to 80ms

Suspect the win is across the board. More to be had, but given the above results thought it already interesting to push this, even if is just a very rough measure of performance impact. 