### PR TITLE
make invitation.createdBy nullable on API level

### DIFF
--- a/src/domain/access/invitation/invitation.resolver.fields.ts
+++ b/src/domain/access/invitation/invitation.resolver.fields.ts
@@ -29,11 +29,15 @@ export class InvitationResolverFields {
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
   @UseGuards(GraphqlGuard)
   @ResolveField('createdBy', () => IUser, {
-    nullable: false,
+    nullable: true,
     description: 'The User who triggered the invitation.',
   })
   @Profiling.api
-  async createdBy(@Parent() invitation: IInvitation): Promise<IUser> {
-    return await this.invitationService.getCreatedBy(invitation);
+  async createdBy(@Parent() invitation: IInvitation): Promise<IUser | null> {
+    try {
+      return await this.invitationService.getCreatedByOrFail(invitation);
+    } catch (error) {
+      return null;
+    }
   }
 }

--- a/src/domain/access/invitation/invitation.service.ts
+++ b/src/domain/access/invitation/invitation.service.ts
@@ -132,7 +132,7 @@ export class InvitationService {
     return contributor;
   }
 
-  async getCreatedByOrFail(invitation: IInvitation): Promise<IUser> {
+  async getCreatedByOrFail(invitation: IInvitation): Promise<IUser | never> {
     const user = await this.userLookupService.getUserOrFail(
       invitation.createdBy
     );

--- a/src/domain/access/invitation/invitation.service.ts
+++ b/src/domain/access/invitation/invitation.service.ts
@@ -132,7 +132,7 @@ export class InvitationService {
     return contributor;
   }
 
-  async getCreatedBy(invitation: IInvitation): Promise<IUser> {
+  async getCreatedByOrFail(invitation: IInvitation): Promise<IUser> {
     const user = await this.userLookupService.getUserOrFail(
       invitation.createdBy
     );


### PR DESCRIPTION
- make application.createdBy field resolver nullable
- changed one method with its proper name