### PR TITLE
platform documentation website link in config locations

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -458,6 +458,9 @@ platform:
   # Acceptable Usage Policy
   aup: ${PLATFORM_AUP}:https://www.alkemio.org/legal/hub/#aup
 
+   # Documentation site
+  documentation: ${PLATFORM_DOCUMENTATION}:https://alkem.io/documentation
+
   # Client can optionally work with a landing page, to give additional information
   landing_page:
     enabled: ${LANDING_PAGE_ENABLED}:false

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -458,8 +458,8 @@ platform:
   # Acceptable Usage Policy
   aup: ${PLATFORM_AUP}:https://www.alkemio.org/legal/hub/#aup
 
-   # Documentation site
-  documentation: ${PLATFORM_DOCUMENTATION}:https://alkem.io/documentation
+   # Documentation site path, endpoint is endpoint_cluster + documentation_path
+  documentation_path: ${PLATFORM_DOCUMENTATION_PATH}:/documentation
 
   # Client can optionally work with a landing page, to give additional information
   landing_page:

--- a/src/common/enums/space.reserved.name.ts
+++ b/src/common/enums/space.reserved.name.ts
@@ -13,4 +13,6 @@ export enum SpaceReservedName {
   ABOUT = 'about',
   PROFILE = 'profile',
   RESTRICTED = 'restricted',
+  DOCS = 'docs',
+  DOCUMENTATION = 'documentation',
 }

--- a/src/platform/configuration/config/config.service.ts
+++ b/src/platform/configuration/config/config.service.ts
@@ -105,6 +105,7 @@ export class KonfigService {
         newuser: platform.newuser,
         tips: platform.tips,
         aup: platform.aup,
+        documentation: platform.documentation,
       },
       sentry: {
         enabled: sentry?.enabled,

--- a/src/platform/configuration/config/config.service.ts
+++ b/src/platform/configuration/config/config.service.ts
@@ -15,6 +15,13 @@ export class KonfigService {
       this.configService.get('hosting.endpoint_cluster', { infer: true })
     ).hostname;
 
+    const platform = this.configService.get('platform', { infer: true });
+
+    const fullDocumentationUrl = new URL(
+      platform.documentation_path,
+      `https://${domain}`
+    ).toString();
+
     const { sentry, apm } = this.configService.get('monitoring', {
       infer: true,
     });
@@ -24,7 +31,6 @@ export class KonfigService {
     const fileConfig = this.configService.get('storage.file', {
       infer: true,
     });
-    const platform = this.configService.get('platform', { infer: true });
     return {
       authentication: {
         providers: await this.getAuthenticationProvidersConfig(),
@@ -105,7 +111,7 @@ export class KonfigService {
         newuser: platform.newuser,
         tips: platform.tips,
         aup: platform.aup,
-        documentation: platform.documentation,
+        documentation: fullDocumentationUrl,
       },
       sentry: {
         enabled: sentry?.enabled,

--- a/src/platform/configuration/config/locations/platform.locations.interface.ts
+++ b/src/platform/configuration/config/locations/platform.locations.interface.ts
@@ -150,4 +150,10 @@ export abstract class IPlatformLocations {
     description: 'URL where users can get tips and tricks',
   })
   aup!: string;
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'URL for the documentation site',
+  })
+  documentation!: string;
 }

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -197,6 +197,7 @@ export type AlkemioConfig = {
     newuser: string;
     tips: string;
     aup: string;
+    documentation: string;
     landing_page: {
       enabled: boolean;
     };

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -197,7 +197,7 @@ export type AlkemioConfig = {
     newuser: string;
     tips: string;
     aup: string;
-    documentation: string;
+    documentation_path: string;
     landing_page: {
       enabled: boolean;
     };


### PR DESCRIPTION
As part of the platform documentation initiative, we provide the documentation link ([platformDomain]/documentation) from the config.locations.

https://github.com/alkem-io/documentation/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a new `documentation` configuration entry to enhance access to platform documentation.
	- Introduced a new `documentation_path` configuration entry for specifying the documentation location.

- **Bug Fixes**
	- None

- **Documentation**
	- Expanded the configuration structure to include dedicated fields for documentation and documentation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->