### PR TITLE
updated search logic to only work with callouts on sets of type collaboration

### DIFF
--- a/src/services/api/search/v2/result/search.result.service.ts
+++ b/src/services/api/search/v2/result/search.result.service.ts
@@ -417,6 +417,7 @@ export class SearchResultService {
         contributions: { whiteboard: true },
       },
       select: {
+        id: true,
         framing: {
           id: true,
           whiteboard: {
@@ -535,9 +536,15 @@ export class SearchResultService {
       },
       select: {
         id: true,
+        nameID: true,
+        type: true,
         calloutsSet: {
+          id: true,
           type: true,
         },
+      },
+      relations: {
+        calloutsSet: true,
       },
     });
     const calloutsInSetType = calloutsWithSet.filter(
@@ -573,9 +580,12 @@ export class SearchResultService {
         },
       },
       select: {
+        id: true,
+        level: true,
         collaboration: {
           id: true,
           calloutsSet: {
+            id: true,
             callouts: {
               id: true,
             },


### PR DESCRIPTION
Only return search results for callouts in spaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced callout filtering capabilities in the search result service.
  - Added ability to filter callouts by specific set type.

- **Improvements**
  - Refined method for retrieving callout parents with more precise type-based filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->