### PR TITLE
renamed space level enum entries

### DIFF
--- a/src/common/enums/space.level.ts
+++ b/src/common/enums/space.level.ts
@@ -1,9 +1,9 @@
 import { registerEnumType } from '@nestjs/graphql';
 
 export enum SpaceLevel {
-  SPACE = 0,
-  CHALLENGE = 1,
-  OPPORTUNITY = 2,
+  L0 = 0,
+  L1 = 1,
+  L2 = 2,
 }
 
 registerEnumType(SpaceLevel, {

--- a/src/core/bootstrap/bootstrap.service.ts
+++ b/src/core/bootstrap/bootstrap.service.ts
@@ -517,7 +517,7 @@ export class BootstrapService {
           displayName: DEFAULT_SPACE_DISPLAYNAME,
           tagline: 'An empty space to be populated',
         },
-        level: SpaceLevel.SPACE,
+        level: SpaceLevel.L0,
         type: SpaceType.SPACE,
         collaborationData: {
           calloutsSetData: {},

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -216,7 +216,7 @@ export class CollaborationService {
     }
 
     switch (space.level) {
-      case SpaceLevel.SPACE:
+      case SpaceLevel.L0:
         const spacesInAccount = await this.entityManager.find(Space, {
           where: {
             levelZeroSpaceID: space.id,
@@ -239,7 +239,7 @@ export class CollaborationService {
           }
           return x.collaboration;
         });
-      case SpaceLevel.CHALLENGE:
+      case SpaceLevel.L1:
         const subsubspaces = space.subspaces;
         if (!subsubspaces) {
           throw new EntityNotInitializedException(

--- a/src/domain/space/account/account.service.ts
+++ b/src/domain/space/account/account.service.ts
@@ -91,7 +91,7 @@ export class AccountService {
     }
 
     // Set data for the root space
-    spaceData.level = SpaceLevel.SPACE;
+    spaceData.level = SpaceLevel.L0;
     spaceData.storageAggregatorParent = account.storageAggregator;
 
     let space = await this.spaceService.createSpace(spaceData, agentInfo);

--- a/src/domain/space/space.defaults/space.defaults.service.ts
+++ b/src/domain/space/space.defaults/space.defaults.service.ts
@@ -193,10 +193,10 @@ export class SpaceDefaultsService {
 
   public getRoleSetCommunityRoles(spaceLevel: SpaceLevel): CreateRoleInput[] {
     switch (spaceLevel) {
-      case SpaceLevel.CHALLENGE:
-      case SpaceLevel.OPPORTUNITY:
+      case SpaceLevel.L1:
+      case SpaceLevel.L2:
         return subspaceCommunityRoles;
-      case SpaceLevel.SPACE:
+      case SpaceLevel.L0:
         return spaceCommunityRoles;
       default:
         throw new EntityNotInitializedException(
@@ -208,11 +208,11 @@ export class SpaceDefaultsService {
 
   public getProfileType(spaceLevel: SpaceLevel): ProfileType {
     switch (spaceLevel) {
-      case SpaceLevel.CHALLENGE:
+      case SpaceLevel.L1:
         return ProfileType.CHALLENGE;
-      case SpaceLevel.OPPORTUNITY:
+      case SpaceLevel.L2:
         return ProfileType.OPPORTUNITY;
-      case SpaceLevel.SPACE:
+      case SpaceLevel.L0:
         return ProfileType.SPACE;
     }
   }
@@ -221,10 +221,10 @@ export class SpaceDefaultsService {
     spaceLevel: SpaceLevel
   ): CreateFormInput {
     switch (spaceLevel) {
-      case SpaceLevel.CHALLENGE:
-      case SpaceLevel.OPPORTUNITY:
+      case SpaceLevel.L1:
+      case SpaceLevel.L2:
         return subspceCommunityApplicationForm;
-      case SpaceLevel.SPACE:
+      case SpaceLevel.L0:
         return spaceCommunityApplicationForm;
     }
   }

--- a/src/domain/space/space/space.resolver.queries.ts
+++ b/src/domain/space/space/space.resolver.queries.ts
@@ -60,7 +60,7 @@ export class SpaceResolverQueries {
   ): Promise<ISpace> {
     const space = await this.spaceService.getSpaceOrFail(ID, {
       where: {
-        level: SpaceLevel.SPACE,
+        level: SpaceLevel.L0,
       },
     });
     return space;

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -121,14 +121,14 @@ export class SpaceAuthorizationService {
     // Note: later will need additional logic here for Templates
     let parentSpaceRoleSet: IRoleSet | undefined;
     switch (space.level) {
-      case SpaceLevel.SPACE: {
+      case SpaceLevel.L0: {
         space.authorization = this.resetToPrivateLevelZeroSpaceAuthorization(
           space.authorization
         );
         break;
       }
-      case SpaceLevel.CHALLENGE:
-      case SpaceLevel.OPPORTUNITY: {
+      case SpaceLevel.L1:
+      case SpaceLevel.L2: {
         if (isPrivate) {
           // Key: private get the base space authorization setup, that is then extended
           space.authorization = this.resetToPrivateLevelZeroSpaceAuthorization(
@@ -262,11 +262,11 @@ export class SpaceAuthorizationService {
     const globalAnonymousRegistered = this.getGlobalAnonymousRegistered();
 
     switch (space.level) {
-      case SpaceLevel.SPACE:
+      case SpaceLevel.L0:
         credentialCriteriasWithAccess.push(...globalAnonymousRegistered);
         break;
 
-      case SpaceLevel.CHALLENGE:
+      case SpaceLevel.L1:
         credentialCriteriasWithAccess.push(
           ...(await this.getL1SpaceLevelCredentials(
             space,
@@ -275,7 +275,7 @@ export class SpaceAuthorizationService {
         );
         break;
 
-      case SpaceLevel.OPPORTUNITY:
+      case SpaceLevel.L2:
         credentialCriteriasWithAccess.push(
           ...(await this.getL2SpaceLevelCredentials(
             space,
@@ -415,7 +415,7 @@ export class SpaceAuthorizationService {
 
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
 
-    const isSubspaceCommunity = space.level !== SpaceLevel.SPACE;
+    const isSubspaceCommunity = space.level !== SpaceLevel.L0;
 
     const communityAuthorizations =
       await this.communityAuthorizationService.applyAuthorizationPolicy(
@@ -442,7 +442,7 @@ export class SpaceAuthorizationService {
     updatedAuthorizations.push(...storageAuthorizations);
 
     // Level zero space only entities
-    if (space.level === SpaceLevel.SPACE) {
+    if (space.level === SpaceLevel.L0) {
       if (!space.templatesManager) {
         throw new RelationshipNotFoundException(
           `Unable to load templatesManager on level zero space for auth reset ${space.id} `,

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -291,7 +291,7 @@ const getSubspacesMock = (
         ...getEntityMock<Account>(),
       },
       type: SpaceType.CHALLENGE,
-      level: SpaceLevel.CHALLENGE,
+      level: SpaceLevel.L1,
       visibility: SpaceVisibility.ACTIVE,
       collaboration: {
         id: '',
@@ -394,7 +394,7 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
         ...getEntityMock<Account>(),
       },
       type: SpaceType.OPPORTUNITY,
-      level: SpaceLevel.OPPORTUNITY,
+      level: SpaceLevel.L2,
       visibility: SpaceVisibility.ACTIVE,
       collaboration: {
         id: '',

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -127,13 +127,13 @@ export class SpaceService {
     if (!spaceData.type) {
       // default to match the level if not specified
       switch (spaceData.level) {
-        case SpaceLevel.SPACE:
+        case SpaceLevel.L0:
           spaceData.type = SpaceType.SPACE;
           break;
-        case SpaceLevel.CHALLENGE:
+        case SpaceLevel.L1:
           spaceData.type = SpaceType.CHALLENGE;
           break;
-        case SpaceLevel.OPPORTUNITY:
+        case SpaceLevel.L2:
           spaceData.type = SpaceType.OPPORTUNITY;
           break;
         default:
@@ -143,7 +143,7 @@ export class SpaceService {
     }
     // Hard code / overwrite for now for root space level
     if (
-      spaceData.level === SpaceLevel.SPACE &&
+      spaceData.level === SpaceLevel.L0 &&
       spaceData.type !== SpaceType.SPACE
     ) {
       throw new NotSupportedException(
@@ -264,7 +264,7 @@ export class SpaceService {
     // save the collaboration and all it's template sets
     await this.save(space);
 
-    if (spaceData.level === SpaceLevel.SPACE) {
+    if (spaceData.level === SpaceLevel.L0) {
       space.levelZeroSpaceID = space.id;
     }
 
@@ -289,7 +289,7 @@ export class SpaceService {
       type: AgentType.SPACE,
     });
 
-    if (space.level === SpaceLevel.SPACE) {
+    if (space.level === SpaceLevel.L0) {
       space.templatesManager = await this.createTemplatesManager();
     }
 
@@ -382,7 +382,7 @@ export class SpaceService {
     await this.licenseService.removeLicenseOrFail(space.license.id);
     await this.authorizationPolicyService.delete(space.authorization);
 
-    if (space.level === SpaceLevel.SPACE) {
+    if (space.level === SpaceLevel.L0) {
       if (!space.templatesManager || !space.templatesManager) {
         throw new RelationshipNotFoundException(
           `Unable to load entities to delete base subspace: ${space.id} `,
@@ -417,7 +417,7 @@ export class SpaceService {
 
       return this.spaceRepository.findBy({
         visibility: spaceVisibilityFilter,
-        level: SpaceLevel.SPACE,
+        level: SpaceLevel.L0,
       });
     }
 
@@ -500,7 +500,7 @@ export class SpaceService {
       spaces = await this.spaceRepository.find({
         where: {
           id: In(args.IDs),
-          level: SpaceLevel.SPACE,
+          level: SpaceLevel.L0,
           visibility: In(visibilities),
         },
         ...options,
@@ -509,7 +509,7 @@ export class SpaceService {
       spaces = await this.spaceRepository.find({
         where: {
           visibility: In(visibilities),
-          level: SpaceLevel.SPACE,
+          level: SpaceLevel.L0,
         },
         ...options,
       });
@@ -571,7 +571,7 @@ export class SpaceService {
     if (visibilities) {
       qb.leftJoinAndSelect('space.authorization', 'authorization');
       qb.where({
-        level: SpaceLevel.SPACE,
+        level: SpaceLevel.L0,
         visibility: In(visibilities),
       });
     }
@@ -589,7 +589,7 @@ export class SpaceService {
     qb.leftJoinAndSelect('space.authorization', 'authorization_policy');
     qb.leftJoinAndSelect('subspace.subspaces', 'subspaces');
     qb.where({
-      level: SpaceLevel.SPACE,
+      level: SpaceLevel.L0,
       id: In(IDs),
     });
     const spacesDataForSorting = await qb.getMany();
@@ -708,7 +708,7 @@ export class SpaceService {
         .leftJoinAndSelect('s.authorization', 'authorization') // eager load the authorization
         .innerJoin(Activity, 'a', 's.collaborationId = a.collaborationID')
         .where({
-          level: SpaceLevel.SPACE,
+          level: SpaceLevel.L0,
           visibility: SpaceVisibility.ACTIVE,
         })
         // activities in the past "daysOld" days
@@ -778,7 +778,7 @@ export class SpaceService {
   ): Promise<ISpace> {
     if (updateData.visibility && updateData.visibility !== space.visibility) {
       // Only update visibility on L0 spaces
-      if (space.level !== SpaceLevel.SPACE) {
+      if (space.level !== SpaceLevel.L0) {
         throw new ValidationException(
           `Unable to update visibility on Space ${space.id} as it is not a L0 space`,
           LogContext.SPACES
@@ -794,7 +794,7 @@ export class SpaceService {
 
     if (updateData.nameID && updateData.nameID !== space.nameID) {
       let reservedNameIDs: string[] = [];
-      if (space.level === SpaceLevel.SPACE) {
+      if (space.level === SpaceLevel.L0) {
         reservedNameIDs =
           await this.namingService.getReservedNameIDsLevelZeroSpaces();
       } else {

--- a/src/domain/storage/storage-aggregator/storage.aggregator.service.ts
+++ b/src/domain/storage/storage-aggregator/storage.aggregator.service.ts
@@ -287,15 +287,15 @@ export class StorageAggregatorService {
   ): Promise<string> {
     let url = '';
     switch (space.level) {
-      case SpaceLevel.OPPORTUNITY:
+      case SpaceLevel.L2:
         url = await this.urlGeneratorService.generateUrlForSubsubspace(
           space.id
         );
         break;
-      case SpaceLevel.CHALLENGE:
+      case SpaceLevel.L1:
         url = await this.urlGeneratorService.generateUrlForSubspace(space.id);
         break;
-      case SpaceLevel.SPACE:
+      case SpaceLevel.L0:
         url = this.urlGeneratorService.generateUrlForSpace(space.nameID);
         break;
     }

--- a/src/domain/timeline/calendar/calendar.service.ts
+++ b/src/domain/timeline/calendar/calendar.service.ts
@@ -101,7 +101,7 @@ export class CalendarService {
       // to be levelZeroSpace = spaceId and level > space level
       .where({
         parentSpace: { id: rootSpaceId },
-        level: SpaceLevel.CHALLENGE,
+        level: SpaceLevel.L1,
       })
       .leftJoin(
         Collaboration,

--- a/src/domain/timeline/event/event.service.ts
+++ b/src/domain/timeline/event/event.service.ts
@@ -223,7 +223,7 @@ export class CalendarEventService {
         'subspace.collaborationId = collaboration.id'
       )
       .where('calendarEvent.id = :id', { id: calendarEvent.id })
-      .andWhere('subspace.level != :level', { level: SpaceLevel.SPACE })
+      .andWhere('subspace.level != :level', { level: SpaceLevel.L0 })
       .select('subspace.*')
       .getRawOne<ISpace>();
   }

--- a/src/services/adapters/activity-adapter/activity.adapter.ts
+++ b/src/services/adapters/activity-adapter/activity.adapter.ts
@@ -76,7 +76,7 @@ export class ActivityAdapter {
       );
     }
     const eventType =
-      subspace.level === SpaceLevel.OPPORTUNITY
+      subspace.level === SpaceLevel.L2
         ? ActivityEventType.OPPORTUNITY_CREATED
         : ActivityEventType.CHALLENGE_CREATED;
 

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -105,7 +105,7 @@ export class ConversionService {
       profileData: {
         displayName: subspace.profile.displayName,
       },
-      level: SpaceLevel.SPACE,
+      level: SpaceLevel.L0,
       type: SpaceType.SPACE,
       collaborationData: {
         calloutsSetData: {},
@@ -288,7 +288,7 @@ export class ConversionService {
         displayName: subsubspace.profile.displayName,
       },
       storageAggregatorParent: levelZeroSpaceStorageAggregator,
-      level: SpaceLevel.CHALLENGE,
+      level: SpaceLevel.L1,
       type: SpaceType.CHALLENGE,
     };
     const emptyChallenge = await this.spaceService.createSubspace(

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -139,7 +139,7 @@ export class MeService {
 
     for (const space of allSpaces) {
       if (
-        (space.level !== SpaceLevel.SPACE && !space.parentSpace) ||
+        (space.level !== SpaceLevel.L0 && !space.parentSpace) ||
         !space.collaboration
       ) {
         this.logger.warn(
@@ -179,15 +179,15 @@ export class MeService {
 
     const levelZeroSpaces = this.filterSpacesByLevel(
       sortedFlatListSpacesWithMembership,
-      SpaceLevel.SPACE
+      SpaceLevel.L0
     );
     const levelOneSpaces = this.filterSpacesByLevel(
       sortedFlatListSpacesWithMembership,
-      SpaceLevel.CHALLENGE
+      SpaceLevel.L1
     );
     const levelTwoSpaces = this.filterSpacesByLevel(
       sortedFlatListSpacesWithMembership,
-      SpaceLevel.OPPORTUNITY
+      SpaceLevel.L2
     );
 
     const levelZeroMemberships = levelZeroSpaces.map(levelZeroSpace => {

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -287,6 +287,7 @@ const getSubpaceRoleResultMock = ({
   roles,
   displayName,
   type,
+  level,
 }: {
   id: string;
   roles: string[];
@@ -300,7 +301,7 @@ const getSubpaceRoleResultMock = ({
     nameID: `subspace-${id}`,
     roles,
     type,
-    level: SpaceLevel.L0,
+    level,
   };
 };
 

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -245,7 +245,7 @@ const getSpaceRoleResultMock = ({
     id,
     displayName,
     type: SpaceType.SPACE,
-    level: SpaceLevel.SPACE,
+    level: SpaceLevel.L0,
     spaceID: id,
     nameID: `space-${id}`,
     visibility: SpaceVisibility.ACTIVE,
@@ -265,7 +265,7 @@ const getSpaceRoleResultMock = ({
         ...getEntityMock<Profile>(),
       },
       type: SpaceType.SPACE,
-      level: SpaceLevel.SPACE,
+      level: SpaceLevel.L0,
       visibility: SpaceVisibility.ACTIVE,
       account: {
         id: `account-${id}`,
@@ -300,7 +300,7 @@ const getSubpaceRoleResultMock = ({
     nameID: `subspace-${id}`,
     roles,
     type,
-    level: SpaceLevel.SPACE,
+    level: SpaceLevel.L0,
   };
 };
 

--- a/src/services/api/roles/util/get.space.roles.for.contributor.entity.data.ts
+++ b/src/services/api/roles/util/get.space.roles.for.contributor.entity.data.ts
@@ -46,8 +46,8 @@ export const getSpaceRolesForContributorEntityData = async (
   };
 
   const [spaces, subspaces] = await Promise.all([
-    fetchData(Space, spaceIds, [SpaceLevel.SPACE], spaceAllowedVisibilities),
-    fetchData(Space, spaceIds, [SpaceLevel.CHALLENGE, SpaceLevel.OPPORTUNITY]),
+    fetchData(Space, spaceIds, [SpaceLevel.L0], spaceAllowedVisibilities),
+    fetchData(Space, spaceIds, [SpaceLevel.L1, SpaceLevel.L2]),
   ]);
 
   return { spaces, subspaces };

--- a/src/services/api/search/v1/search.result.builder.service.ts
+++ b/src/services/api/search/v1/search.result.builder.service.ts
@@ -200,11 +200,11 @@ export default class SearchResultBuilderService
     let subsubspace: ISpace | undefined = undefined;
 
     switch (spaceLoaded?.level) {
-      case SpaceLevel.CHALLENGE: {
+      case SpaceLevel.L1: {
         subspace = spaceLoaded;
         break;
       }
-      case SpaceLevel.OPPORTUNITY: {
+      case SpaceLevel.L2: {
         subspace = spaceLoaded.parentSpace;
         subsubspace = spaceLoaded;
         break;

--- a/src/services/api/search/v1/search.service.ts
+++ b/src/services/api/search/v1/search.service.ts
@@ -980,7 +980,7 @@ export class SearchService {
     const subspaces = await this.spaceRepository.find({
       where: {
         levelZeroSpaceID: In(levelZeroSpaceIDsFilter),
-        level: SpaceLevel.CHALLENGE,
+        level: SpaceLevel.L1,
       },
       relations: {
         collaboration: true,
@@ -996,7 +996,7 @@ export class SearchService {
     const subsubspaces = await this.spaceRepository.find({
       where: {
         levelZeroSpaceID: In(levelZeroSpaceIDsFilter),
-        level: SpaceLevel.OPPORTUNITY,
+        level: SpaceLevel.L2,
       },
       relations: {
         collaboration: true,

--- a/src/services/api/search/v2/ingest/search.ingest.service.ts
+++ b/src/services/api/search/v2/ingest/search.ingest.service.ts
@@ -396,7 +396,7 @@ export class SearchIngestService {
     return this.entityManager.count<Space>(Space, {
       where: {
         visibility: Not(SpaceVisibility.ARCHIVED),
-        level: SpaceLevel.SPACE,
+        level: SpaceLevel.L0,
       },
     });
   }
@@ -406,7 +406,7 @@ export class SearchIngestService {
         ...journeyFindOptions,
         where: {
           visibility: Not(SpaceVisibility.ARCHIVED),
-          level: SpaceLevel.SPACE,
+          level: SpaceLevel.L0,
         },
         relations: {
           ...journeyFindOptions.relations,
@@ -438,7 +438,7 @@ export class SearchIngestService {
     return this.entityManager.count<Space>(Space, {
       where: {
         visibility: Not(SpaceVisibility.ARCHIVED),
-        level: SpaceLevel.CHALLENGE,
+        level: SpaceLevel.L1,
       },
     });
   }
@@ -448,7 +448,7 @@ export class SearchIngestService {
         ...journeyFindOptions,
         where: {
           visibility: Not(SpaceVisibility.ARCHIVED),
-          level: SpaceLevel.CHALLENGE,
+          level: SpaceLevel.L1,
         },
         relations: {
           ...journeyFindOptions.relations,
@@ -483,7 +483,7 @@ export class SearchIngestService {
     return this.entityManager.count<Space>(Space, {
       where: {
         visibility: Not(SpaceVisibility.ARCHIVED),
-        level: SpaceLevel.OPPORTUNITY,
+        level: SpaceLevel.L2,
       },
     });
   }
@@ -493,7 +493,7 @@ export class SearchIngestService {
         ...journeyFindOptions,
         where: {
           visibility: Not(SpaceVisibility.ARCHIVED),
-          level: SpaceLevel.OPPORTUNITY,
+          level: SpaceLevel.L2,
         },
         relations: {
           ...journeyFindOptions.relations,

--- a/src/services/infrastructure/naming/naming.service.ts
+++ b/src/services/infrastructure/naming/naming.service.ts
@@ -40,7 +40,7 @@ export class NamingService {
     const subspaces = await this.entityManager.find(Space, {
       where: {
         levelZeroSpaceID: levelZeroSpaceID,
-        level: Not(SpaceLevel.SPACE),
+        level: Not(SpaceLevel.L0),
       },
       select: {
         nameID: true,
@@ -52,7 +52,7 @@ export class NamingService {
   public async getReservedNameIDsLevelZeroSpaces(): Promise<string[]> {
     const levelZeroSpaces = await this.entityManager.find(Space, {
       where: {
-        level: SpaceLevel.SPACE,
+        level: SpaceLevel.L0,
       },
       select: {
         nameID: true,

--- a/src/services/infrastructure/url-generator/url.generator.service.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.ts
@@ -169,17 +169,17 @@ export class UrlGeneratorService {
     const spaceNameID = space.nameID;
     const baseURL = `${this.endpoint_cluster}/admin/spaces/${spaceNameID}`;
     switch (space.level) {
-      case SpaceLevel.SPACE:
+      case SpaceLevel.L0:
         const spaceAdminUrl = await this.generateAdminUrlForSpace(space.nameID);
         return `${spaceAdminUrl}/community`;
-      case SpaceLevel.CHALLENGE:
+      case SpaceLevel.L1:
         const subspaceAdminUrl = await this.getSubspaceUrlPath(
           this.FIELD_ID,
           space.id,
           true
         );
         return `${subspaceAdminUrl}/community`;
-      case SpaceLevel.OPPORTUNITY:
+      case SpaceLevel.L2:
         const subsubspaceAdminURL = await this.getSubsubspaceUrlPath(
           this.FIELD_ID,
           space.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Updated space level enumeration from `SPACE`, `CHALLENGE`, and `OPPORTUNITY` to `L0`, `L1`, and `L2`
  - Modified space level references across multiple services and components
  - Standardized level classification throughout the application

- **Impact**
  - No functional changes to existing features
  - Improved semantic clarity of space level definitions
  - Consistent level representation across the system
<!-- end of auto-generated comment: release notes by coderabbit.ai -->