### PR TITLE
Skip file reupload if outside Alkemio

### DIFF
--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -25,12 +25,9 @@ export class ProfileDocumentsService {
     fileUrl: string,
     profile: IProfile
   ): Promise<string | undefined> {
+    // if outside Alkemio - skip
     if (!this.documentService.isAlkemioDocumentURL(fileUrl)) {
-      throw new BaseException(
-        'File URL not inside Alkemio',
-        LogContext.COLLABORATION,
-        AlkemioErrorStatus.UNSPECIFIED
-      );
+      return undefined;
     }
 
     const storageBucketToCheck = profile.storageBucket;


### PR DESCRIPTION
- On whiteboard save, URLs outside Alkemio will be skipped for reupload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the document reupload process by returning `undefined` for unrecognized file URLs instead of throwing an exception, streamlining the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->