### PR TITLE
[not urgent] Wait for RabbitMQ to be healthy for some services to start

### DIFF
--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -206,6 +206,9 @@ services:
     hostname: notifications
     image: alkemio/notifications:v0.19.0
     platform: linux/x86_64
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER
@@ -273,6 +276,9 @@ services:
     hostname: whiteboard-collaboration
     image: alkemio/whiteboard-collaboration-service:v0.5.0
     platform: linux/x86_64
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER
@@ -291,6 +297,9 @@ services:
     hostname: file-service
     image: alkemio/file-service:v0.1.2
     platform: linux/x86_64
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -241,6 +241,9 @@ services:
       - WAIT_SLEEP_INTERVAL=30
       - WAIT_HOST_CONNECT_TIMEOUT=30
     restart: always
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
     networks:
       - alkemio_dev_net
     command: sh -c "/wait && npm run start"

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -207,7 +207,8 @@ services:
     image: alkemio/notifications:v0.21.1
     platform: linux/x86_64
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER
@@ -294,7 +295,8 @@ services:
     image: alkemio/whiteboard-collaboration-service:v0.6.0
     platform: linux/x86_64
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER
@@ -314,7 +316,8 @@ services:
     image: alkemio/file-service:v0.1.2
     platform: linux/x86_64
     depends_on:
-        - rabbitmq
+      rabbitmq:
+        condition: service_healthy
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER


### PR DESCRIPTION
This resolves the need of restarting the fileservice and the whiteboard-collaboration-service when restarting the services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved service startup reliability by ensuring notification, whiteboard collaboration, and file services now wait for RabbitMQ to be healthy before starting. This change affects multiple Docker Compose configurations and helps prevent issues caused by dependent services starting too early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->