### PR TITLE
Server 4812 FIx VC creation or at least try to...

### DIFF
--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -12,6 +12,8 @@ export const CREDENTIAL_RULE_SPACE_MEMBERS_READ =
   'credentialRule-spaceMembersRead';
 export const CREDENTIAL_RULE_SPACE_HOST_ASSOCIATES_JOIN =
   'credentialRule-spaceHostAssociatesJoin';
+export const CREDENTIAL_RULE_ACCOUNT_HOST_MANAGE =
+  'credentialRule-accountHostManage';
 export const CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY =
   'credentialRule-contributionCreatedBy';
 export const CREDENTIAL_RULE_CONTRIBUTION_CREATED_BY_DELETE =

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -196,14 +196,10 @@ export class CalloutResolverMutations {
     );
     if (!callout.calloutsSet) {
       throw new RelationshipNotFoundException(
-        `Callout ${callout.id} has no collaboration relationship`,
+        `Callout ${callout.id} has no calloutSet relationship`,
         LogContext.COLLABORATION
       );
     }
-
-    console.log('\n\n\n');
-    console.log(callout.calloutsSet);
-    console.log('\n\n\n');
 
     this.authorizationService.grantAccessOrFail(
       agentInfo,

--- a/src/domain/common/knowledge-base/knowledge.base.entity.ts
+++ b/src/domain/common/knowledge-base/knowledge.base.entity.ts
@@ -3,6 +3,7 @@ import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity/au
 import { Profile } from '@domain/common/profile/profile.entity';
 import { CalloutsSet } from '@domain/collaboration/callouts-set/callouts.set.entity';
 import { IKnowledgeBase } from './knowledge.base.interface';
+import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
 
 @Entity()
 export class KnowledgeBase
@@ -24,4 +25,10 @@ export class KnowledgeBase
   })
   @JoinColumn()
   calloutsSet?: CalloutsSet;
+
+  @OneToOne(
+    () => VirtualContributor,
+    (vc: VirtualContributor) => vc.knowledgeBase
+  )
+  virtualContributor?: VirtualContributor;
 }

--- a/src/domain/common/tagset/tagset.service.ts
+++ b/src/domain/common/tagset/tagset.service.ts
@@ -158,8 +158,12 @@ export class TagsetService {
   async getAllowedValues(tagset: ITagset): Promise<string[]> {
     if (tagset.type === TagsetType.FREEFORM) return [];
 
-    const tagsetTemplate = await this.getTagsetTemplateOrFail(tagset.id);
-    return tagsetTemplate.allowedValues;
+    try {
+      const tagsetTemplate = await this.getTagsetTemplateOrFail(tagset.id);
+      return tagsetTemplate.allowedValues;
+    } catch (error) {
+      return [];
+    }
   }
 
   async getTagsetTemplateOrFail(

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -336,6 +336,7 @@ export class AccountAuthorizationService {
             AuthorizationPrivilege.UPDATE,
             AuthorizationPrivilege.DELETE,
             AuthorizationPrivilege.GRANT,
+            AuthorizationPrivilege.CONTRIBUTE,
           ],
           accountChildEntitiesManage,
           CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -336,8 +336,6 @@ export class AccountAuthorizationService {
             AuthorizationPrivilege.UPDATE,
             AuthorizationPrivilege.DELETE,
             AuthorizationPrivilege.GRANT,
-            //TODO THIS SHOULD NOT BE HERE
-            AuthorizationPrivilege.CONTRIBUTE,
           ],
           accountChildEntitiesManage,
           CREDENTIAL_RULE_TYPES_ACCOUNT_CHILD_ENTITIES

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -336,6 +336,7 @@ export class AccountAuthorizationService {
             AuthorizationPrivilege.UPDATE,
             AuthorizationPrivilege.DELETE,
             AuthorizationPrivilege.GRANT,
+            //TODO THIS SHOULD NOT BE HERE
             AuthorizationPrivilege.CONTRIBUTE,
           ],
           accountChildEntitiesManage,

--- a/src/services/infrastructure/naming/naming.service.ts
+++ b/src/services/infrastructure/naming/naming.service.ts
@@ -290,16 +290,11 @@ export class NamingService {
         },
       },
     });
-    // if (!space || !space.community || !space.community.roleSet) {
-    //   throw new EntityNotInitializedException(
-    //     `Unable to load all entities for space with callout ${calloutID}`,
-    //     LogContext.COMMUNITY
-    //   );
-    // }
 
     // Directly parse the settings string to avoid the need to load the settings service
-    const roleSet = space?.community?.roleSet;
-    const spaceSettings = space?.settings;
+    // We have 2 types of CalloutSet parents now, and KnowledgeBase doesn't have a roleSet and spaceSettings
+    const roleSet: IRoleSet | undefined = space?.community?.roleSet;
+    const spaceSettings: ISpaceSettings | undefined = space?.settings;
 
     return { roleSet: roleSet, spaceSettings };
   }

--- a/src/services/infrastructure/naming/naming.service.ts
+++ b/src/services/infrastructure/naming/naming.service.ts
@@ -271,8 +271,8 @@ export class NamingService {
   }
 
   async getRoleSetAndSettingsForCallout(calloutID: string): Promise<{
-    roleSet: IRoleSet;
-    spaceSettings: ISpaceSettings;
+    roleSet?: IRoleSet;
+    spaceSettings?: ISpaceSettings;
   }> {
     const space = await this.entityManager.findOne(Space, {
       where: {
@@ -290,16 +290,16 @@ export class NamingService {
         },
       },
     });
-    if (!space || !space.community || !space.community.roleSet) {
-      throw new EntityNotInitializedException(
-        `Unable to load all entities for space with callout ${calloutID}`,
-        LogContext.COMMUNITY
-      );
-    }
+    // if (!space || !space.community || !space.community.roleSet) {
+    //   throw new EntityNotInitializedException(
+    //     `Unable to load all entities for space with callout ${calloutID}`,
+    //     LogContext.COMMUNITY
+    //   );
+    // }
 
     // Directly parse the settings string to avoid the need to load the settings service
-    const roleSet = space.community.roleSet;
-    const spaceSettings: ISpaceSettings = space.settings;
+    const roleSet = space?.community?.roleSet;
+    const spaceSettings = space?.settings;
 
     return { roleSet: roleSet, spaceSettings };
   }

--- a/src/services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service.ts
+++ b/src/services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service.ts
@@ -456,9 +456,6 @@ export class StorageAggregatorResolverService {
       },
     });
 
-    console.log(space);
-    console.log(knowledgeBase);
-
     const storageAggregator =
       space?.storageAggregator ||
       knowledgeBase?.virtualContributor?.account?.storageAggregator;

--- a/src/services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service.ts
+++ b/src/services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service.ts
@@ -26,6 +26,7 @@ import { Platform } from '@platform/platform/platform.entity';
 import { TemplatesManager } from '@domain/template/templates-manager';
 import { Template } from '@domain/template/template/template.entity';
 import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
+import { KnowledgeBase } from '@domain/common/knowledge-base/knowledge.base.entity';
 
 @Injectable()
 export class StorageAggregatorResolverService {
@@ -438,12 +439,36 @@ export class StorageAggregatorResolverService {
         storageAggregator: true,
       },
     });
-    if (!space || !space.storageAggregator) {
+    const knowledgeBase = await this.entityManager.findOne(KnowledgeBase, {
+      where: {
+        calloutsSet: {
+          callouts: {
+            id: calloutId,
+          },
+        },
+      },
+      relations: {
+        virtualContributor: {
+          account: {
+            storageAggregator: true,
+          },
+        },
+      },
+    });
+
+    console.log(space);
+    console.log(knowledgeBase);
+
+    const storageAggregator =
+      space?.storageAggregator ||
+      knowledgeBase?.virtualContributor?.account?.storageAggregator;
+
+    if (!storageAggregator) {
       throw new EntityNotFoundException(
         `Unable to retrieve storage aggregator for calloutID: ${calloutId} `,
         LogContext.STORAGE_AGGREGATOR
       );
     }
-    return space.storageAggregator.id;
+    return storageAggregator.id;
   }
 }


### PR DESCRIPTION
Related to : https://github.com/alkem-io/server/issues/4812

Re: no `tagsetTemplateId` crashing the KnowledgeBase callouts preview, I (@bobbykolev ) couldn't fix it as this logic is coupled with flowstates, calloutGroups, etc. See the quick fix that is not ideal: https://github.com/alkem-io/server/pull/4825/commits/7e37597ef94736aac1076daa442ca4bfa6fb2d85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new constant for credential rule management
  - Enhanced virtual contributor and knowledge base entities with new properties
  - Improved authorization and storage aggregator resolution logic

- **Bug Fixes**
  - Updated error handling in tagset service to prevent unhandled promise rejections
  - Modified naming service to support more flexible data retrieval

- **Refactor**
  - Restructured callout contribution creation process
  - Updated method signatures for more robust type handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->