### PR TITLE
ensure authorizations policy is reset for newly created document

### DIFF
--- a/src/platform/admin/avatars/admin.avatar.module.ts
+++ b/src/platform/admin/avatars/admin.avatar.module.ts
@@ -4,6 +4,8 @@ import { AdminSearchContributorsMutations } from './admin.avatarresolver.mutatio
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
+import { ProfileModule } from '@domain/common/profile/profile.module';
+import { StorageBucketModule } from '@domain/storage/storage-bucket/storage.bucket.module';
 
 @Module({
   imports: [
@@ -11,6 +13,8 @@ import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platf
     AuthorizationPolicyModule,
     PlatformAuthorizationPolicyModule,
     ContributorModule,
+    ProfileModule,
+    StorageBucketModule,
   ],
   providers: [AdminSearchContributorsMutations],
   exports: [],

--- a/src/platform/admin/avatars/admin.avatarresolver.mutations.ts
+++ b/src/platform/admin/avatars/admin.avatarresolver.mutations.ts
@@ -2,20 +2,28 @@ import { Inject, LoggerService, UseGuards } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { CurrentUser } from '@src/common/decorators';
 import { GraphqlGuard } from '@core/authorization/graphql.guard';
-import { AuthorizationPrivilege } from '@common/enums';
+import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ContributorService } from '@domain/community/contributor/contributor.service';
 import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { ProfileService } from '@domain/common/profile/profile.service';
+import { StorageBucketAuthorizationService } from '@domain/storage/storage-bucket/storage.bucket.service.authorization';
+import { RelationshipNotFoundException } from '@common/exceptions';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { IProfile } from '@domain/common/profile/profile.interface';
 
 @Resolver()
 export class AdminSearchContributorsMutations {
   constructor(
     private authorizationService: AuthorizationService,
+    private authorizationPolicyService: AuthorizationPolicyService,
     private platformAuthorizationPolicyService: PlatformAuthorizationPolicyService,
     private contributorService: ContributorService,
+    private profileService: ProfileService,
+    private storageBucketAuthorizationService: StorageBucketAuthorizationService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private logger: LoggerService
   ) {}
 
@@ -27,7 +35,7 @@ export class AdminSearchContributorsMutations {
   async adminUpdateContributorAvatars(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('profileID', { type: () => UUID }) profileID: string
-  ) {
+  ): Promise<IProfile> {
     const platformPolicy =
       await this.platformAuthorizationPolicyService.getPlatformAuthorizationPolicy();
     this.authorizationService.grantAccessOrFail(
@@ -37,9 +45,28 @@ export class AdminSearchContributorsMutations {
       `Update contributor avatars to be stored as Documents: ${agentInfo.email}`
     );
 
-    await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
-      profileID,
-      agentInfo.userID
-    );
+    let profile =
+      await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
+        profileID,
+        agentInfo.userID
+      );
+    profile = await this.profileService.getProfileOrFail(profile.id, {
+      relations: {
+        storageBucket: true,
+      },
+    });
+    if (!profile.storageBucket) {
+      throw new RelationshipNotFoundException(
+        `Unable to find StorageBucket for Profile ${profile.id}`,
+        LogContext.USER
+      );
+    }
+    const authorizations =
+      this.storageBucketAuthorizationService.applyAuthorizationPolicy(
+        profile.storageBucket,
+        profile.authorization
+      );
+    await this.authorizationPolicyService.saveAll(authorizations);
+    return await this.profileService.getProfileOrFail(profile.id);
   }
 }


### PR DESCRIPTION
When using `adminUpdateContributorAvatars` make sure auth reset is done so the new document is accessible.