### PR TITLE
Wingback customer data filled in correctly

### DIFF
--- a/src/domain/space/account/account.service.license.ts
+++ b/src/domain/space/account/account.service.license.ts
@@ -95,8 +95,12 @@ export class AccountLicenseService {
     }
 
     const { user, organization } = accountDetails;
-    const name = user?.name ?? organization?.name;
-    const mainEmail = user?.email ?? organization?.email;
+    const name =
+      user?.name ?? (organization?.legalName || organization?.displayName);
+    const mainEmail =
+      user?.email ??
+      (organization?.email ||
+        `dummy-${organization?.nameID}@${organization?.nameID}.com`);
 
     const { id: wingbackCustomerID } =
       await this.licensingWingbackSubscriptionService.createCustomer({

--- a/src/domain/space/account/account.service.ts
+++ b/src/domain/space/account/account.service.ts
@@ -226,13 +226,15 @@ export class AccountService {
     const [account] = await this.accountRepository.query(
       `
         SELECT
-          a.id as accountId, a.externalSubscriptionID as externalSubscriptionID,
-          o.id as orgId, o.contactEmail as orgContactEmail, o.legalEntityName as orgName,
-          u.id as userId, u.email as userEmail, CONCAT(u.firstName, ' ', u.lastName) as userName
-        FROM account as a
-        LEFT JOIN user as u on a.id = u.accountID
-        LEFT JOIN organization as o on a.id = o.accountID
-        WHERE a.id = ?
+          account.id as accountId, account.externalSubscriptionID as externalSubscriptionID,
+          organization.id as orgId, organization.contactEmail as orgContactEmail, organization.legalEntityName as orgLegalName, organization.nameID as orgNameID,
+          profile.displayName as orgDisplayName,
+          user.id as userId, user.email as userEmail, CONCAT(user.firstName, ' ', user.lastName) as userName
+        FROM account
+        LEFT JOIN user on account.id = user.accountID
+        LEFT JOIN organization on account.id = organization.accountID
+        left join profile on organization.profileId = profile.id
+        WHERE account.id = ?
     `,
       [accountID]
     );
@@ -255,7 +257,10 @@ export class AccountService {
         ? {
             id: account.orgId,
             email: account.orgContactEmail,
-            name: account.orgName,
+            legalName: account.orgLegalName,
+            orgLegalName: account.orgLegalName,
+            displayName: account.orgDisplayName,
+            nameID: account.orgNameID,
           }
         : undefined,
     };


### PR DESCRIPTION
The problem with not having these filled in when creating customers is that Wingback sets them to "temporary" which you cannot list and probably other limitations are involved.

Since we don't require the organizations to have a legal name and a contact email:
- the name defaults to the display name if the legal is not available
- the email defaults to "dummy-<org-nameID>@<org-nameID>.com"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved account creation process with more robust logic for selecting account identifiers like display names and email addresses.
  - Enhanced account details retrieval that now presents additional organization-specific information for clearer, more precise account records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->