### PR TITLE
Erase CommunityGuidelines content mutation

### DIFF
--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -273,6 +273,24 @@ export class ProfileService {
     return await this.referenceService.save(newReference);
   }
 
+  async deleteAllReferencesFromProfile(profileId: string): Promise<void> {
+    const profile = await this.getProfileOrFail(profileId, {
+      relations: { references: true },
+    });
+
+    if (!profile.references)
+      throw new EntityNotInitializedException(
+        'References not defined',
+        LogContext.COMMUNITY
+      );
+
+    for (const reference of profile.references) {
+      await this.referenceService.deleteReference({
+        ID: reference.id,
+      });
+    }
+  }
+
   async getProfileOrFail(
     profileID: string,
     options?: FindOneOptions<Profile>

--- a/src/domain/community/community-guidelines/community.guidelines.resolver.mutations.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.resolver.mutations.ts
@@ -61,7 +61,7 @@ export class CommunityGuidelinesResolverMutations {
       agentInfo,
       communityGuidelines.authorization,
       AuthorizationPrivilege.UPDATE,
-      `updateCommunityGuidelines: ${communityGuidelines.id}`
+      `removeCommunityGuidelinesContent: ${communityGuidelines.id}`
     );
 
     return await this.communityGuidelinesService.eraseContent(

--- a/src/domain/community/community-guidelines/community.guidelines.resolver.mutations.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.resolver.mutations.ts
@@ -45,7 +45,7 @@ export class CommunityGuidelinesResolverMutations {
   }
   @UseGuards(GraphqlGuard)
   @Mutation(() => ICommunityGuidelines, {
-    description: 'Updates the CommunityGuidelines.',
+    description: 'Empties the CommunityGuidelines.', // Update mutation doesn't allow empty values. And we cannot really delete the entity, but this will leave it empty.
   })
   @Profiling.api
   async removeCommunityGuidelinesContent(

--- a/src/domain/community/community-guidelines/community.guidelines.resolver.mutations.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.resolver.mutations.ts
@@ -8,6 +8,7 @@ import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { ICommunityGuidelines } from './community.guidelines.interface';
 import { CommunityGuidelinesService } from './community.guidelines.service';
 import { UpdateCommunityGuidelinesEntityInput } from './dto/community.guidelines.dto.update.entity';
+import { RemoveCommunityGuidelinesContentInput as RemoveCommunityGuidelinesContentInput } from './dto/community.guidelines.dto.remove.content';
 
 @Resolver()
 export class CommunityGuidelinesResolverMutations {
@@ -40,6 +41,31 @@ export class CommunityGuidelinesResolverMutations {
     return await this.communityGuidelinesService.update(
       communityGuidelines,
       communityGuidelinesData
+    );
+  }
+  @UseGuards(GraphqlGuard)
+  @Mutation(() => ICommunityGuidelines, {
+    description: 'Updates the CommunityGuidelines.',
+  })
+  @Profiling.api
+  async removeCommunityGuidelinesContent(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('communityGuidelinesData')
+    communityGuidelinesData: RemoveCommunityGuidelinesContentInput
+  ): Promise<ICommunityGuidelines> {
+    const communityGuidelines =
+      await this.communityGuidelinesService.getCommunityGuidelinesOrFail(
+        communityGuidelinesData.communityGuidelinesID
+      );
+    await this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      communityGuidelines.authorization,
+      AuthorizationPrivilege.UPDATE,
+      `updateCommunityGuidelines: ${communityGuidelines.id}`
+    );
+
+    return await this.communityGuidelinesService.eraseContent(
+      communityGuidelines
     );
   }
 }

--- a/src/domain/community/community-guidelines/community.guidelines.service.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.ts
@@ -78,6 +78,25 @@ export class CommunityGuidelinesService {
     return await this.communityGuidelinesRepository.save(communityGuidelines);
   }
 
+  async eraseContent(
+    communityGuidelines: ICommunityGuidelines
+  ): Promise<ICommunityGuidelines> {
+    communityGuidelines.profile = await this.profileService.updateProfile(
+      communityGuidelines.profile,
+      {
+        displayName: '',
+        description: '',
+      }
+    );
+
+    await this.profileService.deleteAllReferencesFromProfile(
+      communityGuidelines.profile.id
+    );
+    communityGuidelines.profile.references = [];
+
+    return await this.communityGuidelinesRepository.save(communityGuidelines);
+  }
+
   async deleteCommunityGuidelines(
     communityGuidelinesID: string
   ): Promise<ICommunityGuidelines> {

--- a/src/domain/community/community-guidelines/dto/community.guidelines.dto.remove.content.ts
+++ b/src/domain/community/community-guidelines/dto/community.guidelines.dto.remove.content.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+
+@InputType()
+export class RemoveCommunityGuidelinesContentInput {
+  @Field(() => UUID, {
+    description: 'ID of the CommunityGuidelines that will be emptied',
+  })
+  communityGuidelinesID!: string;
+}


### PR DESCRIPTION
Add the mutation to empty the CommunityGuidelines content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to delete all references from a specific user profile.
	- Added a mutation to remove content from community guidelines.
	- Implemented a service method to erase content associated with community guidelines.
	- Created a new input type for specifying community guidelines to be emptied.

These enhancements improve user control over profiles and community guidelines management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->