### PR TITLE
Extends AI Persona authorization policies

### DIFF
--- a/src/services/ai-server/ai-persona-service/ai.persona.service.external.config.resolver.fields.ts
+++ b/src/services/ai-server/ai-persona-service/ai.persona.service.external.config.resolver.fields.ts
@@ -1,20 +1,13 @@
 import { UseGuards } from '@nestjs/common';
 import { Resolver, Parent, ResolveField } from '@nestjs/graphql';
-import { AiPersonaService } from './ai.persona.service.entity';
 import { AiPersonaServiceService } from './ai.persona.service.service';
-import { AuthorizationPrivilege } from '@common/enums';
 import { GraphqlGuard } from '@core/authorization';
-import { CurrentUser, Profiling } from '@common/decorators';
-import { AuthorizationService } from '@core/authorization/authorization.service';
-import { AgentInfo } from '@core/authentication.agent.info/agent.info';
+import { Profiling } from '@common/decorators';
 import { IExternalConfig } from './dto';
 
 @Resolver(() => IExternalConfig)
 export class AiPersonaServiceExternalConfigResolverFields {
-  constructor(
-    private authorizationService: AuthorizationService,
-    private aiPersonaServiceService: AiPersonaServiceService
-  ) {}
+  constructor(private aiPersonaServiceService: AiPersonaServiceService) {}
 
   @UseGuards(GraphqlGuard)
   @ResolveField('apiKey', () => String, {
@@ -22,47 +15,7 @@ export class AiPersonaServiceExternalConfigResolverFields {
     description: 'The signature of the API key',
   })
   @Profiling.api
-  async apiKey(
-    @Parent() parent: AiPersonaService,
-    @CurrentUser() agentInfo: AgentInfo
-  ) {
-    // Reload to ensure the authorization is loaded
-    console.log(parent.id); //that's undefined for me and the rest is bollocks @valeksiev please look at it, the resolver is IExternalConfig, so the parent here should be the same type (if resolving JSON is possible that way altogether)
-    const aiPersonaService =
-      await this.aiPersonaServiceService.getAiPersonaServiceOrFail(parent.id);
-
-    this.authorizationService.grantAccessOrFail(
-      agentInfo,
-      aiPersonaService.authorization,
-      AuthorizationPrivilege.READ,
-      `ai persona authorization access: ${aiPersonaService.id}`
-    );
-    return this.aiPersonaServiceService.getApiKeyID(
-      aiPersonaService.externalConfig!
-    );
-  }
-
-  @UseGuards(GraphqlGuard)
-  @ResolveField('externalConfig', () => IExternalConfig, {
-    nullable: true,
-    description: 'The ExternalConfig for this Virtual.',
-  })
-  @Profiling.api
-  async externalConfig(
-    @Parent() parent: AiPersonaService,
-    @CurrentUser() agentInfo: AgentInfo
-  ) {
-    // Reload to ensure the authorization is loaded
-    const aiPersonaService =
-      await this.aiPersonaServiceService.getAiPersonaServiceOrFail(parent.id);
-
-    this.authorizationService.grantAccessOrFail(
-      agentInfo,
-      aiPersonaService.authorization,
-      AuthorizationPrivilege.READ,
-      `ai persona authorization access: ${aiPersonaService.id}`
-    );
-
-    return aiPersonaService.externalConfig;
+  async apiKey(@Parent() parent: IExternalConfig) {
+    return this.aiPersonaServiceService.getApiKeyID(parent);
   }
 }

--- a/src/services/ai-server/ai-persona-service/ai.persona.service.external.config.resolver.fields.ts
+++ b/src/services/ai-server/ai-persona-service/ai.persona.service.external.config.resolver.fields.ts
@@ -1,7 +1,5 @@
-import { UseGuards } from '@nestjs/common';
 import { Resolver, Parent, ResolveField } from '@nestjs/graphql';
 import { AiPersonaServiceService } from './ai.persona.service.service';
-import { GraphqlGuard } from '@core/authorization';
 import { Profiling } from '@common/decorators';
 import { IExternalConfig } from './dto';
 
@@ -9,7 +7,6 @@ import { IExternalConfig } from './dto';
 export class AiPersonaServiceExternalConfigResolverFields {
   constructor(private aiPersonaServiceService: AiPersonaServiceService) {}
 
-  @UseGuards(GraphqlGuard)
   @ResolveField('apiKey', () => String, {
     nullable: true,
     description: 'The signature of the API key',

--- a/src/services/ai-server/ai-persona-service/ai.persona.service.external.config.resolver.fields.ts
+++ b/src/services/ai-server/ai-persona-service/ai.persona.service.external.config.resolver.fields.ts
@@ -22,11 +22,12 @@ export class AiPersonaServiceExternalConfigResolverFields {
     description: 'The signature of the API key',
   })
   @Profiling.api
-  async authorization(
+  async apiKey(
     @Parent() parent: AiPersonaService,
     @CurrentUser() agentInfo: AgentInfo
   ) {
     // Reload to ensure the authorization is loaded
+    console.log(parent.id); //that's undefined for me and the rest is bollocks @valeksiev please look at it, the resolver is IExternalConfig, so the parent here should be the same type (if resolving JSON is possible that way altogether)
     const aiPersonaService =
       await this.aiPersonaServiceService.getAiPersonaServiceOrFail(parent.id);
 

--- a/src/services/ai-server/ai-persona-service/ai.persona.service.resolver.fields.ts
+++ b/src/services/ai-server/ai-persona-service/ai.persona.service.resolver.fields.ts
@@ -7,8 +7,14 @@ import { AuthorizationService } from '@core/authorization/authorization.service'
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { IAiPersonaService } from './ai.persona.service.interface';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
+import { AiPersonaEngine } from '@common/enums/ai.persona.engine';
 import { IExternalConfig } from './dto';
 
+const EXTERNALY_CONFIGURABLE_ENGINES = [
+  AiPersonaEngine.LIBRA_FLOW,
+  AiPersonaEngine.GENERIC_OPENAI,
+  AiPersonaEngine.LIBRA_FLOW,
+];
 @Resolver(() => IAiPersonaService)
 export class AiPersonaServiceResolverFields {
   constructor(
@@ -58,6 +64,9 @@ export class AiPersonaServiceResolverFields {
       AuthorizationPrivilege.READ,
       `ai persona authorization access: ${aiPersonaService.id}`
     );
+    if (!EXTERNALY_CONFIGURABLE_ENGINES.includes(aiPersonaService.engine)) {
+      return null;
+    }
 
     return aiPersonaService.externalConfig;
   }

--- a/src/services/ai-server/ai-persona-service/dto/external.config.ts
+++ b/src/services/ai-server/ai-persona-service/dto/external.config.ts
@@ -49,7 +49,7 @@ export class IExternalConfig {
   @Field(() => String, {
     nullable: true,
     description:
-      'The assistent ID backing the service in OpenAI`s assistant API',
+      'The assistant ID backing the service in OpenAI`s assistant API',
   })
   assistantId?: string;
   @Field(() => OpenAIModel, {


### PR DESCRIPTION
related to https://app.zenhub.com/workspaces/alkemio-development-5ecb98b262ebd9f4aec4194c/issues/gh/alkem-io/client-web/8016

Extends AI Persona authorization policies to include account admin credentials,
allowing hosts to manage resources in their account.

Renames 'authorization' field in the resolver to 'apiKey' for clarity.

Adds debug logging to the resolver, investigating parent ID.

NOTE: THE API KEY LOGIC DOES NOT WORK AND NEEDS ATTENTION!

To test:
Update one AI Persona Service for a VC under e.g. Org Host (make a user ORg Admin, and create the VC with another user in the Org Account) to be libraflow with GA:

```gql
mutation updatePSLibraFlow($data:UpdateAiPersonaServiceInput!) {
  aiServerUpdateAiPersonaService(aiPersonaServiceData: $data) {
    id,
    prompt
  }
}
```
```json
{
  "id": "VC_ID"
}
```

with the Org Admin (non GA!):
```gql
query AiPersonaService($id: UUID!) {
  aiServer {
    aiPersonaService(ID: $id) {
      id
      prompt
      engine
      externalConfig {
        apiKey
        assistantId
        model
        __typename
      }
      __typename
    }
    __typename
  }
}
```
```json
{
  "id": "95a28f56-5f7b-4c8b-bb5a-1f9ab8fb49d9"
}
```
