### PR TITLE
Explicitly add org as member + lead for spaces that are hosted in their account

### DIFF
--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1009,6 +1009,23 @@ export class SpaceService {
     );
   }
 
+  public async assignOrganizationToMemberLeadRoles(
+    roleSet: IRoleSet,
+    organizationID: string
+  ) {
+    await this.roleSetService.assignOrganizationToRole(
+      roleSet,
+      RoleName.MEMBER,
+      organizationID
+    );
+
+    await this.roleSetService.assignOrganizationToRole(
+      roleSet,
+      RoleName.LEAD,
+      organizationID
+    );
+  }
+
   public async update(spaceData: UpdateSpaceInput): Promise<ISpace> {
     const space = await this.getSpaceOrFail(spaceData.ID, {
       relations: {

--- a/src/migrations/1744022375257-spaceL0Host.ts
+++ b/src/migrations/1744022375257-spaceL0Host.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+export class SpaceL0Host1744022375257 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const organizations: {
+      id: string;
+      accountID: string;
+    }[] = await queryRunner.query(`SELECT id, accountID FROM \`organization\``);
+    for (const organization of organizations) {
+      const orgSpaces: {
+        id: string;
+        agentId: string;
+      }[] = await queryRunner.query(
+        `SELECT id, agentId FROM \`space\` WHERE accountId = ? AND level = 0`,
+        [organization.accountID]
+      );
+      for (const space of orgSpaces) {
+        // Create and add the credential to the space agent
+        await this.createCredential(
+          queryRunner,
+          'space-member',
+          space.id,
+          space.agentId
+        );
+        await this.createCredential(
+          queryRunner,
+          'space-lead',
+          space.id,
+          space.agentId
+        );
+      }
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+
+  private async createCredential(
+    queryRunner: QueryRunner,
+    credentialType: string,
+    credentialResourceID: string,
+    agentID: string
+  ): Promise<string> {
+    const credentialID = randomUUID();
+    await queryRunner.query(
+      `INSERT INTO credential (id, version, resourceID, type, agentId) VALUES
+                              (
+                            '${credentialID}',
+                              1,
+                              '${credentialResourceID}',
+                              '${credentialType}',
+                              '${agentID}')`
+    );
+    return credentialID;
+  }
+}

--- a/src/migrations/1744022375257-spaceL0Host.ts
+++ b/src/migrations/1744022375257-spaceL0Host.ts
@@ -6,7 +6,10 @@ export class SpaceL0Host1744022375257 implements MigrationInterface {
     const organizations: {
       id: string;
       accountID: string;
-    }[] = await queryRunner.query(`SELECT id, accountID FROM \`organization\``);
+      agentId: string;
+    }[] = await queryRunner.query(
+      `SELECT id, accountID, agentId FROM \`organization\``
+    );
     for (const organization of organizations) {
       const orgSpaces: {
         id: string;
@@ -21,13 +24,13 @@ export class SpaceL0Host1744022375257 implements MigrationInterface {
           queryRunner,
           'space-member',
           space.id,
-          space.agentId
+          organization.agentId
         );
         await this.createCredential(
           queryRunner,
           'space-lead',
           space.id,
-          space.agentId
+          organization.agentId
         );
       }
     }


### PR DESCRIPTION
Migration to assign the org a member + lead credential.

When a new space is created in an org account, then add the org as member + lead. 

NOTE: this must go with the release for the space admin refactoring, as there we take away the client logic to pick up the provider + show the host org as part of the community. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Organization accounts now benefit from automatic role assignments for designated member and lead contacts.
  - Enhanced space management streamlines role application in organizational contexts.
  
- **Chores**
  - Introduced a background migration to generate necessary credentials for spaces, supporting improved access and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->