### PR TITLE
Proper VC profile Url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-server",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-server",
-      "version": "0.98.0",
+      "version": "0.99.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -571,6 +571,7 @@ export class CalloutService {
     const calloutLoaded = await this.getCalloutOrFail(callout.id, {
       relations: {
         contributions: {
+          post: true,
           whiteboard: true,
         },
         ...relations,

--- a/src/domain/collaboration/callouts-set/callouts.set.service.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.service.ts
@@ -503,11 +503,9 @@ export class CalloutsSetService {
       if (!hasAccess) return false;
 
       // Filter by Callout types
-      if (args.types) {
-        if (!args.types.includes(callout.type)) {
-          return false;
-        }
-      }
+      if (args.types && !args.types.includes(callout.type)) {
+        return false;
+      }      
 
       // Filter by Callout groups
       if (groupNames.length > 0) {

--- a/src/domain/collaboration/callouts-set/callouts.set.service.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.service.ts
@@ -502,6 +502,13 @@ export class CalloutsSetService {
       const hasAccess = this.hasAgentAccessToCallout(callout, agentInfo);
       if (!hasAccess) return false;
 
+      // Filter by Callout types
+      if (args.types) {
+        if (!args.types.includes(callout.type)) {
+          return false;
+        }
+      }
+
       // Filter by Callout groups
       if (groupNames.length > 0) {
         const hasMatchingTagset = callout.framing.profile.tagsets?.some(

--- a/src/domain/collaboration/callouts-set/dto/callouts.set.args.callouts.ts
+++ b/src/domain/collaboration/callouts-set/dto/callouts.set.args.callouts.ts
@@ -1,6 +1,7 @@
 import { ArgsType, Field, Float } from '@nestjs/graphql';
 import { UUID_NAMEID } from '@domain/common/scalars';
 import { TagsetArgs } from '@common/args/tagset.args';
+import { CalloutType } from '@common/enums/callout.type';
 
 @ArgsType()
 export class CalloutsSetArgsCallouts {
@@ -9,6 +10,13 @@ export class CalloutsSetArgsCallouts {
     nullable: true,
   })
   IDs?: string[];
+
+  @Field(() => [CalloutType], {
+    description:
+      'The type of Callouts to return; if omitted return all types of Callouts.',
+    nullable: true,
+  })
+  types?: CalloutType[];
 
   @Field(() => Float, {
     description:

--- a/src/services/infrastructure/url-generator/url.generator.service.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.ts
@@ -691,7 +691,8 @@ export class UrlGeneratorService {
             LogContext.URL_GENERATOR
           );
         }
-        return this.generateUrlForVC(virtualContributor.nameID);
+        const vcUrl = await this.generateUrlForVC(virtualContributor.nameID);
+        return `${vcUrl}/${this.PATH_KNOWLEDGE_BASE}/${callout.nameID}`;
       }
     }
 
@@ -797,7 +798,7 @@ export class UrlGeneratorService {
     const calloutUrlPath = await this.getCalloutUrlPath(
       contribution.callout.id
     );
-    return `${calloutUrlPath}/${this.PATH_POSTS}/${result.postNameId}`;
+    return `${calloutUrlPath}/${this.PATH_KNOWLEDGE_BASE}/${this.PATH_POSTS}/${result.postNameId}`;
   }
 
   public async getWhiteboardUrlPath(whiteboardID: string): Promise<string> {

--- a/src/services/infrastructure/url-generator/url.generator.service.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.ts
@@ -798,7 +798,7 @@ export class UrlGeneratorService {
     const calloutUrlPath = await this.getCalloutUrlPath(
       contribution.callout.id
     );
-    return `${calloutUrlPath}/${this.PATH_KNOWLEDGE_BASE}/${this.PATH_POSTS}/${result.postNameId}`;
+    return `${calloutUrlPath}/${this.PATH_POSTS}/${result.postNameId}`;
   }
 
   public async getWhiteboardUrlPath(whiteboardID: string): Promise<string> {


### PR DESCRIPTION
- Fix url generation for callouts inside VC knowledge-base
- Fix url generation for posts inside callouts inside VC knowledge-base
- Add filter by Callout types functionality on callouts.set.service.ts to be able to retrieve PostsCollections callouts from the client
- Fix a server problem filter post contributions by nameId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added ability to filter callouts by type.
  - Enhanced contribution retrieval with post relation data.

- **Improvements**
  - Updated URL generation for knowledge base callouts.
  - More flexible callout filtering options.

- **Technical Updates**
  - Expanded GraphQL schema to support callout type filtering.
  - Package version updated to 0.99.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->