### PR TITLE
Not throwing on missing Spaces on activity feed

### DIFF
--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -147,12 +147,16 @@ export class ActivityFeedService {
     const successOrNonExistingSpaces =
       await this.spaceLookupService.spacesExist(filteredSpaceIds);
     if (Array.isArray(successOrNonExistingSpaces)) {
-      throw new EntityNotFoundException(
-        `Spaces with the following identifiers not found: '${successOrNonExistingSpaces.join(
-          ','
-        )}'`,
+      this.logger.warn(
+        {
+          message:
+            'Some Spaces were not found when filtering for the activity feed',
+          spaceIds: successOrNonExistingSpaces,
+        },
         LogContext.ACTIVITY
       );
+      // return only the valid Spaces
+      return intersection(filteredSpaceIds, successOrNonExistingSpaces);
     }
 
     return filteredSpaceIds;

--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -132,7 +132,6 @@ export class ActivityFeedService {
    * @param spaceIdsFilter
    * @param spaceIds
    * @returns string[] Filtered array of Space ids
-   * @throws {EntityNotFoundException} If Space(s) do not exist
    */
   private async filterSpacesOrFail(
     spaceIds: string[],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the activity feed experience by gracefully handling scenarios with missing content. Now, instead of causing an interruption, the system logs a warning and continues to display available content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->