### PR TITLE
add limit on returning number of spaces on dashboard; retrieve invitations as count

### DIFF
--- a/src/services/api/me/me.resolver.fields.ts
+++ b/src/services/api/me/me.resolver.fields.ts
@@ -56,6 +56,33 @@ export class MeResolverFields {
   }
 
   @UseGuards(GraphqlGuard)
+  @ResolveField('communityInvitationsCount', () => Number, {
+    description:
+      'The number of invitations the current authenticated user can act on.',
+  })
+  public async communityInvitationsCount(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args({
+      name: 'states',
+      nullable: true,
+      type: () => [String],
+      description: 'The state names you want to filter on',
+    })
+    states: string[]
+  ): Promise<number> {
+    if (agentInfo.userID === '') {
+      throw new ValidationException(
+        'Unable to retrieve invitations as no userID provided.',
+        LogContext.COMMUNITY
+      );
+    }
+    return this.meService.getCommunityInvitationsCountForUser(
+      agentInfo.userID,
+      states
+    );
+  }
+
+  @UseGuards(GraphqlGuard)
   @ResolveField('communityInvitations', () => [CommunityInvitationResult], {
     description: 'The invitations the current authenticated user can act on.',
   })
@@ -113,9 +140,17 @@ export class MeResolverFields {
     description: 'The hierarchy of the Spaces the current user is a member.',
   })
   public spaceMembershipsHierarchical(
-    @CurrentUser() agentInfo: AgentInfo
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args({
+      name: 'limit',
+      type: () => Float,
+      description:
+        'The number of Spaces to return; if omitted return all journeys',
+      nullable: true,
+    })
+    limit: number
   ): Promise<CommunityMembershipResult[]> {
-    return this.meService.getSpaceMembershipsHierarchical(agentInfo);
+    return this.meService.getSpaceMembershipsHierarchical(agentInfo, limit);
   }
 
   @UseGuards(GraphqlGuard)

--- a/src/services/api/me/me.service.ts
+++ b/src/services/api/me/me.service.ts
@@ -30,6 +30,17 @@ export class MeService {
     private readonly logger: LoggerService
   ) {}
 
+  public async getCommunityInvitationsCountForUser(
+    userId: string,
+    states?: string[]
+  ): Promise<number> {
+    const invitations = await this.rolesService.getCommunityInvitationsForUser(
+      userId,
+      states
+    );
+    return invitations.length;
+  }
+
   public async getCommunityInvitationsForUser(
     userId: string,
     states?: string[]
@@ -172,15 +183,19 @@ export class MeService {
   }
 
   public async getSpaceMembershipsHierarchical(
-    agentInfo: AgentInfo
+    agentInfo: AgentInfo,
+    limit?: number
   ): Promise<CommunityMembershipResult[]> {
     const sortedFlatListSpacesWithMembership =
       await this.getSpaceMembershipsForAgentInfo(agentInfo);
 
-    const levelZeroSpaces = this.filterSpacesByLevel(
+    const levelZeroSpacesRaw = this.filterSpacesByLevel(
       sortedFlatListSpacesWithMembership,
       SpaceLevel.L0
     );
+    if (limit) {
+      levelZeroSpacesRaw.splice(limit);
+    }
     const levelOneSpaces = this.filterSpacesByLevel(
       sortedFlatListSpacesWithMembership,
       SpaceLevel.L1
@@ -190,7 +205,7 @@ export class MeService {
       SpaceLevel.L2
     );
 
-    const levelZeroMemberships = levelZeroSpaces.map(levelZeroSpace => {
+    const levelZeroMemberships = levelZeroSpacesRaw.map(levelZeroSpace => {
       const levelZeroMembership: CommunityMembershipResult = {
         id: levelZeroSpace.id,
         space: levelZeroSpace,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability to display the count of community invitations for users.
  - Improved space membership listings by allowing an optional limit on the number of results returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->