### PR TITLE
space invitees to always be able to view about space; fix removal of credentials on org deletion

### DIFF
--- a/src/common/enums/authorization.credential.ts
+++ b/src/common/enums/authorization.credential.ts
@@ -18,6 +18,7 @@ export enum AuthorizationCredential {
   SPACE_MEMBER = 'space-member',
   SPACE_LEAD = 'space-lead',
   SPACE_SUBSPACE_ADMIN = 'space-subspace-admin', // assigned to admins of a subspace for a space
+  SPACE_MEMBER_INVITEE = 'space-invitee', // assigned to users that are invited to join a space / subspace
 
   ORGANIZATION_OWNER = 'organization-owner', // Able to commit an organization
   ORGANIZATION_ADMIN = 'organization-admin', // Able to administer an organization

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -527,7 +527,10 @@ export class RoleSetService {
         if (roleName === RoleName.ADMIN && parentRoleSet) {
           // also assign as subspace admin in parent roleSet if there is a parent roleSet
           const subspaceAdminCredential =
-            await this.getCredentialForSubspaceAdminImplicitRole(parentRoleSet);
+            await this.getCredentialSpaceImplicitRole(
+              parentRoleSet,
+              AuthorizationCredential.SPACE_SUBSPACE_ADMIN
+            );
           const alreadyHasSubspaceAdmin =
             await this.agentService.hasValidCredential(
               agent.id,
@@ -1037,8 +1040,10 @@ export class RoleSetService {
     );
 
     if (!hasAnotherAdminRole) {
-      const credential =
-        await this.getCredentialForSubspaceAdminImplicitRole(roleSet);
+      const credential = await this.getCredentialSpaceImplicitRole(
+        roleSet,
+        AuthorizationCredential.SPACE_SUBSPACE_ADMIN
+      );
 
       return await this.agentService.revokeCredential({
         agentID: agent.id,
@@ -1080,20 +1085,21 @@ export class RoleSetService {
     }
   }
 
-  private async getCredentialForSubspaceAdminImplicitRole(
-    parentRoleSet: IRoleSet
+  private async getCredentialSpaceImplicitRole(
+    roleSet: IRoleSet,
+    implicitRoleCredential: AuthorizationCredential
   ): Promise<ICredentialDefinition> {
-    this.validateRoleSetType(parentRoleSet, RoleSetType.SPACE);
+    this.validateRoleSetType(roleSet, RoleSetType.SPACE);
 
     // Use the admin credential to get the resourceID
     const adminCredential = await this.getCredentialDefinitionForRole(
-      parentRoleSet,
+      roleSet,
       RoleName.ADMIN
     );
     const spaceID = adminCredential.resourceID;
 
     return {
-      type: AuthorizationCredential.SPACE_SUBSPACE_ADMIN,
+      type: implicitRoleCredential,
       resourceID: spaceID,
     };
   }
@@ -1188,8 +1194,10 @@ export class RoleSetService {
     let credential: ICredentialDefinition | undefined = undefined;
     switch (role) {
       case RoleSetRoleImplicit.SUBSPACE_ADMIN:
-        credential =
-          await this.getCredentialForSubspaceAdminImplicitRole(roleSet);
+        credential = await this.getCredentialSpaceImplicitRole(
+          roleSet,
+          AuthorizationCredential.SPACE_SUBSPACE_ADMIN
+        );
         break;
       case RoleSetRoleImplicit.ACCOUNT_ADMIN:
         credential =

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -165,6 +165,8 @@ export class RoleSetService {
       );
     }
 
+    await this.removeAllRoleAssignments(roleSet);
+
     for (const role of roleSet.roles) {
       await this.roleService.removeRole(role);
     }
@@ -263,6 +265,42 @@ export class RoleSetService {
         await this.removeUserFromRole(roleSet, roleName, user.id, false);
       }
 
+      // Remove all implicit role assignments
+      if (roleSet.type === RoleSetType.SPACE) {
+        const invitees = await this.getUsersWithImplicitSpaceRole(
+          roleSet,
+          AuthorizationCredential.SPACE_MEMBER_INVITEE
+        );
+        for (const invitee of invitees) {
+          await this.removeUserFromRole(roleSet, roleName, invitee.id, false);
+        }
+        const subspace_admins = await this.getUsersWithImplicitSpaceRole(
+          roleSet,
+          AuthorizationCredential.SPACE_SUBSPACE_ADMIN
+        );
+        for (const subspaceAdmin of subspace_admins) {
+          await this.removeUserFromRole(
+            roleSet,
+            roleName,
+            subspaceAdmin.id,
+            false
+          );
+        }
+      }
+
+      if (roleSet.type === RoleSetType.ORGANIZATION) {
+        const accountAdmins =
+          await this.getUsersWithImplicitOrganizationAccountAdminRole(roleSet);
+        for (const accountAdmin of accountAdmins) {
+          await this.removeUserFromRole(
+            roleSet,
+            roleName,
+            accountAdmin.id,
+            false
+          );
+        }
+      }
+
       const organizations = await this.getOrganizationsWithRole(
         roleSet,
         roleName
@@ -272,6 +310,19 @@ export class RoleSetService {
           roleSet,
           roleName,
           organization.id,
+          false
+        );
+      }
+
+      const virtualContributors = await this.getVirtualContributorsWithRole(
+        roleSet,
+        roleName
+      );
+      for (const virtualContributor of virtualContributors) {
+        await this.removeVirtualFromRole(
+          roleSet,
+          roleName,
+          virtualContributor.id,
           false
         );
       }
@@ -385,6 +436,33 @@ export class RoleSetService {
       },
       limit
     );
+  }
+
+  private async getUsersWithImplicitSpaceRole(
+    roleSet: IRoleSet,
+    implicitCredential: AuthorizationCredential
+  ): Promise<IUser[]> {
+    const inviteeCredential = await this.getCredentialSpaceImplicitRole(
+      roleSet,
+      implicitCredential
+    );
+
+    return await this.userLookupService.usersWithCredentials({
+      type: inviteeCredential.type,
+      resourceID: inviteeCredential.resourceID,
+    });
+  }
+
+  private async getUsersWithImplicitOrganizationAccountAdminRole(
+    roleSet: IRoleSet
+  ): Promise<IUser[]> {
+    const accountAdminCredential =
+      await this.getCredentialForOrganizationImplicitRole(roleSet);
+
+    return await this.userLookupService.usersWithCredentials({
+      type: accountAdminCredential.type,
+      resourceID: accountAdminCredential.resourceID,
+    });
   }
 
   public async getVirtualContributorsWithRole(
@@ -602,7 +680,8 @@ export class RoleSetService {
           LogContext.COMMUNITY
         );
       }
-
+      const { agent } =
+        await this.contributorService.getContributorAndAgent(contributorID);
       if (invitation.invitedToParent) {
         if (!roleSet.parentRoleSet) {
           throw new EntityNotInitializedException(
@@ -611,8 +690,6 @@ export class RoleSetService {
           );
         }
         // Check if the user is already a member of the parent roleSet
-        const { agent } =
-          await this.contributorService.getContributorAndAgent(contributorID);
         const isMemberOfParentRoleSet = await this.isMember(
           agent,
           roleSet.parentRoleSet
@@ -636,6 +713,13 @@ export class RoleSetService {
         agentInfo,
         true
       );
+      if (
+        roleSet.type === RoleSetType.SPACE &&
+        invitation.contributorType === RoleSetContributorType.USER
+      ) {
+        // Remove the credential for being an invitee
+        await this.removeSpaceInviteeCredential(agent, roleSet);
+      }
       if (invitation.extraRole) {
         try {
           await this.assignContributorToRole(
@@ -666,6 +750,47 @@ export class RoleSetService {
     }
   }
 
+  private async assignSpaceInviteeCredential(agent: IAgent, roleSet: IRoleSet) {
+    const inviteeCredential = await this.getCredentialSpaceImplicitRole(
+      roleSet,
+      AuthorizationCredential.SPACE_MEMBER_INVITEE
+    );
+    const hasInviteeCredential = await this.agentService.hasValidCredential(
+      agent.id,
+      {
+        type: inviteeCredential.type,
+        resourceID: inviteeCredential.resourceID,
+      }
+    );
+    if (!hasInviteeCredential) {
+      await this.agentService.grantCredential({
+        agentID: agent.id,
+        type: inviteeCredential.type,
+        resourceID: inviteeCredential.resourceID,
+      });
+    }
+  }
+
+  private async removeSpaceInviteeCredential(agent: IAgent, roleSet: IRoleSet) {
+    const inviteeCredential = await this.getCredentialSpaceImplicitRole(
+      roleSet,
+      AuthorizationCredential.SPACE_MEMBER_INVITEE
+    );
+    const hasInviteeCredential = await this.agentService.hasValidCredential(
+      agent.id,
+      {
+        type: inviteeCredential.type,
+        resourceID: inviteeCredential.resourceID,
+      }
+    );
+    if (hasInviteeCredential) {
+      await this.agentService.revokeCredential({
+        agentID: agent.id,
+        type: inviteeCredential.type,
+        resourceID: inviteeCredential.resourceID,
+      });
+    }
+  }
   private async contributorAddedToRole(
     contributor: IContributor,
     roleSet: IRoleSet,
@@ -1261,7 +1386,13 @@ export class RoleSetService {
     );
     invitation.roleSet = roleSet;
 
-    return await this.invitationService.save(invitation);
+    const result = await this.invitationService.save(invitation);
+    // Ensure that the user that is invited has a credential for the invitation
+    if (roleSet.type === RoleSetType.SPACE) {
+      await this.assignSpaceInviteeCredential(agent, roleSet);
+    }
+
+    return result;
   }
 
   async createPlatformInvitation(

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -361,8 +361,6 @@ export class OrganizationService {
       );
     }
 
-    await this.roleSetService.removeAllRoleAssignments(organization.roleSet);
-
     await this.profileService.deleteProfile(organization.profile.id);
 
     if (organization.storageAggregator) {

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -285,6 +285,12 @@ export class SpaceAuthorizationService {
         break;
     }
 
+    // An invitee also can always have visibility
+    credentialCriteriasWithAccess.push({
+      type: AuthorizationCredential.SPACE_MEMBER_INVITEE,
+      resourceID: space.id,
+    });
+
     return credentialCriteriasWithAccess;
   }
 


### PR DESCRIPTION
New space implicit credential: SPACE_MEMBER_INVITEE
Assign this credential when invitation is created, remove when it is accepted

Moved the revoking of credentials for roles on deletion inside the roleset entity; previously was on community. This meant that deleting an org would have been leaving credentials behind for users (i.e. orphaned credentials)

Updated space authorization to always allow space invitees to view the space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an invitee credential to grant invited users appropriate access to spaces.
  - Enhanced invitation handling to ensure that users’ access roles update promptly upon accepting an invitation.

- **Refactor**
  - Streamlined role management workflows, improving how implicit roles are assigned and removed.
  - Adjusted the organization deletion process to refine the handling of associated role assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->