### PR TITLE
Fixed proper L0 space agent selection in recursive license assignment

### DIFF
--- a/src/domain/common/license/license.service.ts
+++ b/src/domain/common/license/license.service.ts
@@ -180,7 +180,7 @@ export class LicenseService {
       e => e.type === childEntitlement.type
     );
     if (!parentEntitlement) {
-      throw new RelationshipNotFoundException(
+      throw new EntityNotFoundException(
         `Parent entitlement not found: ${childEntitlement.type}`,
         LogContext.LICENSE
       );
@@ -194,7 +194,7 @@ export class LicenseService {
     license: ILicense | undefined
   ): ILicenseEntitlement[] | never {
     if (!license) {
-      throw new RelationshipNotFoundException(
+      throw new EntityNotFoundException(
         'Unable to load Entitlements for License',
         LogContext.LICENSE
       );

--- a/src/domain/space/space/space.service.license.ts
+++ b/src/domain/space/space/space.service.license.ts
@@ -25,7 +25,10 @@ export class SpaceLicenseService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  async applyLicensePolicy(spaceID: string): Promise<ILicense[]> {
+  async applyLicensePolicy(
+    spaceID: string,
+    agent?: IAgent
+  ): Promise<ILicense[]> {
     const space = await this.spaceService.getSpaceOrFail(spaceID, {
       relations: {
         agent: {
@@ -60,7 +63,10 @@ export class SpaceLicenseService {
     // Ensure always applying from a clean state
     space.license = this.licenseService.reset(space.license);
 
-    space.license = await this.extendLicensePolicy(space.license, space.agent);
+    space.license = await this.extendLicensePolicy(
+      space.license,
+      agent ?? space.agent
+    );
 
     updatedLicenses.push(space.license);
 
@@ -78,7 +84,10 @@ export class SpaceLicenseService {
     updatedLicenses.push(...collaborationLicenses);
 
     for (const subspace of space.subspaces) {
-      const subspaceLicenses = await this.applyLicensePolicy(subspace.id);
+      const subspaceLicenses = await this.applyLicensePolicy(
+        subspace.id,
+        space.agent
+      );
       updatedLicenses.push(...subspaceLicenses);
     }
 

--- a/src/domain/space/space/space.service.license.ts
+++ b/src/domain/space/space/space.service.license.ts
@@ -62,10 +62,11 @@ export class SpaceLicenseService {
 
     // Ensure always applying from a clean state
     space.license = this.licenseService.reset(space.license);
+    const rootLevelSpaceAgent = agent ?? space.agent;
 
     space.license = await this.extendLicensePolicy(
       space.license,
-      agent ?? space.agent
+      rootLevelSpaceAgent
     );
 
     updatedLicenses.push(space.license);
@@ -86,7 +87,7 @@ export class SpaceLicenseService {
     for (const subspace of space.subspaces) {
       const subspaceLicenses = await this.applyLicensePolicy(
         subspace.id,
-        space.agent
+        rootLevelSpaceAgent
       );
       updatedLicenses.push(...subspaceLicenses);
     }


### PR DESCRIPTION
- agent was picked up from the wrong entity, leading to agent being picked up from space on L1 spaces, not from account 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced license policy application with the addition of an optional agent parameter, allowing for more flexible license management across spaces and subspaces.

- **Bug Fixes**
	- Improved error handling by updating exception types for better clarity when entitlements or licenses are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->