### PR TITLE
Dataloader output order now matches input key order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "class-validator": "0.14.0",
         "cookie-parser": "^1.4.6",
         "cross-env": "^7.0.3",
-        "dataloader": "^2.2.2",
+        "dataloader": "^2.2.3",
         "graphql": "^16.9.0",
         "graphql-amqp-subscriptions": "^2.0.0",
         "graphql-helix": "^1.13.0",
@@ -6072,8 +6072,9 @@
       }
     },
     "node_modules/dataloader": {
-      "version": "2.2.2",
-      "license": "MIT"
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -18690,7 +18691,9 @@
       }
     },
     "dataloader": {
-      "version": "2.2.2"
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "class-validator": "0.14.0",
     "cookie-parser": "^1.4.6",
     "cross-env": "^7.0.3",
-    "dataloader": "^2.2.2",
+    "dataloader": "^2.2.3",
     "graphql": "^16.9.0",
     "graphql-amqp-subscriptions": "^2.0.0",
     "graphql-helix": "^1.13.0",

--- a/src/core/dataloader/utils/sort.output.by.keys.ts
+++ b/src/core/dataloader/utils/sort.output.by.keys.ts
@@ -1,0 +1,15 @@
+import { sortBy } from 'lodash';
+
+export const sorOutputByKeys = <T extends { id: string }>(
+  output: T[],
+  keys: readonly string[]
+) => {
+  const orderMap = keys.reduce(
+    (acc, key, index) => {
+      acc[key] = index;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+  return sortBy(output, obj => orderMap[obj.id]);
+};

--- a/src/domain/in-app-notification-reader/field-resolvers/in.app.notification.callout.published.resolver.fields.ts
+++ b/src/domain/in-app-notification-reader/field-resolvers/in.app.notification.callout.published.resolver.fields.ts
@@ -1,5 +1,4 @@
 import { Resolver, ResolveField, Parent } from '@nestjs/graphql';
-import { InAppNotification } from '../in.app.notification.interface';
 import { InAppNotificationCalloutPublished } from '@domain/in-app-notification-reader/dto/in.app.notification.callout.published';
 import { ISpace } from '@domain/space/space/space.interface';
 import { ICallout } from '@domain/collaboration/callout';


### PR DESCRIPTION
From [dataloader README](https://github.com/graphql/dataloader/blob/main/README.md)
> For example, if your batch function was provided the Array of keys: [ 2, 9, 6, 1 ], and loading from a back-end service returned the values:
```
{ id: 9, name: 'Chicago' }
{ id: 1, name: 'New York' }
{ id: 2, name: 'San Francisco' }
```
> Our back-end service returned results in a different order than we requested, likely because it was more efficient for it to do so. Also, it omitted a result for key 6, which we can interpret as no value existing for that key.
To uphold the constraints of the batch function, it must return an Array of values the same length as the Array of keys, **and re-order them to ensure each index aligns with the original keys [ 2, 9, 6, 1 ]**:
```
[
  { id: 2, name: 'San Francisco' },
  { id: 9, name: 'Chicago' },
  null, // or perhaps `new Error()`
  { id: 1, name: 'New York' },
];
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new utility function for sorting output based on specified keys.
- **Enhancements**
	- Improved batch loading functionality to ensure sorted output matches input length.
- **Bug Fixes**
	- Removed unused import to streamline the GraphQL resolver.
- **Dependencies**
	- Updated the version of the `dataloader` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->