### PR TITLE
Added generic auth loading for graphql guards

### DIFF
--- a/src/common/enums/logging.context.ts
+++ b/src/common/enums/logging.context.ts
@@ -78,4 +78,7 @@ export enum LogContext {
   KRATOS = 'kratos',
   WINGBACK = 'wingback',
   WINGBACK_HOOKS = 'wingback-hooks',
+  //
+  AUTH_GUARD = 'auth-guard',
+  CODE_ERRORS = 'code-errors', // This is a special context for logging code errors with potential high impact
 }

--- a/src/core/authorization/graphql.guard.ts
+++ b/src/core/authorization/graphql.guard.ts
@@ -111,32 +111,51 @@ export class GraphqlGuard extends AuthGuard([
           .then((authorization: any) => {
             fieldParent.authorization = authorization;
 
-            const rule = new AuthorizationRuleAgentPrivilege(
-              this.authorizationService,
+            this.executeAuthorizationRule(
               privilege,
               fieldParent,
-              fieldName
+              fieldName,
+              resultAgentInfo
             );
-            rule.execute(resultAgentInfo);
           })
           .catch((error: any) => {
             this.logger.error(
               `Error loading authorization with id ${fieldParent.authorizationId}: ${error}`,
               LogContext.AUTH
             );
+            this.executeAuthorizationRule(
+              privilege,
+              fieldParent,
+              fieldName,
+              resultAgentInfo
+            );
           });
       } else {
-        const rule = new AuthorizationRuleAgentPrivilege(
-          this.authorizationService,
+        this.executeAuthorizationRule(
           privilege,
           fieldParent,
-          fieldName
+          fieldName,
+          resultAgentInfo
         );
-        rule.execute(resultAgentInfo);
       }
     }
 
     return resultAgentInfo;
+  }
+
+  private executeAuthorizationRule(
+    privilege: AuthorizationPrivilege,
+    fieldParent: any,
+    fieldName: any,
+    resultAgentInfo: any
+  ) {
+    const rule = new AuthorizationRuleAgentPrivilege(
+      this.authorizationService,
+      privilege,
+      fieldParent,
+      fieldName
+    );
+    rule.execute(resultAgentInfo);
   }
 
   public createAnonymousAgentInfo(): AgentInfo {

--- a/src/core/authorization/graphql.guard.ts
+++ b/src/core/authorization/graphql.guard.ts
@@ -19,6 +19,9 @@ import { AuthorizationService } from '@core/authorization/authorization.service'
 import { AuthorizationRuleAgentPrivilege } from './authorization.rule.agent.privilege';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
+import { AuthorizationPolicy } from '@domain/common/authorization-policy';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
 
 @Injectable()
 export class GraphqlGuard extends AuthGuard([
@@ -30,6 +33,8 @@ export class GraphqlGuard extends AuthGuard([
   constructor(
     private reflector: Reflector,
     private authorizationService: AuthorizationService,
+    @InjectEntityManager('default')
+    private entityManager: EntityManager,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {
     super();
@@ -98,13 +103,37 @@ export class GraphqlGuard extends AuthGuard([
     );
     if (privilege) {
       const fieldParent = gqlContext.getRoot();
-      const rule = new AuthorizationRuleAgentPrivilege(
-        this.authorizationService,
-        privilege,
-        fieldParent,
-        fieldName
-      );
-      rule.execute(resultAgentInfo);
+      if (fieldParent.authorizationId && !fieldParent.authorization) {
+        this.entityManager
+          .findOne(AuthorizationPolicy, {
+            where: { id: fieldParent.authorizationId },
+          })
+          .then((authorization: any) => {
+            fieldParent.authorization = authorization;
+
+            const rule = new AuthorizationRuleAgentPrivilege(
+              this.authorizationService,
+              privilege,
+              fieldParent,
+              fieldName
+            );
+            rule.execute(resultAgentInfo);
+          })
+          .catch((error: any) => {
+            this.logger.error(
+              `Error loading authorization with id ${fieldParent.authorizationId}: ${error}`,
+              LogContext.AUTH
+            );
+          });
+      } else {
+        const rule = new AuthorizationRuleAgentPrivilege(
+          this.authorizationService,
+          privilege,
+          fieldParent,
+          fieldName
+        );
+        rule.execute(resultAgentInfo);
+      }
     }
 
     return resultAgentInfo;

--- a/src/domain/community/user/user.resolver.spec.ts
+++ b/src/domain/community/user/user.resolver.spec.ts
@@ -14,6 +14,7 @@ import { MockPreferenceSetService } from '@test/mocks/preference.set.service.moc
 import { MockNotificationsService } from '@test/mocks/notifications.service.mock';
 import { MockNotificationAdapter } from '@test/mocks/notification.adapter.service.mock';
 import { MockPlatformAuthorizationService } from '@test/mocks/platform.authorization.service.mock';
+import { MockEntityManagerProvider } from '@test/mocks';
 
 describe('UserResolver', () => {
   let resolver: UserResolverQueries;
@@ -35,6 +36,7 @@ describe('UserResolver', () => {
         MockPreferenceSetService,
         MockNotificationAdapter,
         MockNotificationsService,
+        MockEntityManagerProvider,
         UserResolverMutations,
         UserResolverQueries,
       ],

--- a/src/domain/timeline/event/event.entity.ts
+++ b/src/domain/timeline/event/event.entity.ts
@@ -5,6 +5,7 @@ import { NameableEntity } from '@domain/common/entity/nameable-entity/nameable.e
 import { Room } from '@domain/communication/room/room.entity';
 import { ENUM_LENGTH, UUID_LENGTH } from '@common/constants';
 import { CalendarEventType } from '@common/enums/calendar.event.type';
+import { Space } from '@domain/space/space/space.entity';
 
 @Entity()
 export class CalendarEvent extends NameableEntity implements ICalendarEvent {
@@ -53,6 +54,13 @@ export class CalendarEvent extends NameableEntity implements ICalendarEvent {
 
   @Column('boolean', { nullable: false })
   visibleOnParentCalendar!: boolean;
+
+  // @ManyToOne(() => Space, {
+  //   createForeignKeyConstraints: false,
+  //   eager: false,
+  //   nullable: true,
+  // })
+  subspace?: Space;
 
   constructor() {
     super();

--- a/src/domain/timeline/event/event.entity.ts
+++ b/src/domain/timeline/event/event.entity.ts
@@ -55,13 +55,6 @@ export class CalendarEvent extends NameableEntity implements ICalendarEvent {
   @Column('boolean', { nullable: false })
   visibleOnParentCalendar!: boolean;
 
-  // @ManyToOne(() => Space, {
-  //   createForeignKeyConstraints: false,
-  //   eager: false,
-  //   nullable: true,
-  // })
-  subspace?: Space;
-
   constructor() {
     super();
   }

--- a/src/domain/timeline/event/event.module.ts
+++ b/src/domain/timeline/event/event.module.ts
@@ -11,6 +11,7 @@ import { CalendarEventAuthorizationService } from './event.service.authorization
 import { ProfileModule } from '@domain/common/profile/profile.module';
 import { RoomModule } from '@domain/communication/room/room.module';
 import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
+import { Space } from '@domain/space/space/space.entity';
 
 @Module({
   imports: [
@@ -20,7 +21,7 @@ import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.modu
     VisualModule,
     UserLookupModule,
     ProfileModule,
-    TypeOrmModule.forFeature([CalendarEvent]),
+    TypeOrmModule.forFeature([CalendarEvent, Space]),
   ],
   providers: [
     CalendarEventResolverMutations,

--- a/src/domain/timeline/event/event.service.ts
+++ b/src/domain/timeline/event/event.service.ts
@@ -223,12 +223,6 @@ export class CalendarEventService {
         'subspace',
         'subspace.collaborationId = collaboration.id'
       )
-      // .leftJoinAndMapOne(
-      //   'calendarEvent.subspace',
-      //   Space,
-      //   'subspace',
-      //   'subspace.collaborationId = collaboration.id'
-      // )
       .where('calendarEvent.id = :id', { id: calendarEvent.id })
       .andWhere('subspace.level != :level', { level: SpaceLevel.SPACE })
       .select('subspace.id as spaceId')
@@ -243,12 +237,6 @@ export class CalendarEventService {
     });
 
     return space ?? undefined;
-
-    // return (spaceParentOfTheEvent as ICalendarEvent)?.subspace;
-
-    // return this.calendarEventRepository.findOne({
-    //   where: { id: spaceParentOfTheEvent.id },
-    // });
   }
 
   public async getComments(calendarEventID: string) {

--- a/src/domain/timeline/event/event.service.ts
+++ b/src/domain/timeline/event/event.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, In, Repository } from 'typeorm';
+import { EntityManager, FindOneOptions, In, Repository } from 'typeorm';
 import { EntityNotFoundException } from '@common/exceptions';
 import { LogContext, ProfileType } from '@common/enums';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy';
@@ -31,6 +31,7 @@ export class CalendarEventService {
     private authorizationPolicyService: AuthorizationPolicyService,
     private roomService: RoomService,
     private profileService: ProfileService,
+    @InjectRepository(Space) private spaceRepository: Repository<Space>,
     @InjectRepository(CalendarEvent)
     private calendarEventRepository: Repository<CalendarEvent>,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
@@ -205,10 +206,10 @@ export class CalendarEventService {
     return calendarEventLoaded.profile;
   }
 
-  public getSubspace(
+  public async getSubspace(
     calendarEvent: ICalendarEvent
   ): Promise<ISpace | undefined> {
-    return this.calendarEventRepository
+    const spaceParentOfTheEvent = await this.calendarEventRepository
       .createQueryBuilder('calendarEvent')
       .leftJoin(Calendar, 'calendar', 'calendar.id = calendarEvent.calendarId')
       .leftJoin(Timeline, 'timeline', 'timeline.calendarId = calendar.id')
@@ -222,10 +223,32 @@ export class CalendarEventService {
         'subspace',
         'subspace.collaborationId = collaboration.id'
       )
+      // .leftJoinAndMapOne(
+      //   'calendarEvent.subspace',
+      //   Space,
+      //   'subspace',
+      //   'subspace.collaborationId = collaboration.id'
+      // )
       .where('calendarEvent.id = :id', { id: calendarEvent.id })
       .andWhere('subspace.level != :level', { level: SpaceLevel.SPACE })
-      .select('subspace.*')
-      .getRawOne<ISpace>();
+      .select('subspace.id as spaceId')
+      .getRawOne<{ spaceId: string }>();
+
+    if (!spaceParentOfTheEvent) {
+      return undefined;
+    }
+
+    const space = await this.spaceRepository.findOne({
+      where: { id: spaceParentOfTheEvent.spaceId },
+    });
+
+    return space ?? undefined;
+
+    // return (spaceParentOfTheEvent as ICalendarEvent)?.subspace;
+
+    // return this.calendarEventRepository.findOne({
+    //   where: { id: spaceParentOfTheEvent.id },
+    // });
   }
 
   public async getComments(calendarEventID: string) {


### PR DESCRIPTION
Edit by @hero101
> ### The problem
> The problem was the way the `subspace` field was loaded for calendar events.
Since `Space` and `CalendarEvent` are not related, they are joined with a query via a couple of joins.
The query builder does not obey the rules you have set for the entities - eagerly loading the authorization policy, on which the authorization engine relies.

> ### The workaround
> If the guard detects a missing policy, it will automatically try to load it.

> ### The solution
> Properly loading the entity through TypeORM.

> ### Notes
> This raises a concern for other similar issues. Because of that, we must start to monitor for errors with the context `code-errors` which marks errors for code smells and potential high impact.

---

Problem definition:

If we have an N-th level resolver with authorization, the eager loaded authorization doesn't load. For example:

```typescript
  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ_ABOUT)
  @UseGuards(GraphqlGuard)
  @ResolveField('profile', () => IProfile, {
    nullable: false,
    description: 'The Profile for the Space.',
  })
  async profile(
    @Parent() space: Space,
    @Loader(ProfileLoaderCreator, { parentClassRef: Space })
    loader: ILoader<IProfile>
  ): Promise<IProfile> {
    const profile = await loader.load(space.id);
    return profile;
  }
```

In this code, if we have the following query can not load the authorization for the subspace profile (but would not be able to load anything at that level of field resolvers either):

```gql
query SpaceCalendarEvents($spaceId: UUID!, $includeSubspace: Boolean = false) {
  lookup {
    space(ID: $spaceId) {
      id
      collaboration {
        ...CollaborationTimelineInfo
        __typename
      }
      __typename
    }
    __typename
  }
}

fragment CollaborationTimelineInfo on Collaboration {
  id
  timeline {
    id
    calendar {
      id
      authorization {
        id
        myPrivileges
        __typename
      }
      events {
        ...CalendarEventInfo
        __typename
      }
      __typename
    }
    __typename
  }
  __typename
}

fragment CalendarEventInfo on CalendarEvent {
  id
  nameID
  startDate
  durationDays
  durationMinutes
  wholeDay
  multipleDays
  visibleOnParentCalendar
  profile {
    ...EventProfile
    __typename
  }
  subspace @include(if: $includeSubspace) {
    id
    profile {
      id
      authorization {
        myPrivileges
      }
      displayName
      __typename
    }

    __typename
  }
  __typename
}

fragment EventProfile on Profile {
  id
  url
  displayName
  description
  tagset {
    ...TagsetDetails
    __typename
  }
  references {
    id
    name
    uri
    description
    __typename
  }
  location {
    id
    city
    __typename
  }
  __typename
}

fragment TagsetDetails on Tagset {
  id
  name
  tags
  allowedValues
  type
  __typename
}
```

The `space` entity does not load the authorization, leading to failed guard.

Solution: if the field in the guard has `authorizationId` but no `authorization`, we assume that `typeorm` didn't load the N-th level of relationship and explicitly load it.

Tested locally, works well. Should be an edge case but is likely we hit that in various scenarios. Adds an extra code path for graphql hits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced authorization handling in the GraphQL guard.
  - Introduced optional `subspace` property in the `CalendarEvent` class.
  - Added `Space` entity support in the timeline module and service.

- **Bug Fixes**
  - Improved error management for authorization retrieval.
  - Updated `getSubspace` method to handle asynchronous operations more effectively.

- **Tests**
  - Introduced `MockEntityManagerProvider` to enhance testing setup for `UserResolver`.
  
These updates focus on refining the authorization process, enhancing data handling capabilities, and improving testing infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->