### PR TITLE
Adds subdomain whitelisting to innovation hub

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -75,6 +75,7 @@ security:
 
 innovation_hub:
   header: ${INNOVATION_HUB_HEADER}:origin
+  whitelisted_subdomains: ${INNOVATION_HUB_WHITELISTED_SUBDOMAINS}:identity
 
 search:
   # max results per search

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -75,6 +75,7 @@ security:
 
 innovation_hub:
   header: ${INNOVATION_HUB_HEADER}:origin
+  # comma separated list of subdomains that are not an innovation hub (starting page)
   whitelisted_subdomains: ${INNOVATION_HUB_WHITELISTED_SUBDOMAINS}:identity
 
 search:

--- a/src/common/interceptors/innovation.hub.interceptor.ts
+++ b/src/common/interceptors/innovation.hub.interceptor.ts
@@ -30,9 +30,6 @@ const SUBDOMAIN_REGEX = new RegExp(
   `https?:\/\/(?<${SUBDOMAIN_GROUP}>${SUBDOMAIN_PATTERN})\\.${DOMAIN_PATTERN}.\\w+`
 );
 
-// List of subdomains that should not be treated as innovation hubs
-const WHITELISTED_SUBDOMAINS = ['identity'];
-
 /***
  * Injects the Innovation Hub in the execution context, if matched with the subdomain
  */
@@ -51,16 +48,12 @@ export class InnovationHubInterceptor implements NestInterceptor {
     });
 
     // Get whitelisted subdomains from config or use default list
-    this.whitelistedSubdomains = this.configService.get(
-      'innovation_hub.whitelisted_subdomains',
-      {
-        infer: true,
-      }
-    );
-
-    if (!this.whitelistedSubdomains) {
-      this.whitelistedSubdomains = WHITELISTED_SUBDOMAINS;
-    }
+    this.whitelistedSubdomains =
+      this.configService
+        .get('innovation_hub.whitelisted_subdomains', {
+          infer: true,
+        })
+        .split(',') || [];
   }
 
   async intercept(context: ExecutionContext, next: CallHandler) {

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -27,6 +27,7 @@ export type AlkemioConfig = {
   };
   innovation_hub: {
     header: string;
+    whitelisted_subdomains: string[];
   };
   search: {
     max_results: number;

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -27,7 +27,7 @@ export type AlkemioConfig = {
   };
   innovation_hub: {
     header: string;
-    whitelisted_subdomains: string[];
+    whitelisted_subdomains: string;
   };
   search: {
     max_results: number;


### PR DESCRIPTION
resolves #5120 

Ensures that specific subdomains are excluded from being treated as innovation hubs.

This prevents unintended routing and ensures that designated subdomains, such as 'identity', are not intercepted by the innovation hub logic. The whitelisted subdomains are configurable through the application's configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a whitelist of subdomains excluded from Innovation Hub injection.
- **Configuration**
  - Introduced a new configuration option to specify whitelisted subdomains, defaulting to "identity".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->