### PR TITLE
Unauthenticated users to see the content of a whiteboard in a public space

### DIFF
--- a/src/core/authentication.agent.info/agent.info.service.ts
+++ b/src/core/authentication.agent.info/agent.info.service.ts
@@ -103,6 +103,10 @@ export class AgentInfoService {
   }
 
   public async buildAgentInfoForUser(userId: string): Promise<AgentInfo> {
+    if (!userId) {
+      return this.createAnonymousAgentInfo();
+    }
+
     const user = await this.entityManager.findOneOrFail(User, {
       where: { id: userId },
       relations: {


### PR DESCRIPTION
> Notice: :warning: The change is required since the authorization and lookup do not go through the GraphQL API but through a queue. That requires a separate authorization flow, which did not support unauthenticated access.

Part 2 of 2
 https://github.com/alkem-io/whiteboard-collaboration-service/pull/47

- The server is now building anonymous agent info for empty user ID in `buildAgentInfoForUser` when trying to read access to a whiteboard for collaboration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved agent information handling now provides default data when a valid user identifier isn’t supplied, ensuring a smoother and more reliable experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->