### PR TITLE
Do not fail whiteboard save on a failed file re-upload

### DIFF
--- a/src/common/enums/logging.context.ts
+++ b/src/common/enums/logging.context.ts
@@ -52,6 +52,7 @@ export enum LogContext {
   TAGSET = 'tagset',
   EXCALIDRAW_SERVER = 'excalidraw-server',
   WHITEBOARD_INTEGRATION = 'whiteboard-integration',
+  WHITEBOARDS = 'whiteboards',
   RESOLVER_FIELD = 'resolver-field',
   RESOLVER_QUERY = 'resolver-query',
   MUTATION = 'mutation',

--- a/src/services/whiteboard-integration/whiteboard.integration.service.ts
+++ b/src/services/whiteboard-integration/whiteboard.integration.service.ts
@@ -30,7 +30,6 @@ import {
 } from './outputs';
 import { FetchInputData } from '@services/whiteboard-integration/inputs/fetch.input.data';
 import { AgentInfoService } from '@core/authentication.agent.info/agent.info.service';
-import { setTimeout } from 'timers/promises';
 
 @Injectable()
 export class WhiteboardIntegrationService {

--- a/src/services/whiteboard-integration/whiteboard.integration.service.ts
+++ b/src/services/whiteboard-integration/whiteboard.integration.service.ts
@@ -30,6 +30,7 @@ import {
 } from './outputs';
 import { FetchInputData } from '@services/whiteboard-integration/inputs/fetch.input.data';
 import { AgentInfoService } from '@core/authentication.agent.info/agent.info.service';
+import { setTimeout } from 'timers/promises';
 
 @Injectable()
 export class WhiteboardIntegrationService {
@@ -123,16 +124,9 @@ export class WhiteboardIntegrationService {
         content
       );
     } catch (e: any) {
-      this.logger.error(
-        e?.message,
-        e?.stack,
-        LogContext.WHITEBOARD_INTEGRATION
-      );
-      return new SaveOutputData(
-        new SaveErrorData(
-          'An error occurred while saving the whiteboard content.'
-        )
-      );
+      const message = e?.message ?? JSON.stringify(e);
+      this.logger.error(message, e?.stack, LogContext.WHITEBOARD_INTEGRATION);
+      return new SaveOutputData(new SaveErrorData(message));
     }
     // return success on successful save
     return new SaveOutputData(new SaveContentData());


### PR DESCRIPTION
This change is inspired by some failed whiteboard saves in the past. The code was refusing the save the whiteboard content if there was a problem with some missing file.
Since deleted elements are stored on the whiteboard, some old URLs can persist forever and, at some point, be no longer valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded logging capabilities to include whiteboard activities, enabling clearer tracking of whiteboard-related operations.

- **Bug Fixes**
  - Improved error handling during the file re-upload process for whiteboard documents, ensuring a more robust and seamless experience when issues arise.
  - Enhanced error logging in the save process for whiteboard integration, providing clearer insights into issues encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->