### PR TITLE
improved feedback when using cli to authenticate

### DIFF
--- a/src/common/utils/get.session.ts
+++ b/src/common/utils/get.session.ts
@@ -120,9 +120,14 @@ export const getSessionFromJwt = (token: string): Session | never => {
   }
 
   let session: Session | null;
+  const isBearerToken = token.startsWith('Bearer ');
+  if (isBearerToken) {
+    throw new Error('Bearer token found, not decodable as JWT');
+  }
 
   try {
-    session = jwt_decode<KratosPayload>(token).session;
+    const decodedKatosPaylod = jwt_decode<KratosPayload>(token);
+    session = decodedKatosPaylod.session;
   } catch (error: any) {
     throw new Error(error?.message ?? 'Token is not a valid JWT token!');
   }


### PR DESCRIPTION
Minor improvement to messages logged when using cli for authentication. 

![image](https://github.com/user-attachments/assets/b0895297-c796-459c-b1a4-38c06c4ec0f2)


Now getting:
![image](https://github.com/user-attachments/assets/ee0a5c3b-afe1-41cf-89ee-00d79f4bef76)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for input tokens to prevent Bearer tokens from being processed as JWTs, enhancing security and preventing errors.

- **Refactor**
	- Enhanced code clarity by introducing a clearly named variable for the decoded payload, improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->