### PR TITLE
Removed variables from notification query

### DIFF
--- a/src/domain/in-app-notification-reader/in.app.notification.resolver.queries.ts
+++ b/src/domain/in-app-notification-reader/in.app.notification.resolver.queries.ts
@@ -1,5 +1,4 @@
-import { Args, Query, Resolver } from '@nestjs/graphql';
-import { UUID } from '@domain/common/scalars';
+import { Query, Resolver } from '@nestjs/graphql';
 import { CurrentUser } from '@common/decorators';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { UseGuards } from '@nestjs/common';
@@ -15,21 +14,17 @@ export class InAppNotificationResolverQueries {
   @UseGuards(GraphqlGuard)
   @Query(() => [InAppNotification], {
     nullable: false,
-    description: 'Get all notifications for a receiver.',
+    description: 'Get all notifications for the logged in user.',
   })
-  public async notifications(
-    @CurrentUser() agentInfo: AgentInfo,
-    @Args('receiverID', { type: () => UUID, nullable: false })
-    receiverID: string
-  ) {
-    if (receiverID !== agentInfo.userID) {
+  public notifications(@CurrentUser() agentInfo: AgentInfo) {
+    if (!agentInfo.userID) {
       throw new ForbiddenException(
-        'Users can only view their own notifications',
+        'User could not be resolved',
         LogContext.IN_APP_NOTIFICATION,
-        { receiverID }
+        { agentInfo }
       );
     }
 
-    return this.inAppNotificationReader.getNotifications(receiverID);
+    return this.inAppNotificationReader.getNotifications(agentInfo.userID);
   }
 }


### PR DESCRIPTION
part 2 of 2 
https://github.com/alkem-io/client-web/pull/7481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated in-app notification retrieval to automatically use the logged-in user's notifications
- **Bug Fixes**
  - Simplified notification query method to remove manual receiver ID specification
  - Improved error handling for user authentication
- **Refactor**
  - Streamlined notification retrieval process to enhance user experience and security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->