### PR TITLE
Cleanup roles indexes

### DIFF
--- a/src/migrations/1727872794564-cleanupRolesIndexes.ts
+++ b/src/migrations/1727872794564-cleanupRolesIndexes.ts
@@ -1,29 +1,62 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class Test1727872794564 implements MigrationInterface {
-  name = 'Test1727872794564';
+export class cleanupRolesIndexes1727872794564 implements MigrationInterface {
+  name = 'cleanupRolesIndexes1727872794564';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // platform_invitation
+    // This is the new FK using the old index
     await queryRunner.query(
-      'DROP INDEX `FK_b3d3f3c2ce851d1059c4ed26ba2` ON `platform_invitation`'
+      `ALTER TABLE \`platform_invitation\` DROP FOREIGN KEY \`FK_562dce4a08bb214f08107b3631e\``
+    );
+    // This is the old index that needs to be removed
+    await queryRunner.query(
+      `DROP INDEX \`FK_b3d3f3c2ce851d1059c4ed26ba2\` ON \`platform_invitation\`
+    `
+    );
+    // This will add the index and the FK back
+    await queryRunner.query(
+      `ALTER TABLE \`platform_invitation\` ADD CONSTRAINT \`FK_562dce4a08bb214f08107b3631e\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+    `
+    );
+
+    // application
+    await queryRunner.query(
+      `ALTER TABLE \`application\` DROP FOREIGN KEY \`FK_8fb220ad1ac1f9c86ec39d134e4\``
     );
     await queryRunner.query(
-      'DROP INDEX `FK_500cee6f635849f50e19c7e2b76` ON `application`'
+      `DROP INDEX \`FK_500cee6f635849f50e19c7e2b76\` ON \`application\``
     );
     await queryRunner.query(
-      'DROP INDEX `FK_339c1fe2a9c5caef5b982303fb0` ON `invitation`'
+      `ALTER TABLE \`application\` ADD CONSTRAINT \`FK_8fb220ad1ac1f9c86ec39d134e4\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+
+    // invitation
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` DROP FOREIGN KEY \`FK_6a3b86c6db10582baae7058f5b9\``
+    );
+    await queryRunner.query(
+      `DROP INDEX \`FK_339c1fe2a9c5caef5b982303fb0\` ON \`invitation\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` ADD CONSTRAINT \`FK_6a3b86c6db10582baae7058f5b9\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // leave the FK just add back that wrong index to platform_invitation table
     await queryRunner.query(
-      'CREATE INDEX `FK_339c1fe2a9c5caef5b982303fb0` ON `invitation` (`roleSetId`)'
+      `CREATE INDEX \`FK_b3d3f3c2ce851d1059c4ed26ba2\` ON \`platform_invitation\` (\`roleSetId\`)`
     );
+
+    // leave the FK just add back that wrong index to application table
     await queryRunner.query(
-      'CREATE INDEX `FK_500cee6f635849f50e19c7e2b76` ON `application` (`roleSetId`)'
+      `CREATE INDEX \`FK_500cee6f635849f50e19c7e2b76\` ON \`application\` (\`roleSetId\`)`
     );
+
+    // leave the FK just add back that wrong index to invitation table
     await queryRunner.query(
-      'CREATE INDEX `FK_b3d3f3c2ce851d1059c4ed26ba2` ON `platform_invitation` (`roleSetId`)'
+      `CREATE INDEX \`FK_339c1fe2a9c5caef5b982303fb0\` ON \`invitation\` (\`roleSetId\`)`
     );
   }
 }

--- a/src/migrations/1727872794564-cleanupRolesIndexes.ts
+++ b/src/migrations/1727872794564-cleanupRolesIndexes.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Test1727872794564 implements MigrationInterface {
+  name = 'Test1727872794564';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP INDEX `FK_b3d3f3c2ce851d1059c4ed26ba2` ON `platform_invitation`'
+    );
+    await queryRunner.query(
+      'DROP INDEX `FK_500cee6f635849f50e19c7e2b76` ON `application`'
+    );
+    await queryRunner.query(
+      'DROP INDEX `FK_339c1fe2a9c5caef5b982303fb0` ON `invitation`'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX `FK_339c1fe2a9c5caef5b982303fb0` ON `invitation` (`roleSetId`)'
+    );
+    await queryRunner.query(
+      'CREATE INDEX `FK_500cee6f635849f50e19c7e2b76` ON `application` (`roleSetId`)'
+    );
+    await queryRunner.query(
+      'CREATE INDEX `FK_b3d3f3c2ce851d1059c4ed26ba2` ON `platform_invitation` (`roleSetId`)'
+    );
+  }
+}


### PR DESCRIPTION
- npm run migration:generate was creating those differences

- assuming it was from the roles PR.

- we should always make sure schema is synced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Cleaned up specific database indexes to enhance performance and maintainability.
	- Implemented a migration that allows for easy rollback of changes if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->