### PR TITLE
Bulk update mutations for in-app notification state

### DIFF
--- a/src/domain/in-app-notification-reader/in.app.notification.reader.ts
+++ b/src/domain/in-app-notification-reader/in.app.notification.reader.ts
@@ -8,6 +8,7 @@ import { EntityNotFoundException } from '@common/exceptions';
 import { LogContext } from '@common/enums';
 
 @Injectable()
+// Note: This class is subject to a rename in the future, as it will likely handle all notification operations, not just reading.
 export class InAppNotificationReader {
   constructor(
     @InjectRepository(InAppNotificationEntity)
@@ -64,7 +65,7 @@ export class InAppNotificationReader {
     userId: string,
     state: InAppNotificationState
   ): Promise<UpdateResult> {
-    return await this.inAppNotificationRepo.update(
+    return this.inAppNotificationRepo.update(
       { id: In(notificationIds), receiverID: userId },
       { state }
     );

--- a/src/domain/in-app-notification-reader/in.app.notification.reader.ts
+++ b/src/domain/in-app-notification-reader/in.app.notification.reader.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { Repository, In, UpdateResult } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { InAppNotificationEntity } from '@domain/in-app-notification/in.app.notification.entity';
@@ -57,5 +57,16 @@ export class InAppNotificationReader {
     });
 
     return updatedNotification.state;
+  }
+
+  async bulkUpdateNotificationState(
+    notificationIds: string[],
+    userId: string,
+    state: InAppNotificationState
+  ): Promise<UpdateResult> {
+    return await this.inAppNotificationRepo.update(
+      { id: In(notificationIds), receiverID: userId },
+      { state }
+    );
   }
 }

--- a/src/domain/in-app-notification-reader/in.app.notification.resolver.mutations.ts
+++ b/src/domain/in-app-notification-reader/in.app.notification.resolver.mutations.ts
@@ -41,4 +41,47 @@ export class InAppNotificationResolverMutations {
 
     return notificationData.state;
   }
+
+  private async updateNotificationStates(
+    agentInfo: AgentInfo,
+    notificationIds: string[],
+    state: InAppNotificationState
+  ): Promise<boolean> {
+    const result =
+      await this.inAppNotificationReader.bulkUpdateNotificationState(
+        notificationIds,
+        agentInfo.userID,
+        state
+      );
+
+    return (result?.affected ?? 0) > 0;
+  }
+
+  @Mutation(() => Boolean, {
+    description: 'Mark multiple notifications as read.',
+  })
+  async markNotificationsAsRead(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('notificationIds', { type: () => [String] }) notificationIds: string[]
+  ): Promise<boolean> {
+    return this.updateNotificationStates(
+      agentInfo,
+      notificationIds,
+      InAppNotificationState.READ
+    );
+  }
+
+  @Mutation(() => Boolean, {
+    description: 'Mark multiple notifications as unread.',
+  })
+  async markNotificationsAsUnread(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('notificationIds', { type: () => [String] }) notificationIds: string[]
+  ): Promise<boolean> {
+    return this.updateNotificationStates(
+      agentInfo,
+      notificationIds,
+      InAppNotificationState.UNREAD
+    );
+  }
 }

--- a/src/domain/in-app-notification-reader/in.app.notification.resolver.mutations.ts
+++ b/src/domain/in-app-notification-reader/in.app.notification.resolver.mutations.ts
@@ -42,21 +42,6 @@ export class InAppNotificationResolverMutations {
     return notificationData.state;
   }
 
-  private async updateNotificationStates(
-    agentInfo: AgentInfo,
-    notificationIds: string[],
-    state: InAppNotificationState
-  ): Promise<boolean> {
-    const result =
-      await this.inAppNotificationReader.bulkUpdateNotificationState(
-        notificationIds,
-        agentInfo.userID,
-        state
-      );
-
-    return (result?.affected ?? 0) > 0;
-  }
-
   @Mutation(() => Boolean, {
     description: 'Mark multiple notifications as read.',
   })
@@ -83,5 +68,25 @@ export class InAppNotificationResolverMutations {
       notificationIds,
       InAppNotificationState.UNREAD
     );
+  }
+
+  private async updateNotificationStates(
+    agentInfo: AgentInfo,
+    notificationIds: string[],
+    state: InAppNotificationState
+  ): Promise<boolean> {
+    if (notificationIds.length === 0) {
+      return false;
+    }
+
+    const result =
+      await this.inAppNotificationReader.bulkUpdateNotificationState(
+        notificationIds,
+        agentInfo.userID,
+        state
+      );
+
+    // Note: The `affected` property is not supported by all database drivers. For unsupported drivers, it will be `undefined`.
+    return (result?.affected ?? 0) > 0;
   }
 }


### PR DESCRIPTION
Exposing two mutations for updating the notification state. I decided to make them explicit instead of leaving the client passing the state. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to mark multiple in-app notifications as read or unread at once.
  - Introduced new options to update the state of several notifications simultaneously via batch actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->