### PR TITLE
InnovationFlow States names validation

### DIFF
--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -157,6 +157,9 @@ export class CollaborationService {
   private createInnovationFlowStatesTagsetTemplateInput(
     innovationFlowData: CreateInnovationFlowInput
   ): CreateTagsetTemplateInput {
+    this.innovationFlowService.validateInnovationFlowDefinition(
+      innovationFlowData.states
+    );
     const allowedStates = innovationFlowData.states.map(
       state => state.displayName
     );

--- a/src/domain/collaboration/innovation-flow-states/innovation.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-states/innovation.flow.state.service.ts
@@ -65,10 +65,7 @@ export class InnovationFlowStatesService {
     // Avoid any characters JSON related:
     // This validation is also performed on the client: domain/collaboration/InnovationFlow/InnovationFlowDragNDropEditor/InnovationFlowStateForm.tsx
     // Keep them in sync consistently
-    if (
-      stateNames.filter(name => name.match(/^[^[\],'"{}\\]+$/)).length !==
-      stateNames.length
-    ) {
+    if (stateNames.some(name => !/^[^[\],'"{}\\]+$/.test(name))) {
       throw new ValidationException(
         `Invalid characters found on flow state: ${stateNames}`,
         LogContext.INNOVATION_FLOW

--- a/src/domain/collaboration/innovation-flow-states/innovation.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-states/innovation.flow.state.service.ts
@@ -62,10 +62,10 @@ export class InnovationFlowStatesService {
         LogContext.INNOVATION_FLOW
       );
     }
-    // Avoid any characters JSON related:
+    // Avoid commas in state names, because they are used to separate states in the database
     // This validation is also performed on the client: domain/collaboration/InnovationFlow/InnovationFlowDragNDropEditor/InnovationFlowStateForm.tsx
     // Keep them in sync consistently
-    if (stateNames.some(name => !/^[^[\],'"{}\\]+$/.test(name))) {
+    if (stateNames.some(name => name.includes(','))) {
       throw new ValidationException(
         `Invalid characters found on flow state: ${stateNames}`,
         LogContext.INNOVATION_FLOW

--- a/src/domain/collaboration/innovation-flow-states/innovation.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-states/innovation.flow.state.service.ts
@@ -62,5 +62,17 @@ export class InnovationFlowStatesService {
         LogContext.INNOVATION_FLOW
       );
     }
+    // Avoid any characters JSON related:
+    // This validation is also performed on the client: domain/collaboration/InnovationFlow/InnovationFlowDragNDropEditor/InnovationFlowStateForm.tsx
+    // Keep them in sync consistently
+    if (
+      stateNames.filter(name => name.match(/^[^[\],'"{}\\]+$/)).length !==
+      stateNames.length
+    ) {
+      throw new ValidationException(
+        `Invalid characters found on flow state: ${stateNames}`,
+        LogContext.INNOVATION_FLOW
+      );
+    }
   }
 }

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -27,6 +27,8 @@ import { IInnovationFlowState } from '../innovation-flow-states/innovation.flow.
 import { TagsetService } from '@domain/common/tagset/tagset.service';
 import { UpdateInnovationFlowSingleStateInput } from './dto/innovation.flow.dto.update.single.state';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { CreateInnovationFlowStateInput } from '../innovation-flow-states/dto/innovation.flow.state.dto.create';
+import { UpdateInnovationFlowStateInput } from '../innovation-flow-states/dto/innovation.flow.state.dto.update';
 
 @Injectable()
 export class InnovationFlowService {
@@ -402,5 +404,11 @@ export class InnovationFlowService {
       );
     }
     return currentState;
+  }
+
+  public validateInnovationFlowDefinition(
+    states: CreateInnovationFlowStateInput[] | UpdateInnovationFlowStateInput[]
+  ) {
+    this.innovationFlowStatesService.validateDefinition(states);
   }
 }


### PR DESCRIPTION
- Add validation to InnovationFlow creation, to avoid states with special chars. 
- Avoiding commas should be enough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for innovation flow states to prevent invalid state names
  - Introduced server-side checks to ensure state names do not contain commas

- **Bug Fixes**
  - Enhanced error handling for innovation flow state definitions
  - Improved input validation to catch potential data inconsistencies early

- **Refactor**
  - Strengthened validation logic across collaboration and innovation flow services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->