### PR TITLE
fix empty reference names

### DIFF
--- a/src/domain/common/reference/dto/reference.dto.create.ts
+++ b/src/domain/common/reference/dto/reference.dto.create.ts
@@ -4,12 +4,13 @@ import {
   MID_TEXT_LENGTH,
   SMALL_TEXT_LENGTH,
 } from '@src/common/constants';
-import { IsOptional, MaxLength } from 'class-validator';
+import { IsOptional, MaxLength, MinLength } from 'class-validator';
 
 @InputType()
 @ObjectType('CreateReferenceData')
 export class CreateReferenceInput {
   @Field({ nullable: false })
+  @MinLength(3)
   @MaxLength(SMALL_TEXT_LENGTH)
   name!: string;
 

--- a/src/migrations/1743578542843-fixEmptyCalloutReferenceName.ts
+++ b/src/migrations/1743578542843-fixEmptyCalloutReferenceName.ts
@@ -6,25 +6,12 @@ export class FixEmptyCalloutReferenceName1743578542843
   private readonly DEFAULT_NAME = 'default'; // Define your default name here
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // First, find all references that match the criteria
-    const referencesToUpdate: { id: string }[] = await queryRunner.query(
-      `SELECT r.id as id
-         FROM reference AS r
-         JOIN profile AS p ON r.profileId = p.id
-         JOIN callout_framing AS cf ON cf.profileId = p.id
-         WHERE r.name = ''`
-    );
-
-    if (referencesToUpdate && referencesToUpdate.length > 0) {
-      const referenceIDsToUpdate = referencesToUpdate.map(ref => ref.id);
-      // Update the references with the default name
-      await queryRunner.query(
-        `UPDATE reference
+    await queryRunner.query(
+      `UPDATE reference
              SET name = ?
-             WHERE name = '' AND id IN (?)`,
-        [this.DEFAULT_NAME, referenceIDsToUpdate]
-      );
-    }
+             WHERE name = ''`,
+      [this.DEFAULT_NAME]
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1743578542843-fixEmptyCalloutReferenceName.ts
+++ b/src/migrations/1743578542843-fixEmptyCalloutReferenceName.ts
@@ -7,34 +7,29 @@ export class FixEmptyCalloutReferenceName1743578542843
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     // First, find all references that match the criteria
-    const referencesToUpdate = await queryRunner.query(
-      `SELECT cf.id, r.createdDate
+    const referencesToUpdate: { id: string }[] = await queryRunner.query(
+      `SELECT r.id as id
          FROM reference AS r
          JOIN profile AS p ON r.profileId = p.id
          JOIN callout_framing AS cf ON cf.profileId = p.id
          WHERE r.name = ''`
     );
 
-    if (referencesToUpdate.length > 0) {
+    if (referencesToUpdate && referencesToUpdate.length > 0) {
+      const referenceIDsToUpdate = referencesToUpdate.map(ref => ref.id);
       // Update the references with the default name
       await queryRunner.query(
         `UPDATE reference
              SET name = ?
-             WHERE name = ''`,
-        [this.DEFAULT_NAME]
+             WHERE name = '' AND id IN (?)`,
+        [this.DEFAULT_NAME, referenceIDsToUpdate]
       );
     }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // Revert the changes if needed
-    // You might want to reset the names back to their original state
-    // This is just an example of how you might revert the changes
-    await queryRunner.query(
-      `UPDATE reference
-         SET name = ''
-         WHERE name = ?`,
-      [this.DEFAULT_NAME]
+    console.log(
+      'Rollback not implemented for FixEmptyCalloutReferenceName1743578542843 migration - migration will not be reversible!'
     );
   }
 }

--- a/src/migrations/1743578542843-fixEmptyCalloutReferenceName.ts
+++ b/src/migrations/1743578542843-fixEmptyCalloutReferenceName.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixEmptyCalloutReferenceName1743578542843
+  implements MigrationInterface
+{
+  private readonly DEFAULT_NAME = 'default'; // Define your default name here
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // First, find all references that match the criteria
+    const referencesToUpdate = await queryRunner.query(
+      `SELECT cf.id, r.createdDate
+         FROM reference AS r
+         JOIN profile AS p ON r.profileId = p.id
+         JOIN callout_framing AS cf ON cf.profileId = p.id
+         WHERE r.name = ''`
+    );
+
+    if (referencesToUpdate.length > 0) {
+      // Update the references with the default name
+      await queryRunner.query(
+        `UPDATE reference
+             SET name = ?
+             WHERE name = ''`,
+        [this.DEFAULT_NAME]
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert the changes if needed
+    // You might want to reset the names back to their original state
+    // This is just an example of how you might revert the changes
+    await queryRunner.query(
+      `UPDATE reference
+         SET name = ''
+         WHERE name = ?`,
+      [this.DEFAULT_NAME]
+    );
+  }
+}


### PR DESCRIPTION
- references for calloutFraming profiles with empty name get name 'default'
- we can change the name if needed - it is in a constant in the migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced a minimum of 3 characters for reference names during creation.
  - Automatically updated any previously empty reference names to a default value for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->