### PR TITLE
Licensing: credential based returns limits per type

### DIFF
--- a/src/domain/space/account/account.module.ts
+++ b/src/domain/space/account/account.module.ts
@@ -26,6 +26,7 @@ import { TemporaryStorageModule } from '@services/infrastructure/temporary-stora
 import { LicenseModule } from '@domain/common/license/license.module';
 import { AccountLicenseService } from './account.service.license';
 import { LicensingFrameworkModule } from '@platform/licensing/credential-based/licensing-framework/licensing.framework.module';
+import { LicensingWingbackSubscriptionModule } from '@platform/licensing/wingback-subscription/licensing.wingback.subscription.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { LicensingFrameworkModule } from '@platform/licensing/credential-based/l
     LicensingFrameworkModule,
     LicenseIssuerModule,
     LicensingCredentialBasedModule,
+    LicensingWingbackSubscriptionModule,
     LicenseModule,
     SpaceModule,
     InnovationHubModule,

--- a/src/migrations/1731500015640-licenseEntitlements.ts
+++ b/src/migrations/1731500015640-licenseEntitlements.ts
@@ -610,7 +610,7 @@ const licenseCredentialRules = [
   {
     credentialType: 'space-feature-save-as-template',
     grantedEntitlements: [LicenseEntitlementType.SPACE_FLAG_SAVE_AS_TEMPLATE],
-    name: 'Space Save As Templatet',
+    name: 'Space Save As Template',
   },
   {
     credentialType: 'space-license-free',

--- a/src/migrations/1734087106799-licensePolicyLimits.ts
+++ b/src/migrations/1734087106799-licensePolicyLimits.ts
@@ -82,7 +82,7 @@ const licenseCredentialRules: CredentialRule[] = [
         limit: 1,
       },
     ],
-    name: 'Space Save As Templatet',
+    name: 'Space Save As Template',
   },
   {
     credentialType: LicenseCredential.SPACE_LICENSE_FREE,

--- a/src/migrations/1734087106799-licensePolicyLimits.ts
+++ b/src/migrations/1734087106799-licensePolicyLimits.ts
@@ -1,0 +1,155 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LicensePolicyLimits1734087106799 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [licensePolicy]: {
+      id: string;
+    }[] = await queryRunner.query(`SELECT id FROM license_policy`);
+    await queryRunner.query(
+      `UPDATE license_policy SET credentialRulesStr = ? WHERE id = ?`,
+      [`${JSON.stringify(licenseCredentialRules)}`, licensePolicy.id]
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    console.log('No down migration needed');
+  }
+}
+
+type CredentialRule = {
+  credentialType: LicenseCredential;
+  grantedEntitlements: GrantedEntitlement[];
+  name: string;
+};
+
+type GrantedEntitlement = {
+  type: LicenseEntitlementType;
+  limit: number;
+};
+
+enum LicenseCredential {
+  SPACE_LICENSE_FREE = 'space-license-free',
+  SPACE_LICENSE_PLUS = 'space-license-plus',
+  SPACE_LICENSE_PREMIUM = 'space-license-premium',
+  SPACE_LICENSE_ENTERPRISE = 'space-license-enterprise', // todo: remove for space
+  SPACE_FEATURE_SAVE_AS_TEMPLATE = 'space-feature-save-as-template',
+  SPACE_FEATURE_VIRTUAL_CONTRIBUTORS = 'space-feature-virtual-contributors',
+  SPACE_FEATURE_WHITEBOARD_MULTI_USER = 'space-feature-whiteboard-multi-user',
+  ACCOUNT_LICENSE_PLUS = 'account-license-plus',
+}
+
+enum LicenseEntitlementType {
+  ACCOUNT_SPACE_FREE = 'account-space-free',
+  ACCOUNT_SPACE_PLUS = 'account-space-plus',
+  ACCOUNT_SPACE_PREMIUM = 'account-space-premium',
+  ACCOUNT_VIRTUAL_CONTRIBUTOR = 'account-virtual-contributor',
+  ACCOUNT_INNOVATION_PACK = 'account-innovation-pack',
+  ACCOUNT_INNOVATION_HUB = 'account-innovation-hub',
+  SPACE_FREE = 'space-free',
+  SPACE_PLUS = 'space-plus',
+  SPACE_PREMIUM = 'space-premium',
+  SPACE_FLAG_SAVE_AS_TEMPLATE = 'space-flag-save-as-template',
+  SPACE_FLAG_VIRTUAL_CONTRIBUTOR_ACCESS = 'space-flag-virtual-contributor-access',
+  SPACE_FLAG_WHITEBOARD_MULTI_USER = 'space-flag-whiteboard-multi-user',
+}
+
+const licenseCredentialRules: CredentialRule[] = [
+  {
+    credentialType: LicenseCredential.SPACE_FEATURE_VIRTUAL_CONTRIBUTORS,
+    grantedEntitlements: [
+      {
+        type: LicenseEntitlementType.SPACE_FLAG_VIRTUAL_CONTRIBUTOR_ACCESS,
+        limit: 1,
+      },
+    ],
+    name: 'Space Virtual Contributors',
+  },
+  {
+    credentialType: LicenseCredential.SPACE_FEATURE_WHITEBOARD_MULTI_USER,
+    grantedEntitlements: [
+      {
+        type: LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER,
+        limit: 1,
+      },
+    ],
+    name: 'Space Multi-user whiteboards',
+  },
+  {
+    credentialType: LicenseCredential.SPACE_FEATURE_SAVE_AS_TEMPLATE,
+    grantedEntitlements: [
+      {
+        type: LicenseEntitlementType.SPACE_FLAG_SAVE_AS_TEMPLATE,
+        limit: 1,
+      },
+    ],
+    name: 'Space Save As Templatet',
+  },
+  {
+    credentialType: LicenseCredential.SPACE_LICENSE_FREE,
+    grantedEntitlements: [
+      {
+        type: LicenseEntitlementType.SPACE_FREE,
+        limit: 1,
+      },
+    ],
+    name: 'Space License Free',
+  },
+  {
+    credentialType: LicenseCredential.SPACE_LICENSE_PLUS,
+    grantedEntitlements: [
+      {
+        type: LicenseEntitlementType.SPACE_PLUS,
+        limit: 1,
+      },
+      {
+        type: LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER,
+        limit: 1,
+      },
+      {
+        type: LicenseEntitlementType.SPACE_FLAG_SAVE_AS_TEMPLATE,
+        limit: 1,
+      },
+    ],
+    name: 'Space License Plus',
+  },
+  {
+    credentialType: LicenseCredential.SPACE_LICENSE_PREMIUM,
+    grantedEntitlements: [
+      {
+        type: LicenseEntitlementType.SPACE_PREMIUM,
+        limit: 1,
+      },
+      {
+        type: LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER,
+        limit: 1,
+      },
+      {
+        type: LicenseEntitlementType.SPACE_FLAG_SAVE_AS_TEMPLATE,
+        limit: 1,
+      },
+    ],
+    name: 'Space License Premium',
+  },
+  {
+    credentialType: LicenseCredential.ACCOUNT_LICENSE_PLUS,
+    grantedEntitlements: [
+      {
+        type: LicenseEntitlementType.ACCOUNT_SPACE_FREE,
+        limit: 3,
+      },
+      {
+        type: LicenseEntitlementType.ACCOUNT_VIRTUAL_CONTRIBUTOR,
+        limit: 3,
+      },
+      {
+        type: LicenseEntitlementType.ACCOUNT_INNOVATION_HUB,
+        limit: 1,
+      },
+      {
+        type: LicenseEntitlementType.ACCOUNT_INNOVATION_PACK,
+        limit: 3,
+      },
+    ],
+    name: 'Account License Plus',
+  },
+];

--- a/src/migrations/1734708463555-licensePolicyLimits.ts
+++ b/src/migrations/1734708463555-licensePolicyLimits.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class LicensePolicyLimits1734087106799 implements MigrationInterface {
+export class LicensePolicyLimits1734708463555 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     const [licensePolicy]: {
       id: string;

--- a/src/platform/licensing/credential-based/license-policy/license.policy.service.ts
+++ b/src/platform/licensing/credential-based/license-policy/license.policy.service.ts
@@ -9,7 +9,7 @@ import { LicensingCredentialBasedService } from '@platform/licensing/credential-
 import { LogContext } from '@common/enums/logging.context';
 import { ILicensingCredentialBasedPolicyCredentialRule } from '@platform/licensing/credential-based/licensing-credential-based-entitlements-engine';
 import { LicensingCredentialBasedCredentialType } from '@common/enums/licensing.credential.based.credential.type';
-import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
+import { LicensingGrantedEntitlement } from '@platform/licensing/dto/licensing.dto.granted.entitlement';
 
 @Injectable()
 export class LicensePolicyService {
@@ -22,7 +22,7 @@ export class LicensePolicyService {
   ) {}
 
   createCredentialRule(
-    grantedEntitlements: LicenseEntitlementType[],
+    grantedEntitlements: LicensingGrantedEntitlement[],
     credentialType: LicensingCredentialBasedCredentialType,
     name: string
   ): ILicensingCredentialBasedPolicyCredentialRule {

--- a/src/platform/licensing/credential-based/licensing-credential-based-entitlements-engine/index.ts
+++ b/src/platform/licensing/credential-based/licensing-credential-based-entitlements-engine/index.ts
@@ -1,1 +1,1 @@
-export * from './licensing.credential.based.policy.rule.credential.interface';
+export * from './licensing.credential.based.policy.credential.rule.interface';

--- a/src/platform/licensing/credential-based/licensing-credential-based-entitlements-engine/licensing.credential.based.policy.credential.rule.interface.ts
+++ b/src/platform/licensing/credential-based/licensing-credential-based-entitlements-engine/licensing.credential.based.policy.credential.rule.interface.ts
@@ -1,14 +1,14 @@
 import { LicensingCredentialBasedCredentialType } from '@common/enums/licensing.credential.based.credential.type';
-import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
 import { Field, ObjectType } from '@nestjs/graphql';
+import { LicensingGrantedEntitlement } from '@platform/licensing/dto/licensing.dto.granted.entitlement';
 
 @ObjectType('LicensingCredentialBasedPolicyCredentialRule')
 export abstract class ILicensingCredentialBasedPolicyCredentialRule {
   @Field(() => LicensingCredentialBasedCredentialType)
   credentialType!: LicensingCredentialBasedCredentialType;
 
-  @Field(() => [LicenseEntitlementType])
-  grantedEntitlements!: LicenseEntitlementType[];
+  @Field(() => [LicensingGrantedEntitlement])
+  grantedEntitlements!: LicensingGrantedEntitlement[];
 
   @Field(() => String, { nullable: true })
   name?: string;

--- a/src/platform/licensing/credential-based/licensing-credential-based-entitlements-engine/licensing.credential.based.policy.credential.rule.ts
+++ b/src/platform/licensing/credential-based/licensing-credential-based-entitlements-engine/licensing.credential.based.policy.credential.rule.ts
@@ -1,16 +1,16 @@
 import { LicensingCredentialBasedCredentialType } from '@common/enums/licensing.credential.based.credential.type';
-import { ILicensingCredentialBasedPolicyCredentialRule } from './licensing.credential.based.policy.rule.credential.interface';
-import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
+import { ILicensingCredentialBasedPolicyCredentialRule } from './licensing.credential.based.policy.credential.rule.interface';
+import { LicensingGrantedEntitlement } from '@platform/licensing/dto/licensing.dto.granted.entitlement';
 
 export class LicensingCredentialBasedPolicyCredentialRule
   implements ILicensingCredentialBasedPolicyCredentialRule
 {
   credentialType: LicensingCredentialBasedCredentialType;
-  grantedEntitlements: LicenseEntitlementType[];
+  grantedEntitlements: LicensingGrantedEntitlement[];
   name: string;
 
   constructor(
-    grantedEntitlements: LicenseEntitlementType[],
+    grantedEntitlements: LicensingGrantedEntitlement[],
     credentialType: LicensingCredentialBasedCredentialType,
     name: string
   ) {

--- a/src/platform/licensing/dto/licensing.dto.granted.entitlement.ts
+++ b/src/platform/licensing/dto/licensing.dto.granted.entitlement.ts
@@ -8,6 +8,6 @@ export class LicensingGrantedEntitlement {
   })
   type!: LicenseEntitlementType;
 
-  @Field(() => Number, { nullable: true })
+  @Field(() => Number, { nullable: false })
   limit!: number;
 }

--- a/src/platform/licensing/dto/licensing.dto.granted.entitlement.ts
+++ b/src/platform/licensing/dto/licensing.dto.granted.entitlement.ts
@@ -1,0 +1,13 @@
+import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('LicensingGrantedEntitlement')
+export class LicensingGrantedEntitlement {
+  @Field(() => LicenseEntitlementType, {
+    description: 'The entitlement that is granted.',
+  })
+  type!: LicenseEntitlementType;
+
+  @Field(() => Number, { nullable: true })
+  limit!: number;
+}

--- a/src/platform/licensing/wingback-subscription/licensing.wingback.subscription.service.spec.ts
+++ b/src/platform/licensing/wingback-subscription/licensing.wingback.subscription.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LicensingWingbackSubscriptionService } from './licensing.wingback.subscription.service';
 import { WingbackManager } from '@services/external/wingback';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 
 describe('LicensingWingbackSubscriptionService', () => {
   let service: LicensingWingbackSubscriptionService;
@@ -9,6 +10,7 @@ describe('LicensingWingbackSubscriptionService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LicensingWingbackSubscriptionService,
+        MockWinstonProvider,
         {
           provide: WingbackManager,
           useValue: {

--- a/src/platform/licensing/wingback-subscription/licensing.wingback.subscription.service.ts
+++ b/src/platform/licensing/wingback-subscription/licensing.wingback.subscription.service.ts
@@ -1,10 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { CreateCustomer } from '../../../services/external/wingback/types/wingback.type.create.customer';
 import { WingbackManager } from '@services/external/wingback/wingback.manager';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { LogContext } from '@common/enums';
+import { LicensingGrantedEntitlement } from '../dto/licensing.dto.granted.entitlement';
 
 @Injectable()
 export class LicensingWingbackSubscriptionService {
-  constructor(private readonly wingbackManager: WingbackManager) {}
+  constructor(
+    private readonly wingbackManager: WingbackManager,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
+  ) {}
 
   /**
    * Create a new customer
@@ -15,10 +22,17 @@ export class LicensingWingbackSubscriptionService {
     return this.wingbackManager.createCustomer(data);
   }
 
-  public getEntitlements(
+  public async getEntitlements(
     customerId: string
-  ): Promise<Record<string, unknown>[]> {
-    // TODO: return LicensingGrantedEntitlement[]
-    return this.wingbackManager.getEntitlements(customerId);
+  ): Promise<LicensingGrantedEntitlement[]> {
+    const entitlements: LicensingGrantedEntitlement[] = [];
+    const wingbackEntitlements =
+      await this.wingbackManager.getEntitlements(customerId);
+    // Todo: map the wingback entitlements to the entitlements that are understood within Alkemio Licensing
+    this.logger.verbose?.(
+      `Wingback entitlements: ${JSON.stringify(wingbackEntitlements)}`,
+      LogContext.LICENSE
+    );
+    return entitlements;
   }
 }

--- a/src/platform/licensing/wingback-subscription/licensing.wingback.subscription.service.ts
+++ b/src/platform/licensing/wingback-subscription/licensing.wingback.subscription.service.ts
@@ -18,6 +18,7 @@ export class LicensingWingbackSubscriptionService {
   public getEntitlements(
     customerId: string
   ): Promise<Record<string, unknown>[]> {
+    // TODO: return LicensingGrantedEntitlement[]
     return this.wingbackManager.getEntitlements(customerId);
   }
 }


### PR DESCRIPTION
This allows having the numerical limits specified in the license policy. Previously all limits associated with entitlements were actually booleans, not numbers.
![image](https://github.com/user-attachments/assets/0e5ea800-0ada-4a1c-b683-ba7e4b7b25e0)


A new type is added that can also be used to return granted entitlements from Wingback Subscription

Migration is added to update the credential based licensing policy

The actual resulting licensing credential based rule now looks like: 
![image](https://github.com/user-attachments/assets/26673932-7938-458f-8630-90e51573db29)

Previously grantedEntitlements was just an array of entitlement types, now there is a limit for each one. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `LicensingWingbackSubscriptionModule` to enhance account management.
	- Added a new method to retrieve granted entitlements from the `LicensingWingbackSubscriptionService`.
	- New GraphQL object type `LicensingGrantedEntitlement` created for entitlement representation.

- **Improvements**
	- Refactored entitlement checking logic to streamline license policy applications.
	- Enhanced the `getEntitlements` method to return structured entitlement data.

- **Bug Fixes**
	- Updated handling of entitlement types to improve accuracy in entitlement checks.

- **Chores**
	- Updated import paths for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->