### PR TITLE
Fix StorageBucket settings error for callouts without parent journey

### DIFF
--- a/src/services/infrastructure/url-generator/url.generator.service.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.ts
@@ -667,6 +667,11 @@ export class UrlGeneratorService {
             LogContext.URL_GENERATOR
           );
         }
+
+        if (callout.isTemplate) {
+          return ''; // no journey url path for templates
+        }
+
         const collaborationJourneyUrlPath = await this.getJourneyUrlPath(
           'collaborationId',
           collaboration.id
@@ -741,13 +746,13 @@ export class UrlGeneratorService {
         fieldID
       );
     }
-    if (!collaborationJourneyUrlPath) {
-      throw new EntityNotFoundException(
-        `Unable to find url path for collaboration: ${fieldName} - ${fieldID}`,
-        LogContext.URL_GENERATOR
-      );
-    }
-    return collaborationJourneyUrlPath;
+    // if (!collaborationJourneyUrlPath) {
+    //   throw new EntityNotFoundException(
+    //     `Unable to find url path for collaboration: ${fieldName} - ${fieldID}`,
+    //     LogContext.URL_GENERATOR
+    //   );
+    // }
+    return collaborationJourneyUrlPath ?? '';
   }
 
   public async getPostUrlPath(calloutID: string): Promise<string> {


### PR DESCRIPTION
The template callouts (e.g. tutorials) has a `collaborationId` but they don't have a parent community. 
Although this might be an underlying bug, for now we're passing an empty URL for `callouts.isTemplate`.

Even with the check for isTemplate, the error persisted so for now I decided to return an empty string from the builder, instead of throwing an error. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL generation handling for callout templates
	- Enhanced error management in URL path generation process
	- Implemented graceful handling of scenarios involving template callouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->