### PR TITLE
Change Cleanup callout on Tutorials space template

### DIFF
--- a/src/core/bootstrap/platform-template-definitions/space-tutorials/bootstrap.space.tutorials.callouts.ts
+++ b/src/core/bootstrap/platform-template-definitions/space-tutorials/bootstrap.space.tutorials.callouts.ts
@@ -99,7 +99,7 @@ export const bootstrapSpaceTutorialsCallouts: CreateCalloutInput[] = [
       profile: {
         displayName: '🧹 Cleaning up',
         description:
-          "Done with the tutorials and ready to build up this Space your way? You can move the tutorials to your knowledge base or delete them completely.\n\n*   To move:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Edit\n    *   Scroll down to 'Location'\n    *   Select 'Knowledge Base' or any other page\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm",
+          "Done with the tutorials and ready to build up this Space/Subspace your way? You can move the tutorials or delete them completely. \n\n*   To move in a Space:\n\n    *   Go to the settings using the ⚙️ icon on the top right of the space \n    *   Go to the LAYOUT tab \n    *   Drag the tool to the page you want\n\n* To move in a Subspace:\n\n    *   Go to the innovation flow and click on the icon to manage the flow \n    *   Drag the tool to the phase you want\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm \n\n You can always find the tutorials in the [tutorials template pack](https://alkem.io/innovation-packs/newspace) and in the [documentation](https://alkem.io/docs/how-to/tutorials.en-US).",
       },
     },
   },

--- a/src/migrations/1747050057273-updateTutorialTemplate.ts
+++ b/src/migrations/1747050057273-updateTutorialTemplate.ts
@@ -5,8 +5,8 @@ const PLATFORM_SPACE_TUTORIALS = 'platform-space-tutorials'; // = enum at src/co
 export class UpdateTutorialTemplate1747050057273 implements MigrationInterface {
   private findTemplateProfileId = async (
     queryRunner: QueryRunner
-  ): Promise<string | null> => {
-    const templates: { id: string }[] = await queryRunner.query(`
+  ): Promise<string> => {
+    const templateProfileIds: { id: string }[] = await queryRunner.query(`
       SELECT profile.id FROM template
         JOIN collaboration ON collaboration.id = template.collaborationId
         JOIN callout ON callout.calloutsSetId = collaboration.calloutsSetId
@@ -19,15 +19,12 @@ export class UpdateTutorialTemplate1747050057273 implements MigrationInterface {
       )
       AND profile.description LIKE 'Done with the tutorials and ready to%';
     `);
-    if (templates.length === 0) {
-      console.warn('No templates to update');
-      return null;
-    } else if (templates.length > 1) {
+    if (templateProfileIds.length !== 1) {
       throw new Error(
-        `Found ${templates.length} templates to update, expected only one.`
+        `Found ${templateProfileIds.length} templates to update, expected one.`
       );
     } else {
-      return templates[0].id;
+      return templateProfileIds[0].id;
     }
   };
 
@@ -47,23 +44,19 @@ export class UpdateTutorialTemplate1747050057273 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Updates the text of certain callout in the platform template to create a space with tutorials
     const profileId = await this.findTemplateProfileId(queryRunner);
-    if (profileId) {
-      await this.updateDescription(
-        queryRunner,
-        profileId,
-        'Done with the tutorials and ready to build up this Space/Subspace your way? You can move the tutorials or delete them completely. \n\n*   To move in a Space:\n\n    *   Go to the settings using the ⚙️ icon on the top right of the space \n    *   Go to the LAYOUT tab \n    *   Drag the tool to the page you want\n\n* To move in a Subspace:\n\n    *   Go to the innovation flow and click on the icon to manage the flow \n    *   Drag the tool to the phase you want\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm \n\n You can always find the tutorials in the [tutorials template pack](https://alkem.io/innovation-packs/newspace) and in the [documentation](https://alkem.io/docs/how-to/tutorials.en-US).'
-      );
-    }
+    await this.updateDescription(
+      queryRunner,
+      profileId,
+      'Done with the tutorials and ready to build up this Space/Subspace your way? You can move the tutorials or delete them completely. \n\n*   To move in a Space:\n\n    *   Go to the settings using the ⚙️ icon on the top right of the space \n    *   Go to the LAYOUT tab \n    *   Drag the tool to the page you want\n\n* To move in a Subspace:\n\n    *   Go to the innovation flow and click on the icon to manage the flow \n    *   Drag the tool to the phase you want\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm \n\n You can always find the tutorials in the [tutorials template pack](https://alkem.io/innovation-packs/newspace) and in the [documentation](https://alkem.io/docs/how-to/tutorials.en-US).'
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     const profileId = await this.findTemplateProfileId(queryRunner);
-    if (profileId) {
-      await this.updateDescription(
-        queryRunner,
-        profileId,
-        "Done with the tutorials and ready to build up this Space your way? You can move the tutorials to your knowledge base or delete them completely.\n\n*   To move:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Edit\n    *   Scroll down to 'Location'\n    *   Select 'Knowledge Base' or any other page\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm"
-      );
-    }
+    await this.updateDescription(
+      queryRunner,
+      profileId,
+      "Done with the tutorials and ready to build up this Space your way? You can move the tutorials to your knowledge base or delete them completely.\n\n*   To move:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Edit\n    *   Scroll down to 'Location'\n    *   Select 'Knowledge Base' or any other page\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm"
+    );
   }
 }

--- a/src/migrations/1747050057273-updateTutorialTemplate.ts
+++ b/src/migrations/1747050057273-updateTutorialTemplate.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const PLATFORM_SPACE_TUTORIALS = 'platform-space-tutorials'; // = enum at src/common/enums/template.default.type.ts
+
+export class UpdateTutorialTemplate1747050057273 implements MigrationInterface {
+  private findTemplateProfileId = async (
+    queryRunner: QueryRunner
+  ): Promise<string | null> => {
+    const templates: { id: string }[] = await queryRunner.query(`
+      SELECT profile.id FROM template
+        JOIN collaboration ON collaboration.id = template.collaborationId
+        JOIN callout ON callout.calloutsSetId = collaboration.calloutsSetId
+        JOIN callout_framing ON callout_framing.id = callout.framingId
+        JOIN profile ON profile.id = callout_framing.profileId
+      WHERE template.id IN (
+        SELECT templateId FROM template_default WHERE templatesManagerId IN (
+          SELECT templatesManagerId FROM platform
+        ) AND template_default.type = '${PLATFORM_SPACE_TUTORIALS}'
+      )
+      AND profile.description LIKE 'Done with the tutorials and ready to%';
+    `);
+    if (templates.length === 0) {
+      console.warn('No templates to update');
+      return null;
+    } else if (templates.length > 1) {
+      throw new Error(
+        `Found ${templates.length} templates to update, expected only one.`
+      );
+    } else {
+      return templates[0].id;
+    }
+  };
+
+  private updateDescription = async (
+    queryRunner: QueryRunner,
+    profileId: string,
+    newDescription: string
+  ) => {
+    await queryRunner.query(
+      `
+      UPDATE profile SET description = ? WHERE id = ?;
+    `,
+      [newDescription, profileId]
+    );
+  };
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Updates the text of certain callout in the platform template to create a space with tutorials
+    const profileId = await this.findTemplateProfileId(queryRunner);
+    if (profileId) {
+      await this.updateDescription(
+        queryRunner,
+        profileId,
+        'Done with the tutorials and ready to build up this Space/Subspace your way? You can move the tutorials or delete them completely. \n\n*   To move in a Space:\n\n    *   Go to the settings using the ⚙️ icon on the top right of the space \n    *   Go to the LAYOUT tab \n    *   Drag the tool to the page you want\n\n* To move in a Subspace:\n\n    *   Go to the innovation flow and click on the icon to manage the flow \n    *   Drag the tool to the phase you want\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm \n\n You can always find the tutorials in the [tutorials template pack](https://alkem.io/innovation-packs/newspace) and in the [documentation](https://alkem.io/docs/how-to/tutorials.en-US).'
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const profileId = await this.findTemplateProfileId(queryRunner);
+    if (profileId) {
+      await this.updateDescription(
+        queryRunner,
+        profileId,
+        "Done with the tutorials and ready to build up this Space your way? You can move the tutorials to your knowledge base or delete them completely.\n\n*   To move:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Edit\n    *   Scroll down to 'Location'\n    *   Select 'Knowledge Base' or any other page\n\n*   To remove:\n\n    *   Click on the ⚙️ icon on the block with the tutorial > Delete\n    *   Confirm"
+      );
+    }
+  }
+}


### PR DESCRIPTION
### Describe the background of your pull request

Updating the text of the cleanup default callout. Based on this issue: https://github.com/alkem-io/product/issues/1525

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for moving or deleting tutorials, providing separate steps for actions within a Space and a Subspace.
  - Added helpful links to the tutorials template pack and documentation for further guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->