### PR TITLE
Do not log warnings for child collaboration logging

### DIFF
--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -248,7 +248,7 @@ export class ActivityFeedService {
     agentInfo: AgentInfo,
     spaceIds: string[]
   ): Promise<string[]> {
-    const collaborationIds: string[] = [];
+    const readableCollaborationIds: string[] = [];
     for (const spaceId of spaceIds) {
       // filter the collaborations by read access
       const collaboration =
@@ -261,7 +261,7 @@ export class ActivityFeedService {
           AuthorizationPrivilege.READ,
           `Collaboration activity query: ${agentInfo.email}`
         );
-        collaborationIds.push(collaboration.id);
+        readableCollaborationIds.push(collaboration.id);
       } catch (error) {
         this.logger?.warn(
           `User ${agentInfo.userID} is not able to read collaboration ${collaboration.id}`,
@@ -298,12 +298,14 @@ export class ActivityFeedService {
         }
       );
 
-      const collaborationIds = readableChildCollaborations.map(
+      const readableChildCollaborationIds = readableChildCollaborations.map(
         childCollaboration => childCollaboration.id
       );
+
+      readableCollaborationIds.push(...readableChildCollaborationIds);
     }
 
-    return collaborationIds;
+    return readableCollaborationIds;
   }
 }
 

--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -282,23 +282,20 @@ export class ActivityFeedService {
         );
       }
 
-      // filter the child collaborations by read access
-      for (const childCollaboration of childCollaborations) {
-        try {
+      // Filter the child collaborations by read access
+      const readableChildCollaborations = childCollaborations.filter(
+        childCollaboration =>
           this.authorizationService.grantAccessOrFail(
             agentInfo,
             childCollaboration.authorization,
             AuthorizationPrivilege.READ,
             `Collaboration activity query: ${agentInfo.email}`
-          );
-          collaborationIds.push(childCollaboration.id);
-        } catch (e) {
-          this.logger?.warn(
-            `User ${agentInfo.userID} is not able to read child collaboration ${childCollaboration.id}`,
-            LogContext.ACTIVITY_FEED
-          );
-        }
-      }
+          )
+      );
+
+      const collaborationIds = readableChildCollaborations.map(
+        childCollaboration => childCollaboration.id
+      );
     }
 
     return collaborationIds;

--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -284,13 +284,18 @@ export class ActivityFeedService {
 
       // Filter the child collaborations by read access
       const readableChildCollaborations = childCollaborations.filter(
-        childCollaboration =>
-          this.authorizationService.grantAccessOrFail(
-            agentInfo,
-            childCollaboration.authorization,
-            AuthorizationPrivilege.READ,
-            `Collaboration activity query: ${agentInfo.email}`
-          )
+        childCollaboration => {
+          try {
+            return this.authorizationService.grantAccessOrFail(
+              agentInfo,
+              childCollaboration.authorization,
+              AuthorizationPrivilege.READ,
+              `Collaboration activity query: ${agentInfo.email}`
+            );
+          } catch (e) {
+            return false;
+          }
+        }
       );
 
       const collaborationIds = readableChildCollaborations.map(

--- a/src/services/api/activity-log/activity.log.resolver.queries.ts
+++ b/src/services/api/activity-log/activity.log.resolver.queries.ts
@@ -64,13 +64,18 @@ export class ActivityLogResolverQueries {
 
       // Filter the child collaborations by read access
       const readableChildCollaborations = childCollaborations.filter(
-        childCollaboration =>
-          this.authorizationService.grantAccessOrFail(
-            agentInfo,
-            childCollaboration.authorization,
-            AuthorizationPrivilege.READ,
-            `Collaboration activity query: ${agentInfo.email}`
-          )
+        childCollaboration => {
+          try {
+            return this.authorizationService.grantAccessOrFail(
+              agentInfo,
+              childCollaboration.authorization,
+              AuthorizationPrivilege.READ,
+              `Collaboration activity query: ${agentInfo.email}`
+            );
+          } catch (e) {
+            return false;
+          }
+        }
       );
 
       const childCollaborationIds = readableChildCollaborations.map(

--- a/src/services/api/activity-log/activity.log.resolver.subscriptions.ts
+++ b/src/services/api/activity-log/activity.log.resolver.subscriptions.ts
@@ -142,24 +142,20 @@ export class ActivityLogResolverSubscriptions {
       await this.collaborationService.getChildCollaborationsOrFail(
         collaborationID
       );
-    const childCollaborationIds: string[] = [];
-    // can agent read each collaboration
-    for (const childCollaboration of childCollaborations) {
-      try {
-        await this.authorizationService.grantAccessOrFail(
+    // Filter the child collaborations by read access
+    const readableChildCollaborations = childCollaborations.filter(
+      childCollaboration =>
+        this.authorizationService.grantAccessOrFail(
           agentInfo,
           childCollaboration.authorization,
           AuthorizationPrivilege.READ,
           `Collaboration activity query: ${agentInfo.email}`
-        );
-        childCollaborationIds.push(childCollaboration.id);
-      } catch (e) {
-        this.logger?.warn(
-          `User ${agentInfo.userID} is not able to read child collaboration ${childCollaboration.id}`,
-          LogContext.COLLABORATION
-        );
-      }
-    }
+        )
+    );
+
+    const childCollaborationIds = readableChildCollaborations.map(
+      childCollaboration => childCollaboration.id
+    );
 
     return childCollaborationIds;
   }

--- a/src/services/api/activity-log/activity.log.resolver.subscriptions.ts
+++ b/src/services/api/activity-log/activity.log.resolver.subscriptions.ts
@@ -144,13 +144,18 @@ export class ActivityLogResolverSubscriptions {
       );
     // Filter the child collaborations by read access
     const readableChildCollaborations = childCollaborations.filter(
-      childCollaboration =>
-        this.authorizationService.grantAccessOrFail(
-          agentInfo,
-          childCollaboration.authorization,
-          AuthorizationPrivilege.READ,
-          `Collaboration activity query: ${agentInfo.email}`
-        )
+      childCollaboration => {
+        try {
+          return this.authorizationService.grantAccessOrFail(
+            agentInfo,
+            childCollaboration.authorization,
+            AuthorizationPrivilege.READ,
+            `Collaboration activity query: ${agentInfo.email}`
+          );
+        } catch (e) {
+          return false;
+        }
+      }
     );
 
     const childCollaborationIds = readableChildCollaborations.map(


### PR DESCRIPTION
- logging warning makes no sense
- we say 'include child' and we do not know whether there is access
- if there is no access (and that is perfectly normal) we log a warning (and tons of them)

that doesn't make any sense

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved collaboration access filtering for more efficient processing.
  - Removed warning messages previously shown when access to certain collaborations was denied.

No user-facing features or functionality have changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->