### PR TITLE
Fix migration

### DIFF
--- a/src/migrations/1741340581699-innovation-flow-tagsets.ts
+++ b/src/migrations/1741340581699-innovation-flow-tagsets.ts
@@ -85,15 +85,6 @@ export class InnovationFlowTagsets1741340581699 implements MigrationInterface {
 
     // Now have the data in the new setup, convert the L0 callouts to use the new flow states
     await this.setFlowStateOnLevelZeroCallouts(queryRunner);
-
-    // Finally, delete all tagset templates and tagsets for the groups
-    // TODO: Do not delete anything for now, we may want to do this is it makes sense but remaining rows may be a sign of some callouts that were not properly migrated
-    // await queryRunner.query(
-    //   `DELETE FROM tagset WHERE name = '${this.TAGSET_GROUP}'`
-    // );
-    // await queryRunner.query(
-    //   `DELETE FROM tagset_template WHERE name = '${this.TAGSET_GROUP}'`
-    // );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1741340581699-innovation-flow-tagsets.ts
+++ b/src/migrations/1741340581699-innovation-flow-tagsets.ts
@@ -87,12 +87,13 @@ export class InnovationFlowTagsets1741340581699 implements MigrationInterface {
     await this.setFlowStateOnLevelZeroCallouts(queryRunner);
 
     // Finally, delete all tagset templates and tagsets for the groups
-    await queryRunner.query(
-      `DELETE FROM tagset WHERE name = '${this.TAGSET_GROUP}'`
-    );
-    await queryRunner.query(
-      `DELETE FROM tagset_template WHERE name = '${this.TAGSET_GROUP}'`
-    );
+    // TODO: Do not delete anything for now, we may want to do this is it makes sense but remaining rows may be a sign of some callouts that were not properly migrated
+    // await queryRunner.query(
+    //   `DELETE FROM tagset WHERE name = '${this.TAGSET_GROUP}'`
+    // );
+    // await queryRunner.query(
+    //   `DELETE FROM tagset_template WHERE name = '${this.TAGSET_GROUP}'`
+    // );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
@@ -114,12 +115,14 @@ export class InnovationFlowTagsets1741340581699 implements MigrationInterface {
         calloutClassificationId: string;
         flowTagsetId: string;
         groupTagsetId: string;
+        groupTagsetTemplateId: string;
       }[] = await queryRunner.query(
         `SELECT
             callout.id AS id,
             callout.classificationId AS calloutClassificationId,
             flowTagset.id AS flowTagsetId,
-            groupTagset.id AS groupTagsetId
+            groupTagset.id AS groupTagsetId,
+            groupTagset.tagsetTemplateId AS groupTagsetTemplateId
           FROM callout
             LEFT JOIN callout_framing ON callout.framingId = callout_framing.id
             LEFT JOIN profile ON callout_framing.profileId = profile.id
@@ -138,7 +141,10 @@ export class InnovationFlowTagsets1741340581699 implements MigrationInterface {
         }
         if (callout.groupTagsetId) {
           await queryRunner.query(
-            `UPDATE tagset SET classificationId = '${callout.calloutClassificationId}',profileId=null WHERE id = '${callout.groupTagsetId}'`
+            `UPDATE tagset SET classificationId = '${callout.calloutClassificationId}', profileId=null, name='${this.TAGSET_FLOW}' WHERE id = '${callout.groupTagsetId}'`
+          );
+          await queryRunner.query(
+            `UPDATE tagset_template SET name='${this.TAGSET_FLOW}' WHERE id = '${callout.groupTagsetTemplateId}'`
           );
         }
       }


### PR DESCRIPTION
- Previously the migration was wrongly deleting some tagsets
- In acceptance we have some bad data, but with prod data, these three queries, should return 0 results after the migration:
```
select * from tagset where tagset.name = 'callout-group';
select * from tagset_template where tagset_template.name = 'callout-group';
select * from tagset where profileId is null and classificationId is null and id not in (select tagsetId FROM document);
```


There is also another problem not addressed by this migration, in the VC's knowledgeBases there are some callouts that have classification tagsets, and some others that don't. It doesn't make sense (for now) that they have any tagset in the classification, but this may be addressed in the future with another migration.
```
SELECT callouts_set.*, tagset.* FROM callout 
	JOIN callouts_set ON callouts_set.id = callout.calloutsSetId
    LEFT JOIN tagset ON tagset.classificationId = callout.classificationId
WHERE callouts_set.type = 'knowledge-base';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the tag management update process to enhance data consistency.
  - Replaced removal operations with controlled updates for improved reliability.
  - Introduced a new reference property to better support accurate tagging updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->