### PR TITLE
Adds iframe allowed URL management

### DIFF
--- a/src/platform/platform-settings/platform.settings.service.ts
+++ b/src/platform/platform-settings/platform.settings.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { IPlatformSettings } from './platform.settings.interface';
 import { UpdatePlatformSettingsInput } from './dto/platform.settings.dto.update';
+import { EntityNotInitializedException } from '@common/exceptions';
+import { LogContext } from '@common/enums';
 
 @Injectable()
 export class PlatformSettingsService {
@@ -32,7 +34,12 @@ export class PlatformSettingsService {
     settings: IPlatformSettings,
     iframeAllowedURL: string
   ): string[] {
-    const currentUrls = settings.integration?.iframeAllowedUrls || [];
+    if (!settings.integration)
+      throw new EntityNotInitializedException(
+        'Settings  not initialized',
+        LogContext.PLATFORM
+      );
+    const currentUrls = settings.integration?.iframeAllowedUrls;
 
     // Only add if not already present
     if (!currentUrls.includes(iframeAllowedURL)) {
@@ -46,7 +53,12 @@ export class PlatformSettingsService {
     settings: IPlatformSettings,
     iframeAllowedURL: string
   ): string[] {
-    const currentUrls = settings.integration?.iframeAllowedUrls || [];
+    if (!settings.integration)
+      throw new EntityNotInitializedException(
+        'Settings  not initialized',
+        LogContext.PLATFORM
+      );
+    const currentUrls = settings.integration?.iframeAllowedUrls;
 
     const updatedUrls = currentUrls.filter(url => url !== iframeAllowedURL);
 

--- a/src/platform/platform-settings/platform.settings.service.ts
+++ b/src/platform/platform-settings/platform.settings.service.ts
@@ -30,10 +30,10 @@ export class PlatformSettingsService {
     return updatedSettings;
   }
 
-  public addIframeAllowedURL(
+  public addIframeAllowedURLOrFail(
     settings: IPlatformSettings,
     iframeAllowedURL: string
-  ): string[] {
+  ): string[] | never {
     if (!settings.integration)
       throw new EntityNotInitializedException(
         'Settings  not initialized',
@@ -49,10 +49,10 @@ export class PlatformSettingsService {
     return currentUrls;
   }
 
-  public removeIframeAllowedURL(
+  public removeIframeAllowedURLOrFail(
     settings: IPlatformSettings,
     iframeAllowedURL: string
-  ): string[] {
+  ): string[] | never {
     if (!settings.integration)
       throw new EntityNotInitializedException(
         'Settings  not initialized',

--- a/src/platform/platform-settings/platform.settings.service.ts
+++ b/src/platform/platform-settings/platform.settings.service.ts
@@ -27,4 +27,29 @@ export class PlatformSettingsService {
     }
     return updatedSettings;
   }
+
+  public addIframeAllowedURL(
+    settings: IPlatformSettings,
+    iframeAllowedURL: string
+  ): string[] {
+    const currentUrls = settings.integration?.iframeAllowedUrls || [];
+
+    // Only add if not already present
+    if (!currentUrls.includes(iframeAllowedURL)) {
+      currentUrls.push(iframeAllowedURL);
+    }
+
+    return currentUrls;
+  }
+
+  public removeIframeAllowedURL(
+    settings: IPlatformSettings,
+    iframeAllowedURL: string
+  ): string[] {
+    const currentUrls = settings.integration?.iframeAllowedUrls || [];
+
+    const updatedUrls = currentUrls.filter(url => url !== iframeAllowedURL);
+
+    return updatedUrls;
+  }
 }

--- a/src/platform/platform/platform.resolver.mutations.ts
+++ b/src/platform/platform/platform.resolver.mutations.ts
@@ -70,4 +70,56 @@ export class PlatformResolverMutations {
 
     return platform.settings;
   }
+
+  @Mutation(() => [String], {
+    description: 'Adds an Iframe Allowed URL to the Platform Settings',
+  })
+  async addIframeAllowedURL(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('iframeAllowedURL') iframeAllowedURL: string
+  ): Promise<string[]> {
+    const platform = await this.platformService.getPlatformOrFail();
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      platform.authorization,
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      `add iframe URL: ${iframeAllowedURL}`
+    );
+
+    platform.settings.integration.iframeAllowedUrls =
+      this.platformSettingsService.addIframeAllowedURL(
+        platform.settings,
+        iframeAllowedURL
+      );
+    await this.platformService.savePlatform(platform);
+
+    return platform.settings.integration.iframeAllowedUrls;
+  }
+
+  @Mutation(() => [String], {
+    description: 'Removes an Iframe Allowed URL from the Platform Settings',
+  })
+  async removeIframeAllowedURL(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('iframeAllowedURL') iframeAllowedURL: string
+  ): Promise<string[]> {
+    const platform = await this.platformService.getPlatformOrFail();
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      platform.authorization,
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      `remove iframe URL: ${iframeAllowedURL}`
+    );
+
+    platform.settings.integration.iframeAllowedUrls =
+      this.platformSettingsService.removeIframeAllowedURL(
+        platform.settings,
+        iframeAllowedURL
+      );
+    await this.platformService.savePlatform(platform);
+
+    return platform.settings.integration.iframeAllowedUrls;
+  }
 }

--- a/src/platform/platform/platform.resolver.mutations.ts
+++ b/src/platform/platform/platform.resolver.mutations.ts
@@ -76,7 +76,7 @@ export class PlatformResolverMutations {
   })
   async addIframeAllowedURL(
     @CurrentUser() agentInfo: AgentInfo,
-    @Args('iframeAllowedURL') iframeAllowedURL: string
+    @Args('whitelistedURL') whitelistedURL: string
   ): Promise<string[]> {
     const platform = await this.platformService.getPlatformOrFail();
 
@@ -84,13 +84,13 @@ export class PlatformResolverMutations {
       agentInfo,
       platform.authorization,
       AuthorizationPrivilege.PLATFORM_ADMIN,
-      `add iframe URL: ${iframeAllowedURL}`
+      `add iframe URL: ${whitelistedURL}`
     );
 
     platform.settings.integration.iframeAllowedUrls =
-      this.platformSettingsService.addIframeAllowedURL(
+      this.platformSettingsService.addIframeAllowedURLOrFail(
         platform.settings,
-        iframeAllowedURL
+        whitelistedURL
       );
     await this.platformService.savePlatform(platform);
 
@@ -102,7 +102,7 @@ export class PlatformResolverMutations {
   })
   async removeIframeAllowedURL(
     @CurrentUser() agentInfo: AgentInfo,
-    @Args('iframeAllowedURL') iframeAllowedURL: string
+    @Args('whitelistedURL') whitelistedURL: string
   ): Promise<string[]> {
     const platform = await this.platformService.getPlatformOrFail();
 
@@ -110,13 +110,13 @@ export class PlatformResolverMutations {
       agentInfo,
       platform.authorization,
       AuthorizationPrivilege.PLATFORM_ADMIN,
-      `remove iframe URL: ${iframeAllowedURL}`
+      `remove iframe URL: ${whitelistedURL}`
     );
 
     platform.settings.integration.iframeAllowedUrls =
-      this.platformSettingsService.removeIframeAllowedURL(
+      this.platformSettingsService.removeIframeAllowedURLOrFail(
         platform.settings,
-        iframeAllowedURL
+        whitelistedURL
       );
     await this.platformService.savePlatform(platform);
 


### PR DESCRIPTION
Adds mutations to manage the iframe allowed URLs.
It allows to add and remove URLs from the settings
of the platform.

resolves #5014 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled platform administrators to dynamically add allowed URL entries for iframe content.
  - Provided functionality for administrators to remove existing allowed URL entries, enhancing control over iframe integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->