### PR TITLE
Expose visuals constraints through the API

### DIFF
--- a/src/domain/common/visual/avatar.constants.ts
+++ b/src/domain/common/visual/avatar.constants.ts
@@ -1,2 +1,0 @@
-export const avatarMinImageSize = 190;
-export const avatarMaxImageSize = 410;

--- a/src/domain/common/visual/visual.constraints.ts
+++ b/src/domain/common/visual/visual.constraints.ts
@@ -1,0 +1,106 @@
+import { VisualType } from '@common/enums/visual.type';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+export const VISUAL_ALLOWED_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/svg+xml',
+  'image/webp',
+] as const;
+
+export const VISUAL_CONSTRAINTS = {
+  [VisualType.AVATAR]: {
+    minWidth: 190,
+    maxWidth: 410,
+    minHeight: 190,
+    maxHeight: 410,
+    aspectRatio: 1,
+    allowedTypes: VISUAL_ALLOWED_TYPES,
+  },
+  [VisualType.BANNER]: {
+    minWidth: 384,
+    maxWidth: 1536,
+    minHeight: 64,
+    maxHeight: 256,
+    aspectRatio: 6,
+    allowedTypes: VISUAL_ALLOWED_TYPES,
+  },
+  [VisualType.CARD]: {
+    minWidth: 307,
+    maxWidth: 410,
+    minHeight: 192,
+    maxHeight: 256,
+    aspectRatio: 1.6,
+    allowedTypes: VISUAL_ALLOWED_TYPES,
+  },
+  [VisualType.BANNER_WIDE]: {
+    minWidth: 640,
+    maxWidth: 2560,
+    minHeight: 64,
+    maxHeight: 256,
+    aspectRatio: 10,
+    allowedTypes: VISUAL_ALLOWED_TYPES,
+  },
+} as const;
+
+@ObjectType('VisualConstraints')
+export class VisualConstraints {
+  @Field(() => Number, {
+    description: 'Minimum width resolution.',
+  })
+  minWidth!: number;
+
+  @Field(() => Number, {
+    description: 'Maximum width resolution.',
+  })
+  maxWidth!: number;
+
+  @Field(() => Number, {
+    description: 'Minimum height resolution.',
+  })
+  minHeight!: number;
+
+  @Field(() => Number, {
+    description: 'Maximum height resolution.',
+  })
+  maxHeight!: number;
+
+  @Field(() => Number, {
+    description: 'Dimensions ratio width / height.',
+  })
+  aspectRatio!: number;
+
+  @Field(() => [String], {
+    description: 'Allowed file types.',
+  })
+  allowedTypes!: typeof VISUAL_ALLOWED_TYPES;
+}
+
+@ObjectType('VisualTypeContraints')
+export class VisualTypeConstraints {
+  @Field(() => VisualConstraints, {
+    nullable: false,
+    description: 'Avatar visual dimensions',
+  })
+  public Avatar: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.AVATAR];
+
+  @Field(() => VisualConstraints, {
+    nullable: false,
+    description: 'Banner visual dimensions',
+  })
+  public Banner: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.BANNER];
+
+  @Field(() => VisualConstraints, {
+    nullable: false,
+    description: 'Card visual dimensions',
+  })
+  public Card: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.CARD];
+
+  @Field(() => VisualConstraints, {
+    nullable: false,
+    description: 'BannerWide visual dimensions',
+  })
+  public BannerWide: VisualConstraints =
+    VISUAL_CONSTRAINTS[VisualType.BANNER_WIDE];
+}

--- a/src/domain/common/visual/visual.constraints.ts
+++ b/src/domain/common/visual/visual.constraints.ts
@@ -77,30 +77,30 @@ export class VisualConstraints {
   allowedTypes!: typeof VISUAL_ALLOWED_TYPES;
 }
 
-@ObjectType('VisualTypeContraints')
+@ObjectType('VisualTypeConstraints')
 export class VisualTypeConstraints {
   @Field(() => VisualConstraints, {
     nullable: false,
     description: 'Avatar visual dimensions',
   })
-  public Avatar: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.AVATAR];
+  public avatar: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.AVATAR];
 
   @Field(() => VisualConstraints, {
     nullable: false,
     description: 'Banner visual dimensions',
   })
-  public Banner: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.BANNER];
+  public banner: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.BANNER];
 
   @Field(() => VisualConstraints, {
     nullable: false,
     description: 'Card visual dimensions',
   })
-  public Card: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.CARD];
+  public card: VisualConstraints = VISUAL_CONSTRAINTS[VisualType.CARD];
 
   @Field(() => VisualConstraints, {
     nullable: false,
     description: 'BannerWide visual dimensions',
   })
-  public BannerWide: VisualConstraints =
+  public bannerWide: VisualConstraints =
     VISUAL_CONSTRAINTS[VisualType.BANNER_WIDE];
 }

--- a/src/domain/common/visual/visual.entity.ts
+++ b/src/domain/common/visual/visual.entity.ts
@@ -3,6 +3,7 @@ import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { IVisual } from './visual.interface';
 import { Profile } from '@domain/common/profile/profile.entity';
 import { ALT_TEXT_LENGTH, URI_LENGTH } from '@common/constants';
+import { VISUAL_ALLOWED_TYPES } from './visual.constraints';
 
 @Entity()
 export class Visual extends AuthorizableEntity implements IVisual {
@@ -42,21 +43,11 @@ export class Visual extends AuthorizableEntity implements IVisual {
 
   constructor() {
     super();
-    this.allowedTypes = this.createDefaultAllowedTypes();
+    this.allowedTypes = [...VISUAL_ALLOWED_TYPES];
     this.minHeight = 0;
     this.maxHeight = 0;
     this.minWidth = 0;
     this.maxWidth = 0;
     this.aspectRatio = 1;
-  }
-
-  private createDefaultAllowedTypes(): string[] {
-    return [
-      'image/png',
-      'image/jpeg',
-      'image/jpg',
-      'image/svg+xml',
-      'image/webp',
-    ];
   }
 }

--- a/src/domain/common/visual/visual.service.ts
+++ b/src/domain/common/visual/visual.service.ts
@@ -14,7 +14,6 @@ import { getImageDimensions, streamToBuffer } from '@common/utils';
 import { Visual } from './visual.entity';
 import { IVisual } from './visual.interface';
 import { DeleteVisualInput } from './dto/visual.dto.delete';
-import { avatarMinImageSize, avatarMaxImageSize } from './avatar.constants';
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { ReadStream } from 'fs';
 import { IDocument } from '@domain/storage/document/document.interface';
@@ -22,6 +21,8 @@ import { DocumentService } from '@domain/storage/document/document.service';
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
 import { StorageUploadFailedException } from '@common/exceptions/storage/storage.upload.failed.exception';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { VisualType } from '@common/enums/visual.type';
+import { VISUAL_CONSTRAINTS } from './visual.constraints';
 
 @Injectable()
 export class VisualService {
@@ -188,12 +189,8 @@ export class VisualService {
   public createVisualBanner(uri?: string): IVisual {
     return this.createVisual(
       {
-        name: 'banner',
-        minWidth: 384,
-        maxWidth: 1536,
-        minHeight: 64,
-        maxHeight: 256,
-        aspectRatio: 6,
+        name: VisualType.BANNER,
+        ...VISUAL_CONSTRAINTS[VisualType.BANNER],
       },
       uri
     );
@@ -202,12 +199,8 @@ export class VisualService {
   public createVisualCard(uri?: string): IVisual {
     return this.createVisual(
       {
-        name: 'card',
-        minWidth: 307,
-        maxWidth: 410,
-        minHeight: 192,
-        maxHeight: 256,
-        aspectRatio: 1.6,
+        name: VisualType.CARD,
+        ...VISUAL_CONSTRAINTS[VisualType.CARD],
       },
       uri
     );
@@ -216,12 +209,8 @@ export class VisualService {
   public createVisualBannerWide(uri?: string): IVisual {
     return this.createVisual(
       {
-        name: 'bannerWide',
-        minWidth: 640,
-        maxWidth: 2560,
-        minHeight: 64,
-        maxHeight: 256,
-        aspectRatio: 10,
+        name: VisualType.BANNER_WIDE,
+        ...VISUAL_CONSTRAINTS[VisualType.BANNER_WIDE],
       },
       uri
     );
@@ -229,12 +218,8 @@ export class VisualService {
 
   public createVisualAvatar(): IVisual {
     return this.createVisual({
-      name: 'avatar',
-      minWidth: avatarMinImageSize,
-      maxWidth: avatarMaxImageSize,
-      minHeight: avatarMinImageSize,
-      maxHeight: avatarMaxImageSize,
-      aspectRatio: 1,
+      name: VisualType.AVATAR,
+      ...VISUAL_CONSTRAINTS[VisualType.AVATAR],
     });
   }
 }

--- a/src/platform/configuration/config/config.interface.ts
+++ b/src/platform/configuration/config/config.interface.ts
@@ -6,6 +6,7 @@ import { IApmConfig } from './apm';
 import { IGeoConfig } from './integrations';
 import { IStorageConfig } from './storage';
 import { IPlatformFeatureFlag } from '../feature-flag/platform.feature.flag.interface';
+import { VisualTypeConstraints } from '@domain/common/visual/visual.constraints';
 
 @ObjectType('Config')
 export abstract class IConfig {
@@ -39,6 +40,12 @@ export abstract class IConfig {
       'Elastic APM (RUM & performance monitoring) related configuration.',
   })
   apm?: IApmConfig;
+
+  @Field(() => VisualTypeConstraints, {
+    nullable: false,
+    description: 'Visual constraints for different visual types',
+  })
+  visualTypeConstraints?: VisualTypeConstraints;
 
   @Field(() => IStorageConfig, {
     nullable: false,

--- a/src/platform/configuration/config/config.service.ts
+++ b/src/platform/configuration/config/config.service.ts
@@ -5,6 +5,7 @@ import { IAuthenticationProviderConfig } from './authentication/providers/authen
 import { IOryConfig } from './authentication/providers/ory/ory.config.interface';
 import { PlatformFeatureFlagName } from '@common/enums/platform.feature.flag.name';
 import { AlkemioConfig } from '@src/types';
+import { VisualTypeConstraints } from '@domain/common/visual/visual.constraints';
 
 @Injectable()
 export class KonfigService {
@@ -31,6 +32,7 @@ export class KonfigService {
     const fileConfig = this.configService.get('storage.file', {
       infer: true,
     });
+    const visualTypeConstraints = new VisualTypeConstraints();
     return {
       authentication: {
         providers: await this.getAuthenticationProvidersConfig(),
@@ -119,6 +121,7 @@ export class KonfigService {
         submitPII: sentry?.submit_pii,
         environment: sentry?.environment,
       },
+      visualTypeConstraints,
       apm: {
         rumEnabled: apm?.rumEnabled,
         endpoint: apm?.endpoint,


### PR DESCRIPTION
Goes together with [#7247](https://github.com/alkem-io/client-web/pull/7247)

Exposes a field in platform config to do things like:
```graphql
{
    platform {
     configuration {
       visualTypeContraints {
         Avatar {
           maxWidth
           minWidth
            ...
         }
       }
     }
}
```

It may be better if we expose it as a query where we can do
```graphql
{
    platform {
     configuration {
       visualTypeContraints (type: AVATAR) {
         ...
       }
     }
}
```
but that was complicating a bit the implementation, maybe somebody else can pick it up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced visual constraints for various visual types, enhancing validation for image uploads.
	- Added support for new visual type constraints in configuration.

- **Bug Fixes**
	- Removed outdated avatar size constants to streamline image handling.

- **Refactor**
	- Updated visual entity and service methods to utilize new constants for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->