### PR TITLE
AI Persona Model Card

### DIFF
--- a/src/common/enums/ai.persona.model.card.entry.flag.name.ts
+++ b/src/common/enums/ai.persona.model.card.entry.flag.name.ts
@@ -1,0 +1,16 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum AiPersonaModelCardEntryFlagName {
+  SPACE_DATA_ACCESS_ABOUT = 'space-data-access-about',
+  SPACE_DATA_ACCESS_CONTENT = 'space-data-access-content',
+  SPACE_DATA_ACCESS_SUBSPACES = 'space-data-access-subspaces',
+  SPACE_CAPABILITY_TAGGING = 'space-capability-tagging',
+  SPACE_CAPABILITY_CREATE_CONTENT = 'space-capability-create-content',
+  SPACE_CAPABILITY_COMMUNITY_MANAGEMENT = 'space-capability-community-management',
+  SPACE_ROLE_MEMBER = 'space-role-member',
+  SPACE_ROLE_ADMIN = 'space-role-admin',
+}
+
+registerEnumType(AiPersonaModelCardEntryFlagName, {
+  name: 'AiPersonaModelCardEntryFlagName',
+});

--- a/src/common/enums/ai.persona.model.card.entry.ts
+++ b/src/common/enums/ai.persona.model.card.entry.ts
@@ -1,0 +1,11 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum AiPersonaModelCardEntry {
+  SPACE_CAPABILITIES = 'space-capabilities',
+  SPACE_DATA_ACCESS = 'space-data-access',
+  SPACE_ROLE_REQUIRED = 'space-role-required',
+}
+
+registerEnumType(AiPersonaModelCardEntry, {
+  name: 'AiPersonaModelCardEntry',
+});

--- a/src/domain/community/ai-persona-model-card/ai.persona.model.card.module.ts
+++ b/src/domain/community/ai-persona-model-card/ai.persona.model.card.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
-import { AiPersonaModelCardService } from './ai.persona.model.card.service';
 import { AiPersonaModelCardResolverFields } from './ai.persona.model.card.resolver.fields';
 
 @Module({
   imports: [AuthorizationPolicyModule, AuthorizationModule],
-  providers: [AiPersonaModelCardResolverFields, AiPersonaModelCardService],
-  exports: [AiPersonaModelCardService],
+  providers: [AiPersonaModelCardResolverFields],
+  exports: [],
 })
 export class AiPersonaModelCardModule {}

--- a/src/domain/community/ai-persona-model-card/ai.persona.model.card.module.ts
+++ b/src/domain/community/ai-persona-model-card/ai.persona.model.card.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { AiPersonaModelCardService } from './ai.persona.model.card.service';
+import { AiPersonaModelCardResolverFields } from './ai.persona.model.card.resolver.fields';
+
+@Module({
+  imports: [AuthorizationPolicyModule, AuthorizationModule],
+  providers: [AiPersonaModelCardResolverFields, AiPersonaModelCardService],
+  exports: [AiPersonaModelCardService],
+})
+export class AiPersonaModelCardModule {}

--- a/src/domain/community/ai-persona-model-card/ai.persona.model.card.resolver.fields.ts
+++ b/src/domain/community/ai-persona-model-card/ai.persona.model.card.resolver.fields.ts
@@ -7,6 +7,12 @@ import { ModelCardAiEngineResult } from './dto/ai.persona.model.card.dto.ai.engi
 import { AiPersonaEngine } from '@common/enums/ai.persona.engine';
 import { ModelCardMonitoringResult } from './dto/ai.persona.model.card.dto.monitoring.result';
 
+/*
+ * This resolver is used to provide a set of Model Cards about the AI Persona.
+ * It is at the moment a simple and static set of data that is returned, based on the engine
+ * that is used by the AI Persona. It is expected that the set of Model Cards returned will expand
+ * in the future, as more engines are added and more data is available.
+ */
 @Resolver(() => AiPersonaModelCard)
 export class AiPersonaModelCardResolverFields {
   @ResolveField('spaceUsage', () => [ModelCardSpaceUsageResult], {

--- a/src/domain/community/ai-persona-model-card/ai.persona.model.card.resolver.fields.ts
+++ b/src/domain/community/ai-persona-model-card/ai.persona.model.card.resolver.fields.ts
@@ -1,0 +1,124 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { AiPersonaModelCard } from './dto/ai.persona.model.card.dto.result';
+import { ModelCardSpaceUsageResult } from './dto/ai.persona.model.card.dto.space.usage.result';
+import { AiPersonaModelCardEntry } from '@common/enums/ai.persona.model.card.entry';
+import { AiPersonaModelCardEntryFlagName } from '@common/enums/ai.persona.model.card.entry.flag.name';
+import { ModelCardAiEngineResult } from './dto/ai.persona.model.card.dto.ai.engine.result';
+import { AiPersonaEngine } from '@common/enums/ai.persona.engine';
+import { ModelCardMonitoringResult } from './dto/ai.persona.model.card.dto.monitoring.result';
+
+@Resolver(() => AiPersonaModelCard)
+export class AiPersonaModelCardResolverFields {
+  @ResolveField('spaceUsage', () => [ModelCardSpaceUsageResult], {
+    nullable: true,
+    description:
+      'The Model Card details related to usage of the Ai Persona within a Space.',
+  })
+  myPrivileges(): ModelCardSpaceUsageResult[] {
+    const result: ModelCardSpaceUsageResult[] = [
+      {
+        modelCardEntry: AiPersonaModelCardEntry.SPACE_CAPABILITIES,
+        flags: [
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_CAPABILITY_TAGGING,
+            enabled: true,
+          },
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_CAPABILITY_CREATE_CONTENT,
+            enabled: false,
+          },
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_CAPABILITY_COMMUNITY_MANAGEMENT,
+            enabled: false,
+          },
+        ],
+      },
+      {
+        modelCardEntry: AiPersonaModelCardEntry.SPACE_DATA_ACCESS,
+        flags: [
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_DATA_ACCESS_ABOUT,
+            enabled: true,
+          },
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_DATA_ACCESS_CONTENT,
+            enabled: false,
+          },
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_DATA_ACCESS_SUBSPACES,
+            enabled: false,
+          },
+        ],
+      },
+      {
+        modelCardEntry: AiPersonaModelCardEntry.SPACE_ROLE_REQUIRED,
+        flags: [
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_ROLE_MEMBER,
+            enabled: true,
+          },
+          {
+            name: AiPersonaModelCardEntryFlagName.SPACE_ROLE_ADMIN,
+            enabled: false,
+          },
+        ],
+      },
+    ];
+    return result;
+  }
+
+  @ResolveField('aiEngine', () => ModelCardAiEngineResult, {
+    nullable: true,
+    description:
+      'The model card information about the AI Engine behind the AI Persona.',
+  })
+  async aiEngine(
+    @Parent() modelCard: AiPersonaModelCard
+  ): Promise<ModelCardAiEngineResult> {
+    const engine = modelCard.aiPersonaEngine;
+
+    const isExternal = [
+      AiPersonaEngine.LIBRA_FLOW,
+      AiPersonaEngine.GENERIC_OPENAI,
+    ].includes(engine);
+
+    const isAssistant = engine === AiPersonaEngine.OPENAI_ASSISTANT;
+    const isExternalOrAssistant = isExternal || isAssistant;
+
+    const result: ModelCardAiEngineResult = {
+      isExternal,
+      isUsingOpenWeightsModel: isExternalOrAssistant,
+      isInteractionDataUsedForTraining: isExternalOrAssistant ? null : false,
+      areAnswersRestrictedToBodyOfKnowledge: (() => {
+        switch (engine) {
+          case AiPersonaEngine.GENERIC_OPENAI:
+            return 'No';
+          case AiPersonaEngine.OPENAI_ASSISTANT:
+            return 'Yes, when provided';
+          default:
+            return 'Yes';
+        }
+      })(),
+      canAccessWebWhenAnswering: !isExternal,
+      hostingLocation: isExternalOrAssistant ? 'Unknown' : 'Sweden, EU',
+      additionalTechnicalDetails: isExternal
+        ? 'https://platform.openai.com/docs/overview'
+        : isAssistant
+          ? 'https://platform.openai.com/docs/assistants/overview'
+          : 'https://huggingface.co/mistralai/Mistral-Small-Instruct-2409/tree/main',
+    };
+    return result;
+  }
+
+  @ResolveField('monitoring', () => ModelCardMonitoringResult, {
+    nullable: true,
+    description:
+      'The model card information about the monitoring that is done on usage.',
+  })
+  async monitoring(): Promise<ModelCardMonitoringResult> {
+    const result: ModelCardMonitoringResult = {
+      isUsageMonitoredByAlkemio: true,
+    };
+    return result;
+  }
+}

--- a/src/domain/community/ai-persona-model-card/ai.persona.model.card.resolver.fields.ts
+++ b/src/domain/community/ai-persona-model-card/ai.persona.model.card.resolver.fields.ts
@@ -7,6 +7,8 @@ import { ModelCardAiEngineResult } from './dto/ai.persona.model.card.dto.ai.engi
 import { AiPersonaEngine } from '@common/enums/ai.persona.engine';
 import { ModelCardMonitoringResult } from './dto/ai.persona.model.card.dto.monitoring.result';
 
+const DEFAULT_ENGINE_HOSTING_LOCATION = 'Sweden, EU';
+
 /*
  * This resolver is used to provide a set of Model Cards about the AI Persona.
  * It is at the moment a simple and static set of data that is returned, based on the engine
@@ -105,8 +107,10 @@ export class AiPersonaModelCardResolverFields {
             return 'Yes';
         }
       })(),
-      canAccessWebWhenAnswering: !isExternal,
-      hostingLocation: isExternalOrAssistant ? 'Unknown' : 'Sweden, EU',
+      canAccessWebWhenAnswering: isExternal,
+      hostingLocation: isExternalOrAssistant
+        ? 'Unknown'
+        : DEFAULT_ENGINE_HOSTING_LOCATION,
       additionalTechnicalDetails: isExternal
         ? 'https://platform.openai.com/docs/overview'
         : isAssistant

--- a/src/domain/community/ai-persona-model-card/ai.persona.model.card.service.ts
+++ b/src/domain/community/ai-persona-model-card/ai.persona.model.card.service.ts
@@ -1,6 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class AiPersonaModelCardService {
-  constructor() {}
-}

--- a/src/domain/community/ai-persona-model-card/ai.persona.model.card.service.ts
+++ b/src/domain/community/ai-persona-model-card/ai.persona.model.card.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AiPersonaModelCardService {
+  constructor() {}
+}

--- a/src/domain/community/ai-persona-model-card/docs/ai_model_card_template.md
+++ b/src/domain/community/ai-persona-model-card/docs/ai_model_card_template.md
@@ -1,0 +1,214 @@
+# 🧠 AI Model Card Template
+
+A structured overview of an AI engine's attributes, designed for transparency, traceability, and ethical usage.
+
+---
+
+Model cards, especially for AI engines and large language models, typically include a structured set of **attributes** to promote transparency, reproducibility, safety, and usability. These attributes help users understand what the model is, how it works, what data it's trained on, and under what circumstances it should (or should not) be used.
+
+Below is a categorized list of **commonly used attributes** in model cards related to AI engines:
+
+---
+
+## 🔧 **Technical Details**
+
+| Attribute         | Description                                                                            |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| **Model Name**    | Unique name or identifier of the model.                                                |
+| **Architecture**  | The model type and structure (e.g., Transformer, BERT, LLaMA).                         |
+| **Version**       | Current version of the model, especially if iteratively updated.                       |
+| **Framework**     | Tools or libraries used (e.g., PyTorch, TensorFlow, Hugging Face).                     |
+| **Parameters**    | Number of parameters (e.g., 7B, 13B).                                                  |
+| **Training Time** | Duration or compute cost (e.g., in GPU hours or FLOPs).                                |
+| **License**       | Legal license for use, modification, and distribution (e.g., Apache 2.0, MIT, custom). |
+
+---
+
+## 🧠 **Training Details**
+
+| Attribute           | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| **Training Data**   | Description of datasets used (source, scale, type).        |
+| **Data Period**     | Time range the training data covers (e.g., up to 2023).    |
+| **Preprocessing**   | Steps like tokenization, filtering, normalization.         |
+| **Training Method** | Supervised, unsupervised, RLHF, fine-tuning methods, etc.  |
+| **Data Sources**    | URLs or names of datasets (e.g., Common Crawl, Wikipedia). |
+| **Open Weights**    | Whether model weights are publicly available.              |
+
+---
+
+## 📦 **Deployment and Hosting**
+
+| Attribute              | Description                                                     |
+| ---------------------- | --------------------------------------------------------------- |
+| **Hosting Provider**   | Where the model is served (e.g., AWS, on-device, Hugging Face). |
+| **API Access**         | If the model is accessible via API (public/private).            |
+| **Inference Hardware** | Recommended or used hardware for deployment (e.g., A100, CPU).  |
+
+---
+
+## 🧪 **Evaluation and Metrics**
+
+| Attribute          | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| **Benchmarks**     | Evaluation datasets and scores (e.g., MMLU, HellaSwag, BIG-bench). |
+| **Intended Tasks** | Tasks like summarization, classification, question answering, etc. |
+| **Limitations**    | Known performance weaknesses or blind spots.                       |
+| **Robustness**     | Sensitivity to noise, out-of-distribution inputs, etc.             |
+
+---
+
+## ⚖️ **Ethical Considerations**
+
+| Attribute           | Description                                             |
+| ------------------- | ------------------------------------------------------- |
+| **Bias & Fairness** | Known or evaluated biases in model behavior.            |
+| **Safety Measures** | Guardrails, filters, or moderation techniques in place. |
+| **Misuse Risks**    | Potential harms from malicious or unintended use.       |
+| **Mitigations**     | Steps taken to reduce ethical or safety risks.          |
+
+---
+
+## 👥 **Usage and Audience**
+
+| Attribute               | Description                                                |
+| ----------------------- | ---------------------------------------------------------- |
+| **Intended Users**      | Who should use the model (researchers, enterprises, etc.). |
+| **Not Intended For**    | Clearly outlined inappropriate or unsafe use cases.        |
+| **Languages Supported** | Natural languages the model can understand or generate.    |
+| **Licensing Terms**     | Specific conditions for commercial or non-commercial use.  |
+
+---
+
+## 📜 **Provenance and Governance**
+
+| Attribute               | Description                                      |
+| ----------------------- | ------------------------------------------------ |
+| **Developed By**        | Organization(s) or individuals behind the model. |
+| **Funding**             | Who funded development and training.             |
+| **Version History**     | Changelog or history of updates.                 |
+| **Responsible Contact** | How to reach the creators or maintainers.        |
+
+---
+
+Would you like a structured template (e.g., YAML or JSON) version of these attributes to use for your own AI engines or tools?
+
+---
+
+## 📛 General Information
+
+| Attribute      | Description                                      |
+| -------------- | ------------------------------------------------ |
+| `model_name`   | Name or identifier of the model                  |
+| `version`      | Version number or label                          |
+| `architecture` | Model architecture (e.g., Transformer, LLaMA)    |
+| `framework`    | Framework used (e.g., PyTorch, TensorFlow)       |
+| `parameters`   | Number of parameters (e.g., 7B) or a description |
+
+---
+
+## 🧠 Training Details
+
+```json
+"training": {
+  "training_data": "Description of datasets used",
+  "data_period": {
+    "start": "YYYY-MM-DD",
+    "end": "YYYY-MM-DD"
+  },
+  "data_sources": ["List of dataset names or URLs"],
+  "preprocessing": "Description of preprocessing steps",
+  "training_method": "e.g., supervised, RLHF, fine-tuning",
+  "training_time": "e.g., 1M GPU hours",
+  "open_weights": true
+}
+```
+
+---
+
+## 📦 Deployment & Hosting
+
+```json
+"deployment": {
+  "hosting_provider": "e.g., AWS, on-device, Hugging Face",
+  "inference_hardware": "e.g., A100, CPU, iOS edge device",
+  "api_access": {
+    "available": true,
+    "url": "https://your-api-endpoint.com"
+  }
+}
+```
+
+---
+
+## 🧪 Evaluation & Metrics
+
+```json
+"evaluation": {
+  "benchmarks": [
+    {
+      "name": "MMLU",
+      "score": "78.4%"
+    }
+  ],
+  "intended_tasks": ["Question Answering", "Summarization"],
+  "limitations": ["Struggles with arithmetic reasoning"],
+  "robustness_notes": "Performance degrades on out-of-domain data"
+}
+```
+
+---
+
+## ⚖️ Ethical Considerations
+
+```json
+"ethical_considerations": {
+  "bias_fairness": "Model shows socio-linguistic bias in some groups",
+  "safety_measures": ["Content filters", "Prompt moderation"],
+  "misuse_risks": ["Disinformation", "Impersonation"],
+  "mitigations": ["Red-teaming", "Use-case restriction policies"]
+}
+```
+
+---
+
+## 👥 Usage and Audience
+
+```json
+"usage": {
+  "intended_users": ["Researchers", "Language technologists"],
+  "not_intended_for": ["Autonomous decision-making", "Medical diagnosis"],
+  "languages_supported": ["English", "Spanish", "French"],
+  "licensing_terms": "Use permitted under Apache 2.0 license"
+}
+```
+
+---
+
+## 📜 Provenance and Governance
+
+```json
+"provenance": {
+  "developed_by": "OpenAI / Your Organization",
+  "funding": "Grant XYZ, internal R&D",
+  "version_history": [
+    {
+      "version": "1.0.0",
+      "date": "2024-01-01",
+      "notes": "Initial release"
+    }
+  ],
+  "contact": "mailto:team@yourdomain.com"
+}
+```
+
+---
+
+## 🗂 Metadata
+
+```json
+"metadata": {
+  "last_updated": "2025-05-17",
+  "license": "Apache 2.0"
+}
+```

--- a/src/domain/community/ai-persona-model-card/docs/model.card.json
+++ b/src/domain/community/ai-persona-model-card/docs/model.card.json
@@ -1,0 +1,66 @@
+{
+  "model_name": "string",
+  "version": "string",
+  "architecture": "string",
+  "framework": "string",
+  "parameters": "string or number",
+  "training": {
+    "training_data": "string (e.g., sources, description)",
+    "data_period": {
+      "start": "YYYY-MM-DD",
+      "end": "YYYY-MM-DD"
+    },
+    "data_sources": ["string"],
+    "preprocessing": "string",
+    "training_method": "string",
+    "training_time": "string (e.g., 1M GPU hours)",
+    "open_weights": true
+  },
+  "deployment": {
+    "hosting_provider": "string",
+    "inference_hardware": "string",
+    "api_access": {
+      "available": true,
+      "url": "string (if applicable)"
+    }
+  },
+  "evaluation": {
+    "benchmarks": [
+      {
+        "name": "string",
+        "score": "string or number"
+      }
+    ],
+    "intended_tasks": ["string"],
+    "limitations": ["string"],
+    "robustness_notes": "string"
+  },
+  "ethical_considerations": {
+    "bias_fairness": "string",
+    "safety_measures": ["string"],
+    "misuse_risks": ["string"],
+    "mitigations": ["string"]
+  },
+  "usage": {
+    "intended_users": ["string"],
+    "not_intended_for": ["string"],
+    "languages_supported": ["string"],
+    "licensing_terms": "string"
+  },
+  "provenance": {
+    "developed_by": "string",
+    "funding": "string",
+    "version_history": [
+      {
+        "version": "string",
+        "date": "YYYY-MM-DD",
+        "notes": "string"
+      }
+    ],
+    "contact": "string (email or URL)"
+  },
+  "metadata": {
+    "last_updated": "YYYY-MM-DD",
+    "license": "string (e.g., Apache 2.0, MIT)"
+  }
+}

--- a/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.ai.engine.result.ts
+++ b/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.ai.engine.result.ts
@@ -1,0 +1,50 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class ModelCardAiEngineResult {
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      'Is the AI Persona using an AI Engine not provided by Alkemio?',
+  })
+  isExternal!: boolean;
+
+  @Field(() => Boolean, {
+    nullable: false,
+    description: 'Does the VC use an open-weight model?',
+  })
+  isUsingOpenWeightsModel!: boolean;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Is interaction data used in any way for model training? Null means Unknown.',
+  })
+  isInteractionDataUsedForTraining!: boolean | null;
+
+  @Field(() => String, {
+    nullable: false,
+    description:
+      'Is the VC prompted to limit the responses to a specific body of knowledge?',
+  })
+  areAnswersRestrictedToBodyOfKnowledge!: string;
+
+  @Field(() => Boolean, {
+    nullable: false,
+    description: 'Can the VC access or search the web?',
+  })
+  canAccessWebWhenAnswering!: boolean;
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'Where is the AI service hosted?',
+  })
+  hostingLocation!: string;
+
+  @Field(() => String, {
+    nullable: false,
+    description:
+      'Access to detailed information on the underlying models specifications',
+  })
+  additionalTechnicalDetails!: string;
+}

--- a/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.entry.flag.ts
+++ b/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.entry.flag.ts
@@ -1,0 +1,17 @@
+import { AiPersonaModelCardEntryFlagName } from '@common/enums/ai.persona.model.card.entry.flag.name';
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('AiPersonaModelCardFlag')
+export class AiPersonaModelCardEntryFlag {
+  @Field(() => AiPersonaModelCardEntryFlagName, {
+    description: 'The name of the Model Card Entry flag',
+    nullable: false,
+  })
+  name!: AiPersonaModelCardEntryFlagName;
+
+  @Field(() => Boolean, {
+    description: 'Is this model card entry flag enabled?',
+    nullable: false,
+  })
+  enabled!: boolean;
+}

--- a/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.monitoring.result.ts
+++ b/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.monitoring.result.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class ModelCardMonitoringResult {
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      'Since Alkemio facilitates the interaction with the external provider, it holds an operational responsibility to monitor the service. As with all data and interactions on the platform, these are governed by our <a href="https://welcome.alkem.io/legal/#tc" target="_blank" ref="noreferer">Terms & Conditions</a>.',
+  })
+  isUsageMonitoredByAlkemio!: boolean;
+}

--- a/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.result.ts
+++ b/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.result.ts
@@ -1,0 +1,9 @@
+import { AiPersonaEngine } from '@common/enums/ai.persona.engine';
+import { AiPersona } from '@domain/community/ai-persona/ai.persona.entity';
+import { ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class AiPersonaModelCard {
+  aiPersona!: AiPersona;
+  aiPersonaEngine!: AiPersonaEngine;
+}

--- a/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.space.usage.result.ts
+++ b/src/domain/community/ai-persona-model-card/dto/ai.persona.model.card.dto.space.usage.result.ts
@@ -1,0 +1,17 @@
+import { AiPersonaModelCardEntry } from '@common/enums/ai.persona.model.card.entry';
+import { Field, ObjectType } from '@nestjs/graphql';
+import { AiPersonaModelCardEntryFlag } from './ai.persona.model.card.dto.entry.flag';
+
+@ObjectType()
+export class ModelCardSpaceUsageResult {
+  @Field(() => AiPersonaModelCardEntry, {
+    description: 'The Model Card Entry type.',
+  })
+  modelCardEntry!: AiPersonaModelCardEntry;
+
+  @Field(() => [AiPersonaModelCardEntryFlag], {
+    nullable: false,
+    description: 'The Flags for this Model Card Entry.',
+  })
+  flags?: AiPersonaModelCardEntryFlag[];
+}

--- a/src/domain/community/ai-persona/ai.persona.module.ts
+++ b/src/domain/community/ai-persona/ai.persona.module.ts
@@ -8,12 +8,14 @@ import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/a
 import { AiPersona } from './ai.persona.entity';
 import { AiPersonaResolverFields } from './ai.persona.resolver.fields';
 import { AiServerAdapterModule } from '@services/adapters/ai-server-adapter/ai.server.adapter.module';
+import { AiPersonaModelCardModule } from '../ai-persona-model-card/ai.persona.model.card.module';
 
 @Module({
   imports: [
     AuthorizationPolicyModule,
     AuthorizationModule,
     AiServerAdapterModule,
+    AiPersonaModelCardModule,
     TypeOrmModule.forFeature([AiPersona]),
   ],
   providers: [

--- a/src/domain/community/ai-persona/ai.persona.resolver.fields.ts
+++ b/src/domain/community/ai-persona/ai.persona.resolver.fields.ts
@@ -66,9 +66,7 @@ export class AiPersonaResolverFields {
     nullable: false,
     description: 'The model card information about this AI Persona.',
   })
-  async membership(
-    @Parent() aiPersona: AiPersona
-  ): Promise<AiPersonaModelCard> {
+  async modelCard(@Parent() aiPersona: AiPersona): Promise<AiPersonaModelCard> {
     const engine = await this.aiServerAdapter.getPersonaServiceEngine(
       aiPersona.aiPersonaServiceID
     );

--- a/src/domain/community/ai-persona/ai.persona.resolver.fields.ts
+++ b/src/domain/community/ai-persona/ai.persona.resolver.fields.ts
@@ -12,6 +12,7 @@ import { AiPersonaBodyOfKnowledgeType } from '@common/enums/ai.persona.body.of.k
 import { AiServerAdapter } from '@services/adapters/ai-server-adapter/ai.server.adapter';
 import { AiPersonaInteractionMode } from '@common/enums/ai.persona.interaction.mode';
 import { AiPersonaEngine } from '@common/enums/ai.persona.engine';
+import { AiPersonaModelCard } from '../ai-persona-model-card/dto/ai.persona.model.card.dto.result';
 
 @Resolver(() => IAiPersona)
 export class AiPersonaResolverFields {
@@ -57,6 +58,26 @@ export class AiPersonaResolverFields {
     return await this.aiServerAdapter.getPersonaServiceEngine(
       aiPersona.aiPersonaServiceID
     );
+  }
+
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
+  @ResolveField('modelCard', () => AiPersonaModelCard, {
+    nullable: false,
+    description: 'The model card information about this AI Persona.',
+  })
+  async membership(
+    @Parent() aiPersona: AiPersona
+  ): Promise<AiPersonaModelCard> {
+    const engine = await this.aiServerAdapter.getPersonaServiceEngine(
+      aiPersona.aiPersonaServiceID
+    );
+    const modelCard: AiPersonaModelCard = {
+      aiPersona,
+      aiPersonaEngine: engine,
+    };
+
+    return modelCard;
   }
 
   @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)


### PR DESCRIPTION
Adds the model card meta information about an AI Persona, providing the same set of results as was hard coded in the client.

```
query {
  virtualContributors {
    id
    aiPersona {
      id
      modelCard {
        spaceUsage {
          modelCardEntry 
          flags {
            name
            enabled
          }
        }
        aiEngine {
          isExternal
          hostingLocation
          isUsingOpenWeightsModel
          isInteractionDataUsedForTraining
          canAccessWebWhenAnswering
        }
        monitoring {
          isUsageMonitoredByAlkemio
        }
      }
    }
  }
}
```

gives

![image](https://github.com/user-attachments/assets/bcb8489f-55f3-43aa-b1a2-eeb6833c61f4)


To discuss: remove fields that are not used on AiPersona?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced AI Persona Model Card functionality, providing detailed information about AI personas, including capabilities, data access, required roles, engine details, and monitoring status.
  - Added GraphQL fields and types to expose model card data, such as engine metadata, space usage, and monitoring status.
  - Integrated comprehensive documentation and a JSON schema template for AI model cards to support transparency and standardization.
  - Enabled users to view model card information directly from AI persona profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->