### PR TITLE
Fix updateCalloutVisibility throwing an error

### DIFF
--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -122,7 +122,7 @@ export class CalloutResolverMutations {
     const savedCallout =
       await this.calloutService.updateCalloutVisibility(calloutData);
 
-    if (savedCallout.visibility !== oldVisibility) {
+    if (!savedCallout.isTemplate && savedCallout.visibility !== oldVisibility) {
       if (savedCallout.visibility === CalloutVisibility.PUBLISHED) {
         // Save published info
         await this.calloutService.updateCalloutPublishInfo(


### PR DESCRIPTION
 Fix updateCalloutVisibility throwing `Unable to find space for whiteboard` 
When passing a callout from DRAFT to PUBLISHED a notification is generated.
But in the case of a callout being a template it shouldn't be notifying anyone