### PR TITLE
filter out demo spaces for unauthenticated users search in elastic

### DIFF
--- a/src/services/api/search/v2/extract/build.search.query.ts
+++ b/src/services/api/search/v2/extract/build.search.query.ts
@@ -3,41 +3,50 @@ import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 
 export const buildSearchQuery = (
   terms: string,
-  spaceIdFilter?: string,
-  onlyPublicResults: boolean = false
-): QueryDslQueryContainer => ({
-  bool: {
-    must: [
-      {
-        // Match the terms in any TEXT field
-        // Accumulate the score from all fields - more matches on more fields will result in a higher score
-        multi_match: {
-          query: terms,
-          type: 'most_fields',
-          fields: ['*'],
+  options?: {
+    spaceIdFilter?: string;
+    excludeDemoSpaces?: boolean;
+  }
+): QueryDslQueryContainer => {
+  const { spaceIdFilter, excludeDemoSpaces } = options ?? {};
+  return {
+    bool: {
+      must: [
+        {
+          // Match the terms in any TEXT field
+          // Accumulate the score from all fields - more matches on more fields will result in a higher score
+          multi_match: {
+            query: terms,
+            type: 'most_fields',
+            fields: ['*'],
+          },
         },
-      },
-    ],
-    // Filter the results by the spaceID and visibility
-    filter: buildFilter(
-      spaceIdFilter,
-      onlyPublicResults === true ? SpaceVisibility.ACTIVE : undefined
-    ),
-  },
-});
+      ],
+      // Filter the results by the spaceID and visibility
+      filter: buildFilter({
+        spaceIdFilter,
+        excludeDemoSpaces,
+      }),
+    },
+  };
+};
 
-const buildFilter = (
-  spaceIdFilter?: string,
-  visibilityFilter?: string
-): QueryDslQueryContainer | undefined => {
+const buildFilter = (opts?: {
+  spaceIdFilter?: string;
+  excludeDemoSpaces?: boolean;
+}): QueryDslQueryContainer | undefined => {
+  const { spaceIdFilter, excludeDemoSpaces } = opts ?? {};
+
   const filters: QueryDslQueryContainer[] = [];
 
   if (spaceIdFilter) {
     filters.push({
       bool: {
+        // match either of the two conditions
         minimum_should_match: 1,
         should: [
-          // Include entities without spaceID
+          // the spaceID field is not applicable for some entities,
+          // so we want them included in the results
           {
             bool: {
               must_not: {
@@ -47,7 +56,7 @@ const buildFilter = (
               },
             },
           },
-          // Filter entities with the specified spaceID
+          // if the spaceID field exists, we want to filter by it
           {
             term: {
               spaceID: spaceIdFilter,
@@ -58,10 +67,10 @@ const buildFilter = (
     });
   }
 
-  if (visibilityFilter) {
+  if (excludeDemoSpaces) {
     filters.push({
       term: {
-        visibility: visibilityFilter,
+        visibility: SpaceVisibility.ACTIVE,
       },
     });
   }

--- a/src/services/api/search/v2/extract/search.extract.service.ts
+++ b/src/services/api/search/v2/extract/search.extract.service.ts
@@ -85,7 +85,11 @@ export class SearchExtractService {
       onlyPublicResults
     );
     // the main search query built using query DSL
-    const query = buildSearchQuery(terms, searchData.searchInSpaceFilter);
+    const query = buildSearchQuery(
+      terms,
+      searchData.searchInSpaceFilter,
+      onlyPublicResults
+    );
     // used with function_score to boost results based on visibility
     const functions = functionScoreFunctions;
 

--- a/src/services/api/search/v2/extract/search.extract.service.ts
+++ b/src/services/api/search/v2/extract/search.extract.service.ts
@@ -70,7 +70,7 @@ export class SearchExtractService {
 
   public async search(
     searchData: SearchInput,
-    onlyPublicResults: boolean
+    excludeDemoSpaces: boolean
   ): Promise<ISearchResult[] | never> {
     if (!this.client) {
       throw new Error('Elasticsearch client not initialized');
@@ -82,14 +82,13 @@ export class SearchExtractService {
     const terms = filteredTerms.join(' ');
     const indicesToSearchOn = this.getIndices(
       searchData.typesFilter,
-      onlyPublicResults
+      excludeDemoSpaces
     );
     // the main search query built using query DSL
-    const query = buildSearchQuery(
-      terms,
-      searchData.searchInSpaceFilter,
-      onlyPublicResults
-    );
+    const query = buildSearchQuery(terms, {
+      spaceIdFilter: searchData.searchInSpaceFilter,
+      excludeDemoSpaces,
+    });
     // used with function_score to boost results based on visibility
     const functions = functionScoreFunctions;
 

--- a/src/services/api/search/v2/result/search.result.service.ts
+++ b/src/services/api/search/v2/result/search.result.service.ts
@@ -182,7 +182,9 @@ export class SearchResultService {
     const subspaceIds = rawSearchResults.map(hit => hit.result.id);
 
     const subspaces = await this.entityManager.find(Space, {
-      where: { id: In(subspaceIds) },
+      where: {
+        id: In(subspaceIds),
+      },
       relations: { parentSpace: true },
     });
 

--- a/src/services/api/search/v2/search2.service.ts
+++ b/src/services/api/search/v2/search2.service.ts
@@ -23,7 +23,7 @@ export class Search2Service {
     searchData: SearchInput,
     agentInfo: AgentInfo
   ): Promise<ISearchResults> {
-    const onlyPublicResults = !agentInfo.email;
+    const excludeDemoSpaces = !agentInfo.email;
     if (
       searchData.searchInSpaceFilter &&
       !isUUID(searchData.searchInSpaceFilter)
@@ -45,7 +45,7 @@ export class Search2Service {
     }
     const searchResults = await this.searchExtractService.search(
       searchData,
-      onlyPublicResults
+      excludeDemoSpaces
     );
     return this.searchResultService.resolveSearchResults(
       searchResults,


### PR DESCRIPTION
- expanded elastic filter to include searching only in public spaces for authenticated users
- search is on elastic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality to filter results based on visibility with the addition of an exclude demo spaces parameter.
	- Improved query structuring for subspace search results, enhancing readability.

- **Bug Fixes**
	- Maintained robust error handling and logging for search operations.

- **Chores**
	- Minor formatting updates for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->