### PR TITLE
Removed CreateAccountInput

### DIFF
--- a/src/core/validation/handlers/base/base.handler.ts
+++ b/src/core/validation/handlers/base/base.handler.ts
@@ -65,7 +65,6 @@ import { UpdateInnovationFlowStateInput } from '@domain/collaboration/innovation
 import { CreateCollaborationInput } from '@domain/collaboration/collaboration/dto/collaboration.dto.create';
 import { UpdateSpaceSettingsEntityInput } from '@domain/space/space.settings/dto/space.settings.dto.update';
 import { UpdateSpaceSettingsInput } from '@domain/space/space/dto/space.dto.update.settings';
-import { CreateAccountInput } from '@domain/space/account/dto';
 import { UpdateCommunityGuidelinesInput } from '@domain/community/community-guidelines/dto/community.guidelines.dto.update';
 import { ForumCreateDiscussionInput } from '@platform/forum/dto/forum.dto.create.discussion';
 import { CreateCollaborationOnSpaceInput } from '@domain/space/space/dto/space.dto.create.collaboration';
@@ -133,7 +132,6 @@ export class BaseHandler extends AbstractHandler {
       CreateReferenceOnProfileInput,
       CreateTagsetOnProfileInput,
       CreateCalendarEventOnCalendarInput,
-      CreateAccountInput,
       DeleteDocumentInput,
       UpdateActorInput,
       UpdatePostInput,

--- a/src/domain/space/account/account.resolver.mutations.ts
+++ b/src/domain/space/account/account.resolver.mutations.ts
@@ -71,7 +71,7 @@ export class AccountResolverMutations {
   ) {}
 
   @UseGuards(GraphqlGuard)
-  @Mutation(() => IAccount, {
+  @Mutation(() => ISpace, {
     description: 'Creates a new Level Zero Space within the specified Account.',
   })
   async createSpace(

--- a/src/domain/space/account/dto/account.dto.create.ts
+++ b/src/domain/space/account/dto/account.dto.create.ts
@@ -1,1 +1,0 @@
-export class CreateAccountInput {}

--- a/src/domain/space/account/dto/index.ts
+++ b/src/domain/space/account/dto/index.ts
@@ -1,1 +1,0 @@
-export * from './account.dto.create';


### PR DESCRIPTION
- the input was not used
- adjusted the return type of `createSpace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed `CreateAccountInput` DTO and related imports
	- Updated `createSpace` mutation return type from `IAccount` to `ISpace`

- **Breaking Changes**
	- Removed account creation input type, which may impact existing account creation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->