### PR TITLE
fix name of update classificaiton mutation

### DIFF
--- a/src/domain/common/classification/classification.resolver.mutations.ts
+++ b/src/domain/common/classification/classification.resolver.mutations.ts
@@ -17,9 +17,9 @@ export class ClassificationResolverMutations {
   ) {}
 
   @Mutation(() => ITagset, {
-    description: 'Updates the specified Tagset.',
+    description: 'Updates a Tagset on a Classification.',
   })
-  async updateProfile(
+  async updateClassificationTagset(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('updateData') updateData: UpdateClassificationSelectTagsetValueInput
   ): Promise<ITagset> {


### PR DESCRIPTION
Simple but nasty error, this is blocking the client-lib api updates. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised the tag update operation to clearly indicate its role in classification management, providing enhanced clarity in its description without altering its underlying functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->