### PR TITLE
Dataloader auto resolve

### DIFF
--- a/src/core/dataloader/creators/base/data.loader.creator.base.options.ts
+++ b/src/core/dataloader/creators/base/data.loader.creator.base.options.ts
@@ -29,10 +29,28 @@ export interface DataLoaderCreatorBaseOptions<TParent, TResult> {
    */
   cache?: boolean;
   /***
-   * What to return when resolving the unresolved result for a key.
-   * The default behaviour is to return an error - set to true to return NULL instead.
-   * This is useful when an a result is expected to be null and it's not an
-   * exceptional case.
+   * Overwrites the default behaviour of what to return when resolving the unresolved result for a key.
+   * This is useful when the result is expected to be null, and it's not an exceptional case.
+   * ---
+   * The default behaviour is determined by the Loader decorator on the dataloader`s creation.
+   * If the underlying graphql field, for which the dataloader is created, is nullable - the result can be resolved to null.
+   * <br/>
+   * Example:
+   * ```
+   * @ResolveField(() => ICallout, {
+   *   nullable: true,
+   *   description: 'The Callout that was published.',
+   * })
+   * public callout(
+   *   @Parent() { payload }: InAppNotificationCalloutPublished,
+   *   @Loader(CalloutLoaderCreator) loader: ILoader<ICallout | null>
+   * ) {
+   *   return loader.load(payload.calloutID);
+   * }
+   * ```
+   * The `callout` is decorated as nullable, so the dataloader will auto-resolve to `null` if the result is not found.
+   * <br/>
+   * You can override this behaviour by setting the option to `false`. That way the problematic values will always be resolved to errors.
    */
   resolveToNull?: boolean;
 }

--- a/src/core/dataloader/creators/base/data.loader.creator.ts
+++ b/src/core/dataloader/creators/base/data.loader.creator.ts
@@ -1,6 +1,9 @@
 import { ILoader } from '../../loader.interface';
 import { DataLoaderCreatorOptions } from './data.loader.creator.options';
+import { EntityNotFoundException } from '@common/exceptions';
 
 export interface DataLoaderCreator<TReturn> {
-  create(options?: DataLoaderCreatorOptions<TReturn>): ILoader<TReturn>;
+  create(
+    options?: DataLoaderCreatorOptions<TReturn>
+  ): ILoader<TReturn | null | EntityNotFoundException>;
 }

--- a/src/core/dataloader/creators/base/index.ts
+++ b/src/core/dataloader/creators/base/index.ts
@@ -1,5 +1,6 @@
 export * from './data.loader.creator';
 
+export * from './data.loader.creator.base.options';
 export * from './data.loader.creator.options';
 export * from './data.loader.creator.limit.options';
 export * from './data.loader.creator.pagination.options';

--- a/src/core/dataloader/creators/loader.creators/in-app-notification/callout.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/in-app-notification/callout.loader.creator.ts
@@ -1,21 +1,27 @@
 import { EntityManager, In } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
-import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import {
+  DataLoaderCreator,
+  DataLoaderCreatorBaseOptions,
+} from '@core/dataloader/creators/base';
 import { createBatchLoader } from '@core/dataloader/utils';
 import { ILoader } from '@core/dataloader/loader.interface';
 import { Callout, ICallout } from '@domain/collaboration/callout';
+import { EntityNotFoundException } from '@common/exceptions';
 
 @Injectable()
 export class CalloutLoaderCreator implements DataLoaderCreator<ICallout> {
   constructor(@InjectEntityManager() private manager: EntityManager) {}
 
-  public create(): ILoader<ICallout> {
-    return createBatchLoader(
-      this.constructor.name,
-      Callout.name,
-      this.calloutInBatch
-    );
+  public create(
+    options?: DataLoaderCreatorBaseOptions<any, any>
+  ): ILoader<ICallout | null | EntityNotFoundException> {
+    return createBatchLoader(this.calloutInBatch, {
+      name: this.constructor.name,
+      loadedTypeName: Callout.name,
+      resolveToNull: options?.resolveToNull,
+    });
   }
 
   private calloutInBatch = (

--- a/src/core/dataloader/creators/loader.creators/in-app-notification/community.type.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/in-app-notification/community.type.loader.creator.ts
@@ -2,7 +2,10 @@ import { EntityManager } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { CommunityContributorType } from '@common/enums/community.contributor.type';
-import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import {
+  DataLoaderCreator,
+  DataLoaderCreatorBaseOptions,
+} from '@core/dataloader/creators/base';
 import { createBatchLoader } from '@core/dataloader/utils';
 import { User } from '@domain/community/user/user.entity';
 import { Organization } from '@domain/community/organization';
@@ -14,12 +17,12 @@ export class CommunityTypeLoaderCreator
 {
   constructor(@InjectEntityManager() private manager: EntityManager) {}
 
-  create() {
-    return createBatchLoader(
-      this.constructor.name,
-      'CommunityContributorType',
-      this.communityTypeInBatch
-    );
+  create(options?: DataLoaderCreatorBaseOptions<any, any>) {
+    return createBatchLoader(this.communityTypeInBatch, {
+      name: this.constructor.name,
+      loadedTypeName: 'CommunityContributorType',
+      resolveToNull: options?.resolveToNull,
+    });
   }
 
   private async communityTypeInBatch(

--- a/src/core/dataloader/creators/loader.creators/in-app-notification/contributor.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/in-app-notification/contributor.loader.creator.ts
@@ -1,7 +1,10 @@
 import { EntityManager, In } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
-import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import {
+  DataLoaderCreator,
+  DataLoaderCreatorBaseOptions,
+} from '@core/dataloader/creators/base';
 import { createBatchLoader } from '@core/dataloader/utils';
 import { ILoader } from '@core/dataloader/loader.interface';
 import { IContributor } from '@domain/community/contributor/contributor.interface';
@@ -9,6 +12,7 @@ import { User } from '@domain/community/user/user.entity';
 import { Organization } from '@domain/community/organization';
 import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
 import { IContributorBase } from '@domain/community/contributor';
+import { EntityNotFoundException } from '@common/exceptions';
 
 @Injectable()
 export class ContributorLoaderCreator
@@ -16,12 +20,14 @@ export class ContributorLoaderCreator
 {
   constructor(@InjectEntityManager() private manager: EntityManager) {}
 
-  public create(): ILoader<IContributor> {
-    return createBatchLoader(
-      this.constructor.name,
-      'Contributor',
-      this.contributorsInBatch
-    );
+  public create(
+    options?: DataLoaderCreatorBaseOptions<any, any>
+  ): ILoader<IContributor | null | EntityNotFoundException> {
+    return createBatchLoader(this.contributorsInBatch, {
+      name: this.constructor.name,
+      loadedTypeName: 'Contributor',
+      resolveToNull: options?.resolveToNull,
+    });
   }
 
   private contributorsInBatch = async (

--- a/src/core/dataloader/creators/loader.creators/in-app-notification/space.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/in-app-notification/space.loader.creator.ts
@@ -1,22 +1,28 @@
 import { EntityManager, In } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
-import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import {
+  DataLoaderCreator,
+  DataLoaderCreatorBaseOptions,
+} from '@core/dataloader/creators/base';
 import { createBatchLoader } from '@core/dataloader/utils';
 import { ILoader } from '@core/dataloader/loader.interface';
 import { ISpace } from '@domain/space/space/space.interface';
 import { Space } from '@domain/space/space/space.entity';
+import { EntityNotFoundException } from '@common/exceptions';
 
 @Injectable()
 export class SpaceLoaderCreator implements DataLoaderCreator<ISpace> {
   constructor(@InjectEntityManager() private manager: EntityManager) {}
 
-  public create(): ILoader<ISpace> {
-    return createBatchLoader(
-      this.constructor.name,
-      Space.name,
-      this.spaceInBatch
-    );
+  public create(
+    options?: DataLoaderCreatorBaseOptions<any, any>
+  ): ILoader<ISpace | null | EntityNotFoundException> {
+    return createBatchLoader(this.spaceInBatch, {
+      name: this.constructor.name,
+      loadedTypeName: Space.name,
+      resolveToNull: options?.resolveToNull,
+    });
   }
 
   private spaceInBatch = (keys: ReadonlyArray<string>): Promise<Space[]> => {

--- a/src/core/dataloader/decorators/data.loader.decorator.ts
+++ b/src/core/dataloader/decorators/data.loader.decorator.ts
@@ -1,14 +1,12 @@
+import { isNonNullType } from 'graphql/type';
 import { createParamDecorator, ExecutionContext, Type } from '@nestjs/common';
-import { APP_INTERCEPTOR } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { DataLoaderInterceptorNotProvided } from '@common/exceptions/data-loader';
 import { DATA_LOADER_CTX_INJECT_TOKEN } from '../data.loader.inject.token';
-import { DataLoaderInterceptor } from '../interceptors';
 import { DataLoaderCreator, DataLoaderCreatorOptions } from '../creators/base';
 
 export function Loader<TParent, TReturn>(
   creatorRef: Type<DataLoaderCreator<TReturn>>,
-  options?: DataLoaderCreatorOptions<TReturn, TParent>
+  options: DataLoaderCreatorOptions<TReturn, TParent> = {}
 ): ParameterDecorator {
   return createParamDecorator(
     (
@@ -17,11 +15,14 @@ export function Loader<TParent, TReturn>(
     ) => {
       const ctx =
         GqlExecutionContext.create(context).getContext<IGraphQLContext>();
+      // as the default behaviour we resolve to null if the field is nullable
+      if (options.resolveToNull === undefined) {
+        const info = context.getArgByIndex(3);
+        const fieldName = info.fieldName;
+        const field = info.parentType.getFields()[fieldName];
 
-      if (!ctx[DATA_LOADER_CTX_INJECT_TOKEN]) {
-        throw new DataLoaderInterceptorNotProvided(
-          `You must provide ${DataLoaderInterceptor.name} globally with the ${APP_INTERCEPTOR} injector token`
-        );
+        options.resolveToNull = !isNonNullType(field.type);
+        console.log(info.parentType.name, fieldName, options.resolveToNull);
       }
 
       return ctx[DATA_LOADER_CTX_INJECT_TOKEN].get(innerCreatorRef, options);

--- a/src/core/dataloader/utils/createTypedBatchLoader.ts
+++ b/src/core/dataloader/utils/createTypedBatchLoader.ts
@@ -3,17 +3,22 @@ import { EntityNotFoundException } from '@common/exceptions';
 import { LogContext } from '@common/enums';
 import { ILoader } from '../loader.interface';
 import { sorOutputByKeys } from '@core/dataloader/utils/sort.output.by.keys';
+import { DataLoaderCreatorBaseOptions } from '@core/dataloader/creators/base/data.loader.creator.base.options';
 
 export const createBatchLoader = <TResult extends { id: string }>(
-  name: string, // for debugging purposes
-  loadedTypeName: string, // for debugging purposes
-  batchLoadFn: (keys: ReadonlyArray<string>) => Promise<TResult[]>
-): ILoader<TResult> => {
-  // the data loader returns an array the MUST match the input length
+  batchLoadFn: (keys: ReadonlyArray<string>) => Promise<TResult[]>,
+  options?: {
+    name: string; // for debugging purposes
+    loadedTypeName: string; // for debugging purposes
+  } & Pick<DataLoaderCreatorBaseOptions<any, any>, 'resolveToNull'>
+): ILoader<TResult | null | EntityNotFoundException> => {
+  // the data loader returns an array the MUST match the input length AND input key order
   // the provided batch function does not necessarily complete this requirement
-  // so we create a wrapper function that executes the batch function and ensure the output length
+  // so we create a wrapper function that executes the batch function and ensure the output length and order
   // by either returning the original output (if the length matches) or filling the missing values with errors
-  const loadAndEnsureOutputLengthAndOrder = async (keys: readonly string[]) => {
+  const loadAndEnsureOutputLengthAndOrder = async (
+    keys: readonly string[]
+  ): Promise<(TResult | null | Error)[]> => {
     const unsortedOutput = await batchLoadFn(keys);
     const sortedOutput = sorOutputByKeys(unsortedOutput, keys);
     if (sortedOutput.length == keys.length) {
@@ -29,16 +34,19 @@ export const createBatchLoader = <TResult extends { id: string }>(
       key => resultsById.get(key) ?? resolveUnresolvedForKey(key)
     );
   };
+  const { name, loadedTypeName, resolveToNull } = options ?? {};
   // a function to resolve an unresolved entity for a given key (e.g. if not found, etc.)
   const resolveUnresolvedForKey = (key: string) => {
-    return new EntityNotFoundException(
-      `Could not find ${loadedTypeName} for the given key`,
-      LogContext.DATA_LOADER,
-      { id: key }
-    );
+    return resolveToNull
+      ? null
+      : new EntityNotFoundException(
+          `Could not find ${loadedTypeName} for the given key`,
+          LogContext.DATA_LOADER,
+          { id: key }
+        );
   };
 
-  return new DataLoader<string, TResult>(
+  return new DataLoader<string, TResult | null>(
     keys => loadAndEnsureOutputLengthAndOrder(keys),
     {
       cache: true,

--- a/src/core/dataloader/utils/createTypedRelationLoader.ts
+++ b/src/core/dataloader/utils/createTypedRelationLoader.ts
@@ -12,14 +12,14 @@ import { selectOptionsFromFields } from './selectOptionsFromFields';
 
 export const createTypedRelationDataLoader = <
   TParent extends { id: string } & { [key: string]: any }, // todo better type,
-  TResult
+  TResult,
 >(
   manager: EntityManager,
   parentClassRef: Type<TParent>,
   relations: FindOptionsRelations<TParent>,
   name: string,
   options?: DataLoaderCreatorOptions<TResult, TParent>
-): ILoader<TResult> => {
+): ILoader<TResult | null> => {
   const { fields, ...restOptions } = options ?? {};
 
   const topRelation = <keyof TResult>Object.keys(relations)[0];
@@ -33,9 +33,9 @@ export const createTypedRelationDataLoader = <
       : fields
     : { id: true };
 
-  return new DataLoader<string, TResult>(
+  return new DataLoader<string, TResult | null>(
     keys =>
-      findByBatchIds<TParent, TResult>(
+      findByBatchIds<TParent, TResult | null>(
         manager,
         parentClassRef,
         keys as string[],

--- a/src/core/dataloader/utils/createTypedSimpleLoader.ts
+++ b/src/core/dataloader/utils/createTypedSimpleLoader.ts
@@ -11,7 +11,7 @@ export const createTypedSimpleDataLoader = <TResult extends { id: string }>(
   classRef: Type<TResult>,
   name: string,
   options?: DataLoaderCreatorOptions<TResult, TResult>
-): ILoader<TResult> => {
+): ILoader<TResult | null> => {
   const { fields, ...restOptions } = options ?? {};
   // if fields ia specified, select specific fields, otherwise select all fields
   const selectOptions = fields
@@ -23,7 +23,7 @@ export const createTypedSimpleDataLoader = <TResult extends { id: string }>(
       : fields
     : undefined;
 
-  return new DataLoader<string, TResult>(
+  return new DataLoader<string, TResult | null>(
     keys =>
       findByBatchIdsSimple(manager, classRef, keys as string[], {
         ...restOptions,

--- a/src/core/dataloader/utils/findByBatchIds.ts
+++ b/src/core/dataloader/utils/findByBatchIds.ts
@@ -7,18 +7,18 @@ import {
 import { Type } from '@nestjs/common';
 import { EntityNotFoundException } from '@common/exceptions';
 import { LogContext } from '@common/enums';
-import { FindByBatchIdsOptions } from '../utils';
+import { FindByBatchIdsOptions, sorOutputByKeys } from '../utils';
 
 export const findByBatchIds = async <
   TParent extends { id: string } & { [key: string]: any }, // todo better type
-  TResult
+  TResult,
 >(
   manager: EntityManager,
   classRef: Type<TParent>,
   ids: string[],
   relations: FindOptionsRelations<TParent>,
   options?: FindByBatchIdsOptions<TParent, TResult>
-): Promise<(TResult | Error)[] | never> => {
+): Promise<(TResult | null | Error)[] | never> => {
   if (!ids.length) {
     return [];
   }
@@ -33,7 +33,7 @@ export const findByBatchIds = async <
 
   const { select, limit } = options ?? {};
 
-  const results = await manager.find<TParent>(classRef, {
+  const unsortedResults = await manager.find<TParent>(classRef, {
     take: limit,
     where: {
       id: In(ids),
@@ -41,6 +41,7 @@ export const findByBatchIds = async <
     relations: relations,
     select: select,
   });
+  const sortedResults = sorOutputByKeys(unsortedResults, ids);
 
   const topLevelRelation = relationKeys[0];
 
@@ -48,16 +49,21 @@ export const findByBatchIds = async <
     options?.getResult?.(result) ?? result[topLevelRelation];
   // return empty object because DataLoader does not allow to return NULL values
   // handle the value when the result is returned
-  const resolveUnresolvedForKey = options?.resolveToNull
-    ? () => ({} as TResult)
-    : (key: string) =>
-        new EntityNotFoundException(
-          `Could not load relation '${topLevelRelation}' for ${classRef.name}: ${key}`,
-          LogContext.DATA_LOADER
+  const resolveUnresolvedForKey = (key: string) => {
+    return options?.resolveToNull
+      ? null
+      : new EntityNotFoundException(
+          `Could not load relation '${topLevelRelation}' for ${classRef.name} for the given key`,
+          LogContext.DATA_LOADER,
+          { id: key }
         );
+  };
 
   const resultsById = new Map<string, TResult>(
-    results.map<[string, TResult]>(result => [result.id, getRelation(result)])
+    sortedResults.map<[string, TResult]>(result => [
+      result.id,
+      getRelation(result),
+    ])
   );
   // ensure the result length matches the input length
   return ids.map(id => resultsById.get(id) ?? resolveUnresolvedForKey(id));

--- a/src/core/dataloader/utils/findByBatchIdsSimple.ts
+++ b/src/core/dataloader/utils/findByBatchIdsSimple.ts
@@ -9,7 +9,7 @@ export const findByBatchIdsSimple = async <TResult extends { id: string }>(
   classRef: Type<TResult>,
   ids: string[],
   options?: FindByBatchIdsOptions<TResult, TResult>
-): Promise<(TResult | Error)[] | never> => {
+): Promise<(TResult | null | Error)[] | never> => {
   if (!ids.length) {
     return [];
   }
@@ -25,13 +25,15 @@ export const findByBatchIdsSimple = async <TResult extends { id: string }>(
   });
   // return empty object because DataLoader does not allow to return NULL values
   // handle the value when the result is returned
-  const resolveUnresolvedForKey = options?.resolveToNull
-    ? () => ({} as TResult)
-    : (key: string) =>
-        new EntityNotFoundException(
-          `Could not load resource for '${key}'`,
-          LogContext.DATA_LOADER
+  const resolveUnresolvedForKey = (key: string) => {
+    return options?.resolveToNull
+      ? null
+      : new EntityNotFoundException(
+          `Could not find ${classRef.name} for the given key`,
+          LogContext.DATA_LOADER,
+          { id: key }
         );
+  };
 
   const resultsById = new Map<string, TResult>(
     results.map<[string, TResult]>(result => [result.id, result])

--- a/src/core/dataloader/utils/index.ts
+++ b/src/core/dataloader/utils/index.ts
@@ -5,3 +5,4 @@ export * from './createTypedSimpleLoader';
 export * from './createTypedBatchLoader';
 export * from './selectOptionsFromFields';
 export * from './find.by.batch.options';
+export * from './sort.output.by.keys';

--- a/src/domain/collaboration/callout/callout.resolver.fields.ts
+++ b/src/domain/collaboration/callout/callout.resolver.fields.ts
@@ -126,7 +126,7 @@ export class CalloutResolverFields {
   })
   async publishedBy(
     @Parent() callout: ICallout,
-    @Loader(UserLoaderCreator, { resolveToNull: true }) loader: ILoader<IUser>
+    @Loader(UserLoaderCreator) loader: ILoader<IUser | null>
   ): Promise<IUser | null> {
     const publishedBy = callout.publishedBy;
     if (!publishedBy) {
@@ -154,31 +154,13 @@ export class CalloutResolverFields {
   })
   async createdBy(
     @Parent() callout: ICallout,
-    @Loader(UserLoaderCreator, { resolveToNull: true }) loader: ILoader<IUser>
+    @Loader(UserLoaderCreator) loader: ILoader<IUser | null>
   ): Promise<IUser | null> {
     const createdBy = callout.createdBy;
     if (!createdBy) {
       return null;
     }
 
-    try {
-      return await loader
-        .load(createdBy)
-        // empty object is result because DataLoader does not allow to return NULL values
-        // handle the value when the result is returned
-        .then(x => {
-          return !Object.keys(x).length ? null : x;
-        });
-    } catch (e: unknown) {
-      if (e instanceof EntityNotFoundException) {
-        this.logger?.warn(
-          `createdBy '${createdBy}' unable to be resolved when resolving callout '${callout.id}'`,
-          LogContext.COLLABORATION
-        );
-        return null;
-      } else {
-        throw e;
-      }
-    }
+    return loader.load(createdBy);
   }
 }

--- a/src/domain/common/whiteboard/whiteboard.resolver.fields.ts
+++ b/src/domain/common/whiteboard/whiteboard.resolver.fields.ts
@@ -40,7 +40,7 @@ export class WhiteboardResolverFields {
   })
   async createdBy(
     @Parent() whiteboard: IWhiteboard,
-    @Loader(UserLoaderCreator, { resolveToNull: true }) loader: ILoader<IUser>
+    @Loader(UserLoaderCreator) loader: ILoader<IUser | null>
   ): Promise<IUser | null> {
     const createdBy = whiteboard.createdBy;
     if (!createdBy) {
@@ -51,25 +51,7 @@ export class WhiteboardResolverFields {
       return null;
     }
 
-    try {
-      return await loader
-        .load(createdBy)
-        // empty object is result because DataLoader does not allow to return NULL values
-        // handle the value when the result is returned
-        .then(x => {
-          return !Object.keys(x).length ? null : x;
-        });
-    } catch (e: unknown) {
-      if (e instanceof EntityNotFoundException) {
-        this.logger?.warn(
-          `createdBy '${createdBy}' unable to be resolved when resolving whiteboard '${whiteboard.id}'`,
-          LogContext.COLLABORATION
-        );
-        return null;
-      } else {
-        throw e;
-      }
-    }
+    return loader.load(createdBy);
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/domain/in-app-notification-reader/dto/in.app.notification.callout.published.ts
+++ b/src/domain/in-app-notification-reader/dto/in.app.notification.callout.published.ts
@@ -15,6 +15,6 @@ export abstract class InAppNotificationCalloutPublished extends InAppNotificatio
   type!: NotificationEventType.COLLABORATION_CALLOUT_PUBLISHED;
   payload!: InAppNotificationCalloutPublishedPayload;
   // fields resolved by a concrete resolver
-  callout!: ICallout;
-  space!: ISpace;
+  callout?: ICallout;
+  space?: ISpace;
 }

--- a/src/domain/in-app-notification-reader/dto/in.app.notification.community.new.member.ts
+++ b/src/domain/in-app-notification-reader/dto/in.app.notification.community.new.member.ts
@@ -18,7 +18,7 @@ export class InAppNotificationCommunityNewMember extends InAppNotificationBase()
   type!: NotificationEventType.COMMUNITY_NEW_MEMBER;
   payload!: InAppNotificationCommunityNewMemberPayload;
   // fields resolved by a concrete resolver
-  contributorType?: CommunityContributorType;
+  contributorType!: CommunityContributorType;
   actor?: IContributor;
   space?: ISpace;
 }

--- a/src/domain/in-app-notification-reader/dto/in.app.notification.user.mentioned.ts
+++ b/src/domain/in-app-notification-reader/dto/in.app.notification.user.mentioned.ts
@@ -17,7 +17,7 @@ export class InAppNotificationUserMentioned extends InAppNotificationBase() {
   type!: NotificationEventType.COMMUNICATION_USER_MENTION;
   payload!: InAppNotificationContributorMentionedPayload;
   // fields resolved by a concrete resolver
-  contributorType?: CommunityContributorType;
-  comment?: string;
-  commentUrl?: string;
+  contributorType!: CommunityContributorType;
+  comment!: string;
+  commentUrl!: string;
 }

--- a/src/domain/in-app-notification-reader/field-resolvers/in.app.notification.callout.published.resolver.fields.ts
+++ b/src/domain/in-app-notification-reader/field-resolvers/in.app.notification.callout.published.resolver.fields.ts
@@ -12,23 +12,25 @@ import { ILoader } from '@core/dataloader/loader.interface';
 @Resolver(() => InAppNotificationCalloutPublished)
 export class InAppNotificationCalloutPublishedResolverFields {
   @ResolveField(() => ICallout, {
-    nullable: false,
+    nullable: true,
     description: 'The Callout that was published.',
   })
   public callout(
     @Parent() { payload }: InAppNotificationCalloutPublished,
-    @Loader(CalloutLoaderCreator) loader: ILoader<ICallout>
+    @Loader(CalloutLoaderCreator, { resolveToNull: true })
+    loader: ILoader<ICallout>
   ) {
     return loader.load(payload.calloutID);
   }
 
   @ResolveField(() => ISpace, {
-    nullable: false,
+    nullable: true,
     description: 'Where the callout is located.',
   })
   public space(
     @Parent() { payload }: InAppNotificationCalloutPublished,
-    @Loader(SpaceLoaderCreator) loader: ILoader<ISpace>
+    @Loader(SpaceLoaderCreator, { resolveToNull: true })
+    loader: ILoader<ISpace>
   ) {
     return loader.load(payload.spaceID);
   }

--- a/src/domain/in-app-notification-reader/field-resolvers/in.app.notification.community.new.member.resolver.fields.ts
+++ b/src/domain/in-app-notification-reader/field-resolvers/in.app.notification.community.new.member.resolver.fields.ts
@@ -21,24 +21,26 @@ export class InAppNotificationCommunityNewMemberResolverFields {
   }
 
   @ResolveField(() => IContributor, {
-    nullable: false,
+    nullable: true,
     description: 'The Contributor that joined.',
   })
   // todo: rename?
   public actor(
     @Parent() { payload }: InAppNotificationCommunityNewMember,
-    @Loader(ContributorLoaderCreator) loader: ILoader<IContributor>
+    @Loader(ContributorLoaderCreator, { resolveToNull: true })
+    loader: ILoader<IContributor>
   ) {
     return loader.load(payload.newMemberID);
   }
 
   @ResolveField(() => ISpace, {
-    nullable: false,
+    nullable: true,
     description: 'The Space that was joined.',
   })
   public space(
     @Parent() { payload }: InAppNotificationCommunityNewMember,
-    @Loader(SpaceLoaderCreator) loader: ILoader<ISpace>
+    @Loader(SpaceLoaderCreator, { resolveToNull: true })
+    loader: ILoader<ISpace>
   ) {
     return loader.load(payload.spaceID);
   }


### PR DESCRIPTION
Dataloaders now auto-resolves for nullable graphql fields as the default behaviour when resolving the unresolved result for a key.
This is useful when the result is expected to be null, and it's not an exceptional case.

The default behaviour is determined by the Loader decorator on the dataloader`s creation.
If the underlying graphql field, for which the dataloader is created, is nullable - the result can be resolved to null.
Example:
```
@ResolveField(() => ICallout, {
  nullable: true,
  description: 'The Callout that was published.',
})
public callout(
  @Parent() { payload }: InAppNotificationCalloutPublished,
  @Loader(CalloutLoaderCreator) loader: ILoader<ICallout | null>
) {
  return loader.load(payload.calloutID);
}
```
The `callout` is decorated as nullable, so the dataloader will auto-resolve to `null` if the result is not found.
You can override this behaviour by setting the `resolveToNull` flag to `false`. That way the problematic values will always be resolved to errors.