### PR TITLE
accept empty string for who and why (about)

### DIFF
--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -79,12 +79,10 @@ export class SpaceAboutService {
         profile: true,
       },
     });
-    if (spaceAboutUpdateData.why) {
-      spaceAbout.why = spaceAboutUpdateData.why;
-    }
-    if (spaceAboutUpdateData.who) {
-      spaceAbout.who = spaceAboutUpdateData.who;
-    }
+
+    // preserve the why and who if not provided but update with empty string
+    spaceAbout.why = spaceAboutUpdateData.why ?? spaceAbout.why;
+    spaceAbout.who = spaceAboutUpdateData.who ?? spaceAbout.who;
 
     if (spaceAboutUpdateData.profile) {
       spaceAbout.profile = await this.profileService.updateProfile(


### PR DESCRIPTION
Fixing - can't remove who and why in space about settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the update process for the About section. Now, when updating your details, only the information you explicitly change is modified, while existing content is preserved, resulting in a more consistent and reliable editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->