### PR TITLE
expanded information regarding authentication for Users

### DIFF
--- a/src/domain/community/user/dto/roles.dto.authentication.result.ts
+++ b/src/domain/community/user/dto/roles.dto.authentication.result.ts
@@ -1,0 +1,18 @@
+import { AuthenticationType } from '@common/enums/authentication.type';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class UserAuthenticationResult {
+  @Field(() => AuthenticationType, {
+    description:
+      'The Authentication Method used for this User. One of email, linkedin, microsoft, or unknown',
+    nullable: false,
+  })
+  method!: AuthenticationType;
+
+  @Field(() => Date, {
+    description: 'When the Kratos Account for the user was created',
+    nullable: true,
+  })
+  createdAt?: Date;
+}

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -63,7 +63,6 @@ import { AgentType } from '@common/enums/agent.type';
 import { ContributorService } from '../contributor/contributor.service';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
 import { AccountType } from '@common/enums/account.type';
-import { AuthenticationType } from '@common/enums/authentication.type';
 import { KratosService } from '@services/infrastructure/kratos/kratos.service';
 
 @Injectable()
@@ -88,20 +87,6 @@ export class UserService {
     private readonly logger: LoggerService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache
   ) {}
-
-  /**
-   * Retrieves the authentication type associated with a given email.
-   *
-   * @param email - The email address to look up the authentication type for.
-   * @returns A promise that resolves to the authentication type.
-   */
-  public async getAuthenticationTypeByEmail(
-    email: string
-  ): Promise<AuthenticationType> {
-    const identity = await this.kratosService.getIdentityByEmail(email);
-    if (!identity) return AuthenticationType.UNKNOWN;
-    return this.kratosService.mapAuthenticationType(identity);
-  }
 
   private getUserCommunicationIdCacheKey(communicationId: string): string {
     return `@user:communicationId:${communicationId}`;


### PR DESCRIPTION
Replaces the single field with an object that can hold more data. For now added the meta data for when the authentication account was created (should be same as User.createdDate field but might show differences)

Later to look at getting last logged in etc so users can see their login history etc. 

![image](https://github.com/user-attachments/assets/0f414c2a-9ed3-4938-bd66-f64cfde796ad)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `UserAuthenticationResult` object type for enhanced user authentication data.
	- Updated user authentication field to provide more detailed results, including the method and creation date.

- **Bug Fixes**
	- Improved integration with the `KratosService` for fetching user identity information.

- **Chores**
	- Removed the deprecated method for retrieving authentication type by email from the user service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->