### PR TITLE
Allow roleSet invitation to an extra Role

### DIFF
--- a/src/core/authorization/authorization.service.ts
+++ b/src/core/authorization/authorization.service.ts
@@ -89,7 +89,7 @@ export class AuthorizationService {
       );
     if (authorization.credentialRules === '') {
       throw new AuthorizationInvalidPolicyException(
-        `AuthorizationPolicy without credential rules provided: ${authorization.id}`,
+        `AuthorizationPolicy without credential rules provided: ${authorization.id}, type: ${authorization.type}`,
         LogContext.AUTH
       );
     }
@@ -130,7 +130,7 @@ export class AuthorizationService {
           for (const privilege of rule.grantedPrivileges) {
             if (privilege === privilegeRequired) {
               this.logger.verbose?.(
-                `[CredentialRule] Granted privilege '${privilegeRequired}' using rule '${rule.name}' on authorization ${authorization.id}`,
+                `[CredentialRule] Granted privilege '${privilegeRequired}' using rule '${rule.name}' on authorization ${authorization.id} on type: ${authorization.type}`,
                 LogContext.AUTH_POLICY
               );
               return true;

--- a/src/domain/access/invitation/dto/invitation.dto.create.ts
+++ b/src/domain/access/invitation/dto/invitation.dto.create.ts
@@ -1,4 +1,9 @@
-import { MID_TEXT_LENGTH, UUID_LENGTH } from '@common/constants';
+import {
+  MID_TEXT_LENGTH,
+  SMALL_TEXT_LENGTH,
+  UUID_LENGTH,
+} from '@common/constants';
+import { CommunityRoleType } from '@common/enums/community.role';
 import { UUID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
 import { IsOptional, MaxLength } from 'class-validator';
@@ -7,11 +12,11 @@ import { IsOptional, MaxLength } from 'class-validator';
 export class CreateInvitationInput {
   @Field(() => UUID, {
     nullable: false,
-    description: 'The identifier for the contributor being invited.',
+    description:
+      'The identifier for the contributor being invited to join in the entry Role.',
   })
-  @IsOptional()
   @MaxLength(UUID_LENGTH)
-  invitedContributor!: string;
+  invitedContributorID!: string;
 
   @Field({ nullable: true })
   @IsOptional()
@@ -22,4 +27,13 @@ export class CreateInvitationInput {
 
   roleSetID!: string;
   invitedToParent!: boolean;
+
+  @Field(() => CommunityRoleType, {
+    nullable: true,
+    description:
+      'An additional role to assign to the Contributor, in addition to the entry Role.',
+  })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  extraRole?: CommunityRoleType;
 }

--- a/src/domain/access/invitation/invitation.entity.ts
+++ b/src/domain/access/invitation/invitation.entity.ts
@@ -18,7 +18,7 @@ export class Invitation extends AuthorizableEntity implements IInvitation {
   lifecycle!: Lifecycle;
 
   @Column('char', { length: UUID_LENGTH, nullable: false })
-  invitedContributor!: string;
+  invitedContributorID!: string;
 
   @Column('char', { length: UUID_LENGTH, nullable: false })
   createdBy!: string;

--- a/src/domain/access/invitation/invitation.entity.ts
+++ b/src/domain/access/invitation/invitation.entity.ts
@@ -5,6 +5,7 @@ import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { CommunityContributorType } from '@common/enums/community.contributor.type';
 import { ENUM_LENGTH, MID_TEXT_LENGTH, UUID_LENGTH } from '@common/constants';
 import { RoleSet } from '@domain/access/role-set/role.set.entity';
+import { CommunityRoleType } from '@common/enums/community.role';
 @Entity()
 export class Invitation extends AuthorizableEntity implements IInvitation {
   // todo ID in migration is varchar - must be char(36)
@@ -37,4 +38,10 @@ export class Invitation extends AuthorizableEntity implements IInvitation {
     onDelete: 'CASCADE',
   })
   roleSet?: RoleSet;
+
+  @Column('varchar', {
+    length: ENUM_LENGTH,
+    nullable: true,
+  })
+  extraRole?: CommunityRoleType;
 }

--- a/src/domain/access/invitation/invitation.interface.ts
+++ b/src/domain/access/invitation/invitation.interface.ts
@@ -3,6 +3,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { IAuthorizable } from '@domain/common/entity/authorizable-entity';
 import { CommunityContributorType } from '@common/enums/community.contributor.type';
 import { IRoleSet } from '@domain/access/role-set';
+import { CommunityRoleType } from '@common/enums/community.role';
 
 @ObjectType('Invitation')
 export class IInvitation extends IAuthorizable {
@@ -35,4 +36,11 @@ export class IInvitation extends IAuthorizable {
     description: 'The type of contributor that is invited.',
   })
   contributorType!: CommunityContributorType;
+
+  @Field(() => CommunityRoleType, {
+    nullable: true,
+    description:
+      'An additional role to assign to the Contributor, in addition to the entry Role.',
+  })
+  extraRole?: CommunityRoleType;
 }

--- a/src/domain/access/invitation/invitation.interface.ts
+++ b/src/domain/access/invitation/invitation.interface.ts
@@ -7,7 +7,7 @@ import { CommunityRoleType } from '@common/enums/community.role';
 
 @ObjectType('Invitation')
 export class IInvitation extends IAuthorizable {
-  invitedContributor!: string;
+  invitedContributorID!: string;
   createdBy!: string;
 
   roleSet?: IRoleSet;

--- a/src/domain/access/invitation/invitation.service.ts
+++ b/src/domain/access/invitation/invitation.service.ts
@@ -111,7 +111,7 @@ export class InvitationService {
   async getInvitedContributor(invitation: IInvitation): Promise<IContributor> {
     const contributor =
       await this.contributorService.getContributorByUuidOrFail(
-        invitation.invitedContributor
+        invitation.invitedContributorID
       );
     if (!contributor)
       throw new RelationshipNotFoundException(
@@ -137,7 +137,7 @@ export class InvitationService {
   ): Promise<IInvitation[]> {
     const existingInvitations = await this.invitationRepository.find({
       where: {
-        invitedContributor: contributorID,
+        invitedContributorID: contributorID,
         roleSet: { id: roleSetID },
       },
       relations: { roleSet: true },
@@ -153,7 +153,7 @@ export class InvitationService {
   ): Promise<IInvitation[]> {
     const findOpts: FindManyOptions<Invitation> = {
       relations: { roleSet: true },
-      where: { invitedContributor: contributorID },
+      where: { invitedContributorID: contributorID },
     };
 
     if (states.length) {

--- a/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
+++ b/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
@@ -1,7 +1,12 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { UUID } from '@domain/common/scalars';
 import { IsOptional, MaxLength } from 'class-validator';
-import { MID_TEXT_LENGTH, UUID_LENGTH } from '@common/constants';
+import {
+  MID_TEXT_LENGTH,
+  SMALL_TEXT_LENGTH,
+  UUID_LENGTH,
+} from '@common/constants';
+import { CommunityRoleType } from '@common/enums/community.role';
 
 @InputType()
 export class InviteForEntryRoleOnRoleSetInput {
@@ -19,6 +24,15 @@ export class InviteForEntryRoleOnRoleSetInput {
   @IsOptional()
   @MaxLength(MID_TEXT_LENGTH)
   welcomeMessage?: string;
+
+  @Field(() => CommunityRoleType, {
+    nullable: true,
+    description:
+      'An additional role to assign to the Contributors, in addition to the entry Role.',
+  })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  extraRole?: CommunityRoleType;
 
   createdBy!: string;
 

--- a/src/domain/access/role-set/role.set.lifecycle.invitation.options.provider.ts
+++ b/src/domain/access/role-set/role.set.lifecycle.invitation.options.provider.ts
@@ -94,7 +94,7 @@ export class RoleSetInvitationLifecycleOptionsProvider {
                 },
               }
             );
-            const contributorID = invitation.invitedContributor;
+            const contributorID = invitation.invitedContributorID;
             const roleSet = invitation.roleSet;
             if (!contributorID || !roleSet) {
               throw new EntityNotInitializedException(

--- a/src/domain/access/role-set/role.set.lifecycle.invitation.options.provider.ts
+++ b/src/domain/access/role-set/role.set.lifecycle.invitation.options.provider.ts
@@ -127,6 +127,16 @@ export class RoleSetInvitationLifecycleOptionsProvider {
               event.agentInfo,
               true
             );
+            if (invitation.extraRole) {
+              await this.roleSetService.assignContributorToRole(
+                roleSet,
+                invitation.extraRole,
+                contributorID,
+                invitation.contributorType,
+                event.agentInfo,
+                false
+              );
+            }
           } finally {
             resolve();
           }

--- a/src/domain/access/role-set/role.set.resolver.mutations.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.ts
@@ -507,6 +507,7 @@ export class RoleSetResolverMutations {
           invitedContributor,
           agentInfo,
           invitationData.invitedToParent,
+          invitationData.extraRole,
           invitationData.welcomeMessage
         );
       })
@@ -518,6 +519,7 @@ export class RoleSetResolverMutations {
     invitedContributor: IContributor,
     agentInfo: AgentInfo,
     invitedToParent: boolean,
+    extraRole?: CommunityRoleType,
     welcomeMessage?: string
   ): Promise<IInvitation> {
     const input: CreateInvitationInput = {
@@ -525,6 +527,7 @@ export class RoleSetResolverMutations {
       invitedContributorID: invitedContributor.id,
       createdBy: agentInfo.userID,
       invitedToParent,
+      extraRole,
       welcomeMessage,
     };
 

--- a/src/domain/access/role-set/role.set.resolver.mutations.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.ts
@@ -306,6 +306,7 @@ export class RoleSetResolverMutations {
       roleData.contributorID
     );
   }
+
   @UseGuards(GraphqlGuard)
   @Mutation(() => IRoleSet, {
     description:
@@ -521,7 +522,7 @@ export class RoleSetResolverMutations {
   ): Promise<IInvitation> {
     const input: CreateInvitationInput = {
       roleSetID: roleSet.id,
-      invitedContributor: invitedContributor.id,
+      invitedContributorID: invitedContributor.id,
       createdBy: agentInfo.userID,
       invitedToParent,
       welcomeMessage,

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1023,7 +1023,7 @@ export class RoleSetService {
   ): Promise<IInvitation> {
     const { contributor: contributor, agent } =
       await this.contributorService.getContributorAndAgent(
-        invitationData.invitedContributor
+        invitationData.invitedContributorID
       );
     const roleSet = await this.getRoleSetOrFail(invitationData.roleSetID);
 

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1082,7 +1082,7 @@ export class RoleSetService {
     const openInvitation = await this.findOpenInvitation(user.id, roleSet.id);
     if (openInvitation) {
       throw new RoleSetMembershipException(
-        `Application not possible: An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributor} (${openInvitation.contributorType}) on RoleSet: ${roleSet.id}.`,
+        `Application not possible: An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributorID} (${openInvitation.contributorType}) on RoleSet: ${roleSet.id}.`,
         LogContext.COMMUNITY
       );
     }
@@ -1107,7 +1107,7 @@ export class RoleSetService {
     );
     if (openInvitation) {
       throw new RoleSetMembershipException(
-        `Invitation not possible: An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributor} (${openInvitation.contributorType}) on RoleSet: ${roleSet.id}.`,
+        `Invitation not possible: An open invitation (ID: ${openInvitation.id}) already exists for contributor ${openInvitation.invitedContributorID} (${openInvitation.contributorType}) on RoleSet: ${roleSet.id}.`,
         LogContext.COMMUNITY
       );
     }

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -592,7 +592,7 @@ export class VirtualContributorService {
   //adding this to avoid circular dependency between VirtualContributor, Room, and Invitation
   private async deleteVCInvitations(contributorID: string) {
     const invitations = await this.entityManager.find(Invitation, {
-      where: { invitedContributor: contributorID },
+      where: { invitedContributorID: contributorID },
     });
     for (const invitation of invitations) {
       if (invitation.authorization) {

--- a/src/migrations/1727872794564-cleanupRolesIndexes.ts
+++ b/src/migrations/1727872794564-cleanupRolesIndexes.ts
@@ -6,39 +6,41 @@ export class cleanupRolesIndexes1727872794564 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // platform_invitation
     // This is the new FK using the old index
-    // await queryRunner.query(
-    //   `ALTER TABLE \`platform_invitation\` DROP FOREIGN KEY \`FK_562dce4a08bb214f08107b3631e\``
-    // );
-    // // This is the old index that needs to be removed
-    // await queryRunner.query(
-    //   `DROP INDEX \`FK_b3d3f3c2ce851d1059c4ed26ba2\` ON \`platform_invitation\`
-    // `
-    // );
-    // // This will add the index and the FK back
-    // await queryRunner.query(
-    //   `ALTER TABLE \`platform_invitation\` ADD CONSTRAINT \`FK_562dce4a08bb214f08107b3631e\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
-    // `
-    // );
-    // // application
-    // await queryRunner.query(
-    //   `ALTER TABLE \`application\` DROP FOREIGN KEY \`FK_8fb220ad1ac1f9c86ec39d134e4\``
-    // );
-    // await queryRunner.query(
-    //   `DROP INDEX \`FK_500cee6f635849f50e19c7e2b76\` ON \`application\``
-    // );
-    // await queryRunner.query(
-    //   `ALTER TABLE \`application\` ADD CONSTRAINT \`FK_8fb220ad1ac1f9c86ec39d134e4\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
-    // );
-    // // invitation
-    // await queryRunner.query(
-    //   `ALTER TABLE \`invitation\` DROP FOREIGN KEY \`FK_6a3b86c6db10582baae7058f5b9\``
-    // );
-    // await queryRunner.query(
-    //   `DROP INDEX \`FK_339c1fe2a9c5caef5b982303fb0\` ON \`invitation\``
-    // );
-    // await queryRunner.query(
-    //   `ALTER TABLE \`invitation\` ADD CONSTRAINT \`FK_6a3b86c6db10582baae7058f5b9\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
-    // );
+    await queryRunner.query(
+      `ALTER TABLE \`platform_invitation\` DROP FOREIGN KEY \`FK_562dce4a08bb214f08107b3631e\``
+    );
+    // This is the old index that needs to be removed
+    await queryRunner.query(
+      `DROP INDEX \`FK_b3d3f3c2ce851d1059c4ed26ba2\` ON \`platform_invitation\`
+    `
+    );
+    // This will add the index and the FK back
+    await queryRunner.query(
+      `ALTER TABLE \`platform_invitation\` ADD CONSTRAINT \`FK_562dce4a08bb214f08107b3631e\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+    `
+    );
+
+    // application
+    await queryRunner.query(
+      `ALTER TABLE \`application\` DROP FOREIGN KEY \`FK_8fb220ad1ac1f9c86ec39d134e4\``
+    );
+    await queryRunner.query(
+      `DROP INDEX \`FK_500cee6f635849f50e19c7e2b76\` ON \`application\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`application\` ADD CONSTRAINT \`FK_8fb220ad1ac1f9c86ec39d134e4\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+
+    // invitation
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` DROP FOREIGN KEY \`FK_6a3b86c6db10582baae7058f5b9\``
+    );
+    await queryRunner.query(
+      `DROP INDEX \`FK_339c1fe2a9c5caef5b982303fb0\` ON \`invitation\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` ADD CONSTRAINT \`FK_6a3b86c6db10582baae7058f5b9\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1727872794564-cleanupRolesIndexes.ts
+++ b/src/migrations/1727872794564-cleanupRolesIndexes.ts
@@ -6,41 +6,39 @@ export class cleanupRolesIndexes1727872794564 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // platform_invitation
     // This is the new FK using the old index
-    await queryRunner.query(
-      `ALTER TABLE \`platform_invitation\` DROP FOREIGN KEY \`FK_562dce4a08bb214f08107b3631e\``
-    );
-    // This is the old index that needs to be removed
-    await queryRunner.query(
-      `DROP INDEX \`FK_b3d3f3c2ce851d1059c4ed26ba2\` ON \`platform_invitation\`
-    `
-    );
-    // This will add the index and the FK back
-    await queryRunner.query(
-      `ALTER TABLE \`platform_invitation\` ADD CONSTRAINT \`FK_562dce4a08bb214f08107b3631e\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
-    `
-    );
-
-    // application
-    await queryRunner.query(
-      `ALTER TABLE \`application\` DROP FOREIGN KEY \`FK_8fb220ad1ac1f9c86ec39d134e4\``
-    );
-    await queryRunner.query(
-      `DROP INDEX \`FK_500cee6f635849f50e19c7e2b76\` ON \`application\``
-    );
-    await queryRunner.query(
-      `ALTER TABLE \`application\` ADD CONSTRAINT \`FK_8fb220ad1ac1f9c86ec39d134e4\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
-    );
-
-    // invitation
-    await queryRunner.query(
-      `ALTER TABLE \`invitation\` DROP FOREIGN KEY \`FK_6a3b86c6db10582baae7058f5b9\``
-    );
-    await queryRunner.query(
-      `DROP INDEX \`FK_339c1fe2a9c5caef5b982303fb0\` ON \`invitation\``
-    );
-    await queryRunner.query(
-      `ALTER TABLE \`invitation\` ADD CONSTRAINT \`FK_6a3b86c6db10582baae7058f5b9\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
-    );
+    // await queryRunner.query(
+    //   `ALTER TABLE \`platform_invitation\` DROP FOREIGN KEY \`FK_562dce4a08bb214f08107b3631e\``
+    // );
+    // // This is the old index that needs to be removed
+    // await queryRunner.query(
+    //   `DROP INDEX \`FK_b3d3f3c2ce851d1059c4ed26ba2\` ON \`platform_invitation\`
+    // `
+    // );
+    // // This will add the index and the FK back
+    // await queryRunner.query(
+    //   `ALTER TABLE \`platform_invitation\` ADD CONSTRAINT \`FK_562dce4a08bb214f08107b3631e\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+    // `
+    // );
+    // // application
+    // await queryRunner.query(
+    //   `ALTER TABLE \`application\` DROP FOREIGN KEY \`FK_8fb220ad1ac1f9c86ec39d134e4\``
+    // );
+    // await queryRunner.query(
+    //   `DROP INDEX \`FK_500cee6f635849f50e19c7e2b76\` ON \`application\``
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE \`application\` ADD CONSTRAINT \`FK_8fb220ad1ac1f9c86ec39d134e4\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
+    // );
+    // // invitation
+    // await queryRunner.query(
+    //   `ALTER TABLE \`invitation\` DROP FOREIGN KEY \`FK_6a3b86c6db10582baae7058f5b9\``
+    // );
+    // await queryRunner.query(
+    //   `DROP INDEX \`FK_339c1fe2a9c5caef5b982303fb0\` ON \`invitation\``
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE \`invitation\` ADD CONSTRAINT \`FK_6a3b86c6db10582baae7058f5b9\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
+    // );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1727930288139-invitationToRole.ts
+++ b/src/migrations/1727930288139-invitationToRole.ts
@@ -7,11 +7,29 @@ export class InvitationToRole1727930288139 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE \`invitation\` ADD \`extraRole\` varchar(128) NULL`
     );
+    await queryRunner.query(
+      `DROP INDEX \`FK_562dce4a08bb214f08107b3631e\` ON \`platform_invitation\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` CHANGE \`invitedContributor\` \`invitedContributorID\` char(36) NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`platform_invitation\` ADD CONSTRAINT \`FK_562dce4a08bb214f08107b3631e\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE \`invitation\` DROP COLUMN \`extraRole\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`platform_invitation\` DROP FOREIGN KEY \`FK_562dce4a08bb214f08107b3631e\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` CHANGE \`invitedContributorID\` \`invitedContributor\` char(36) NOT NULL`
+    );
+    await queryRunner.query(
+      `CREATE INDEX \`FK_562dce4a08bb214f08107b3631e\` ON \`platform_invitation\` (\`roleSetId\`)`
     );
   }
 }

--- a/src/migrations/1727930288139-invitationToRole.ts
+++ b/src/migrations/1727930288139-invitationToRole.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InvitationToRole1727930288139 implements MigrationInterface {
+  name = 'InvitationToRole1727930288139';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` ADD \`extraRole\` varchar(128) NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` DROP COLUMN \`extraRole\``
+    );
+  }
+}

--- a/src/migrations/1727930288139-invitationToRole.ts
+++ b/src/migrations/1727930288139-invitationToRole.ts
@@ -7,14 +7,9 @@ export class InvitationToRole1727930288139 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE \`invitation\` ADD \`extraRole\` varchar(128) NULL`
     );
-    await queryRunner.query(
-      `DROP INDEX \`FK_562dce4a08bb214f08107b3631e\` ON \`platform_invitation\``
-    );
+
     await queryRunner.query(
       `ALTER TABLE \`invitation\` CHANGE \`invitedContributor\` \`invitedContributorID\` char(36) NOT NULL`
-    );
-    await queryRunner.query(
-      `ALTER TABLE \`platform_invitation\` ADD CONSTRAINT \`FK_562dce4a08bb214f08107b3631e\` FOREIGN KEY (\`roleSetId\`) REFERENCES \`role_set\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`
     );
   }
 
@@ -22,14 +17,9 @@ export class InvitationToRole1727930288139 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE \`invitation\` DROP COLUMN \`extraRole\``
     );
-    await queryRunner.query(
-      `ALTER TABLE \`platform_invitation\` DROP FOREIGN KEY \`FK_562dce4a08bb214f08107b3631e\``
-    );
+
     await queryRunner.query(
       `ALTER TABLE \`invitation\` CHANGE \`invitedContributorID\` \`invitedContributor\` char(36) NOT NULL`
-    );
-    await queryRunner.query(
-      `CREATE INDEX \`FK_562dce4a08bb214f08107b3631e\` ON \`platform_invitation\` (\`roleSetId\`)`
     );
   }
 }

--- a/src/services/api/registration/registration.service.ts
+++ b/src/services/api/registration/registration.service.ts
@@ -124,7 +124,7 @@ export class RegistrationService {
       // Process community invitations
       if (roleSet) {
         const invitationInput: CreateInvitationInput = {
-          invitedContributor: user.id,
+          invitedContributorID: user.id,
           roleSetID: roleSet.id,
           createdBy: platformInvitation.createdBy,
           invitedToParent: platformInvitation.communityInvitedToParent,

--- a/src/services/api/roles/roles.service.ts
+++ b/src/services/api/roles/roles.service.ts
@@ -241,7 +241,7 @@ export class RolesService {
       invitation.createdDate,
       invitation.updatedDate
     );
-    invitationResult.contributorID = invitation.invitedContributor;
+    invitationResult.contributorID = invitation.invitedContributorID;
     invitationResult.contributorType = invitation.contributorType;
 
     invitationResult.createdBy = invitation.createdBy ?? '';


### PR DESCRIPTION
Additional parameter added to the create invitation DTO, that is then honored when the invitation is accepted. 

Renamed invitedContributor on invitation to be invitedContributorID as it is an ID

Note: this update does not require client changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes
- **New Features**
	- Added an optional `extraRole` field for invitations to assign additional roles.

- **Improvements**
	- Enhanced error messages for authorization and invitation processes for better clarity.
	- Updated naming conventions for contributor identifiers to `invitedContributorID` for consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new mutation `joinRoleSet` allowing users to join a RoleSet without approval.
	- Added an optional `extraRole` field for invitations to assign additional roles.

- **Improvements**
	- Enhanced error messages for authorization and invitation processes for better clarity.
	- Updated naming conventions for contributor identifiers to `invitedContributorID` for consistency.
	- Improved structure and clarity of invitation input data with updated field names and descriptions.

- **Bug Fixes**
	- Corrected references to contributor identifiers in various service methods to ensure accurate data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->