### PR TITLE
properly retrieve license with entitlements for checking on invitation

### DIFF
--- a/src/domain/access/role-set/role.set.resolver.mutations.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.ts
@@ -540,6 +540,9 @@ export class RoleSetResolverMutations {
           parentRoleSet: {
             authorization: true,
           },
+          license: {
+            entitlements: true,
+          },
         },
       }
     );


### PR DESCRIPTION
The server is now validating the entitlement on both add + invite:

![image](https://github.com/user-attachments/assets/5b65be73-7a3f-49ce-a2f5-5dcdcc6793ab)


There should be a separate issue for the client to not display these options to the user. Please duplicate this issue if not separately already raised. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The contributor invitation process now includes enhanced eligibility verification checks that ensure invitations are processed more reliably. By integrating additional measures, the system supports refined validations for special contributor types, improving overall security and delivering a smoother user experience when managing contributor invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->