### PR TITLE
Set initial values to `VcInteraction` `externalMetadata` field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.93.2",
+  "version": "0.93.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.93.2",
+      "version": "0.93.3",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.93.2",
+  "version": "0.93.3",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/migrations/1729511643484-setUpEmptyExternalMetadataForVcInteractions.ts
+++ b/src/migrations/1729511643484-setUpEmptyExternalMetadataForVcInteractions.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SetUpEmptyExternalMetadataForVcInteractions1729511643484
+  implements MigrationInterface
+{
+  name = 'SetUpEmptyExternalMetadataForVcInteractions1729511643484';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`vc_interaction\` SET \`externalMetadata\` = '{}' WHERE externalMetadata IS NULL OR externalMetadata = ''`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated project version to 0.93.3.
	- Introduced a migration to set external metadata for all `vc_interaction` records to an empty JSON object.

- **Bug Fixes**
	- Ensured consistency in the `externalMetadata` field across records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->