### PR TITLE
Authorization: account admins; license managers

### DIFF
--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -36,6 +36,7 @@ export enum AuthorizationPrivilege {
   COMMUNITY_ASSIGN_VC_FROM_ACCOUNT = 'community-assign-vc-from-account', // allow adding a VC as member to a community from an account
   UPDATE_CALLOUT_PUBLISHER = 'update-callout-publisher',
   READ_ABOUT = 'read-about', // access the external about information for an entity
+  READ_LICENSE = 'read-license', // access the licensing information for an entity
   READ_USERS = 'read-users',
   READ_USER_PII = 'read-user-pii',
   READ_USER_SETTINGS = 'read-user-settings',

--- a/src/domain/space/space/space.resolver.fields.ts
+++ b/src/domain/space/space/space.resolver.fields.ts
@@ -99,7 +99,7 @@ export class SpaceResolverFields {
     return loader.load(space.id);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ_LICENSE)
   @UseGuards(GraphqlGuard)
   @ResolveField('license', () => ILicense, {
     nullable: false,

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -437,10 +437,26 @@ export class SpaceAuthorizationService {
       );
     updatedAuthorizations.push(...collaborationAuthorizations);
 
+    const clonedSpaceAuthorization =
+      this.authorizationPolicyService.cloneAuthorizationPolicy(
+        space.authorization
+      );
+    const readAccessLicense =
+      this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
+        [AuthorizationPrivilege.READ],
+        [
+          AuthorizationCredential.GLOBAL_LICENSE_MANAGER,
+          AuthorizationCredential.GLOBAL_SUPPORT,
+        ],
+        'Read access to License'
+      );
+    readAccessLicense.cascade = true;
+    clonedSpaceAuthorization.credentialRules.push(readAccessLicense);
+
     const licenseAuthorizations =
       this.licenseAuthorizationService.applyAuthorizationPolicy(
         space.license,
-        space.authorization
+        clonedSpaceAuthorization
       );
     updatedAuthorizations.push(...licenseAuthorizations);
 
@@ -626,6 +642,7 @@ export class SpaceAuthorizationService {
         [
           AuthorizationCredential.GLOBAL_ADMIN,
           AuthorizationCredential.GLOBAL_SUPPORT,
+          AuthorizationCredential.GLOBAL_LICENSE_MANAGER,
         ],
         CREDENTIAL_RULE_TYPES_SPACE_PLATFORM_SETTINGS
       );

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -83,6 +83,7 @@ export class SpaceAuthorizationService {
         subspaces: true,
         templatesManager: true,
         license: true,
+        account: true,
       },
     });
     if (


### PR DESCRIPTION
Ensure the License Managers have the ReadAbout privilege on all L0 spaces

For Account Admins:
- ensure they can ReadAbout all L0 spaces in the account
- ensure that they can access the license field

For access to License, there is a new privilege: READ_LICENSE. This is because this information is between READ_ABOUT and READ - the account admin should not have READ to the space to be able to see all the license details. And READ_ABOUT should not grant the user access to the License. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated licensing access permission that offers more granular control over viewing licensing information.
	- Enhanced space access policies ensure that account administrators and global roles can now view license details alongside other space information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->