### PR TITLE
Fix client/7535 - Handle when agentInfo.userId is null

### DIFF
--- a/src/services/api/me/me.resolver.fields.ts
+++ b/src/services/api/me/me.resolver.fields.ts
@@ -47,6 +47,10 @@ export class MeResolverFields {
         LogContext.RESOLVER_FIELD
       );
     }
+    // When the user is just registered, the agentInfo.userID is still null
+    if (email && !agentInfo.userID) {
+      return null;
+    }
 
     return this.userService.getUserOrFail(agentInfo.userID);
   }


### PR DESCRIPTION
- Latest commits have changed `return this.userService.getUserByEmail(email);` to `return this.userService.getUserOrFail(agentInfo.userID);` https://github.com/alkem-io/server/commit/2fb59d97629a3ee9c9bd2a0e359c9d6e9c2ea207#diff-a7b689f9fcf3216de6244683564c3a9e279bb58fa4b6b1159ce82a668634361f
- `getUserByEmail` was just returning `null`, `getUserOrFail` is throwing an exception when the userID passed is null.
- When the user has just registered, agentInfo still doesn't have the `userId`, because there's no user yet in the database.
- Added a handler for this case. When the userId is not yet set, just return null like the previous code was doing. The client handles that null correctly and calls the mutation to create the user in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user registration handling by adding a validation check for newly registered users without a user ID
  - Prevented potential processing errors for users in an incomplete registration state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->