### PR TITLE
Fix guidelines on creation getting subspace profile data

### DIFF
--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -226,10 +226,10 @@ export class SpaceService {
         type: RoleSetType.SPACE,
       },
       guidelines: {
-        // TODO: get this from defaults service
+        // TODO: get this from defaults service, currently create with empty
         profile: {
-          displayName: spaceData.profileData.displayName,
-          description: spaceData.profileData.description,
+          displayName: '',
+          description: '',
         },
       },
     };


### PR DESCRIPTION
In the subspace (Space) creation, the `profileData` was used to populate the community guidelines. This looks like a bug, as the Subspace profileData has nothing to do with the community's guidelines. 

The fix is to set empty guidelines on creation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the setup for new spaces by initializing community guidelines with blank values. This change offers a clean starting point, allowing users to customize community details as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->