### PR TITLE
Fix:ENTITY_NOT_FOUND Error is triggered after first login #4790

### DIFF
--- a/src/platform/platform.role/platform.role.service.ts
+++ b/src/platform/platform.role/platform.role.service.ts
@@ -175,6 +175,9 @@ export class PlatformRoleService {
 
   async getPlatformRoles(agentInfo: AgentInfo): Promise<PlatformRole[]> {
     const result: PlatformRole[] = [];
+    if (!agentInfo.agentID) {
+      return result;
+    }
     const agent = await this.agentService.getAgentOrFail(agentInfo.agentID);
     const roles: PlatformRole[] = Object.values(PlatformRole) as PlatformRole[];
     for (const role of roles) {


### PR DESCRIPTION
- #4790 
- Client shouldn't be requesting this (fixed here: ) but I think the server should not throw an exception either when not logged in. Just returning empty privileges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in platform roles retrieval process
	- Added a safeguard to prevent potential errors when agent information is incomplete

The changes enhance the reliability of the platform roles service by ensuring more robust handling of agent data retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->