### PR TITLE
Fix nameId resolution of template

### DIFF
--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -389,7 +389,7 @@ export class TemplateService {
         templatesSet: {
           id: templatesSetID,
         },
-        id: templateNameId,
+        nameID: templateNameId,
       },
     });
 


### PR DESCRIPTION
Fixes small mistake in the previous pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the template retrieval logic to use `nameID` instead of `id`, ensuring accurate identification of templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->