### PR TITLE
Fix: inviteForEntryRoleOnRoleSet mutation not working

### DIFF
--- a/src/domain/access/invitation/invitation.service.ts
+++ b/src/domain/access/invitation/invitation.service.ts
@@ -12,7 +12,13 @@ import {
   RelationshipNotFoundException,
 } from '@common/exceptions';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindManyOptions, FindOneOptions, Repository } from 'typeorm';
+import {
+  FindManyOptions,
+  FindOneOptions,
+  FindOptionsWhere,
+  In,
+  Repository,
+} from 'typeorm';
 import { LifecycleService } from '@domain/common/lifecycle/lifecycle.service';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -106,6 +112,23 @@ export class InvitationService {
         LogContext.COMMUNITY
       );
     return invitation;
+  }
+
+  async getInvitationsOrFail(
+    invitationIds: string[],
+    options?: FindOptionsWhere<Invitation>[]
+  ): Promise<IInvitation[] | never> {
+    const invitations = await this.invitationRepository.findBy({
+      ...options,
+      id: In(invitationIds),
+    });
+
+    if (!invitations || invitationIds.length !== invitations.length)
+      throw new EntityNotFoundException(
+        `Some invitations couldn't be found with these Ids:${JSON.stringify(invitationIds)}`,
+        LogContext.COMMUNITY
+      );
+    return invitations;
   }
 
   async save(invitation: IInvitation): Promise<IInvitation> {

--- a/src/domain/access/invitation/invitation.service.ts
+++ b/src/domain/access/invitation/invitation.service.ts
@@ -116,7 +116,7 @@ export class InvitationService {
 
   async getInvitationsOrFail(
     invitationIds: string[],
-    options?: FindOptionsWhere<Invitation>[]
+    options?: FindOptionsWhere<Invitation>
   ): Promise<IInvitation[] | never> {
     const invitations = await this.invitationRepository.findBy({
       ...options,

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -305,9 +305,17 @@ export class RoleSetResolverMutationsMembership {
       );
     invitationResults.push(...newUserInvitationResults);
 
-    // TODO: Why do we need to reset the authorizations to all the invitations & applications
-    // and not just to the newly created ones
+    // Reset all authorizations on the invitations and applications because it's easier
     await this.resetAuthorizationsOnRoleSetApplicationsInvitations(roleSet.id);
+
+    // Reload the invitations to get the latest authorizations
+    for (const result of invitationResults) {
+      if (result.invitation) {
+        result.invitation = await this.invitationService.getInvitationOrFail(
+          result.invitation.id
+        );
+      }
+    }
 
     await this.sendNotificationEventsForInvitationsOnSpaceRoleSet(
       roleSet,
@@ -637,11 +645,6 @@ export class RoleSetResolverMutationsMembership {
 
       const invitation =
         await this.roleSetService.createInvitationExistingContributor(input);
-
-      await this.invitationAuthorizationService.applyAuthorizationPolicy(
-        invitation,
-        roleSet.authorization
-      );
 
       const invitationResult: RoleSetInvitationResult = {
         type: RoleSetInvitationResultType.INVITED_TO_ROLE_SET,

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -61,6 +61,7 @@ import { InstrumentResolver } from '@src/apm/decorators';
 import { RoleSetInvitationResult } from './dto/role.set.invitation.result';
 import { RoleSetInvitationResultType } from '@common/enums/role.set.invitation.result.type';
 import { RoleSetContributorType } from '@common/enums/role.set.contributor.type';
+import { compact } from 'lodash';
 
 @InstrumentResolver()
 @Resolver()
@@ -307,10 +308,15 @@ export class RoleSetResolverMutationsMembership {
     await this.resetAuthorizationsOnRoleSetApplicationsInvitations(roleSet.id);
 
     // Reload the invitations to get the latest authorizations
+    const invitationsReloaded =
+      await this.invitationService.getInvitationsOrFail(
+        compact(invitationResults.map(result => result.invitation?.id))
+      );
+
     for (const result of invitationResults) {
       if (result.invitation) {
-        result.invitation = await this.invitationService.getInvitationOrFail(
-          result.invitation.id
+        result.invitation = invitationsReloaded.find(
+          invitationReloaded => invitationReloaded.id === result.invitation!.id
         );
       }
     }

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -61,7 +61,6 @@ import { InstrumentResolver } from '@src/apm/decorators';
 import { RoleSetInvitationResult } from './dto/role.set.invitation.result';
 import { RoleSetInvitationResultType } from '@common/enums/role.set.invitation.result.type';
 import { RoleSetContributorType } from '@common/enums/role.set.contributor.type';
-import { InvitationAuthorizationService } from '../invitation/invitation.service.authorization';
 
 @InstrumentResolver()
 @Resolver()
@@ -80,7 +79,6 @@ export class RoleSetResolverMutationsMembership {
     private roleSetServiceLifecycleInvitation: RoleSetServiceLifecycleInvitation,
     private applicationService: ApplicationService,
     private invitationService: InvitationService,
-    private invitationAuthorizationService: InvitationAuthorizationService,
     private contributorService: ContributorService,
     private platformInvitationService: PlatformInvitationService,
     private licenseService: LicenseService,

--- a/src/services/api/lookup/lookup.module.ts
+++ b/src/services/api/lookup/lookup.module.ts
@@ -14,6 +14,7 @@ import { CalendarEventModule } from '@domain/timeline/event/event.module';
 import { CalendarModule } from '@domain/timeline/calendar/calendar.module';
 import { ApplicationModule } from '@domain/access/application/application.module';
 import { InvitationModule } from '@domain/access/invitation/invitation.module';
+import { PlatformInvitationModule } from '@domain/access/invitation.platform/platform.invitation.module';
 import { WhiteboardModule } from '@domain/common/whiteboard';
 import { DocumentModule } from '@domain/storage/document/document.module';
 import { StorageAggregatorModule } from '@domain/storage/storage-aggregator/storage.aggregator.module';
@@ -61,6 +62,7 @@ import { SpaceAboutModule } from '@domain/space/space.about/space.about.module';
     RoomModule,
     ApplicationModule,
     InvitationModule,
+    PlatformInvitationModule,
     InnovationHubModule,
     DocumentModule,
     StorageAggregatorModule,

--- a/src/services/api/lookup/lookup.resolver.fields.ts
+++ b/src/services/api/lookup/lookup.resolver.fields.ts
@@ -26,8 +26,10 @@ import { ICalendar } from '@domain/timeline/calendar/calendar.interface';
 import { CalendarService } from '@domain/timeline/calendar/calendar.service';
 import { ApplicationService } from '@domain/access/application/application.service';
 import { InvitationService } from '@domain/access/invitation/invitation.service';
+import { PlatformInvitationService } from '@domain/access/invitation.platform/platform.invitation.service';
 import { IApplication } from '@domain/access/application';
 import { IInvitation } from '@domain/access/invitation';
+import { IPlatformInvitation } from '@domain/access/invitation.platform';
 import { WhiteboardService } from '@domain/common/whiteboard';
 import { IWhiteboard } from '@domain/common/whiteboard/types';
 import { DocumentService } from '@domain/storage/document/document.service';
@@ -83,6 +85,7 @@ export class LookupResolverFields {
     private communityService: CommunityService,
     private applicationService: ApplicationService,
     private invitationService: InvitationService,
+    private platformInvitationService: PlatformInvitationService,
     private collaborationService: CollaborationService,
     private spaceAboutService: SpaceAboutService,
     private whiteboardService: WhiteboardService,
@@ -414,6 +417,26 @@ export class LookupResolverFields {
     );
 
     return invitation;
+  }
+
+  @ResolveField(() => IPlatformInvitation, {
+    nullable: true,
+    description: 'Lookup the specified PlatformInvitation',
+  })
+  async platformInvitation(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('ID', { type: () => UUID }) id: string
+  ): Promise<IPlatformInvitation> {
+    const platformInvitation =
+      await this.platformInvitationService.getPlatformInvitationOrFail(id);
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      platformInvitation.authorization,
+      AuthorizationPrivilege.READ,
+      `lookup Platform Invitation: ${platformInvitation.id}`
+    );
+
+    return platformInvitation;
   }
 
   @ResolveField(() => ICommunity, {


### PR DESCRIPTION
### Context
This mutation works well
```graphql
mutation {
  inviteForEntryRoleOnRoleSet(
    invitationData: {
      invitedContributorIDs: ["01a59c53-095b-4448-a3dc-8a38a6da5c88"], 
      invitedUserEmails: [], 
      roleSetID: "b73c7f12-d338-44d2-ac11-00850e633d72", 
      welcomeMessage: "Hi"
    }
  ) {
    type
    invitation {
      id
    }
  }
}

```
but if I retrieve contributor information it gives an error
```graphql
mutation {
  inviteForEntryRoleOnRoleSet(
    invitationData: {
      invitedContributorIDs: ["01a59c53-095b-4448-a3dc-8a38a6da5c88"], 
      invitedUserEmails: [], 
      roleSetID: "b73c7f12-d338-44d2-ac11-00850e633d72", 
      welcomeMessage: "Hi"
    }
  ) {
    type
    invitation {
      id
      contributor{
        id
      }
    }
  }
}

```

```
User (....) does not have credentials that grant 'read' access to Invitation.contributor with id 'f6194eca-3def-4603-97c9-ca7c40ce2c66' with authorization: 729db71d-a3cf-42ae-8741-bf374873dc3f",
"stacktrace": [
          "ForbiddenAuthorizationPolicyException: User (...) does not have credentials that grant 'read' access to Invitation.contributor with id 'f6194eca-3def-4603-97c9-ca7c40ce2c66' with authorization: 729db71d-a3cf-42ae-8741-bf374873dc3f",
          "    at new BaseException (/home/carlos/DEV/Alkemio/server/src/common/exceptions/base.exception.ts:15:5)",
          "    at new ForbiddenAuthorizationPolicyException (/home/carlos/DEV/Alkemio/server/src/common/exceptions/forbidden.authorization.policy.exception.ts:15:5)",
          "    at AuthorizationRuleAgentPrivilege.execute (/home/carlos/DEV/Alkemio/server/src/core/authorization/authorization.rule.agent.privilege.ts:50:13)",
          "    at GraphqlGuard.executeAuthorizationRule (/home/carlos/DEV/Alkemio/server/src/core/authorization/graphql.guard.ts:169:10)",
          "    at GraphqlGuard.handleRequest (/home/carlos/DEV/Alkemio/server/src/core/authorization/graphql.guard.ts:145:14)",
          "    at /home/carlos/DEV/Alkemio/server/node_modules/@nestjs/passport/dist/auth.guard.js:44:124",
          "    at /home/carlos/DEV/Alkemio/server/node_modules/@nestjs/passport/dist/auth.guard.js:83:24",
          "    at OryStrategy.success (/home/carlos/DEV/Alkemio/server/node_modules/passport/lib/middleware/authenticate.js:222:18)",
          "    at verified (/home/carlos/DEV/Alkemio/server/node_modules/passport-jwt/lib/strategy.js:115:41)",
          "    at OryStrategy.callback [as _verify] (/home/carlos/DEV/Alkemio/server/node_modules/@nestjs/passport/dist/passport/passport.strategy.js:16:25)",
          "    at processTicksAndRejections (node:internal/process/task_queues:95:5)"
        ]
```

With the help of @hero101 we have realized that the authorization in the invitation is not yet ready when retrieving the `contributor` field, and the Guard rejects the permission, the array of credentials is empty.

That is not happening when we initialize the authorization just after creating the invitation.
But there is another place, where we reset authorization of all the invitations and applications of the roleset after every invitation or application - is there a reason for that?




By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to look up platform invitations by ID with proper access control.
- **Chores**
  - Improved handling of contributor invitations to ensure proper authorization policies are applied.
  - Enhanced invitation data consistency by reloading updated invitation states after authorization resets.
  - Extended invitation service to fetch multiple invitations at once with validation.
  - Integrated platform invitation module into the lookup service for expanded functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->