### PR TITLE
made lookup by nameID to be separate to lookup by UUID

### DIFF
--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -380,31 +380,22 @@ export class TemplateService {
     });
   }
 
-  async getTemplateInTemplatesSetOrFail(
+  async getTemplateByNameIDInTemplatesSetOrFail(
     templatesSetID: string,
-    templateIdOrNameId: string
+    templateNameId: string
   ): Promise<ITemplate> {
-    let template = await this.templateRepository.findOne({
+    const template = await this.templateRepository.findOne({
       where: {
         templatesSet: {
           id: templatesSetID,
         },
-        nameID: templateIdOrNameId,
+        id: templateNameId,
       },
     });
-    if (!template) {
-      template = await this.templateRepository.findOne({
-        where: {
-          templatesSet: {
-            id: templatesSetID,
-          },
-          id: templateIdOrNameId,
-        },
-      });
-    }
+
     if (!template) {
       throw new EntityNotFoundException(
-        `Templates with ID/NameId(${templatesSetID}) not found!`,
+        `Templates with NameID (${templateNameId}) not found in templatesSet with ID: ${templatesSetID}!`,
         LogContext.TEMPLATES
       );
     }

--- a/src/library/innovation-pack/innovaton.pack.service.ts
+++ b/src/library/innovation-pack/innovaton.pack.service.ts
@@ -1,4 +1,3 @@
-import { UUID_LENGTH } from '@common/constants';
 import { LogContext, ProfileType } from '@common/enums';
 import {
   EntityNotFoundException,
@@ -148,23 +147,31 @@ export class InnovationPackService {
     innovationPackID: string,
     options?: FindOneOptions<InnovationPack>
   ): Promise<IInnovationPack | never> {
-    let innovationPack: IInnovationPack | null = null;
-    if (innovationPackID.length === UUID_LENGTH) {
-      innovationPack = await this.innovationPackRepository.findOne({
-        where: { id: innovationPackID },
-        ...options,
-      });
-    }
-    if (!innovationPack) {
-      // look up based on nameID
-      innovationPack = await this.innovationPackRepository.findOne({
-        where: { nameID: innovationPackID },
-        ...options,
-      });
-    }
+    const innovationPack = await this.innovationPackRepository.findOne({
+      where: { id: innovationPackID },
+      ...options,
+    });
+
     if (!innovationPack)
       throw new EntityNotFoundException(
         `Unable to find InnovationPack with ID: ${innovationPackID}`,
+        LogContext.LIBRARY
+      );
+    return innovationPack;
+  }
+
+  async getInnovationPackByNameIdOrFail(
+    innovationPackNameID: string,
+    options?: FindOneOptions<InnovationPack>
+  ): Promise<IInnovationPack | never> {
+    const innovationPack = await this.innovationPackRepository.findOne({
+      where: { nameID: innovationPackNameID },
+      ...options,
+    });
+
+    if (!innovationPack)
+      throw new EntityNotFoundException(
+        `Unable to find InnovationPack using NameID: ${innovationPackNameID}`,
         LogContext.LIBRARY
       );
     return innovationPack;

--- a/src/services/api/lookup-by-name/lookup.by.name.resolver.fields.ts
+++ b/src/services/api/lookup-by-name/lookup.by.name.resolver.fields.ts
@@ -31,7 +31,7 @@ export class LookupByNameResolverFields {
     @Args('NAMEID', { type: () => NameID }) nameid: string
   ): Promise<IInnovationPack> {
     const innovationPack =
-      await this.innovationPackService.getInnovationPackOrFail(nameid);
+      await this.innovationPackService.getInnovationPackByNameIdOrFail(nameid);
     this.authorizationService.grantAccessOrFail(
       agentInfo,
       innovationPack.authorization,
@@ -46,23 +46,24 @@ export class LookupByNameResolverFields {
   @ResolveField(() => ITemplate, {
     nullable: true,
     description:
-      'Lookup the specified Template using a templatesSetId and NameID',
+      'Lookup the specified Template using a templatesSetId and the template NameID',
   })
   async template(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('templatesSetID', { type: () => UUID }) ID: string,
     @Args('NAMEID', { type: () => NameID }) nameID: string
   ): Promise<ITemplate> {
-    const template = await this.templateService.getTemplateInTemplatesSetOrFail(
-      ID,
-      nameID
-    );
+    const template =
+      await this.templateService.getTemplateByNameIDInTemplatesSetOrFail(
+        ID,
+        nameID
+      );
 
     this.authorizationService.grantAccessOrFail(
       agentInfo,
       template.authorization,
       AuthorizationPrivilege.READ,
-      `lookup InnovationPack by NameID: ${template.id}`
+      `lookup template by NameID: ${template.id}`
     );
 
     return template;


### PR DESCRIPTION
The paths should be logically full separate
Error message should now give more information if it is still happening. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to fetch an Innovation Pack by its NameID.
  
- **Enhancements**
  - Improved clarity in method naming and error handling for fetching templates and innovation packs.
  - Updated documentation for resolver methods to better describe functionality.

- **Bug Fixes**
  - Adjusted error messages to reflect accurate search criteria for templates and innovation packs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->