### PR TITLE
proper fix on authorizations for collboration, calloutSet, license field resolvers

### DIFF
--- a/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
+++ b/src/domain/collaboration/collaboration/collaboration.resolver.fields.ts
@@ -45,7 +45,7 @@ export class CollaborationResolverFields {
     return loader.load(collaboration.id);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ_ABOUT)
   @ResolveField('calloutsSet', () => ICalloutsSet, {
     nullable: false,
     description: 'The calloutsSet with Callouts in use by this Space',

--- a/src/domain/common/license/license.service.authorization.ts
+++ b/src/domain/common/license/license.service.authorization.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { ILicense } from './license.interface';
+import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential.interface';
+import { POLICY_RULE_READ_ABOUT } from '@common/constants/authorization/policy.rule.constants';
+import { AuthorizationPrivilege } from '@common/enums';
 
 @Injectable()
 export class LicenseAuthorizationService {
@@ -9,7 +12,8 @@ export class LicenseAuthorizationService {
 
   applyAuthorizationPolicy(
     license: ILicense,
-    parentAuthorization: IAuthorizationPolicy | undefined
+    parentAuthorization: IAuthorizationPolicy | undefined,
+    credentialRulesFromParent: IAuthorizationPolicyRuleCredential[] = []
   ): IAuthorizationPolicy[] {
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
 
@@ -18,6 +22,20 @@ export class LicenseAuthorizationService {
         license.authorization,
         parentAuthorization
       );
+    updatedAuthorizations.push(license.authorization);
+
+    // If can READ_ABOUT on Context, then also allow general READ
+    license.authorization =
+      this.authorizationPolicyService.appendPrivilegeAuthorizationRuleMapping(
+        license.authorization,
+        AuthorizationPrivilege.READ_ABOUT,
+        [AuthorizationPrivilege.READ],
+        POLICY_RULE_READ_ABOUT
+      );
+    license.authorization.credentialRules.push(...credentialRulesFromParent);
+    updatedAuthorizations.push(license.authorization);
+
+    license.authorization.credentialRules.push(...credentialRulesFromParent);
     updatedAuthorizations.push(license.authorization);
 
     return updatedAuthorizations;

--- a/src/domain/common/license/license.service.authorization.ts
+++ b/src/domain/common/license/license.service.authorization.ts
@@ -35,9 +35,6 @@ export class LicenseAuthorizationService {
     license.authorization.credentialRules.push(...credentialRulesFromParent);
     updatedAuthorizations.push(license.authorization);
 
-    license.authorization.credentialRules.push(...credentialRulesFromParent);
-    updatedAuthorizations.push(license.authorization);
-
     return updatedAuthorizations;
   }
 }

--- a/src/domain/space/space/space.resolver.fields.ts
+++ b/src/domain/space/space/space.resolver.fields.ts
@@ -89,6 +89,8 @@ export class SpaceResolverFields {
     return this.spaceService.activeSubscription(space);
   }
 
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ_ABOUT)
+  @UseGuards(GraphqlGuard)
   @ResolveField('collaboration', () => ICollaboration, {
     nullable: false,
     description: 'The collaboration for the Space.',
@@ -101,7 +103,7 @@ export class SpaceResolverFields {
     return loader.load(space.id);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ_ABOUT)
   @UseGuards(GraphqlGuard)
   @ResolveField('license', () => ILicense, {
     nullable: false,

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -378,20 +378,6 @@ export class SpaceAuthorizationService {
     }
   }
 
-  private createCredentialRuleSpaceCollaborationVisibility(
-    credentialCriterias: ICredentialDefinition[],
-    isPrivate: boolean
-  ): IAuthorizationPolicyRuleCredential | undefined {
-    if (!isPrivate) {
-      const newRule = this.authorizationPolicyService.createCredentialRule(
-        [AuthorizationPrivilege.READ],
-        credentialCriterias,
-        'Space visibility public'
-      );
-      return newRule;
-    }
-  }
-
   private appendCredentialRuleSpaceVisibility(
     credentialCriterias: ICredentialDefinition[],
     isPrivate: boolean,
@@ -462,7 +448,7 @@ export class SpaceAuthorizationService {
     updatedAuthorizations.push(...communityAuthorizations);
 
     const credentialRuleAccessSpaceCollaboration =
-      this.createCredentialRuleSpaceCollaborationVisibility(
+      this.createCredentialRuleSpaceVisibility(
         credentialCriteriasWithAccessToSpace,
         isPrivate
       );
@@ -495,13 +481,6 @@ export class SpaceAuthorizationService {
         space.authorization
       );
     updatedAuthorizations.push(...storageAuthorizations);
-
-    const licenseAuthorizations =
-      this.licenseAuthorizationService.applyAuthorizationPolicy(
-        space.license,
-        space.authorization
-      );
-    updatedAuthorizations.push(...licenseAuthorizations);
 
     // Level zero space only entities
     if (space.level === SpaceLevel.SPACE) {
@@ -564,18 +543,18 @@ export class SpaceAuthorizationService {
       }
     }
 
-    const credentialRuleAccessSpaceContextProfile =
+    const credentialRuleAnonymousRegisteredAccess =
       this.createCredentialRuleSpaceVisibility(
         credentialCriteriasWithAccessToSpace,
         isPrivate
       );
-    credentialRuleAccessSpaceContextProfile.cascade = true;
+    credentialRuleAnonymousRegisteredAccess.cascade = true;
 
     const profileAuthorizations =
       await this.profileAuthorizationService.applyAuthorizationPolicy(
         space.profile.id,
         clonedAuthorization,
-        [credentialRuleAccessSpaceContextProfile]
+        [credentialRuleAnonymousRegisteredAccess]
       );
     updatedAuthorizations.push(...profileAuthorizations);
 
@@ -583,9 +562,17 @@ export class SpaceAuthorizationService {
       await this.contextAuthorizationService.applyAuthorizationPolicy(
         space.context,
         clonedAuthorization,
-        [credentialRuleAccessSpaceContextProfile]
+        [credentialRuleAnonymousRegisteredAccess]
       );
     updatedAuthorizations.push(...contextAuthorizations);
+
+    const licenseAuthorizations =
+      this.licenseAuthorizationService.applyAuthorizationPolicy(
+        space.license,
+        space.authorization,
+        [credentialRuleAnonymousRegisteredAccess]
+      );
+    updatedAuthorizations.push(...licenseAuthorizations);
 
     return updatedAuthorizations;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Authorization Updates**
  - Modified authorization privileges for collaboration and license resolvers to require `READ_ABOUT`
  - Enhanced access control for the `calloutsSet` field
  - Streamlined credential rule creation for space visibility and collaboration

- **Access Control Improvements**
  - Introduced more granular authorization checks
  - Consolidated authorization logic across different service layers
  - Enhanced permission management for space and collaboration contexts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->