### PR TITLE
added platform invite for extra role on RoleSet

### DIFF
--- a/src/domain/access/role-set/dto/role.set.dto.platform.invitation.community.ts
+++ b/src/domain/access/role-set/dto/role.set.dto.platform.invitation.community.ts
@@ -1,12 +1,22 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { UUID } from '@domain/common/scalars';
-import { MaxLength } from 'class-validator';
-import { UUID_LENGTH } from '@common/constants';
+import { IsOptional, MaxLength } from 'class-validator';
+import { SMALL_TEXT_LENGTH, UUID_LENGTH } from '@common/constants';
 import { CreatePlatformInvitationInput } from '@platform/invitation/dto/platform.invitation.dto.create';
+import { CommunityRoleType } from '@common/enums/community.role';
 
 @InputType()
 export class InviteNewContributorForRoleOnRoleSetInput extends CreatePlatformInvitationInput {
   @Field(() => UUID, { nullable: false })
   @MaxLength(UUID_LENGTH)
   roleSetID!: string;
+
+  @Field(() => CommunityRoleType, {
+    nullable: true,
+    description:
+      'An additional role to assign to the Contributors, in addition to the entry Role.',
+  })
+  @IsOptional()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  roleSetExtraRole?: CommunityRoleType;
 }

--- a/src/domain/access/role-set/role.set.resolver.mutations.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.ts
@@ -637,7 +637,7 @@ export class RoleSetResolverMutations {
           LogContext.COMMUNITY
         );
       } else {
-        invitationData.communityInvitedToParent = true;
+        invitationData.roleSetInvitedToParent = true;
       }
     }
 

--- a/src/migrations/1728936661201-invitationCommunityExtraRole.ts
+++ b/src/migrations/1728936661201-invitationCommunityExtraRole.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InvitationCommunityExtraRole1728936661201
+  implements MigrationInterface
+{
+  name = 'InvitationCommunityExtraRole1728936661201';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameColumn(
+      'platform_invitation',
+      'communityInvitedToParent',
+      'roleSetInvitedToParent'
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`platform_invitation\` ADD \`roleSetExtraRole\` varchar(128) NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameColumn(
+      'platform_invitation',
+      'roleSetInvitedToParent',
+      'communityInvitedToParent'
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`platform_invitation\` DROP COLUMN \`roleSetExtraRole\``
+    );
+  }
+}

--- a/src/platform/invitation/dto/platform.invitation.dto.create.ts
+++ b/src/platform/invitation/dto/platform.invitation.dto.create.ts
@@ -1,4 +1,5 @@
 import { MID_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@common/constants';
+import { CommunityRoleType } from '@common/enums/community.role';
 import { PlatformRole } from '@common/enums/platform.role';
 import { Field, InputType } from '@nestjs/graphql';
 import { IsEmail, IsOptional, MaxLength } from 'class-validator';
@@ -30,6 +31,8 @@ export class CreatePlatformInvitationInput {
   createdBy!: string;
 
   roleSetID?: string;
-  communityInvitedToParent!: boolean;
+  roleSetInvitedToParent!: boolean;
+  roleSetExtraRole?: CommunityRoleType;
+
   platformRole?: PlatformRole;
 }

--- a/src/platform/invitation/platform.invitation.entity.ts
+++ b/src/platform/invitation/platform.invitation.entity.ts
@@ -10,6 +10,7 @@ import {
   UUID_LENGTH,
 } from '@common/constants';
 import { RoleSet } from '@domain/access/role-set/role.set.entity';
+import { CommunityRoleType } from '@common/enums/community.role';
 @Entity()
 export class PlatformInvitation
   extends AuthorizableEntity
@@ -23,7 +24,13 @@ export class PlatformInvitation
   roleSet?: RoleSet;
 
   @Column('boolean', { default: false })
-  communityInvitedToParent!: boolean;
+  roleSetInvitedToParent!: boolean;
+
+  @Column('varchar', {
+    length: ENUM_LENGTH,
+    nullable: true,
+  })
+  roleSetExtraRole?: CommunityRoleType;
 
   // Platform invitations for Community
   @ManyToOne(() => Platform, platform => platform.platformInvitations, {

--- a/src/platform/invitation/platform.invitation.interface.ts
+++ b/src/platform/invitation/platform.invitation.interface.ts
@@ -3,6 +3,7 @@ import { IAuthorizable } from '@domain/common/entity/authorizable-entity';
 import { PlatformRole } from '@common/enums/platform.role';
 import { IPlatform } from '@platform/platfrom/platform.interface';
 import { IRoleSet } from '@domain/access/role-set';
+import { CommunityRoleType } from '@common/enums/community.role';
 
 @ObjectType('PlatformInvitation')
 export class IPlatformInvitation extends IAuthorizable {
@@ -40,7 +41,14 @@ export class IPlatformInvitation extends IAuthorizable {
     description:
       'Whether to also add the invited user to the parent community.',
   })
-  communityInvitedToParent!: boolean;
+  roleSetInvitedToParent!: boolean;
+
+  @Field(() => CommunityRoleType, {
+    nullable: true,
+    description:
+      'An additional role to assign to the Contributor, in addition to the entry Role.',
+  })
+  roleSetExtraRole?: CommunityRoleType;
 
   @Field(() => PlatformRole, {
     nullable: true,

--- a/src/services/api/registration/registration.service.ts
+++ b/src/services/api/registration/registration.service.ts
@@ -127,14 +127,14 @@ export class RegistrationService {
           invitedContributorID: user.id,
           roleSetID: roleSet.id,
           createdBy: platformInvitation.createdBy,
-          invitedToParent: platformInvitation.communityInvitedToParent,
+          extraRole: platformInvitation.roleSetExtraRole,
+          invitedToParent: platformInvitation.roleSetInvitedToParent,
         };
         let invitation =
           await this.roleSetService.createInvitationExistingContributor(
             invitationInput
           );
-        invitation.invitedToParent =
-          platformInvitation.communityInvitedToParent;
+        invitation.invitedToParent = platformInvitation.roleSetInvitedToParent;
 
         invitation = await this.invitationService.save(invitation);
         const authorization =


### PR DESCRIPTION
Additional parameter on inviteUserToPlatformAndRoleSet mutation:
- roleSetExtraRole

Migration is added. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional field `roleSetExtraRole` for assigning additional roles to contributors.
	- Updated invitation context to reflect a new naming convention for role invitations.

- **Bug Fixes**
	- Resolved inconsistencies in property names related to community and role set invitations.

- **Chores**
	- Updated migration scripts to accommodate new database structure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->