### PR TITLE
Github as oidc provider locally

### DIFF
--- a/.build/ory/kratos/kratos.yml
+++ b/.build/ory/kratos/kratos.yml
@@ -45,6 +45,13 @@ selfservice:
             scope:
               - profile
               - email
+          - id: github
+            provider: github
+            client_id: Ov23lizFYULcSqONM2wR
+            client_secret: d8859d62246220dc3434f3d43e4ee6de54d9e021
+            mapper_url: file:///etc/config/kratos/oidc/oidc.github.jsonnet
+            scope:
+              - user:email
 
   flows:
     error:

--- a/.build/ory/kratos/oidc/oidc.github.jsonnet
+++ b/.build/ory/kratos/oidc/oidc.github.jsonnet
@@ -1,17 +1,22 @@
 local claims = {
-  email_verified: false
+  email_verified: true,
 } + std.extVar('claims');
-
 {
   identity: {
     traits: {
-      // Allowing unverified email addresses enables account
-      // enumeration attacks, especially if the value is used for
-      // e.g. verification or as a password login identifier.
-      //
-      // Therefore we only return the email if it (a) exists and (b) is marked verified
-      // by GitHub.
-      [if "email" in claims && claims.email_verified then "email" else null]: claims.email,
+      [if "email" in claims && claims.email != null && claims.email_verified then "email" else null]: claims.email,
+      name: {
+        first: if "name" in claims && claims.name != null && claims.name != "" then
+                 std.split(claims.name, ' ')[0]
+               else if "login" in claims then
+                 claims.login
+               else
+                 "",
+        last: if "name" in claims && claims.name != null && std.length(std.split(claims.name, ' ')) > 1 then
+                std.join(' ', std.split(claims.name, ' ')[1:])
+              else
+                "",
+      },
     },
   },
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GitHub as a new sign-in option using OpenID Connect (OIDC).

- **Enhancements**
  - Improved identity mapping for GitHub sign-ins: email is now marked as verified by default, and user names are more accurately split into first and last names when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->