### PR TITLE
Set assignToNewOrganizationAccounts default value to true for VC Space License

### DIFF
--- a/src/migrations/1726582217409-SetAssignToNewOrganizationAccounts.ts
+++ b/src/migrations/1726582217409-SetAssignToNewOrganizationAccounts.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SetAssignToNewOrganizationAccounts1726582217409
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+          UPDATE \`license_plan\`
+          SET assignToNewOrganizationAccounts = true
+          WHERE name = 'SPACE_FEATURE_VIRTUAL_CONTIBUTORS';
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+          UPDATE \`license_plan\`
+          SET assignToNewOrganizationAccounts = false
+          WHERE name = 'SPACE_FEATURE_VIRTUAL_CONTIBUTORS';
+      `);
+  }
+}


### PR DESCRIPTION

We need VC Space License Feature enabled for newly created spaces to allow VC creation in Organization Accounts.

As we're storing the License Plans in the DB, this change is only in the license_plans table (migration switching the value from false to true);

Relates to: https://github.com/alkem-io/server/issues/4532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new policy for account assignments, enabling automatic assignment to new organization accounts for specific license plans.
  
- **Bug Fixes**
	- Implemented rollback functionality for the new account assignment feature, ensuring flexibility in database management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->