### PR TITLE
GraphiQL config at /graphiql

### DIFF
--- a/.build/ory/oathkeeper/access-rules.yml
+++ b/.build/ory/oathkeeper/access-rules.yml
@@ -23,6 +23,30 @@
               - unauthorized
               - forbidden
 
+- id: 'alkemio:graphiql:protected'
+  upstream:
+    preserve_host: true
+    url: 'http://host.docker.internal:4000'
+  match:
+    url: 'http://localhost:3000/graphiql'
+    methods:
+      - POST
+      - GET
+  authenticators:
+    - handler: cookie_session
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: id_token
+  errors:
+    - handler: redirect
+      config:
+        to: http://localhost:3000/login
+        when:
+          - error:
+              - unauthorized
+              - forbidden
 
 - id: 'alkemio:api:private:rest:storage'
   upstream:

--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -115,6 +115,12 @@ http:
       entryPoints:
         - 'web'
 
+    graphiql:
+      rule: 'PathPrefix(`/graphiql`)'
+      service: 'oathkeeper-proxy'
+      entryPoints:
+        - 'web'
+
     api-public-graphql:
       rule: 'PathPrefix(`/api/public/graphql`)'
       service: 'alkemio-server'

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,8 @@
         "dataloader": "^2.2.2",
         "graphql": "^16.9.0",
         "graphql-amqp-subscriptions": "^2.0.0",
+        "graphql-helix": "^1.13.0",
+        "graphql-http": "^1.22.3",
         "graphql-subscriptions": "^2.0.0",
         "graphql-type-json": "^0.3.2",
         "graphql-upload": "^13.0.0",
@@ -8046,6 +8048,28 @@
         "amqplib": "0.x",
         "graphql": "16.x",
         "graphql-subscriptions": "2.x"
+      }
+    },
+    "node_modules/graphql-helix": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/graphql-helix/-/graphql-helix-1.13.0.tgz",
+      "integrity": "sha512-cqDKMoRywKjnL0ZWCTB0GOiBgsH6d3nU4JGDF6RuzAyd35tmalzKpSxkx3NNp4H5RvnKWnrukWzR51wUq277ng==",
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.3.tgz",
+      "integrity": "sha512-sgUz/2DZt+QvY6WrpAsAXUvhnIkp2eX9jN78V8DAtFcpZi/nfDrzDt2byYjyoJzRcWuqhE0K63g1QMewt73U6A==",
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/graphql-request": {
@@ -20192,6 +20216,18 @@
         "iterall": "1.3.0",
         "uuid": "9.0.1"
       }
+    },
+    "graphql-helix": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/graphql-helix/-/graphql-helix-1.13.0.tgz",
+      "integrity": "sha512-cqDKMoRywKjnL0ZWCTB0GOiBgsH6d3nU4JGDF6RuzAyd35tmalzKpSxkx3NNp4H5RvnKWnrukWzR51wUq277ng==",
+      "requires": {}
+    },
+    "graphql-http": {
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.3.tgz",
+      "integrity": "sha512-sgUz/2DZt+QvY6WrpAsAXUvhnIkp2eX9jN78V8DAtFcpZi/nfDrzDt2byYjyoJzRcWuqhE0K63g1QMewt73U6A==",
+      "requires": {}
     },
     "graphql-request": {
       "version": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "dataloader": "^2.2.2",
     "graphql": "^16.9.0",
     "graphql-amqp-subscriptions": "^2.0.0",
+    "graphql-helix": "^1.13.0",
+    "graphql-http": "^1.22.3",
     "graphql-subscriptions": "^2.0.0",
     "graphql-type-json": "^0.3.2",
     "graphql-upload": "^13.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ import cookieParser from 'cookie-parser';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { INestApplication } from '@nestjs/common';
 import { AlkemioConfig } from '@src/types';
+import { renderGraphiQL } from 'graphql-helix';
+import { Request, Response } from 'express';
 
 const bootstrap = async () => {
   const app = await NestFactory.create(AppModule, {
@@ -70,6 +72,16 @@ const bootstrap = async () => {
       limit: max_json_payload_size,
     })
   );
+
+  // Serve the GraphiQL interface at '/graphiql'
+  app.use('/graphiql', (_req: Request, res: Response) => {
+    res.send(
+      renderGraphiQL({
+        endpoint: '/graphql',
+        //subscriptionsEndpoint: '/graphql',
+      })
+    );
+  });
 
   await app.listen(port);
 


### PR DESCRIPTION
- GraphiQL added as interface at /graphiql
- Playground still available at /graphql

note: subscriptions not working at GraphiQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new access rule for the GraphiQL interface, enhancing security and request handling.
	- Added a new router for the GraphiQL service, allowing seamless traffic management for requests to `/graphiql`.
	- Implemented a new endpoint for serving the GraphiQL interface, improving user interaction with GraphQL queries.

- **Dependencies**
	- Added new dependencies: `graphql-helix` and `graphql-http`, expanding GraphQL handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->