### PR TITLE
fix dashboard access on private spaces for non-members

### DIFF
--- a/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
+++ b/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
@@ -94,8 +94,6 @@ export class CollaborationResolverFields {
     return tagsetTemplateSet.tagsetTemplates;
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('license', () => ILicense, {
     nullable: false,
     description: 'The License operating on this Collaboration.',

--- a/src/domain/space/space/space.resolver.fields.ts
+++ b/src/domain/space/space/space.resolver.fields.ts
@@ -106,7 +106,6 @@ export class SpaceResolverFields {
     return this.spaceService.activeSubscription(space);
   }
 
-  @UseGuards(GraphqlGuard)
   @ResolveField('collaboration', () => ICollaboration, {
     nullable: false,
     description: 'The collaboration for the Space.',

--- a/src/services/api/lookup/lookup.resolver.fields.ts
+++ b/src/services/api/lookup/lookup.resolver.fields.ts
@@ -426,7 +426,6 @@ export class LookupResolverFields {
     return community;
   }
 
-  @UseGuards(GraphqlGuard)
   @ResolveField(() => ICollaboration, {
     nullable: true,
     description: 'Lookup the specified Collaboration',
@@ -437,12 +436,6 @@ export class LookupResolverFields {
   ): Promise<ICollaboration> {
     const collaboration =
       await this.collaborationService.getCollaborationOrFail(id);
-    this.authorizationService.grantAccessOrFail(
-      agentInfo,
-      collaboration.authorization,
-      AuthorizationPrivilege.READ,
-      `lookup Collaboration: ${collaboration.id}`
-    );
 
     return collaboration;
   }


### PR DESCRIPTION
- removed checks on collaboration - protected by its children field resolvers
- removed checks on license - I should always be able to check what's available on an entity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated authorization handling for the `collaboration` field across multiple resolvers.
  
- **Bug Fixes**
	- Removed unnecessary authorization checks for the `license` and `collaboration` fields, streamlining access control.

- **Refactor**
	- Adjusted method signatures to reflect changes in authorization decorators while maintaining overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->