### PR TITLE
Profile on knowledge base visible on private

### DIFF
--- a/src/domain/collaboration/callouts-set/callouts.set.service.authorization.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.service.authorization.ts
@@ -12,6 +12,7 @@ import {
   POLICY_RULE_CALLOUT_CONTRIBUTE,
   POLICY_RULE_COLLABORATION_CREATE,
 } from '@common/constants';
+import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential.interface';
 
 @Injectable()
 export class CalloutsSetAuthorizationService {
@@ -25,7 +26,8 @@ export class CalloutsSetAuthorizationService {
     calloutsSetInput: ICalloutsSet,
     parentAuthorization: IAuthorizationPolicy | undefined,
     roleSet?: IRoleSet,
-    spaceSettings?: ISpaceSettings
+    spaceSettings?: ISpaceSettings,
+    credentialRulesFromParent: IAuthorizationPolicyRuleCredential[] = []
   ): Promise<IAuthorizationPolicy[]> {
     const calloutsSet = await this.calloutsSetService.getCalloutsSetOrFail(
       calloutsSetInput.id,
@@ -48,6 +50,9 @@ export class CalloutsSetAuthorizationService {
     calloutsSet.authorization = await this.appendPrivilegeRules(
       calloutsSet.authorization,
       spaceSettings
+    );
+    calloutsSet.authorization.credentialRules.push(
+      ...credentialRulesFromParent
     );
 
     if (calloutsSet.callouts) {

--- a/src/domain/common/knowledge-base/knowledge.base.resolver.fields.ts
+++ b/src/domain/common/knowledge-base/knowledge.base.resolver.fields.ts
@@ -3,7 +3,7 @@ import { UseGuards } from '@nestjs/common';
 import { GraphqlGuard } from '@core/authorization';
 import { IProfile } from '@domain/common/profile/profile.interface';
 import { IKnowledgeBase } from './knowledge.base.interface';
-import { AuthorizationAgentPrivilege, Profiling } from '@common/decorators';
+import { AuthorizationAgentPrivilege } from '@common/decorators';
 import { Loader } from '@core/dataloader/decorators';
 import { KnowledgeBase } from './knowledge.base.entity';
 import {
@@ -19,13 +19,12 @@ import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 export class KnowledgeBaseResolverFields {
   constructor(private knowledgeBaseService: KnowledgeBaseService) {}
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ_ABOUT)
   @UseGuards(GraphqlGuard)
   @ResolveField('profile', () => IProfile, {
     nullable: false,
     description: 'The Profile for describing this KnowledgeBase.',
   })
-  @Profiling.api
   async profile(
     @Parent() knowledgeBase: IKnowledgeBase,
     @Loader(ProfileLoaderCreator, { parentClassRef: KnowledgeBase })

--- a/src/domain/common/knowledge-base/knowledge.base.service.authorization.ts
+++ b/src/domain/common/knowledge-base/knowledge.base.service.authorization.ts
@@ -7,6 +7,7 @@ import { IKnowledgeBase } from './knowledge.base.interface';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
 import { LogContext } from '@common/enums/logging.context';
 import { CalloutsSetAuthorizationService } from '@domain/collaboration/callouts-set/callouts.set.service.authorization';
+import { AuthorizationPrivilege } from '@common/enums';
 
 @Injectable()
 export class KnowledgeBaseAuthorizationService {
@@ -19,7 +20,8 @@ export class KnowledgeBaseAuthorizationService {
 
   public async applyAuthorizationPolicy(
     knowledgeBaseInput: IKnowledgeBase,
-    parentAuthorization: IAuthorizationPolicy | undefined
+    parentAuthorization: IAuthorizationPolicy | undefined,
+    knowledgeBaseVisible: boolean
   ): Promise<IAuthorizationPolicy[]> {
     const knowledgeBase =
       await this.knowledgeBaseService.getKnowledgeBaseOrFail(
@@ -46,6 +48,14 @@ export class KnowledgeBaseAuthorizationService {
         knowledgeBase.authorization,
         parentAuthorization
       );
+    if (knowledgeBaseVisible) {
+      knowledgeBase.authorization =
+        this.authorizationPolicyService.appendCredentialRuleAnonymousRegisteredAccess(
+          knowledgeBase.authorization,
+          AuthorizationPrivilege.READ,
+          true
+        );
+    }
     updatedAuthorizations.push(knowledgeBase.authorization);
 
     const profileAuthorizations =

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -12,6 +12,7 @@ import {
   CREDENTIAL_RULE_TYPES_VC_GLOBAL_COMMUNITY_READ,
   CREDENTIAL_RULE_TYPES_VC_GLOBAL_SUPPORT_MANAGE,
   CREDENTIAL_RULE_VIRTUAL_CONTRIBUTOR_PLATFORM_SETTINGS,
+  POLICY_RULE_READ_ABOUT,
 } from '@common/constants';
 import { IVirtualContributor } from './virtual.contributor.interface';
 import { AgentAuthorizationService } from '@domain/agent/agent/agent.service.authorization';
@@ -131,6 +132,14 @@ export class VirtualContributorAuthorizationService {
       );
     updatedAuthorizations.push(...knowledgeBaseAuthorizations);
 
+    virtual.authorization =
+      this.authorizationPolicyService.appendPrivilegeAuthorizationRuleMapping(
+        virtual.authorization,
+        AuthorizationPrivilege.READ,
+        [AuthorizationPrivilege.READ_ABOUT],
+        POLICY_RULE_READ_ABOUT
+      );
+    updatedAuthorizations.push(virtual.authorization);
     return updatedAuthorizations;
   }
 

--- a/src/platform/admin/licensing/admin.licensing.resolver.mutations.ts
+++ b/src/platform/admin/licensing/admin.licensing.resolver.mutations.ts
@@ -48,7 +48,7 @@ export class AdminLicensingResolverMutations {
     this.authorizationService.grantAccessOrFail(
       agentInfo,
       account.authorization,
-      AuthorizationPrivilege.TRANSFER_RESOURCE,
+      AuthorizationPrivilege.TRANSFER_RESOURCE_OFFER, // TODO: this is wrong, need to create a new privilege
       `create Wingback account for account (${accountID})`
     );
 

--- a/src/services/api/lookup-by-name/lookup.by.name.resolver.fields.ts
+++ b/src/services/api/lookup-by-name/lookup.by.name.resolver.fields.ts
@@ -113,6 +113,7 @@ export class LookupByNameResolverFields {
     return user.id;
   }
 
+  @UseGuards(GraphqlGuard)
   @ResolveField(() => String, {
     nullable: true,
     description: 'Lookup the ID of the specified Organization using a NameID',
@@ -127,18 +128,27 @@ export class LookupByNameResolverFields {
     return organization.id;
   }
 
+  @UseGuards(GraphqlGuard)
   @ResolveField(() => String, {
     nullable: true,
     description:
       'Lookup the ID of the specified Virtual Contributor using a NameID',
   })
   async virtualContributor(
+    @CurrentUser() agentInfo: AgentInfo,
     @Args('NAMEID', { type: () => NameID }) nameid: string
   ): Promise<string> {
     const virtualContributor =
       await this.virtualContributorLookupService.getVirtualContributorByNameIdOrFail(
         nameid
       );
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      virtualContributor.authorization,
+      AuthorizationPrivilege.READ_ABOUT,
+      `lookup virtual contributor by NameID: ${virtualContributor.id}`
+    );
 
     return virtualContributor.id;
   }

--- a/src/services/api/lookup/lookup.resolver.fields.ts
+++ b/src/services/api/lookup/lookup.resolver.fields.ts
@@ -224,7 +224,7 @@ export class LookupResolverFields {
     this.authorizationService.grantAccessOrFail(
       agentInfo,
       virtualContributor.authorization,
-      AuthorizationPrivilege.READ,
+      AuthorizationPrivilege.READ_ABOUT,
       `lookup VirtualContributor: ${virtualContributor.id}`
     );
     return virtualContributor;


### PR DESCRIPTION
Logic around authorization for VC updated so that if not hidden then all users get READ_ABOUT

Then if the KB is public, then all users get READ



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new lookup methods for organizations and virtual contributors, enabling enhanced retrieval of identification data with improved security checks.

- **Refactor**
	- Updated authorization and privacy controls across collaboration, knowledge base, and contributor areas to streamline data access based on visibility settings and refined security privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->