### PR TITLE
make settingsStr --> settings and JSON instead of text in mySQL

### DIFF
--- a/src/domain/space/space.settings/space.settings.service.ts
+++ b/src/domain/space/space.settings/space.settings.service.ts
@@ -9,19 +9,6 @@ export class SpaceSettingsService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  public getSettings(settingsStr: string): ISpaceSettings {
-    const states: ISpaceSettings = this.deserializeSettings(settingsStr);
-    return states;
-  }
-
-  public serializeSettings(settings: ISpaceSettings): string {
-    return JSON.stringify(settings);
-  }
-
-  private deserializeSettings(settingsStr: string): ISpaceSettings {
-    return JSON.parse(settingsStr);
-  }
-
   public updateSettings(
     settings: ISpaceSettings,
     updateData: UpdateSpaceSettingsEntityInput

--- a/src/domain/space/space/sort.spaces.by.activity.spec.ts
+++ b/src/domain/space/space/sort.spaces.by.activity.spec.ts
@@ -7,6 +7,8 @@ import { SpaceType } from '@common/enums/space.type';
 import { SpaceVisibility } from '@common/enums/space.visibility';
 import { ProfileType } from '@common/enums';
 import { AccountType } from '@common/enums/account.type';
+import { CommunityMembershipPolicy } from '@common/enums/community.membership.policy';
+import { SpacePrivacyMode } from '@common/enums/space.privacy.mode';
 
 const createTestActivity = (createdDate: Date): IActivity => {
   return {
@@ -22,12 +24,30 @@ const createTestActivity = (createdDate: Date): IActivity => {
   };
 };
 
+const spaceSettings = {
+  privacy: {
+    mode: SpacePrivacyMode.PUBLIC,
+    allowPlatformSupportAsAdmin: false,
+  },
+  membership: {
+    policy: CommunityMembershipPolicy.OPEN,
+    trustedOrganizations: [],
+    allowSubspaceAdminsToInviteMembers: false,
+  },
+  collaboration: {
+    inheritMembershipRights: true,
+    allowMembersToCreateSubspaces: true,
+    allowMembersToCreateCallouts: true,
+    allowEventsFromSubspaces: true,
+  },
+};
+
 const createTestSpace = (id: string): ISpace => {
   return {
     id,
     rowId: 1,
     nameID: 'space1',
-    settingsStr: '',
+    settings: spaceSettings,
     levelZeroSpaceID: '',
     visibility: SpaceVisibility.ACTIVE,
     profile: {

--- a/src/domain/space/space/space.entity.ts
+++ b/src/domain/space/space/space.entity.ts
@@ -22,6 +22,7 @@ import { Profile } from '@domain/common/profile';
 import { TemplatesManager } from '@domain/template/templates-manager';
 import { License } from '@domain/common/license/license.entity';
 import { SpaceLevel } from '@common/enums/space.level';
+import { ISpaceSettings } from '../space.settings/space.settings.interface';
 @Entity()
 export class Space extends NameableEntity implements ISpace {
   @OneToOne(() => Profile, {
@@ -85,8 +86,8 @@ export class Space extends NameableEntity implements ISpace {
   @JoinColumn()
   agent?: Agent;
 
-  @Column('text')
-  settingsStr: string = '';
+  @Column('json', { nullable: true })
+  settings: ISpaceSettings;
 
   @OneToOne(() => StorageAggregator, {
     eager: false,
@@ -130,5 +131,6 @@ export class Space extends NameableEntity implements ISpace {
   constructor() {
     super();
     this.nameID = '';
+    this.settings = {} as ISpaceSettings;
   }
 }

--- a/src/domain/space/space/space.interface.ts
+++ b/src/domain/space/space/space.interface.ts
@@ -11,6 +11,7 @@ import { SpaceVisibility } from '@common/enums/space.visibility';
 import { ITemplatesManager } from '@domain/template/templates-manager';
 import { ILicense } from '@domain/common/license/license.interface';
 import { SpaceLevel } from '@common/enums/space.level';
+import { ISpaceSettings } from '../space.settings/space.settings.interface';
 
 @ObjectType('Space')
 export class ISpace extends INameable {
@@ -46,7 +47,7 @@ export class ISpace extends INameable {
   context?: IContext;
   community?: ICommunity;
 
-  settingsStr!: string;
+  settings!: ISpaceSettings;
 
   storageAggregator?: IStorageAggregator;
 

--- a/src/domain/space/space/space.resolver.fields.ts
+++ b/src/domain/space/space/space.resolver.fields.ts
@@ -251,7 +251,7 @@ export class SpaceResolverFields {
   })
   @UseGuards(GraphqlGuard)
   settings(@Parent() space: ISpace): ISpaceSettings {
-    return this.spaceService.getSettings(space);
+    return space.settings;
   }
 
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -104,9 +104,7 @@ export class SpaceAuthorizationService {
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
 
     const spaceVisibility = space.visibility;
-    const spaceSettings = this.spaceSettingsService.getSettings(
-      space.settingsStr
-    );
+    const spaceSettings = space.settings;
     const isPrivate = spaceSettings.privacy.mode === SpacePrivacyMode.PRIVATE;
 
     // Store the provided parent authorization so that later resets can happen

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -21,6 +21,8 @@ import { AccountType } from '@common/enums/account.type';
 import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ISpaceSettings } from '@domain/space/space.settings/space.settings.interface';
+import { SpacePrivacyMode } from '@common/enums/space.privacy.mode';
+import { CommunityMembershipPolicy } from '@common/enums/community.membership.policy';
 
 const moduleMocker = new ModuleMocker(global);
 
@@ -56,11 +58,10 @@ describe('SpaceService', () => {
       } as ISpaceSettings;
       const space = {
         id: spaceId,
-        settingsStr: JSON.stringify(settingsData),
+        settings: settingsData,
       } as Space;
 
       jest.spyOn(spaceRepository, 'findOneOrFail').mockResolvedValue(space);
-      jest.spyOn(service, 'getSettings').mockReturnValue(settingsData);
 
       const result = await service.shouldUpdateAuthorizationPolicy(
         spaceId,
@@ -85,11 +86,10 @@ describe('SpaceService', () => {
       } as ISpaceSettings;
       const space = {
         id: spaceId,
-        settingsStr: JSON.stringify(originalSettings),
+        settings: originalSettings,
       } as Space;
 
       jest.spyOn(spaceRepository, 'findOneOrFail').mockResolvedValue(space);
-      jest.spyOn(service, 'getSettings').mockReturnValue(originalSettings);
 
       const result = await service.shouldUpdateAuthorizationPolicy(
         spaceId,
@@ -108,11 +108,10 @@ describe('SpaceService', () => {
       } as ISpaceSettings;
       const space = {
         id: spaceId,
-        settingsStr: JSON.stringify(originalSettings),
+        settings: originalSettings,
       } as Space;
 
       jest.spyOn(spaceRepository, 'findOneOrFail').mockResolvedValue(space);
-      jest.spyOn(service, 'getSettings').mockReturnValue(originalSettings);
 
       const result = await service.shouldUpdateAuthorizationPolicy(
         spaceId,
@@ -252,6 +251,24 @@ const getAuthorizationPolicyMock = (
   ...getEntityMock<AuthorizationPolicy>(),
 });
 
+const spaceSettings = {
+  privacy: {
+    mode: SpacePrivacyMode.PUBLIC,
+    allowPlatformSupportAsAdmin: false,
+  },
+  membership: {
+    policy: CommunityMembershipPolicy.OPEN,
+    trustedOrganizations: [],
+    allowSubspaceAdminsToInviteMembers: false,
+  },
+  collaboration: {
+    inheritMembershipRights: true,
+    allowMembersToCreateSubspaces: true,
+    allowMembersToCreateCallouts: true,
+    allowEventsFromSubspaces: true,
+  },
+};
+
 const getSubspacesMock = (
   spaceId: string,
   count: number,
@@ -263,7 +280,7 @@ const getSubspacesMock = (
       id: `${spaceId}.${i}`,
       rowId: i,
       nameID: `challenge-${spaceId}.${i}`,
-      settingsStr: JSON.stringify({}),
+      settings: spaceSettings,
       levelZeroSpaceID: spaceId,
       account: {
         id: `account-${spaceId}.${i}`,
@@ -360,7 +377,7 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
       id: `${subsubspaceId}.${i}`,
       rowId: i,
       nameID: `subsubspace-${subsubspaceId}.${i}`,
-      settingsStr: JSON.stringify({}),
+      settings: spaceSettings,
       levelZeroSpaceID: subsubspaceId,
       account: {
         id: `account-${subsubspaceId}.${i}`,
@@ -452,18 +469,20 @@ const getSpaceMock = ({
   anonymousReadAccess,
   challengesCount,
   opportunitiesCounts,
+  settings,
 }: {
   id: string;
   visibility: SpaceVisibility;
   anonymousReadAccess: boolean;
   challengesCount: number;
   opportunitiesCounts: number[];
+  settings: ISpaceSettings;
 }): Space => {
   return {
     id,
     rowId: parseInt(id),
     nameID: `space-${id}`,
-    settingsStr: JSON.stringify({}),
+    settings: settings,
     levelZeroSpaceID: '',
     profile: {
       id: `profile-${id}`,
@@ -512,6 +531,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 1,
     opportunitiesCounts: [5],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PUBLIC,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '2',
@@ -519,6 +545,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 2,
     opportunitiesCounts: [5, 3],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PUBLIC,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '3',
@@ -526,6 +559,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.DEMO,
     challengesCount: 3,
     opportunitiesCounts: [5, 3, 1],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PUBLIC,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '4',
@@ -533,6 +573,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.DEMO,
     challengesCount: 3,
     opportunitiesCounts: [1, 2, 1],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PRIVATE,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '5',
@@ -540,6 +587,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 1,
     opportunitiesCounts: [1],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PRIVATE,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '6',
@@ -547,6 +601,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 3,
     opportunitiesCounts: [1, 1, 6],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PUBLIC,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '7',
@@ -554,6 +615,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.ARCHIVED,
     challengesCount: 0,
     opportunitiesCounts: [],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PUBLIC,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '8',
@@ -561,6 +629,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.DEMO,
     challengesCount: 0,
     opportunitiesCounts: [],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PUBLIC,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '9',
@@ -568,6 +643,13 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.ACTIVE,
     challengesCount: 0,
     opportunitiesCounts: [],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PRIVATE,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
   getSpaceMock({
     id: '10',
@@ -575,5 +657,12 @@ const spaceTestData: Space[] = [
     visibility: SpaceVisibility.DEMO,
     challengesCount: 3,
     opportunitiesCounts: [1, 2, 0],
+    settings: {
+      ...spaceSettings,
+      privacy: {
+        mode: SpacePrivacyMode.PRIVATE,
+        allowPlatformSupportAsAdmin: false,
+      },
+    },
   }),
 ];

--- a/src/domain/timeline/calendar/calendar.resolver.fields.ts
+++ b/src/domain/timeline/calendar/calendar.resolver.fields.ts
@@ -54,10 +54,7 @@ export class CalendarResolverFields {
       calendar.id
     );
 
-    const spaceSettings = this.spaceSettingsService.getSettings(
-      space.settingsStr
-    );
-
+    const spaceSettings = space.settings;
     const shouldSubspaceEventsBubble =
       spaceSettings.collaboration.allowEventsFromSubspaces;
 

--- a/src/migrations/1734708463412-spaceSettingsJSON.ts
+++ b/src/migrations/1734708463412-spaceSettingsJSON.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SpaceSettingsJSON1734708463412 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`space\` CHANGE \`settingsStr\` \`settings\` text NOT NULL`
+    );
+    await queryRunner.query(
+      "UPDATE `space` SET `settings` = '[]' WHERE `settings` IS NULL OR `settings` = ''"
+    );
+    await queryRunner.query(
+      'ALTER TABLE `space` MODIFY COLUMN `settings` json null'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `space` MODIFY COLUMN `settings` text'
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`space\` CHANGE \`settings\` \`settingsStr\` text NOT NULL`
+    );
+  }
+}

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -33,6 +33,8 @@ import { MockVirtualContributorService } from '@test/mocks/virtual.contributor.s
 import { IUser } from '@domain/community/user/user.interface';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { AccountType } from '@common/enums/account.type';
+import { CommunityMembershipPolicy } from '@common/enums/community.membership.policy';
+import { SpacePrivacyMode } from '@common/enums/space.privacy.mode';
 
 describe('RolesService', () => {
   let rolesService: RolesService;
@@ -206,6 +208,24 @@ describe('RolesService', () => {
   });
 });
 
+const spaceSettings = {
+  privacy: {
+    mode: SpacePrivacyMode.PUBLIC,
+    allowPlatformSupportAsAdmin: false,
+  },
+  membership: {
+    policy: CommunityMembershipPolicy.OPEN,
+    trustedOrganizations: [],
+    allowSubspaceAdminsToInviteMembers: false,
+  },
+  collaboration: {
+    inheritMembershipRights: true,
+    allowMembersToCreateSubspaces: true,
+    allowMembersToCreateCallouts: true,
+    allowEventsFromSubspaces: true,
+  },
+};
+
 const getSpaceRoleResultMock = ({
   id,
   roles,
@@ -226,7 +246,7 @@ const getSpaceRoleResultMock = ({
     roles,
     space: {
       id,
-      settingsStr: JSON.stringify({}),
+      settings: spaceSettings,
       rowId: parseInt(id),
       nameID: `space-${id}`,
       levelZeroSpaceID: '',

--- a/src/services/api/search/v2/result/search.result.service.ts
+++ b/src/services/api/search/v2/result/search.result.service.ts
@@ -625,7 +625,19 @@ export class SearchResultService {
         id: true,
         type: true,
         level: true,
-        settingsStr: true,
+        settings: {
+          collaboration: {
+            allowEventsFromSubspaces: true,
+            allowMembersToCreateCallouts: true,
+            allowMembersToCreateSubspaces: true,
+            inheritMembershipRights: true,
+          },
+          membership: {
+            allowSubspaceAdminsToInviteMembers: true,
+            policy: true,
+          },
+          privacy: { allowPlatformSupportAsAdmin: true, mode: true },
+        },
         visibility: true,
         collaboration: {
           id: true,

--- a/src/services/infrastructure/naming/naming.service.ts
+++ b/src/services/infrastructure/naming/naming.service.ts
@@ -264,7 +264,7 @@ export class NamingService {
     }
     // Directly parse the settings string to avoid the need to load the settings service
     const roleSet = space.community.roleSet;
-    const spaceSettings: ISpaceSettings = JSON.parse(space.settingsStr);
+    const spaceSettings: ISpaceSettings = space.settings;
     return { roleSet, spaceSettings };
   }
 
@@ -295,7 +295,7 @@ export class NamingService {
 
     // Directly parse the settings string to avoid the need to load the settings service
     const roleSet = space.community.roleSet;
-    const spaceSettings: ISpaceSettings = JSON.parse(space.settingsStr);
+    const spaceSettings: ISpaceSettings = space.settings;
 
     return { roleSet: roleSet, spaceSettings };
   }


### PR DESCRIPTION
- needed the JSON to make the tests work without mocking the world
- made settingsStr --> settings (JSON)
- migrated data
- validated that the algorithm preserved behavior (assuming anonymous = privacy mode public)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced structured space settings management, replacing string-based settings with a JSON object.
	- Enhanced space sorting logic to consider privacy and membership settings.
	- Added new constants for privacy and membership policies to improve configuration management.

- **Bug Fixes**
	- Simplified retrieval of space settings across various services, reducing dependency on service calls.

- **Tests**
	- Updated test cases to reflect the new structured settings format, improving clarity and maintainability.

- **Chores**
	- Added migration to transition existing settings to the new JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->