### PR TITLE
Reduce the permissions required to resolve a spaceNameId to a spaceId

### DIFF
--- a/src/services/api/lookup-by-name/lookup.by.name.resolver.fields.ts
+++ b/src/services/api/lookup-by-name/lookup.by.name.resolver.fields.ts
@@ -87,8 +87,8 @@ export class LookupByNameResolverFields {
     this.authorizationService.grantAccessOrFail(
       agentInfo,
       space.authorization,
-      AuthorizationPrivilege.READ,
-      `lookup L0 Space by NameID: ${space.id}`
+      AuthorizationPrivilege.READ_ABOUT,
+      `lookup L0 Space by NameID: ${nameid}`
     );
 
     return space;


### PR DESCRIPTION
There's no task number about this. 
But Evgeni pointed me to a problem in dev:
`"message":"Authorization: unable to grant 'read' privilege: lookup L0 Space by NameID: 59f90753-7f4f-454f-802c-2ceb892da9fe user: on authorization 122c7b32-0fbd-489b-b098-27be80145882 of type 'space'"`
![image](https://github.com/user-attachments/assets/8afae7a1-69a6-4ebb-bb58-a0b0e4bfc23b)
On the `/spaces` url we are resolving the space named `welcome-space` to show the Welcome Space on the first position.


- I think anybody with the READ_ABOUT permission should be able to resolve a spaceNameId to id. And not necessarily needs the READ permission.
- Also I think the error message should show the nameId requested