### PR TITLE
authenticated_at field for user authentication

### DIFF
--- a/src/domain/community/user/dto/roles.dto.authentication.result.ts
+++ b/src/domain/community/user/dto/roles.dto.authentication.result.ts
@@ -15,4 +15,10 @@ export class UserAuthenticationResult {
     nullable: true,
   })
   createdAt?: Date;
+
+  @Field(() => Date, {
+    description: 'When the Kratos Account for the user last logged in',
+    nullable: true,
+  })
+  authenticatedAt?: Date;
 }

--- a/src/domain/community/user/user.resolver.fields.ts
+++ b/src/domain/community/user/user.resolver.fields.ts
@@ -269,8 +269,7 @@ export class UserResolverFields {
       if (identity) {
         result.method =
           await this.kratosService.getAuthenticationTypeFromIdentity(identity);
-        result.createdAt =
-          await this.kratosService.getCreatedAtByEmail(identity);
+        result.createdAt = await this.kratosService.getCreatedAt(identity);
         result.authenticatedAt =
           await this.kratosService.getAuthenticatedAt(identity);
       }

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -483,7 +483,10 @@ export class KratosService {
   public async getAuthenticationTypeFromIdentity(
     identity: Identity
   ): Promise<AuthenticationType> {
-    if (!identity) return AuthenticationType.UNKNOWN;
+    if (!identity) {
+      return AuthenticationType.UNKNOWN;
+    }
+
     return this.mapAuthenticationType(identity);
   }
 

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -466,12 +466,10 @@ export class KratosService {
   /**
    * Retrieves the date at which the account associated with a given email was created.
    *
-   * @param email - The email address to look up the authentication type for.
-   * @returns A promise that resolves to the authentication type.
+   * @param identity - The identity to look up the creation date for.
+   * @returns A promise that resolves to the creation date.
    */
-  public async getCreatedAtByEmail(
-    identity: Identity
-  ): Promise<Date | undefined> {
+  public async getCreatedAt(identity: Identity): Promise<Date | undefined> {
     if (!identity || !identity.created_at) return undefined;
     return new Date(identity.created_at);
   }


### PR DESCRIPTION
- refactored some API logic - moved it to a service, where its place should be
- naive implementation, following the assumption that this will be executed for a single user from API (and not queried on the client somewhere in a key page)
   - much faster implementation would be with a custom field resolver + dataloader that makes on call to Kratos, but that is already not the case for the rest of the `authentication` field, so I believe this is not in-scope at the moment

It's trivial to get the latest `authenticated_at` from a session, but not from an Identity. Identities have multiple Sessions so I retrieve all the sessions for an Identity, Reduce them and Sort them, which is as fast as it gets given the mix of our and Kratos' approach (for a single user).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User authentication responses now include a new field that displays the last login timestamp, giving users better insight into their account activity.

- **Refactor**
  - Internal authentication processing has been streamlined to ensure more accurate and efficient delivery of account details.
  - Removed unnecessary private methods to enhance code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->