### PR TITLE
7327 Don't allow nameIds on createSubspaceInput

### DIFF
--- a/src/domain/space/space/dto/space.dto.create.subspace.ts
+++ b/src/domain/space/space/dto/space.dto.create.subspace.ts
@@ -1,9 +1,9 @@
-import { UUID_NAMEID } from '@domain/common/scalars';
+import { UUID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
 import { CreateSpaceInput } from './space.dto.create';
 
 @InputType()
 export class CreateSubspaceInput extends CreateSpaceInput {
-  @Field(() => UUID_NAMEID, { nullable: false })
+  @Field(() => UUID, { nullable: false })
   spaceID!: string;
 }


### PR DESCRIPTION
### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the type for the `spaceID` field in the subspace creation input to use the correct UUID type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->