### PR TITLE
Backup scripts updated

### DIFF
--- a/.scripts/backups/restore_latest_backup.sh
+++ b/.scripts/backups/restore_latest_backup.sh
@@ -1,5 +1,122 @@
 #!/bin/bash
 
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Function to detect the operating system
+detect_os() {
+    OS_TYPE=""
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        OS_TYPE="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        OS_TYPE="macos"
+    else
+        echo "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+}
+
+# Function to install AWS CLI v2
+install_aws_cli_v2() {
+    echo "Installing AWS CLI v2..."
+    if [[ "$OS_TYPE" == "linux" ]]; then
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+        rm -rf awscliv2.zip aws
+    elif [[ "$OS_TYPE" == "macos" ]]; then
+        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+        sudo installer -pkg AWSCLIV2.pkg -target /
+        rm AWSCLIV2.pkg
+    else
+        echo "Unsupported OS for AWS CLI v2 installation."
+        exit 1
+    fi
+
+    # Verify AWS CLI v2 installation
+    if ! aws --version 2>&1 | grep -q "aws-cli/2"; then
+        echo "AWS CLI v2 installation failed."
+        exit 1
+    fi
+    echo "AWS CLI v2 installed successfully."
+}
+
+# Function to check and install required dependencies
+check_and_install_dependencies() {
+    # Detect OS
+    detect_os
+
+    # Check AWS CLI installation
+    if ! command -v aws &> /dev/null; then
+        echo "AWS CLI not found. Installing AWS CLI v2..."
+        install_aws_cli_v2
+    else
+        AWS_CLI_VERSION=$(aws --version 2>&1 | awk '{print $1}' | cut -d/ -f2)
+        AWS_CLI_MAJOR_VERSION=$(echo "$AWS_CLI_VERSION" | cut -d. -f1)
+
+        if [[ "$AWS_CLI_MAJOR_VERSION" -lt 2 ]]; then
+            echo "AWS CLI version is lower than v2. Installing AWS CLI v2..."
+            install_aws_cli_v2
+        else
+            echo "AWS CLI v2 is already installed."
+        fi
+    fi
+}
+
+# Function to handle AWS CLI configuration
+configure_aws_cli() {
+    AWS_CONFIG_FILE=~/.aws/config
+
+    if [[ -f "$AWS_CONFIG_FILE" ]]; then
+        echo "Existing AWS configuration found."
+        read -p "Do you want to overwrite the current AWS configuration? (y/n) " choice
+        case "$choice" in
+            y|Y )
+                echo "Overwriting AWS CLI configuration..."
+                configure_aws_settings
+                ;;
+            n|N )
+                echo "Keeping the existing AWS CLI configuration."
+                ;;
+            * )
+                echo "Invalid choice. Exiting."
+                exit 1
+                ;;
+        esac
+    else
+        echo "No existing AWS CLI configuration found. Configuring AWS CLI."
+        configure_aws_settings
+    fi
+}
+
+# Function to set AWS configuration
+configure_aws_settings() {
+    mkdir -p ~/.aws
+    cat > ~/.aws/config << EOL
+[default]
+region = nl-ams
+output = json
+services = scw-nl-ams
+
+[services scw-nl-ams]
+s3 =
+  endpoint_url = https://s3.nl-ams.scw.cloud
+  max_concurrent_requests = 100
+  max_queue_size = 1000
+  multipart_threshold = 50 MB
+  multipart_chunksize = 10 MB
+s3api =
+  endpoint_url = https://s3.nl-ams.scw.cloud
+EOL
+    echo "AWS CLI configuration updated successfully."
+}
+
+# Call the dependency check function
+check_and_install_dependencies
+
+# Call the AWS configuration function
+configure_aws_cli
+
 # The storage is the first argument passed to the script. Default to 'mysql' if not provided.
 STORAGE=${1:-mysql}
 
@@ -18,7 +135,7 @@ if [[ "$ENV" != "acc" && "$ENV" != "dev" && "$ENV" != "sandbox" && "$ENV" != "pr
     exit 1
 fi
 
-# Determine the S3 bucket based on the environment
+# Determine the S3 bucket and path based on the environment
 if [[ "$ENV" == "prod" ]]; then
     S3_BUCKET="alkemio-s3-backups-prod"
     S3_PATH="s3://$S3_BUCKET/storage/$STORAGE/backups/"
@@ -31,19 +148,29 @@ echo "Using S3 bucket: $S3_BUCKET"
 echo "Using S3 path: $S3_PATH"
 
 # Source environment variables from .env file
-source .env
+if [[ -f .env ]]; then
+    source .env
+else
+    echo ".env file not found. Please ensure it exists in the current directory."
+    exit 1
+fi
 
 # Get the latest file in the S3 bucket
-if [[ $STORAGE == "mysql" ]]; then
-    latest_file=$(aws s3 ls $S3_PATH --recursive | grep $MYSQL_DATABASE | sort | tail -n 1 | awk '{print $4}')
-elif [[ $STORAGE == "postgres" ]]; then
-    latest_file=$(aws s3 ls $S3_PATH --recursive | sort | tail -n 1 | awk '{print $4}')
+if [[ "$STORAGE" == "mysql" ]]; then
+    latest_file=$(aws s3 ls "$S3_PATH" --recursive | grep "$MYSQL_DATABASE" | sort | tail -n 1 | awk '{print $4}')
+elif [[ "$STORAGE" == "postgres" ]]; then
+    latest_file=$(aws s3 ls "$S3_PATH" --recursive | sort | tail -n 1 | awk '{print $4}')
+fi
+
+if [[ -z "$latest_file" ]]; then
+    echo "No backup files found in $S3_PATH."
+    exit 1
 fi
 
 echo "Latest file: $latest_file"
 
 # Download the latest file
-aws s3 cp s3://$S3_BUCKET/$latest_file .
+aws s3 cp "s3://$S3_BUCKET/$latest_file" .
 
 echo "Downloaded $latest_file from $S3_PATH"
 


### PR DESCRIPTION
- scripts updated to download backups from S3
- updated the script to validate hard dependency on aws cli v2 and install it if not present
- updated the script to use the new base paths of the backups in s3, and to use the different buckets
- to use, the AWS credentials in .env need to be set (will be sent separately)
- if a ~/.aws/config is already present, the user is prompted whether to override it

- draft until prod backups are deployed / validated
- validated locally with acc