### PR TITLE
Avoid circular dependencies on JSON.stringify

### DIFF
--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -229,7 +229,7 @@ export class CalloutContributionService {
   }
 
   public async getPost(
-    calloutContributionInput: ICalloutContribution,
+    calloutContributionInput: Pick<ICalloutContribution, 'id'>,
     relations?: FindOptionsRelations<ICalloutContribution>
   ): Promise<IPost | null> {
     const calloutContribution = await this.getCalloutContributionOrFail(

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -229,7 +229,7 @@ export class CalloutContributionService {
   }
 
   public async getPost(
-    calloutContributionInput: Pick<ICalloutContribution, 'id'>,
+    calloutContributionInput: ICalloutContribution,
     relations?: FindOptionsRelations<ICalloutContribution>
   ): Promise<IPost | null> {
     const calloutContribution = await this.getCalloutContributionOrFail(

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -259,18 +259,31 @@ export class CalloutResolverMutations {
         );
 
       if (contributionData.post && contribution.post) {
+        const post = await this.calloutContributionService.getPost(
+          {
+            id: contribution.id,
+          },
+          {
+            post: {
+              authorization: true,
+              profile: true,
+              comments: true,
+            },
+          }
+        );
+        if (!post) {
+          throw new RelationshipNotFoundException(
+            `Unable to find post for callout contribution: ${contribution.id}`,
+            LogContext.COLLABORATION
+          );
+        }
+
         const postCreatedEvent: CalloutPostCreatedPayload = {
           eventID: `callout-post-created-${Math.round(Math.random() * 100)}`,
           calloutID: callout.id,
           contributionID: contribution.id,
           sortOrder: contribution.sortOrder,
-          post: {
-            ...contribution.post,
-            profile: {
-              ...contribution.post.profile,
-              storageBucket: undefined,
-            },
-          },
+          post,
         };
         await this.postCreatedSubscription.publish(
           SubscriptionType.CALLOUT_POST_CREATED,

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -260,9 +260,7 @@ export class CalloutResolverMutations {
 
       if (contributionData.post && contribution.post) {
         const post = await this.calloutContributionService.getPost(
-          {
-            id: contribution.id,
-          },
+          contribution,
           {
             post: {
               authorization: true,

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -264,7 +264,13 @@ export class CalloutResolverMutations {
           calloutID: callout.id,
           contributionID: contribution.id,
           sortOrder: contribution.sortOrder,
-          post: contribution.post,
+          post: {
+            ...contribution.post,
+            profile: {
+              ...contribution.post.profile,
+              storageBucket: undefined,
+            },
+          },
         };
         await this.postCreatedSubscription.publish(
           SubscriptionType.CALLOUT_POST_CREATED,


### PR DESCRIPTION
- This is related to the last changes about moving documents to the correct StorageBucket when creating an entity.
- It's because now the newly created `StorageBucket` has documents, before it didn't. Those documents point to their parent `StorageBucket` which inside has `documents` which... creates a circular reference.
- The error is thrown from somewhere inside `server/node_modules/graphql-amqp-subscriptions/dist/amqp/publisher.js`
- We are calling it from around the line 278: 
```
  await this.postCreatedSubscription.publish(
    SubscriptionType.CALLOUT_POST_CREATED,
    postCreatedEvent
  );
```
Fix:
- I am deconstructing the post object so what is passed to the subscription doesn't have `StorageBucket`. 
- I have confirmed that the client is not querying the StorageBucket in the subscription.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the data integrity for contributions by ensuring the correct post information is utilized during creation.
	- Improved event publication by updating the post details associated with contributions.

The changes focus on optimizing data handling, ensuring a more reliable experience for users without altering visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->