### PR TITLE
extend scalar validation for nameID to 28 symbols for edge cases for nameIDs with reservedNames with 25 characters

### DIFF
--- a/src/domain/common/scalars/scalar.nameid.ts
+++ b/src/domain/common/scalars/scalar.nameid.ts
@@ -8,10 +8,10 @@ import { Kind, ValueNode } from 'graphql';
 @Scalar('NameID')
 export class NameID implements CustomScalar<string, string> {
   static MIN_LENGTH = 3;
-  static MAX_LENGTH = NAMEID_MAX_LENGTH + 2; // the sliced 25 symbols, concatenated with '-' and a digit, for nameIDs generated with 25 characters and overlapping a reserved nameID
+  static MAX_LENGTH = NAMEID_MAX_LENGTH + 3; // the sliced 25 symbols, concatenated with '-' and a digit (or two), for nameIDs generated with 25 characters and overlapping a reserved nameID
   static REGEX = /^[a-zA-Z0-9\-]+$/;
   description =
-    'A human readable identifier, 3 <= length <= 27. Used for URL paths in clients. Characters allowed: a-z,A-Z,0-9.';
+    'A human readable identifier, 3 <= length <= 28. Used for URL paths in clients. Characters allowed: a-z,A-Z,0-9.';
 
   parseValue(value: unknown): string {
     return this.validate(value);

--- a/src/domain/common/scalars/scalar.nameid.ts
+++ b/src/domain/common/scalars/scalar.nameid.ts
@@ -8,10 +8,10 @@ import { Kind, ValueNode } from 'graphql';
 @Scalar('NameID')
 export class NameID implements CustomScalar<string, string> {
   static MIN_LENGTH = 3;
-  static MAX_LENGTH = NAMEID_MAX_LENGTH;
+  static MAX_LENGTH = NAMEID_MAX_LENGTH + 2; // the sliced 25 symbols, concatenated with '-' and a digit, for nameIDs generated with 25 characters and overlapping a reserved nameID
   static REGEX = /^[a-zA-Z0-9\-]+$/;
   description =
-    'A human readable identifier, 3 <= length <= 25. Used for URL paths in clients. Characters allowed: a-z,A-Z,0-9.';
+    'A human readable identifier, 3 <= length <= 27. Used for URL paths in clients. Characters allowed: a-z,A-Z,0-9.';
 
   parseValue(value: unknown): string {
     return this.validate(value);


### PR DESCRIPTION
Resolves #4663
- the scalar and the schema have different max length (25 vs 36 chars)
- reserved nameIDs can be up to 25 characters
- if a reserve nameID is generated, -{d} is appended, generating two extra characters
- this results in nameID up to 27 characters, failing Scalar validation

Solution: expanded scalar validation to max 27 characters. There shouldn't be downside risks with this approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `NameID` scalar to support a length of 3 to 27 characters, enhancing flexibility for nameID generation.

- **Documentation**
	- Revised description for the `NameID` scalar to reflect the new valid length range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->