### PR TITLE
Increases invitation welcome message length

### DIFF
--- a/src/common/constants/entity.field.length.constants.ts
+++ b/src/common/constants/entity.field.length.constants.ts
@@ -4,6 +4,7 @@ export const ALT_TEXT_LENGTH = 120;
 export const SMALL_TEXT_LENGTH = 128;
 export const MID_TEXT_LENGTH = 512;
 export const LONG_TEXT_LENGTH = 2048;
+export const LONGER_TEXT_LENGTH = 8192;
 export const VERY_LONG_TEXT_LENGTH = 32784;
 export const HUGE_TEXT_LENGTH = 65568;
 // ids

--- a/src/domain/access/invitation/invitation.entity.ts
+++ b/src/domain/access/invitation/invitation.entity.ts
@@ -3,7 +3,11 @@ import { Lifecycle } from '@domain/common/lifecycle/lifecycle.entity';
 import { IInvitation } from './invitation.interface';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { RoleSetContributorType } from '@common/enums/role.set.contributor.type';
-import { ENUM_LENGTH, MID_TEXT_LENGTH, UUID_LENGTH } from '@common/constants';
+import {
+  ENUM_LENGTH,
+  LONGER_TEXT_LENGTH,
+  UUID_LENGTH,
+} from '@common/constants';
 import { RoleSet } from '@domain/access/role-set/role.set.entity';
 import { RoleName } from '@common/enums/role.name';
 @Entity()
@@ -23,7 +27,7 @@ export class Invitation extends AuthorizableEntity implements IInvitation {
   @Column('char', { length: UUID_LENGTH, nullable: false })
   createdBy!: string;
 
-  @Column('varchar', { length: MID_TEXT_LENGTH, nullable: true })
+  @Column('varchar', { length: LONGER_TEXT_LENGTH, nullable: true })
   welcomeMessage?: string;
 
   @Column('boolean', { default: false })

--- a/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
+++ b/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
@@ -2,6 +2,7 @@ import { Field, InputType } from '@nestjs/graphql';
 import { UUID } from '@domain/common/scalars';
 import { IsEmail, IsOptional, MaxLength } from 'class-validator';
 import {
+  LONGER_TEXT_LENGTH,
   MID_TEXT_LENGTH,
   SMALL_TEXT_LENGTH,
   UUID_LENGTH,
@@ -29,7 +30,7 @@ export class InviteForEntryRoleOnRoleSetInput {
 
   @Field({ nullable: true, description: 'The welcome message to send' })
   @IsOptional()
-  @MaxLength(MID_TEXT_LENGTH)
+  @MaxLength(LONGER_TEXT_LENGTH)
   welcomeMessage?: string;
 
   @Field(() => RoleName, {

--- a/src/migrations/1747641383717-longerInvitationWelcomeMessage.ts
+++ b/src/migrations/1747641383717-longerInvitationWelcomeMessage.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LongerInvitationWelcomeMessage1747641383717
+  implements MigrationInterface
+{
+  name = 'LongerInvitationWelcomeMessage1747641383717';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `invitation` MODIFY `welcomeMessage` varchar(8192) NULL'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `invitation` MODIFY `welcomeMessage` varchar(512) NULL'
+    );
+  }
+}


### PR DESCRIPTION
Extends the maximum length of the invitation welcome message.

This change allows for more detailed and informative welcome messages to be sent to new users upon invitation. It increases the length to accommodate longer, more personalized messages.
