### PR TITLE
Invitations private subspaces

### DIFF
--- a/src/domain/space/space/dto/space.dto.create.ts
+++ b/src/domain/space/space/dto/space.dto.create.ts
@@ -6,6 +6,7 @@ import { Type } from 'class-transformer';
 import { CreateContextInput } from '@domain/context/context/dto/context.dto.create';
 import { CreateNameableInput } from '@domain/common/entity/nameable-entity/dto/nameable.dto.create';
 import { CreateCollaborationOnSpaceInput } from './space.dto.create.collaboration';
+import { SpaceLevel } from '@common/enums/space.level';
 
 @InputType()
 export class CreateSpaceInput extends CreateNameableInput {
@@ -27,7 +28,7 @@ export class CreateSpaceInput extends CreateNameableInput {
   // For passing on the hierarchy of storage aggregators
   storageAggregatorParent?: IStorageAggregator;
 
-  level!: number;
+  level!: SpaceLevel;
 
   @Field(() => SpaceType, { nullable: true })
   @IsOptional()

--- a/src/domain/space/space/space.interface.ts
+++ b/src/domain/space/space/space.interface.ts
@@ -10,6 +10,7 @@ import { IAccount } from '../account/account.interface';
 import { SpaceVisibility } from '@common/enums/space.visibility';
 import { ITemplatesSet } from '@domain/template/templates-set/templates.set.interface';
 import { ISpaceDefaults } from '../space.defaults/space.defaults.interface';
+import { SpaceLevel } from '@common/enums/space.level';
 
 @ObjectType('Space')
 export class ISpace extends INameable {
@@ -20,11 +21,11 @@ export class ISpace extends INameable {
 
   account?: IAccount;
 
-  @Field(() => Number, {
+  @Field(() => SpaceLevel, {
     description:
       'The level of this Space, representing the number of Spaces above this one.',
   })
-  level!: number;
+  level!: SpaceLevel;
 
   @Field(() => SpaceType, {
     nullable: false,

--- a/src/services/api/me/dto/me.pending.membership.result.ts
+++ b/src/services/api/me/dto/me.pending.membership.result.ts
@@ -1,6 +1,6 @@
 import { UUID } from '@domain/common/scalars';
 import { Field, ObjectType } from '@nestjs/graphql';
-import { SpaceInfo } from './me.space.info';
+import { SpacePendingMembershipInfo } from './me.space.pending.membership.info';
 
 @ObjectType()
 export class CommunityPendingMembershipResult {
@@ -9,9 +9,9 @@ export class CommunityPendingMembershipResult {
   })
   id!: string;
 
-  @Field(() => SpaceInfo, {
+  @Field(() => SpacePendingMembershipInfo, {
     description:
       'The key information for the Space that the application/invitation is for',
   })
-  spaceInfo!: SpaceInfo;
+  spacePendingMembershipInfo!: SpacePendingMembershipInfo;
 }

--- a/src/services/api/me/dto/me.pending.membership.result.ts
+++ b/src/services/api/me/dto/me.pending.membership.result.ts
@@ -1,6 +1,6 @@
 import { UUID } from '@domain/common/scalars';
 import { Field, ObjectType } from '@nestjs/graphql';
-import { ISpace } from '@domain/space/space/space.interface';
+import { SpaceInfo } from './me.space.info';
 
 @ObjectType()
 export class CommunityPendingMembershipResult {
@@ -9,8 +9,9 @@ export class CommunityPendingMembershipResult {
   })
   id!: string;
 
-  @Field(() => ISpace, {
-    description: 'The space that the application is for',
+  @Field(() => SpaceInfo, {
+    description:
+      'The key information for the Space that the application/invitation is for',
   })
-  space!: ISpace;
+  spaceInfo!: SpaceInfo;
 }

--- a/src/services/api/me/dto/me.space.info.ts
+++ b/src/services/api/me/dto/me.space.info.ts
@@ -4,6 +4,7 @@ import { NameID } from '@domain/common/scalars';
 import { IProfile } from '@domain/common/profile';
 import { IContext } from '@domain/context';
 import { SpaceLevel } from '@common/enums/space.level';
+import { ICommunityGuidelines } from '@domain/community/community-guidelines/community.guidelines.interface';
 
 @ObjectType()
 export class SpaceInfo {
@@ -31,4 +32,9 @@ export class SpaceInfo {
     description: 'The Context of the Space',
   })
   context!: IContext;
+
+  @Field(() => ICommunityGuidelines, {
+    description: 'The CommunityGuidelines for the Space',
+  })
+  communityGuidelines?: ICommunityGuidelines;
 }

--- a/src/services/api/me/dto/me.space.info.ts
+++ b/src/services/api/me/dto/me.space.info.ts
@@ -1,0 +1,34 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { NameID } from '@domain/common/scalars';
+import { IProfile } from '@domain/common/profile';
+import { IContext } from '@domain/context';
+import { SpaceLevel } from '@common/enums/space.level';
+
+@ObjectType()
+export class SpaceInfo {
+  @Field(() => UUID, {
+    description: 'The Space ID',
+  })
+  id!: string;
+
+  @Field(() => NameID, {
+    description: 'The Space nameID',
+  })
+  nameID!: string;
+
+  @Field(() => IProfile, {
+    description: 'The Profile of the Space',
+  })
+  profile!: IProfile;
+
+  @Field(() => SpaceLevel, {
+    description: 'The Level of the Space',
+  })
+  level!: SpaceLevel;
+
+  @Field(() => IContext, {
+    description: 'The Context of the Space',
+  })
+  context!: IContext;
+}

--- a/src/services/api/me/dto/me.space.pending.membership.info.ts
+++ b/src/services/api/me/dto/me.space.pending.membership.info.ts
@@ -1,22 +1,19 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { UUID } from '@domain/common/scalars/scalar.uuid';
-import { NameID } from '@domain/common/scalars';
 import { IProfile } from '@domain/common/profile';
 import { IContext } from '@domain/context';
 import { SpaceLevel } from '@common/enums/space.level';
 import { ICommunityGuidelines } from '@domain/community/community-guidelines/community.guidelines.interface';
 
+// Class to return the set of information that a user that is invited / had an application for a Space
+// needs to see to be able to make a decision
+// TBD: decide what fields go in here, including if we want to return full entities like the Profile or only part of that entity.
 @ObjectType()
-export class SpaceInfo {
+export class SpacePendingMembershipInfo {
   @Field(() => UUID, {
     description: 'The Space ID',
   })
   id!: string;
-
-  @Field(() => NameID, {
-    description: 'The Space nameID',
-  })
-  nameID!: string;
 
   @Field(() => IProfile, {
     description: 'The Profile of the Space',

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -65,6 +65,7 @@ export class MeService {
           level: space.level,
           profile: space.profile,
           context: space.context,
+          communityGuidelines: space.community?.guidelines,
         },
       });
     }
@@ -104,6 +105,7 @@ export class MeService {
           level: space.level,
           profile: space.profile,
           context: space.context,
+          communityGuidelines: space.community?.guidelines,
         },
       });
     }

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -59,9 +59,8 @@ export class MeService {
       results.push({
         id: `${invitation.id}`,
         invitation: invitation,
-        spaceInfo: {
+        spacePendingMembershipInfo: {
           id: space.id,
-          nameID: space.nameID,
           level: space.level,
           profile: space.profile,
           context: space.context,
@@ -99,9 +98,8 @@ export class MeService {
       results.push({
         id: `${application.id}`,
         application: application,
-        spaceInfo: {
+        spacePendingMembershipInfo: {
           id: space.id,
-          nameID: space.nameID,
           level: space.level,
           profile: space.profile,
           context: space.context,

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -50,10 +50,22 @@ export class MeService {
         await this.communityResolverService.getSpaceForRoleSetOrFail(
           invitation.roleSet.id
         );
+      if (!space.profile || !space.context) {
+        throw new EntityNotFoundException(
+          `Missing entities on Space loaded for Invitation ${invitation.id}`,
+          LogContext.COMMUNITY
+        );
+      }
       results.push({
         id: `${invitation.id}`,
         invitation: invitation,
-        space: space,
+        spaceInfo: {
+          id: space.id,
+          nameID: space.nameID,
+          level: space.level,
+          profile: space.profile,
+          context: space.context,
+        },
       });
     }
     return results;
@@ -77,10 +89,22 @@ export class MeService {
         await this.communityResolverService.getSpaceForRoleSetOrFail(
           application.roleSet.id
         );
+      if (!space.profile || !space.context) {
+        throw new EntityNotFoundException(
+          `Missing entities on Space loaded for Application ${application.id}`,
+          LogContext.COMMUNITY
+        );
+      }
       results.push({
         id: `${application.id}`,
         application: application,
-        space: space,
+        spaceInfo: {
+          id: space.id,
+          nameID: space.nameID,
+          level: space.level,
+          profile: space.profile,
+          context: space.context,
+        },
       });
     }
     return results;

--- a/src/services/api/roles/dto/roles.dto.result.community.ts
+++ b/src/services/api/roles/dto/roles.dto.result.community.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { SpaceType } from '@common/enums/space.type';
 import { RolesResult } from './roles.dto.result';
+import { SpaceLevel } from '@common/enums/space.level';
 
 @ObjectType()
 export class RolesResultCommunity extends RolesResult {
@@ -10,11 +11,11 @@ export class RolesResultCommunity extends RolesResult {
   })
   type!: SpaceType;
 
-  @Field(() => Number, {
+  @Field(() => SpaceLevel, {
     nullable: false,
     description: 'The level of the Space e.g. space/challenge/opportunity.',
   })
-  level!: number;
+  level!: SpaceLevel;
 
   constructor(
     nameID: string,

--- a/src/services/infrastructure/entity-resolver/community.resolver.service.ts
+++ b/src/services/infrastructure/entity-resolver/community.resolver.service.ts
@@ -320,6 +320,7 @@ export class CommunityResolverService {
       },
       relations: {
         profile: true,
+        context: true,
       },
     });
     if (!space) {


### PR DESCRIPTION
https://github.com/alkem-io/client-web/issues/7026

Modify the return type of community invitations/applications to return enough information about the space for the user to make a choice. 

Also fixed the typing on Space.level field in some places. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `SpacePendingMembershipInfo` type to enhance user membership information.
	- Updated the `CreateSpaceInput` and `ISpace` classes to utilize the `SpaceLevel` enum for better data validation.
- **Bug Fixes**
	- Added checks in the `MeService` to ensure required properties are present, improving error handling.
- **Refactor**
	- Updated various class properties to use the new `SpaceLevel` type, ensuring consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->