### PR TITLE
Authorization: remove usage of anonymousReadAccess

### DIFF
--- a/src/common/enums/authorization.credential.ts
+++ b/src/common/enums/authorization.credential.ts
@@ -5,6 +5,7 @@ export enum AuthorizationCredential {
   GLOBAL_ADMIN = 'global-admin', // able to do everything, god mode
   GLOBAL_SUPPORT = 'global-support', // able to manage platform level information, can per space have admin rights
   GLOBAL_LICENSE_MANAGER = 'global-license-manager', // able to manage platform level information, can per space have admin rights
+  GLOBAL_ANONYMOUS = 'global-anonymous', // credential issued to all non-authenticated interactions
   GLOBAL_REGISTERED = 'global-registered', // credential issued to all registered users
   GLOBAL_COMMUNITY_READ = 'global-community-read', // able to view all details of the top level community
   GLOBAL_SPACES_READER = 'global-spaces-read', // able to view all details of the top level community

--- a/src/core/authentication.agent.info/agent.info.metadata.ts
+++ b/src/core/authentication.agent.info/agent.info.metadata.ts
@@ -1,9 +1,9 @@
-import { ICredential } from '@domain/agent/credential';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 
 export class AgentInfoMetadata {
   userID!: string;
   email!: string;
-  credentials: ICredential[] = [];
+  credentials: ICredentialDefinition[] = [];
   communicationID!: string;
   agentID!: string;
   did!: string;

--- a/src/core/authentication.agent.info/agent.info.module.ts
+++ b/src/core/authentication.agent.info/agent.info.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AgentInfoCacheService } from './agent.info.cache.service';
+import { AgentInfoService } from './agent.info.service';
 @Module({
   imports: [],
-  providers: [AgentInfoCacheService],
-  exports: [AgentInfoCacheService],
+  providers: [AgentInfoService, AgentInfoCacheService],
+  exports: [AgentInfoService, AgentInfoCacheService],
 })
 export class AuthenticationAgentInfoModule {}

--- a/src/core/authentication.agent.info/agent.info.service.ts
+++ b/src/core/authentication.agent.info/agent.info.service.ts
@@ -1,0 +1,143 @@
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
+import { AgentInfo } from './agent.info';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { AuthorizationCredential, LogContext } from '@common/enums';
+import { EntityNotInitializedException } from '@common/exceptions/entity.not.initialized.exception';
+import { IVerifiedCredential } from '@domain/agent/verified-credential/verified.credential.interface';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+import { User } from '@domain/community/user/user.entity';
+import { AgentInfoMetadata } from './agent.info.metadata';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { EntityNotFoundException } from '@common/exceptions/entity.not.found.exception';
+@Injectable()
+export class AgentInfoService {
+  constructor(
+    @InjectEntityManager('default')
+    private entityManager: EntityManager,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
+  ) {}
+
+  // Note for now a very empty service, but later as we start allowing "acting as" agents this service will expand.
+  // To consider: moving function related to AgentInfoMetaData from user service here, to remove dependency on UserModule in Authentication Module
+  public createAnonymousAgentInfo(): AgentInfo {
+    const emptyAgentInfo = new AgentInfo();
+    const anonymousCredential: ICredentialDefinition = {
+      type: AuthorizationCredential.GLOBAL_ANONYMOUS,
+      resourceID: '',
+    };
+    emptyAgentInfo.credentials = [anonymousCredential];
+    return emptyAgentInfo;
+  }
+
+  /**
+   * Retrieves the agent information metadata for a given email.
+   *
+   * @param email - The email address of the user whose agent information metadata is to be retrieved.
+   * @returns A promise that resolves to the agent information metadata if found, or undefined if the user is not registered.
+   * @throws Will log an error message if the user is not registered.
+   */
+  public async getAgentInfoMetadata(
+    email: string
+  ): Promise<AgentInfoMetadata | undefined> {
+    try {
+      const user = await this.entityManager.findOneOrFail(User, {
+        where: {
+          email: email,
+        },
+        relations: {
+          agent: {
+            credentials: true,
+          },
+        },
+      });
+      if (!user || !user.agent || !user.agent.credentials) {
+        throw new EntityNotFoundException(
+          `Unable to load User, Agent or Credentials for User: ${email}`,
+          LogContext.COMMUNITY
+        );
+      }
+      const userAgentInfoMetadata = new AgentInfoMetadata();
+      userAgentInfoMetadata.credentials = user.agent.credentials;
+      userAgentInfoMetadata.agentID = user.agent.id;
+      userAgentInfoMetadata.userID = user.id;
+      userAgentInfoMetadata.communicationID = user.communicationID;
+      return userAgentInfoMetadata;
+    } catch (error) {
+      this.logger.verbose?.(
+        `User not registered: ${email}, ${error}`,
+        LogContext.AUTH
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Populates the given `agentInfo` object with metadata from `agentInfoMetadata`.
+   *
+   * @param agentInfo - The agent information object to be populated.
+   * @param agentInfoMetadata - The metadata containing information to populate the agent info.
+   *
+   * @remarks
+   * This method assigns the `agentID`, `userID`, and `communicationID` from `agentInfoMetadata` to `agentInfo`.
+   * If `agentInfoMetadata` contains credentials, they are also assigned to `agentInfo`.
+   * If credentials are not available, a warning is logged.
+   */
+  public populateAgentInfoWithMetadata(
+    agentInfo: AgentInfo,
+    agentInfoMetadata: AgentInfoMetadata
+  ): void {
+    agentInfo.agentID = agentInfoMetadata.agentID;
+    agentInfo.userID = agentInfoMetadata.userID;
+    agentInfo.communicationID = agentInfoMetadata.communicationID;
+
+    if (agentInfoMetadata.credentials) {
+      agentInfo.credentials = agentInfoMetadata.credentials;
+    } else {
+      this.logger.warn?.(
+        `Authentication Info: Unable to retrieve credentials for registered user: ${agentInfo.email}`,
+        LogContext.AUTH
+      );
+    }
+  }
+
+  public async buildAgentInfoForUser(userId: string): Promise<AgentInfo> {
+    const user = await this.entityManager.findOneOrFail(User, {
+      where: { id: userId },
+      relations: {
+        agent: {
+          credentials: true,
+        },
+      },
+    });
+
+    if (!user.agent || !user.agent.credentials) {
+      throw new EntityNotInitializedException(
+        `Agent not loaded for User: ${user.id}`,
+        LogContext.WHITEBOARD_INTEGRATION,
+        { userId }
+      );
+    }
+
+    // const verifiedCredentials =
+    //   await this.agentService.getVerifiedCredentials(user.agent);
+    const verifiedCredentials = [] as IVerifiedCredential[];
+    // construct the agent info object needed for isAccessGranted
+    let credentials: ICredentialDefinition[] = [];
+
+    if (credentials.length !== 0) {
+      credentials = user.agent.credentials.map(c => {
+        return {
+          type: c.type,
+          resourceID: c.resourceID,
+        };
+      });
+    }
+
+    const agentInfo = new AgentInfo();
+    agentInfo.credentials = credentials;
+    agentInfo.verifiedCredentials = verifiedCredentials;
+    return agentInfo;
+  }
+}

--- a/src/core/authentication.agent.info/agent.info.service.ts
+++ b/src/core/authentication.agent.info/agent.info.service.ts
@@ -126,7 +126,7 @@ export class AgentInfoService {
     // construct the agent info object needed for isAccessGranted
     let credentials: ICredentialDefinition[] = [];
 
-    if (credentials.length !== 0) {
+    if (user.agent.credentials.length !== 0) {
       credentials = user.agent.credentials.map(c => {
         return {
           type: c.type,

--- a/src/core/authentication.agent.info/agent.info.ts
+++ b/src/core/authentication.agent.info/agent.info.ts
@@ -1,4 +1,4 @@
-import { ICredential } from '@domain/agent/credential';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 import { IVerifiedCredential } from '@domain/agent/verified-credential/verified.credential.interface';
 export class AgentInfo {
   userID = '';
@@ -6,7 +6,7 @@ export class AgentInfo {
   emailVerified = false;
   firstName = '';
   lastName = '';
-  credentials: ICredential[] = [];
+  credentials: ICredentialDefinition[] = [];
   verifiedCredentials: IVerifiedCredential[] = [];
   communicationID = '';
   agentID = '';

--- a/src/core/authentication/authentication.module.ts
+++ b/src/core/authentication/authentication.module.ts
@@ -1,27 +1,23 @@
 import { Module } from '@nestjs/common';
 import { CacheModule } from '@nestjs/cache-manager';
 import { PassportModule } from '@nestjs/passport';
-import { UserModule } from '@domain/community/user/user.module';
 import { AuthenticationService } from './authentication.service';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { OryStrategy } from './ory.strategy';
-import { CredentialModule } from '@domain/agent/credential/credential.module';
 import { OryApiStrategy } from './ory.api.strategy';
-import { AgentModule } from '@domain/agent/agent/agent.module';
 import { AuthenticationAgentInfoModule } from '@core/authentication.agent.info/agent.info.module';
 import { KratosModule } from '@services/infrastructure/kratos/kratos.module';
+import { AgentModule } from '@domain/agent/agent/agent.module';
 @Module({
   imports: [
     PassportModule.register({
       session: false,
       defaultStrategy: 'oathkeeper-jwt',
     }),
-    UserModule,
-    AgentModule,
-    CredentialModule,
     AuthenticationAgentInfoModule,
     KratosModule,
+    AgentModule,
     CacheModule.register(),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/src/core/authorization/authorization.service.ts
+++ b/src/core/authorization/authorization.service.ts
@@ -54,9 +54,7 @@ export class AuthorizationService {
     } has credentials '${JSON.stringify(
       agentInfo.credentials,
       this.replacer
-    )}'; authorization definition: anonymousAccess=${
-      authorization?.anonymousReadAccess
-    } & rules: ${authorization?.credentialRules}`;
+    )}'; authorization definition: rules: ${authorization?.credentialRules}`;
     this.logger.debug?.(msg, LogContext.AUTH_POLICY);
   }
 
@@ -106,16 +104,6 @@ export class AuthorizationService {
         'Authorization: no definition provided',
         LogContext.AUTH_POLICY
       );
-    }
-    if (
-      authorization.anonymousReadAccess &&
-      privilegeRequired === AuthorizationPrivilege.READ
-    ) {
-      this.logger.verbose?.(
-        `Granted privilege '${privilegeRequired}' using rule 'AnonymousReadAccess'`,
-        LogContext.AUTH_POLICY
-      );
-      return true;
     }
 
     // Keep track of all the granted privileges via Credential rules so can use with Privilege rules
@@ -188,10 +176,6 @@ export class AuthorizationService {
     authorization: IAuthorizationPolicy
   ) {
     const grantedPrivileges: AuthorizationPrivilege[] = [];
-
-    if (authorization.anonymousReadAccess) {
-      grantedPrivileges.push(AuthorizationPrivilege.READ);
-    }
 
     const credentialRules = this.convertCredentialRulesStr(
       authorization.credentialRules

--- a/src/core/authorization/authorization.service.ts
+++ b/src/core/authorization/authorization.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { ICredential } from '@domain/agent/credential/credential.interface';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import {
   EntityNotInitializedException,
@@ -15,6 +14,7 @@ import { IAuthorizationPolicyRuleVerifiedCredential } from './authorization.poli
 import { AuthorizationInvalidPolicyException } from '@common/exceptions/authorization.invalid.policy.exception';
 import { IAuthorizationPolicyRulePrivilege } from './authorization.policy.rule.privilege.interface';
 import { ForbiddenAuthorizationPolicyException } from '@common/exceptions/forbidden.authorization.policy.exception';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 
 @Injectable()
 export class AuthorizationService {
@@ -183,7 +183,7 @@ export class AuthorizationService {
   }
 
   getGrantedPrivileges(
-    credentials: ICredential[],
+    credentials: ICredentialDefinition[],
     verifiedCredentials: IVerifiedCredential[],
     authorization: IAuthorizationPolicy
   ) {
@@ -236,7 +236,7 @@ export class AuthorizationService {
   }
 
   private isCredentialMatch(
-    credential: ICredential,
+    credential: ICredentialDefinition,
     credentialRule: IAuthorizationPolicyRuleCredential
   ): boolean {
     const criterias = credentialRule.criterias;

--- a/src/core/authorization/graphql.guard.ts
+++ b/src/core/authorization/graphql.guard.ts
@@ -9,11 +9,16 @@ import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { AuthorizationPrivilege, LogContext } from '@common/enums';
+import {
+  AuthorizationCredential,
+  AuthorizationPrivilege,
+  LogContext,
+} from '@common/enums';
 import { AuthenticationException } from '@common/exceptions';
 import { AuthorizationService } from '@core/authorization/authorization.service';
-import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { AuthorizationRuleAgentPrivilege } from './authorization.rule.agent.privilege';
+import { AgentInfo } from '@core/authentication.agent.info/agent.info';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 
 @Injectable()
 export class GraphqlGuard extends AuthGuard([
@@ -83,7 +88,7 @@ export class GraphqlGuard extends AuthGuard([
         `[${this.instanceId}] - AgentInfo NOT present or false: ${agentInfo}`,
         LogContext.AUTH
       );
-      resultAgentInfo = new AgentInfo();
+      resultAgentInfo = this.createAnonymousAgentInfo();
     }
 
     // Apply any rules
@@ -103,5 +108,15 @@ export class GraphqlGuard extends AuthGuard([
     }
 
     return resultAgentInfo;
+  }
+
+  public createAnonymousAgentInfo(): AgentInfo {
+    const emptyAgentInfo = new AgentInfo();
+    const anonymousCredential: ICredentialDefinition = {
+      type: AuthorizationCredential.GLOBAL_ANONYMOUS,
+      resourceID: '',
+    };
+    emptyAgentInfo.credentials = [anonymousCredential];
+    return emptyAgentInfo;
   }
 }

--- a/src/domain/access/role-set/role.set.service.authorization.ts
+++ b/src/domain/access/role-set/role.set.service.authorization.ts
@@ -111,9 +111,6 @@ export class RoleSetAuthorizationService {
       );
     }
 
-    // always false
-    roleSet.authorization.anonymousReadAccess = false;
-
     updatedAuthorizations.push(roleSet.authorization);
 
     for (const application of roleSet.applications) {

--- a/src/domain/common/authorization-policy/authorization.policy.entity.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.entity.ts
@@ -18,9 +18,6 @@ export class AuthorizationPolicy
   @Column('text')
   verifiedCredentialRules: string;
 
-  @Column()
-  anonymousReadAccess: boolean;
-
   @Column('varchar', { length: ENUM_LENGTH, nullable: false })
   type!: AuthorizationPolicyType;
 
@@ -36,7 +33,6 @@ export class AuthorizationPolicy
 
   constructor(type: AuthorizationPolicyType) {
     super();
-    this.anonymousReadAccess = false;
     this.credentialRules = '';
     this.verifiedCredentialRules = '';
     this.privilegeRules = '';

--- a/src/domain/common/authorization-policy/authorization.policy.interface.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.interface.ts
@@ -4,9 +4,6 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType('Authorization')
 export abstract class IAuthorizationPolicy extends IBaseAlkemio {
-  @Field(() => Boolean)
-  anonymousReadAccess!: boolean;
-
   // exposed via field resolver
   credentialRules!: string;
   verifiedCredentialRules!: string;

--- a/src/domain/common/authorization-policy/authorization.policy.service.ts
+++ b/src/domain/common/authorization-policy/authorization.policy.service.ts
@@ -257,20 +257,21 @@ export class AuthorizationPolicyService {
     return auth;
   }
 
-  public appendCredentialRuleAnonymousReadAccess(
-    authorization: IAuthorizationPolicy | undefined
+  public appendCredentialRuleAnonymousAccess(
+    authorization: IAuthorizationPolicy | undefined,
+    privilege: AuthorizationPrivilege
   ): IAuthorizationPolicy {
     const auth = this.validateAuthorization(authorization);
     const rules = this.authorizationService.convertCredentialRulesStr(
       auth.credentialRules
     );
     const newRule = this.createCredentialRuleUsingTypesOnly(
-      [AuthorizationPrivilege.READ],
+      [privilege],
       [
         AuthorizationCredential.GLOBAL_ANONYMOUS,
         AuthorizationCredential.GLOBAL_REGISTERED,
       ],
-      'Anonymous Read Access'
+      `Anonymous agent granted '${privilege}' access`
     );
     rules.push(newRule);
     auth.credentialRules = JSON.stringify(rules);

--- a/src/domain/community/community-guidelines/community.guidelines.service.authorization.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.authorization.ts
@@ -3,6 +3,7 @@ import { AuthorizationPolicyService } from '@domain/common/authorization-policy/
 import { ICommunityGuidelines } from './community.guidelines.interface';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { ProfileAuthorizationService } from '@domain/common/profile/profile.service.authorization';
+import { AuthorizationPrivilege } from '@common/enums';
 
 @Injectable()
 export class CommunityGuidelinesAuthorizationService {
@@ -28,8 +29,9 @@ export class CommunityGuidelinesAuthorizationService {
       );
     // All content on community guidelines is public
     communityGuidelines.authorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        communityGuidelines.authorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        communityGuidelines.authorization,
+        AuthorizationPrivilege.READ
       );
     updatedAuthorizations.push(communityGuidelines.authorization);
 

--- a/src/domain/community/community-guidelines/community.guidelines.service.authorization.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.authorization.ts
@@ -27,7 +27,10 @@ export class CommunityGuidelinesAuthorizationService {
         parentAuthorization
       );
     // All content on community guidelines is public
-    communityGuidelines.authorization.anonymousReadAccess = true;
+    communityGuidelines.authorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        communityGuidelines.authorization
+      );
     updatedAuthorizations.push(communityGuidelines.authorization);
 
     const profileAuthorizations =

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -70,11 +70,8 @@ export class CommunityAuthorizationService {
 
     community.authorization = await this.extendAuthorizationPolicy(
       community.authorization,
-      parentAuthorization?.anonymousReadAccess
+      spaceSettings.privacy.mode === 'public'
     );
-
-    // always false
-    community.authorization.anonymousReadAccess = false;
 
     updatedAuthorizations.push(community.authorization);
 

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -96,8 +96,9 @@ export class OrganizationAuthorizationService {
       );
     // To ensure that profile on an organization is always publicly visible, even for non-authenticated users
     clonedOrganizationAuthorizationAnonymousAccess =
-      this.authorizationPolicy.appendCredentialRuleAnonymousReadAccess(
-        clonedOrganizationAuthorizationAnonymousAccess
+      this.authorizationPolicy.appendCredentialRuleAnonymousAccess(
+        clonedOrganizationAuthorizationAnonymousAccess,
+        AuthorizationPrivilege.READ
       );
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(

--- a/src/domain/community/organization/organization.service.authorization.ts
+++ b/src/domain/community/organization/organization.service.authorization.ts
@@ -90,12 +90,15 @@ export class OrganizationAuthorizationService {
     updatedAuthorizations.push(organization.authorization);
 
     // NOTE: Clone the authorization policy to ensure the changes are local to profile
-    const clonedOrganizationAuthorizationAnonymousAccess =
+    let clonedOrganizationAuthorizationAnonymousAccess =
       this.authorizationPolicyService.cloneAuthorizationPolicy(
         organization.authorization
       );
     // To ensure that profile on an organization is always publicly visible, even for non-authenticated users
-    clonedOrganizationAuthorizationAnonymousAccess.anonymousReadAccess = true;
+    clonedOrganizationAuthorizationAnonymousAccess =
+      this.authorizationPolicy.appendCredentialRuleAnonymousReadAccess(
+        clonedOrganizationAuthorizationAnonymousAccess
+      );
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
         organization.profile.id,

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -136,8 +136,9 @@ export class UserAuthorizationService {
       );
     // To ensure that profile + context on a space are always publicly visible, even for private spaces
     clonedAnonymousReadAccessAuthorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        clonedAnonymousReadAccessAuthorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        clonedAnonymousReadAccessAuthorization,
+        AuthorizationPrivilege.READ
       );
 
     // cascade

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -130,12 +130,15 @@ export class UserAuthorizationService {
     updatedAuthorizations.push(user.authorization);
 
     // NOTE: Clone the authorization policy to ensure the changes are local to profile
-    const clonedAnonymousReadAccessAuthorization =
+    let clonedAnonymousReadAccessAuthorization =
       this.authorizationPolicyService.cloneAuthorizationPolicy(
         user.authorization
       );
     // To ensure that profile + context on a space are always publicly visible, even for private spaces
-    clonedAnonymousReadAccessAuthorization.anonymousReadAccess = true;
+    clonedAnonymousReadAccessAuthorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        clonedAnonymousReadAccessAuthorization
+      );
 
     // cascade
     const profileAuthorizations =

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -44,7 +44,6 @@ import { getPaginationResults } from '@core/pagination/pagination.fn';
 import { IPaginatedType } from '@core/pagination/paginated.type';
 import { CreateProfileInput } from '@domain/common/profile/dto/profile.dto.create';
 import { validateEmail } from '@common/utils';
-import { AgentInfoMetadata } from '@core/authentication.agent.info/agent.info.metadata';
 import { RoleSetCredentials } from './dto/user.dto.role.set.credentials';
 import { RoleSetMemberCredentials } from './dto/user.dto.role.set.member.credentials';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
@@ -928,32 +927,5 @@ export class UserService {
       base,
       reservedNameIDs
     );
-  }
-
-  public async getAgentInfoMetadata(
-    email: string
-  ): Promise<AgentInfoMetadata> | never {
-    const user = await this.userRepository.findOne({
-      where: {
-        email: email,
-      },
-      relations: {
-        agent: {
-          credentials: true,
-        },
-      },
-    });
-    if (!user || !user.agent || !user.agent.credentials) {
-      throw new EntityNotFoundException(
-        `Unable to load User, Agent or Credentials for User: ${email}`,
-        LogContext.COMMUNITY
-      );
-    }
-    const agentInfo = new AgentInfoMetadata();
-    agentInfo.credentials = user.agent.credentials;
-    agentInfo.agentID = user.agent.id;
-    agentInfo.userID = user.id;
-    agentInfo.communicationID = user.communicationID;
-    return agentInfo;
   }
 }

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -65,12 +65,15 @@ export class VirtualContributorAuthorizationService {
     updatedAuthorizations.push(virtual.authorization);
 
     // NOTE: Clone the authorization policy to ensure the changes are local to profile
-    const clonedVirtualAuthorizationAnonymousAccess =
+    let clonedVirtualAuthorizationAnonymousAccess =
       this.authorizationPolicyService.cloneAuthorizationPolicy(
         virtual.authorization
       );
     // To ensure that profile on an virtual is always publicly visible, even for non-authenticated users
-    clonedVirtualAuthorizationAnonymousAccess.anonymousReadAccess = true;
+    clonedVirtualAuthorizationAnonymousAccess =
+      this.authorizationPolicy.appendCredentialRuleAnonymousReadAccess(
+        clonedVirtualAuthorizationAnonymousAccess
+      );
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
         virtual.profile.id,

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -71,8 +71,9 @@ export class VirtualContributorAuthorizationService {
       );
     // To ensure that profile on an virtual is always publicly visible, even for non-authenticated users
     clonedVirtualAuthorizationAnonymousAccess =
-      this.authorizationPolicy.appendCredentialRuleAnonymousReadAccess(
-        clonedVirtualAuthorizationAnonymousAccess
+      this.authorizationPolicy.appendCredentialRuleAnonymousAccess(
+        clonedVirtualAuthorizationAnonymousAccess,
+        AuthorizationPrivilege.READ
       );
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(

--- a/src/domain/innovation-hub/innovation.hub.service.authorization.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.authorization.ts
@@ -42,11 +42,14 @@ export class InnovationHubAuthorizationService {
 
     // Clone the authorization policy + allow anonymous read access to ensure
     // pages are visible / loadable by all users
-    const clonedAuthorization =
+    let clonedAuthorization =
       this.authorizationPolicyService.cloneAuthorizationPolicy(
         parentAuthorization
       );
-    clonedAuthorization.anonymousReadAccess = true;
+    clonedAuthorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        clonedAuthorization
+      );
 
     hub.authorization =
       this.authorizationPolicyService.inheritParentAuthorization(

--- a/src/domain/innovation-hub/innovation.hub.service.authorization.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.authorization.ts
@@ -47,8 +47,9 @@ export class InnovationHubAuthorizationService {
         parentAuthorization
       );
     clonedAuthorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        clonedAuthorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        clonedAuthorization,
+        AuthorizationPrivilege.READ
       );
 
     hub.authorization =

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -86,8 +86,9 @@ export class AccountAuthorizationService {
       account.authorization
     );
     account.authorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        account.authorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        account.authorization,
+        AuthorizationPrivilege.READ
       );
     account.authorization =
       this.platformAuthorizationService.inheritRootAuthorizationPolicy(
@@ -226,8 +227,9 @@ export class AccountAuthorizationService {
     const newRules: IAuthorizationPolicyRuleCredential[] = [];
     // By default it is world visible. TODO: work through the logic on this
     const updatedAuthorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        authorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        authorization,
+        AuthorizationPrivilege.READ
       );
 
     // Allow global admins to reset authorization, manage platform settings

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -85,7 +85,10 @@ export class AccountAuthorizationService {
     account.authorization = this.authorizationPolicyService.reset(
       account.authorization
     );
-    account.authorization.anonymousReadAccess = false;
+    account.authorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        account.authorization
+      );
     account.authorization =
       this.platformAuthorizationService.inheritRootAuthorizationPolicy(
         account.authorization
@@ -222,7 +225,10 @@ export class AccountAuthorizationService {
 
     const newRules: IAuthorizationPolicyRuleCredential[] = [];
     // By default it is world visible. TODO: work through the logic on this
-    authorization.anonymousReadAccess = true;
+    const updatedAuthorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        authorization
+      );
 
     // Allow global admins to reset authorization, manage platform settings
     // and transfer resources
@@ -308,7 +314,7 @@ export class AccountAuthorizationService {
     newRules.push(createInnovationPack);
 
     return this.authorizationPolicyService.appendCredentialAuthorizationRules(
-      authorization,
+      updatedAuthorization,
       newRules
     );
   }

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -123,12 +123,16 @@ export class SpaceAuthorizationService {
         space.authorization = this.resetToPrivateLevelZeroSpaceAuthorization(
           space.authorization
         );
-        if (!isPrivate) {
-          space.authorization =
-            this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-              space.authorization
-            );
+        let anonymousAccessPrivilege = AuthorizationPrivilege.READ;
+        if (isPrivate) {
+          anonymousAccessPrivilege = AuthorizationPrivilege.READ_ABOUT;
         }
+        space.authorization =
+          this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+            space.authorization,
+            anonymousAccessPrivilege
+          );
+
         break;
       }
       case SpaceLevel.CHALLENGE:
@@ -337,8 +341,9 @@ export class SpaceAuthorizationService {
     switch (space.level) {
       case SpaceLevel.SPACE: {
         clonedAuthorization =
-          this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-            clonedAuthorization
+          this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+            clonedAuthorization,
+            AuthorizationPrivilege.READ
           );
         break;
       }

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -124,7 +124,10 @@ export class SpaceAuthorizationService {
           space.authorization
         );
         if (!isPrivate) {
-          space.authorization.anonymousReadAccess = true;
+          space.authorization =
+            this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+              space.authorization
+            );
         }
         break;
       }
@@ -144,8 +147,6 @@ export class SpaceAuthorizationService {
               space.authorization,
               parentAuthorization
             );
-          space.authorization.anonymousReadAccess =
-            parentAuthorization.anonymousReadAccess;
         }
         // For subspace, the parent space admins credentials should be allowed to delete
         const parentSpaceCommunity = space.parentSpace?.community;
@@ -174,8 +175,7 @@ export class SpaceAuthorizationService {
 
         break;
       case SpaceVisibility.ARCHIVED:
-        // ensure it has visibility privilege set to private
-        space.authorization.anonymousReadAccess = false;
+        // ensure it has visibility privilege set to priva
         spaceMembershipAllowed = false;
         break;
     }
@@ -336,7 +336,10 @@ export class SpaceAuthorizationService {
       );
     switch (space.level) {
       case SpaceLevel.SPACE: {
-        clonedAuthorization.anonymousReadAccess = true;
+        clonedAuthorization =
+          this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+            clonedAuthorization
+          );
         break;
       }
       case SpaceLevel.CHALLENGE:
@@ -518,7 +521,6 @@ export class SpaceAuthorizationService {
   ): IAuthorizationPolicy {
     let updatedAuthorization =
       this.authorizationPolicyService.reset(authorizationPolicy);
-    updatedAuthorization.anonymousReadAccess = false;
     updatedAuthorization =
       this.platformAuthorizationService.inheritRootAuthorizationPolicy(
         updatedAuthorization

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -239,12 +239,8 @@ const getEntityMock = <T>() => ({
   },
 });
 
-const getAuthorizationPolicyMock = (
-  id: string,
-  anonymousReadAccess: boolean
-): AuthorizationPolicy => ({
+const getAuthorizationPolicyMock = (id: string): AuthorizationPolicy => ({
   id,
-  anonymousReadAccess,
   credentialRules: '',
   privilegeRules: '',
   type: AuthorizationPolicyType.SPACE,
@@ -449,13 +445,11 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
 const getSpaceMock = ({
   id,
   visibility,
-  anonymousReadAccess,
   challengesCount,
   opportunitiesCounts,
 }: {
   id: string;
   visibility: SpaceVisibility;
-  anonymousReadAccess: boolean;
   challengesCount: number;
   opportunitiesCounts: number[];
 }): Space => {
@@ -486,10 +480,7 @@ const getSpaceMock = ({
       type: AccountType.ORGANIZATION,
       ...getEntityMock<Account>(),
     },
-    authorization: getAuthorizationPolicyMock(
-      `auth-${id}`,
-      anonymousReadAccess
-    ),
+    authorization: getAuthorizationPolicyMock(`auth-${id}`),
     subspaces: getSubspacesMock(id, challengesCount, opportunitiesCounts),
     ...getEntityMock<Space>(),
   };
@@ -508,70 +499,60 @@ const getFilteredSpaces = (
 const spaceTestData: Space[] = [
   getSpaceMock({
     id: '1',
-    anonymousReadAccess: true,
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 1,
     opportunitiesCounts: [5],
   }),
   getSpaceMock({
     id: '2',
-    anonymousReadAccess: true,
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 2,
     opportunitiesCounts: [5, 3],
   }),
   getSpaceMock({
     id: '3',
-    anonymousReadAccess: true,
     visibility: SpaceVisibility.DEMO,
     challengesCount: 3,
     opportunitiesCounts: [5, 3, 1],
   }),
   getSpaceMock({
     id: '4',
-    anonymousReadAccess: false,
     visibility: SpaceVisibility.DEMO,
     challengesCount: 3,
     opportunitiesCounts: [1, 2, 1],
   }),
   getSpaceMock({
     id: '5',
-    anonymousReadAccess: false,
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 1,
     opportunitiesCounts: [1],
   }),
   getSpaceMock({
     id: '6',
-    anonymousReadAccess: true,
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 3,
     opportunitiesCounts: [1, 1, 6],
   }),
   getSpaceMock({
     id: '7',
-    anonymousReadAccess: true,
     visibility: SpaceVisibility.ARCHIVED,
     challengesCount: 0,
     opportunitiesCounts: [],
   }),
   getSpaceMock({
     id: '8',
-    anonymousReadAccess: true,
     visibility: SpaceVisibility.DEMO,
     challengesCount: 0,
     opportunitiesCounts: [],
   }),
   getSpaceMock({
     id: '9',
-    anonymousReadAccess: false,
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 0,
     opportunitiesCounts: [],
   }),
   getSpaceMock({
     id: '10',
-    anonymousReadAccess: false,
     visibility: SpaceVisibility.DEMO,
     challengesCount: 3,
     opportunitiesCounts: [1, 2, 0],

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -84,6 +84,7 @@ import { LicenseService } from '@domain/common/license/license.service';
 import { LicenseType } from '@common/enums/license.type';
 import { getDiff, hasOnlyAllowedFields } from '@common/utils';
 import { ILicensePlan } from '@platform/licensing/credential-based/license-plan/license.plan.interface';
+import { SpacePrivacyMode } from '@common/enums/space.privacy.mode';
 
 const EXPLORE_SPACES_LIMIT = 30;
 const EXPLORE_SPACES_ACTIVITY_DAYS_OLD = 30;
@@ -588,47 +589,34 @@ export class SpaceService {
   }
 
   private sortSpacesDefault(spacesData: Space[]): string[] {
-    const sortedSpaces = spacesData.sort((a, b) => {
-      const visibilityA = a.visibility;
-      const visibilityB = b.visibility;
+    const spacesDataForSorting: SpaceSortingData[] = [];
+    for (const space of spacesData) {
+      const settings = this.getSettings(space);
+      let subspacesCount = 0;
+      if (space.subspaces) {
+        subspacesCount = this.getSubspaceAndSubsubspacesCount(space.subspaces);
+      }
+      const spaceSortingData: SpaceSortingData = {
+        id: space.id,
+        visibility: space.visibility,
+        accessModeIsPublic: settings.privacy.mode === SpacePrivacyMode.PUBLIC,
+        subspacesCount,
+      };
+      spacesDataForSorting.push(spaceSortingData);
+    }
+    const sortedSpaces = spacesDataForSorting.sort((a, b) => {
       if (
-        visibilityA !== visibilityB &&
-        (visibilityA === SpaceVisibility.DEMO ||
-          visibilityB === SpaceVisibility.DEMO)
+        a.visibility !== b.visibility &&
+        (a.visibility === SpaceVisibility.DEMO ||
+          b.visibility === SpaceVisibility.DEMO)
       )
-        return visibilityA === SpaceVisibility.DEMO ? 1 : -1;
+        return a.visibility === SpaceVisibility.DEMO ? 1 : -1;
 
-      if (
-        a.authorization?.anonymousReadAccess === true &&
-        b.authorization?.anonymousReadAccess === false
-      )
-        return -1;
-      if (
-        a.authorization?.anonymousReadAccess === false &&
-        b.authorization?.anonymousReadAccess === true
-      )
-        return 1;
+      if (a.accessModeIsPublic && !b.accessModeIsPublic) return -1;
+      if (!a.accessModeIsPublic && b.accessModeIsPublic) return 1;
 
-      if (!a.subspaces && b.subspaces) return 1;
-      if (a.subspaces && !b.subspaces) return -1;
-      if (!a.subspaces && !b.subspaces) return 0;
-
-      // Shouldn't get there
-      if (!a.subspaces || !b.subspaces)
-        throw new ValidationException(
-          `Critical error when comparing Spaces! Critical error when loading Subspaces for Space ${a} and Space ${b}`,
-          LogContext.SPACES
-        );
-
-      const subspacesCountA = this.getSubspaceAndSubsubspacesCount(
-        a?.subspaces
-      );
-      const subspacesCountB = this.getSubspaceAndSubsubspacesCount(
-        b?.subspaces
-      );
-
-      if (subspacesCountA > subspacesCountB) return -1;
-      if (subspacesCountA < subspacesCountB) return 1;
+      if (a.subspacesCount > b.subspacesCount) return -1;
+      if (a.subspacesCount < b.subspacesCount) return 1;
 
       return 0;
     });
@@ -1487,3 +1475,10 @@ export class SpaceService {
     return metrics;
   }
 }
+
+type SpaceSortingData = {
+  id: string;
+  subspacesCount: number;
+  visibility: SpaceVisibility;
+  accessModeIsPublic: boolean;
+};

--- a/src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.ts
+++ b/src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.ts
@@ -3,7 +3,7 @@ import { AuthorizationPolicyService } from '@domain/common/authorization-policy/
 import { StorageAggregatorService } from './storage.aggregator.service';
 import { IStorageAggregator } from './storage.aggregator.interface';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
-import { LogContext } from '@common/enums';
+import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { StorageBucketAuthorizationService } from '../storage-bucket/storage.bucket.service.authorization';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
 
@@ -49,8 +49,9 @@ export class StorageAggregatorAuthorizationService {
         parentAuthorization
       );
     storageAggregator.authorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        storageAggregator.authorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        storageAggregator.authorization,
+        AuthorizationPrivilege.READ
       );
     updatedAuthorizations.push(storageAggregator.authorization);
 

--- a/src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.ts
+++ b/src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.ts
@@ -48,7 +48,10 @@ export class StorageAggregatorAuthorizationService {
         storageAggregator.authorization,
         parentAuthorization
       );
-    storageAggregator.authorization.anonymousReadAccess = true;
+    storageAggregator.authorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        storageAggregator.authorization
+      );
     updatedAuthorizations.push(storageAggregator.authorization);
 
     const bucketAuthorizations =

--- a/src/library/library/library.service.authorization.ts
+++ b/src/library/library/library.service.authorization.ts
@@ -21,7 +21,10 @@ export class LibraryAuthorizationService {
         parentAuthorization
       );
     // For now the library is world visible
-    library.authorization.anonymousReadAccess = true;
+    library.authorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        library.authorization
+      );
 
     return library.authorization;
   }

--- a/src/library/library/library.service.authorization.ts
+++ b/src/library/library/library.service.authorization.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { ILibrary } from './library.interface';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 
 @Injectable()
 export class LibraryAuthorizationService {
@@ -22,8 +23,9 @@ export class LibraryAuthorizationService {
       );
     // For now the library is world visible
     library.authorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        library.authorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        library.authorization,
+        AuthorizationPrivilege.READ
       );
 
     return library.authorization;

--- a/src/migrations/1733732413177-authAnonymousReadAccess.ts
+++ b/src/migrations/1733732413177-authAnonymousReadAccess.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AuthAnonymousReadAccess1733732413139
+export class AuthAnonymousReadAccess1733732413177
   implements MigrationInterface
 {
-  name = 'AuthAnonymousReadAccess1733732413139';
+  name = 'AuthAnonymousReadAccess1733732413177';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/src/migrations/1733732413177-authAnonymousReadAccess.ts
+++ b/src/migrations/1733732413177-authAnonymousReadAccess.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AuthAnonymousReadAccess1733732413139
+  implements MigrationInterface
+{
+  name = 'AuthAnonymousReadAccess1733732413139';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`authorization_policy\` DROP COLUMN \`anonymousReadAccess\``
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/platform/forum-discussion/discussion.service.authorization.ts
+++ b/src/platform/forum-discussion/discussion.service.authorization.ts
@@ -67,7 +67,10 @@ export class DiscussionAuthorizationService {
     switch (discussion.privacy) {
       case ForumDiscussionPrivacy.PUBLIC:
         // To ensure that the discussion + discussion profile is visible for non-authenticated users
-        discussion.authorization.anonymousReadAccess = true;
+        discussion.authorization =
+          this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+            discussion.authorization
+          );
         break;
       case ForumDiscussionPrivacy.AUTHENTICATED:
         break;

--- a/src/platform/forum-discussion/discussion.service.authorization.ts
+++ b/src/platform/forum-discussion/discussion.service.authorization.ts
@@ -68,8 +68,9 @@ export class DiscussionAuthorizationService {
       case ForumDiscussionPrivacy.PUBLIC:
         // To ensure that the discussion + discussion profile is visible for non-authenticated users
         discussion.authorization =
-          this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-            discussion.authorization
+          this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+            discussion.authorization,
+            AuthorizationPrivilege.READ
           );
         break;
       case ForumDiscussionPrivacy.AUTHENTICATED:

--- a/src/platform/licensing/credential-based/licensing-framework/licensing.framework.service.authorization.ts
+++ b/src/platform/licensing/credential-based/licensing-framework/licensing.framework.service.authorization.ts
@@ -58,8 +58,9 @@ export class LicensingFrameworkAuthorizationService {
         parentAuthorization
       );
     licensing.authorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        licensing.authorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        licensing.authorization,
+        AuthorizationPrivilege.READ
       );
     licensing.authorization = await this.appendCredentialRules(
       licensing.authorization

--- a/src/platform/licensing/credential-based/licensing-framework/licensing.framework.service.authorization.ts
+++ b/src/platform/licensing/credential-based/licensing-framework/licensing.framework.service.authorization.ts
@@ -57,7 +57,10 @@ export class LicensingFrameworkAuthorizationService {
         licensing.authorization,
         parentAuthorization
       );
-    licensing.authorization.anonymousReadAccess = true;
+    licensing.authorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        licensing.authorization
+      );
     licensing.authorization = await this.appendCredentialRules(
       licensing.authorization
     );

--- a/src/platform/platform/platform.service.authorization.ts
+++ b/src/platform/platform/platform.service.authorization.ts
@@ -128,8 +128,9 @@ export class PlatformAuthorizationService {
     platformStorageAuth =
       this.extendStorageAuthorizationPolicy(platformStorageAuth);
     platformStorageAuth =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        platformStorageAuth
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        platformStorageAuth,
+        AuthorizationPrivilege.READ
       );
 
     const storageAuthorizations =
@@ -184,8 +185,9 @@ export class PlatformAuthorizationService {
 
     // Set globally visible to replicate what already
     const updatedAuthorization =
-      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
-        authorization
+      this.authorizationPolicyService.appendCredentialRuleAnonymousAccess(
+        authorization,
+        AuthorizationPrivilege.READ
       );
 
     return this.authorizationPolicyService.appendCredentialAuthorizationRules(

--- a/src/platform/platform/platform.service.authorization.ts
+++ b/src/platform/platform/platform.service.authorization.ts
@@ -127,7 +127,10 @@ export class PlatformAuthorizationService {
       );
     platformStorageAuth =
       this.extendStorageAuthorizationPolicy(platformStorageAuth);
-    platformStorageAuth.anonymousReadAccess = true;
+    platformStorageAuth =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        platformStorageAuth
+      );
 
     const storageAuthorizations =
       await this.storageAggregatorAuthorizationService.applyAuthorizationPolicy(
@@ -180,14 +183,15 @@ export class PlatformAuthorizationService {
     newRules.push(communicationRules);
 
     // Set globally visible to replicate what already
-    authorization.anonymousReadAccess = true;
+    const updatedAuthorization =
+      this.authorizationPolicyService.appendCredentialRuleAnonymousReadAccess(
+        authorization
+      );
 
-    this.authorizationPolicyService.appendCredentialAuthorizationRules(
-      authorization,
+    return this.authorizationPolicyService.appendCredentialAuthorizationRules(
+      updatedAuthorization,
       newRules
     );
-
-    return authorization;
   }
 
   private extendStorageAuthorizationPolicy(

--- a/src/services/ai-server/ai-server/ai.server.service.authorization.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.authorization.ts
@@ -40,8 +40,6 @@ export class AiServerAuthorizationService {
     aiServer.authorization = this.authorizationPolicyService.reset(
       aiServer.authorization
     );
-
-    aiServer.authorization.anonymousReadAccess = false;
     aiServer.authorization = await this.appendCredentialRules(
       aiServer.authorization
     );

--- a/src/services/api/roles/util/group.credentials.by.entity.ts
+++ b/src/services/api/roles/util/group.credentials.by.entity.ts
@@ -1,8 +1,8 @@
-import { ICredential } from '@src/domain';
 import { AuthorizationCredential } from '@common/enums';
 import { OrganizationRole } from '@common/enums/organization.role';
 import { CommunityRoleType } from '@common/enums/community.role';
 import { CommunityRoleImplicit } from '@common/enums/community.role.implicit';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
 
 export type CredentialRole =
   | OrganizationRole
@@ -26,7 +26,9 @@ export type CredentialMap = Map<
  * The types are represented by an array because they are guaranteed unique,
  * meaning an User (whose credentials are parsed here) can't have two credentials of type 'space-admin' for the same Space
  */
-export const groupCredentialsByEntity = (credentials: ICredential[]) => {
+export const groupCredentialsByEntity = (
+  credentials: ICredentialDefinition[]
+) => {
   return credentials.reduce<CredentialMap>((map, credential) => {
     if (
       credential.type === AuthorizationCredential.SPACE_ADMIN ||
@@ -50,7 +52,7 @@ export const groupCredentialsByEntity = (credentials: ICredential[]) => {
 const setMap = (
   map: CredentialMap,
   type: EntityCredentialType,
-  credential: ICredential
+  credential: ICredentialDefinition
 ) => {
   const roleMap = map.get(type);
   if (roleMap) {

--- a/src/services/external/excalidraw-backend/middlewares/socket.data.init.middleware.ts
+++ b/src/services/external/excalidraw-backend/middlewares/socket.data.init.middleware.ts
@@ -1,16 +1,29 @@
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { SocketIoSocket } from '../types/socket.io.socket';
 import { SimpleMiddlewareHandler } from './middleware.handler.type';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
+import { AuthorizationCredential } from '@common/enums/authorization.credential';
 
 export const socketDataInitMiddleware: SimpleMiddlewareHandler = (
   socket: SocketIoSocket,
   next: (err?: Error) => void
 ) => {
-  socket.data.agentInfo = new AgentInfo();
+  socket.data.agentInfo = createAnonymousAgentInfo();
   socket.data.lastContributed = -1;
   socket.data.read = false;
   socket.data.update = false;
   socket.data.session = undefined;
 
   next();
+};
+
+// Todo: duplicate as have both service + function implementations
+const createAnonymousAgentInfo = (): AgentInfo => {
+  const emptyAgentInfo = new AgentInfo();
+  const anonymousCredential: ICredentialDefinition = {
+    type: AuthorizationCredential.GLOBAL_ANONYMOUS,
+    resourceID: '',
+  };
+  emptyAgentInfo.credentials = [anonymousCredential];
+  return emptyAgentInfo;
 };

--- a/src/services/file-integration/file.integration.service.ts
+++ b/src/services/file-integration/file.integration.service.ts
@@ -37,9 +37,8 @@ export class FileIntegrationService {
       });
     }
 
-    const requesterAgentInfo = await this.authenticationService.getAgentInfo(
-      auth
-    );
+    const requesterAgentInfo =
+      await this.authenticationService.getAgentInfo(auth);
 
     let document: IDocument | undefined;
     try {

--- a/src/services/whiteboard-integration/whiteboard.integration.module.ts
+++ b/src/services/whiteboard-integration/whiteboard.integration.module.ts
@@ -1,19 +1,19 @@
 import { Module } from '@nestjs/common';
 import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { WhiteboardModule } from '@domain/common/whiteboard';
-import { UserModule } from '@domain/community/user/user.module';
 import { AuthenticationModule } from '@core/authentication/authentication.module';
 import { WhiteboardIntegrationService } from './whiteboard.integration.service';
 import { WhiteboardIntegrationController } from './whiteboard.integration.controller';
 import { ContributionReporterModule } from '@services/external/elasticsearch/contribution-reporter';
 import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
 import { ActivityAdapterModule } from '@services/adapters/activity-adapter/activity.adapter.module';
+import { AuthenticationAgentInfoModule } from '@core/authentication.agent.info/agent.info.module';
 
 @Module({
   imports: [
     AuthorizationModule,
     WhiteboardModule,
-    UserModule,
+    AuthenticationAgentInfoModule,
     AuthenticationModule,
     ContributionReporterModule,
     EntityResolverModule,

--- a/test/data/agent.json
+++ b/test/data/agent.json
@@ -5,7 +5,6 @@
     "password": "",
     "id": "8f5c08b1-444a-42c0-8f48-58b3ddef53b0",
     "authorization": {
-      "anonymousReadAccess": false,
       "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-admin\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-owner\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-associate\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"global-registered\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
       "verifiedCredentialRules": "[]",
       "privilegeRules": "",

--- a/test/data/organization.json
+++ b/test/data/organization.json
@@ -14,7 +14,6 @@
       "displayName": "host org",
       "type": "organization",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"user-self\",\"resourceID\":\"b69f82a1-bc7d-486c-85f9-e7ac6e689f4e\",\"grantedPrivileges\":[\"create\",\"read\",\"update\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",
@@ -30,7 +29,6 @@
       "updatedDate": {},
       "version": 1,
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-admin\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-owner\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-associate\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"global-registered\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",
@@ -45,7 +43,6 @@
       ]
     },
     "authorization": {
-      "anonymousReadAccess": false,
       "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-admin\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-owner\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"grant\",\"create\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"organization-associate\",\"resourceID\":\"03bb5b07-f134-4074-97b9-1dd7950c7fa4\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"global-registered\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
       "verifiedCredentialRules": "[]",
       "privilegeRules": "",

--- a/test/data/space.json
+++ b/test/data/space.json
@@ -14,7 +14,6 @@
       "displayName": "UN Sustainable Development Goals",
       "type": "space",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"user-self\",\"resourceID\":\"b69f82a1-bc7d-486c-85f9-e7ac6e689f4e\",\"grantedPrivileges\":[\"create\",\"read\",\"update\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",
@@ -29,7 +28,6 @@
       "policy": "{\"member\":{\"credential\":{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\"},\"minOrg\":0,\"maxOrg\":-1,\"minUser\":0,\"maxUser\":-1},\"lead\":{\"credential\":{\"type\":\"space-host\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\"},\"minOrg\":0,\"maxOrg\":1,\"minUser\":0,\"maxUser\":2}}",
       "id": "d9269921-1660-4f76-95d1-16c5b3d06fb1",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-registered\",\"resourceID\":\"\",\"grantedPrivileges\":[\"community-apply\"],\"cascade\":false}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "[]",
@@ -37,7 +35,6 @@
       }
     },
     "authorization": {
-      "anonymousReadAccess": false,
       "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
       "verifiedCredentialRules": "[]",
       "privilegeRules": "",
@@ -55,7 +52,6 @@
       "name": "default",
       "id": "093da171-5454-452f-b024-937ccb057920",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",

--- a/test/data/subspace.json
+++ b/test/data/subspace.json
@@ -14,7 +14,6 @@
       "type": "challenge",
       "displayName": "12 Responsible Consumption + Production",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"user-self\",\"resourceID\":\"b69f82a1-bc7d-486c-85f9-e7ac6e689f4e\",\"grantedPrivileges\":[\"create\",\"read\",\"update\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",
@@ -32,7 +31,6 @@
       "updatedDate": {},
       "version": 3,
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"31ad6631-2004-4b08-a6d7-07b9df2c49db\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"31ad6631-2004-4b08-a6d7-07b9df2c49db\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"community-apply\"],\"cascade\":false}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "[]",
@@ -40,7 +38,6 @@
       }
     },
     "authorization": {
-      "anonymousReadAccess": false,
       "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"31ad6631-2004-4b08-a6d7-07b9df2c49db\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"31ad6631-2004-4b08-a6d7-07b9df2c49db\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
       "verifiedCredentialRules": "[]",
       "privilegeRules": "",
@@ -51,7 +48,6 @@
       "name": "default",
       "id": "d7b970ba-13c7-4657-a205-6d2334d789dc",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"31ad6631-2004-4b08-a6d7-07b9df2c49db\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"31ad6631-2004-4b08-a6d7-07b9df2c49db\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",

--- a/test/data/subsubspace.json
+++ b/test/data/subsubspace.json
@@ -14,7 +14,6 @@
       "type": "opportunity",
       "displayName": "Food security and nutrition and sustainable agriculture",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"user-self\",\"resourceID\":\"b69f82a1-bc7d-486c-85f9-e7ac6e689f4e\",\"grantedPrivileges\":[\"create\",\"read\",\"update\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",
@@ -29,7 +28,6 @@
       "policy": "{\"member\":{\"credential\":{\"type\":\"space-member\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\"},\"minOrg\":0,\"maxOrg\":-1,\"minUser\":0,\"maxUser\":-1},\"lead\":{\"credential\":{\"type\":\"space-lead\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\"},\"minOrg\":0,\"maxOrg\":9,\"minUser\":0,\"maxUser\":2}}",
       "id": "29f45a73-1231-409c-9a85-b63a6b008e0f",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"3896cb16-3487-49be-b6d8-6b6ddd0e9229\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"3896cb16-3487-49be-b6d8-6b6ddd0e9229\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "[]",
@@ -37,7 +35,6 @@
       }
     },
     "authorization": {
-      "anonymousReadAccess": false,
       "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"3896cb16-3487-49be-b6d8-6b6ddd0e9229\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"3896cb16-3487-49be-b6d8-6b6ddd0e9229\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
       "verifiedCredentialRules": "[]",
       "privilegeRules": "",
@@ -55,7 +52,6 @@
       "name": "default",
       "id": "90bd8cd1-0a3e-4ce9-a146-8aa67d7270d8",
       "authorization": {
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"00655835-4d15-4546-801e-1ab80ac3078a\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"3896cb16-3487-49be-b6d8-6b6ddd0e9229\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"3896cb16-3487-49be-b6d8-6b6ddd0e9229\",\"grantedPrivileges\":[\"read\"],\"cascade\":true},{\"type\":\"space-admin\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"grant\",\"delete\"],\"cascade\":true},{\"type\":\"space-member\",\"resourceID\":\"d3c76102-087b-4b40-8aa5-b5e6023784d0\",\"grantedPrivileges\":[\"read\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",

--- a/test/data/user.json
+++ b/test/data/user.json
@@ -18,7 +18,6 @@
       "storageSpaceId": "storageSpaceId",
       "type": "user",
       "authorization": {
-        "anonymousReadAccess": false,
         "type": "profile",
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"user-self\",\"resourceID\":\"b69f82a1-bc7d-486c-85f9-e7ac6e689f4e\",\"grantedPrivileges\":[\"create\",\"read\",\"update\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
@@ -35,7 +34,6 @@
       "id": "07c6ec54-524a-4d7f-9f58-a4c50f0c0496",
       "authorization": {
         "type": "agent",
-        "anonymousReadAccess": false,
         "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"user-self\",\"resourceID\":\"b69f82a1-bc7d-486c-85f9-e7ac6e689f4e\",\"grantedPrivileges\":[\"create\",\"read\",\"update\"],\"cascade\":true}]",
         "verifiedCredentialRules": "[]",
         "privilegeRules": "",
@@ -366,7 +364,6 @@
       ]
     },
     "authorization": {
-      "anonymousReadAccess": false,
       "type": "profile",
       "credentialRules": "[{\"type\":\"global-admin\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"grant\",\"read\",\"update\",\"delete\"],\"cascade\":true},{\"type\":\"global-admin-community\",\"resourceID\":\"\",\"grantedPrivileges\":[\"create\",\"read\",\"update\",\"delete\",\"grant\"],\"cascade\":true},{\"type\":\"user-self\",\"resourceID\":\"b69f82a1-bc7d-486c-85f9-e7ac6e689f4e\",\"grantedPrivileges\":[\"create\",\"read\",\"update\"],\"cascade\":true}]",
       "verifiedCredentialRules": "[]",


### PR DESCRIPTION
Triggered by work on READ_ABOUT...where we will need more control that the simple flag that controls READ access.

Add new global credential GLOBAL_ANONYMOUS
Assign this credential to AgentInfos that are representing anonymous usage

Removed flag from authorization policy
Added utility method to assign a credential rule for anonymous usage with a specified privilege to an authorization policy

Updated Space sorting to use privacy mode (public/private) instead of anonymousReadAccess (basically fixing a potential bug). Potentially the new setup is also faster.

Reworked handling of AgentInfo to bring the creation / updating of this data structure to be in one place

Client PR is already merged

Initial results:
![image](https://github.com/user-attachments/assets/3adc43e0-0126-46cf-9e15-a2f37043bc3f)

Todo:
- check for edge cases by having test suites passing; there may be cases where something is over ruled in the child previously which the new setup will not cover
- update unit tests on Space: they were using anonymousReadAccess but now should be using settings.privacy.mode = Public/Private
- see if can easily share the logic for generating an AgentInfo for anonymous user requests, currently duplicated 3x. Problems with module dependency in one case, plus second case where have functional vs service usage.
- check with light testing the impact this has on performance; risk is that it is heavier
- test test test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new enumeration value `GLOBAL_ANONYMOUS` for non-authenticated interactions.
  - Added `AgentInfoService` to enhance agent information management.
  - Implemented methods for creating and managing anonymous agent information.

- **Bug Fixes**
  - Removed redundant `anonymousReadAccess` properties from various authorization contexts.

- **Refactor**
  - Updated logic for handling anonymous read access across multiple services and modules to use method calls instead of direct property assignments.

- **Documentation**
  - Adjusted JSON structures in test data to reflect changes in authorization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->