### PR TITLE
fixed creation of url for whiteboard template

### DIFF
--- a/src/services/adapters/notification-adapter/notification.payload.builder.ts
+++ b/src/services/adapters/notification-adapter/notification.payload.builder.ts
@@ -211,7 +211,8 @@ export class NotificationPayloadBuilder {
       callout.id
     );
     const whiteboardURL = await this.urlGeneratorService.getWhiteboardUrlPath(
-      whiteboard.id
+      whiteboard.id,
+      whiteboard.nameID
     );
     const payload: CollaborationWhiteboardCreatedEventPayload = {
       callout: {


### PR DESCRIPTION
The code was not handling the case where a whiteboard was a direct template, and the field was queried on the profile of the whiteboard (not on the template)

This is causing storage bucket lookups to fail whenever there are whiteboard templates in the library. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced whiteboard notifications with additional identifying details, resulting in more descriptive links.
  - Improved whiteboard URL generation using profile identifiers for more precise link resolution and enhanced error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->