### PR TITLE
fixed assignent of license plans on converted L0 space; fixed converting L1 with L2

### DIFF
--- a/src/services/api/conversion/conversion.module.ts
+++ b/src/services/api/conversion/conversion.module.ts
@@ -13,11 +13,13 @@ import { PlatformModule } from '@platform/platform/platform.module';
 import { TemplatesManagerModule } from '@domain/template/templates-manager/templates.manager.module';
 import { InnovationFlowModule } from '@domain/collaboration/innovation-flow/innovation.flow.module';
 import { TemplateModule } from '@domain/template/template/template.module';
+import { AccountHostModule } from '@domain/space/account.host/account.host.module';
 
 @Module({
   imports: [
     AuthorizationModule,
     SpaceModule,
+    AccountHostModule,
     RoleSetModule,
     AuthorizationModule,
     AuthorizationPolicyModule,

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -27,6 +27,7 @@ import { IUser } from '@domain/community/user/user.interface';
 import { IOrganization } from '@domain/community/organization/organization.interface';
 import { IVirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.interface';
 import { AccountHostService } from '@domain/space/account.host/account.host.service';
+import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 
 export class ConversionService {
   constructor(
@@ -78,6 +79,7 @@ export class ConversionService {
     const subspacesL1 = spaceL1.subspaces;
     const roleSetL1 = spaceL1.community.roleSet;
     const agentL1 = spaceL1.agent;
+    const storageAggregatorL1 = spaceL1.storageAggregator;
 
     const spaceL0Orig = await this.spaceService.getSpaceOrFail(
       spaceL1.levelZeroSpaceID,
@@ -174,14 +176,58 @@ export class ConversionService {
     );
     await this.spaceService.save(spaceL0Orig);
 
-    // Now migrate all the child L2 spaces...
+    // Now migrate all the child L2 spaces...note: this needs to go through a different path than the isolated conversion L2 to L1
     for (const spaceL2 of subspacesL1) {
-      await this.convertSpaceL2ToSpaceL1OrFail({
-        spaceL2ID: spaceL2.id,
-      });
+      await this.updateChildSpaceL2ToL1(
+        spaceL2.id,
+        spaceL1,
+        storageAggregatorL1,
+        roleSetL1
+      );
     }
 
     return spaceL1;
+  }
+
+  private async updateChildSpaceL2ToL1(
+    spaceL2ID: string,
+    spaceL0: ISpace,
+    storageAggregatorL0: IStorageAggregator,
+    roleSetL0: IRoleSet
+  ): Promise<ISpace> {
+    const spaceL2 = await this.spaceService.getSpaceOrFail(spaceL2ID, {
+      relations: {
+        storageAggregator: true,
+        parentSpace: true,
+        community: {
+          roleSet: true,
+        },
+      },
+    });
+    if (
+      !spaceL2.storageAggregator ||
+      !spaceL2.parentSpace ||
+      !spaceL2.community ||
+      !spaceL2.community.roleSet
+    ) {
+      throw new EntityNotInitializedException(
+        `Unable to locate all entities on on Space L2: ${spaceL2.id}`,
+        LogContext.CONVERSION
+      );
+    }
+    const roleSetL2 = spaceL2.community.roleSet;
+
+    spaceL2.level = SpaceLevel.L1;
+    spaceL2.type = SpaceType.CHALLENGE;
+    spaceL2.parentSpace = spaceL0;
+    spaceL2.levelZeroSpaceID = spaceL0.id;
+    spaceL2.storageAggregator.parentStorageAggregator = storageAggregatorL0;
+    spaceL2.community.roleSet =
+      await this.roleSetService.setParentRoleSetAndCredentials(
+        roleSetL2,
+        roleSetL0
+      );
+    return await this.spaceService.save(spaceL2);
   }
 
   private async getInnovationFlowForSpaceL0(): Promise<IInnovationFlowState[]> {
@@ -223,23 +269,10 @@ export class ConversionService {
           community: {
             roleSet: true,
           },
-          storageAggregator: true,
-          parentSpace: {
-            storageAggregator: true,
-            parentSpace: {
-              storageAggregator: true,
-            },
-          },
         },
       }
     );
-    if (
-      !spaceL2.community ||
-      !spaceL2.storageAggregator ||
-      !spaceL2.parentSpace ||
-      !spaceL2.parentSpace.storageAggregator ||
-      !spaceL2.parentSpace.parentSpace
-    ) {
+    if (!spaceL2.community) {
       throw new EntityNotInitializedException(
         `Unable to locate all entities on on Space L2: ${spaceL2.id}`,
         LogContext.CONVERSION
@@ -285,17 +318,12 @@ export class ConversionService {
       );
     }
 
-    spaceL2.level = SpaceLevel.L1;
-    spaceL2.type = SpaceType.CHALLENGE;
-    spaceL2.parentSpace = spaceL0;
-    spaceL2.storageAggregator.parentStorageAggregator = storageAggregatorL0;
-    spaceL2.community.roleSet =
-      await this.roleSetService.setParentRoleSetAndCredentials(
-        roleSetL2,
-        roleSetL0
-      );
-
-    spaceL2 = await this.spaceService.save(spaceL2);
+    spaceL2 = await this.updateChildSpaceL2ToL1(
+      spaceL2.id,
+      spaceL0,
+      storageAggregatorL0,
+      roleSetL0
+    );
     // and add back in the admins
     for (const userAdmin of userAdmins) {
       await this.roleSetService.assignUserToRole(
@@ -304,7 +332,7 @@ export class ConversionService {
         userAdmin.id
       );
     }
-    return spaceL2;
+    return await this.spaceService.getSpaceOrFail(spaceL2.id);
   }
 
   async convertSpaceL1ToSpaceL2OrFail(


### PR DESCRIPTION
Ensure that newly created L0 spaces go through the same license assignment path as when creating a new space on an account.

Updated the logic for updating a L2 to L1 to have it applicable also when updating a L1 with child L2. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced conversion workflows with integrated account management that now automatically assigns appropriate license plans.
  - Improved validation ensures all required information, including the `agent` property, is present during conversion, leading to more reliable processing. 
  - Refactored logic for updating child space data to streamline operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->