### PR TITLE
fix demo space search visibility

### DIFF
--- a/src/services/api/search/v2/search2.service.ts
+++ b/src/services/api/search/v2/search2.service.ts
@@ -50,6 +50,7 @@ export class Search2Service {
     return this.searchResultService.resolveSearchResults(
       searchResults,
       agentInfo,
+      onlyPublicResults,
       searchData.searchInSpaceFilter
     );
   }


### PR DESCRIPTION
- filter out DEMO spaces when we have `onlyPublicResults` (we are unauthenticated)
- so far the filter was only an intersection of indices, but it needed to go deeper than that, based on the state of the `Space`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality to filter results based on visibility with the new `onlyPublicResults` parameter.
- **Bug Fixes**
	- Improved error handling for space identification failures, providing detailed logs when a space is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->