### PR TITLE
AiPersonaService authorization + cascade from AiPersona 

### DIFF
--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -116,12 +116,12 @@ export class VirtualContributorAuthorizationService {
       );
     updatedAuthorizations.push(agentAuthorization);
 
-    const aiPersonaAuthorization =
-      this.aiPersonaAuthorizationService.applyAuthorizationPolicy(
+    const aiPersonaAuthorizations =
+      await this.aiPersonaAuthorizationService.applyAuthorizationPolicy(
         virtual.aiPersona,
         virtual.authorization
       );
-    updatedAuthorizations.push(aiPersonaAuthorization);
+    updatedAuthorizations.push(...aiPersonaAuthorizations);
 
     // The KnowledgeBase needs to start from a reset VC auth, and then use the criterias with access to go further
     const knowledgeBaseAuthorizations =

--- a/src/services/adapters/ai-server-adapter/ai.server.adapter.ts
+++ b/src/services/adapters/ai-server-adapter/ai.server.adapter.ts
@@ -10,6 +10,7 @@ import { IAiPersonaService } from '@services/ai-server/ai-persona-service';
 import { AiPersonaBodyOfKnowledgeType } from '@common/enums/ai.persona.body.of.knowledge.type';
 import { LogContext } from '@common/enums';
 import { AiPersonaEngine } from '@common/enums/ai.persona.engine';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 
 @Injectable()
 export class AiServerAdapter {
@@ -75,6 +76,14 @@ export class AiServerAdapter {
 
   async updateAiPersonaService(updateData: UpdateAiPersonaServiceInput) {
     return this.aiServer.updateAiPersonaService(updateData);
+  }
+
+  async resetAuthorizationOnAiPersonaService(
+    personaServiceID: string
+  ): Promise<IAuthorizationPolicy[]> {
+    return await this.aiServer.resetAuthorizationPolicyOnAiPersonaService(
+      personaServiceID
+    );
   }
 
   invoke(invocationInput: AiServerAdapterInvocationInput): Promise<void> {

--- a/src/services/ai-server/ai-persona-service/ai.persona.service.service.authorization.ts
+++ b/src/services/ai-server/ai-persona-service/ai.persona.service.service.authorization.ts
@@ -6,8 +6,6 @@ import {
 } from '@common/exceptions';
 import { AiPersonaServiceService } from './ai.persona.service.service';
 import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential.interface';
-
-import { IAiPersonaService } from './ai.persona.service.interface';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { LogContext } from '@common/enums/logging.context';
 import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
@@ -28,12 +26,12 @@ export class AiPersonaServiceAuthorizationService {
   ) {}
 
   async applyAuthorizationPolicy(
-    aiPersonaServiceInput: IAiPersonaService,
+    aiPersonaServiceID: string,
     parentAuthorization: IAuthorizationPolicy | undefined
   ): Promise<IAuthorizationPolicy[]> {
     const aiPersonaService =
       await this.aiPersonaServiceService.getAiPersonaServiceOrFail(
-        aiPersonaServiceInput.id,
+        aiPersonaServiceID,
         {
           relations: {
             authorization: true,
@@ -41,25 +39,16 @@ export class AiPersonaServiceAuthorizationService {
         }
       );
 
-    const VC = await this.entityManager.findOne(VirtualContributor, {
-      where: {
-        aiPersona: {
-          aiPersonaServiceID: aiPersonaServiceInput.id,
-        },
-      },
-      relations: {
-        account: true,
-      },
-    });
-
-    const aiPersonaAccountID: string | undefined = VC?.account?.id;
-
     if (!aiPersonaService.authorization)
       throw new RelationshipNotFoundException(
         `Unable to load entities for AI Persona Service: ${aiPersonaService.id} `,
         LogContext.COMMUNITY
       );
 
+    const accountID =
+      await this.getAccountIdForVirtualContributorUsingAiPersonaService(
+        aiPersonaServiceID
+      );
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
 
     aiPersonaService.authorization = this.authorizationPolicyService.reset(
@@ -72,29 +61,44 @@ export class AiPersonaServiceAuthorizationService {
       );
     aiPersonaService.authorization = this.appendCredentialRules(
       aiPersonaService.authorization,
-      aiPersonaService.id
+      aiPersonaService.id,
+      accountID
     );
-
-    if (aiPersonaAccountID) {
-      const accountAdminCredential: ICredentialDefinition = {
-        type: AuthorizationCredential.ACCOUNT_ADMIN,
-        resourceID: aiPersonaAccountID,
-      };
-
-      aiPersonaService.authorization = await this.extendAuthorizationPolicy(
-        aiPersonaService.authorization,
-        accountAdminCredential
-      );
-    }
 
     updatedAuthorizations.push(aiPersonaService.authorization);
 
     return updatedAuthorizations;
   }
 
+  private async getAccountIdForVirtualContributorUsingAiPersonaService(
+    aiPersonaServiceID: string
+  ): Promise<string> {
+    const virtualContributor = await this.entityManager.findOne(
+      VirtualContributor,
+      {
+        where: {
+          aiPersona: {
+            aiPersonaServiceID: aiPersonaServiceID,
+          },
+        },
+        relations: {
+          account: true,
+        },
+      }
+    );
+    if (!virtualContributor || !virtualContributor.account) {
+      throw new RelationshipNotFoundException(
+        `Virtual contributor not found for AI Persona Service with account: ${aiPersonaServiceID}`,
+        LogContext.AI_PERSONA_SERVICE
+      );
+    }
+    return virtualContributor.account.id;
+  }
+
   private appendCredentialRules(
     authorization: IAuthorizationPolicy | undefined,
-    virtualID: string
+    virtualID: string,
+    accountID: string
   ): IAuthorizationPolicy {
     if (!authorization)
       throw new EntityNotInitializedException(
@@ -104,27 +108,10 @@ export class AiPersonaServiceAuthorizationService {
 
     const newRules: IAuthorizationPolicyRuleCredential[] = [];
 
-    const updatedAuthorization =
-      this.authorizationPolicy.appendCredentialAuthorizationRules(
-        authorization,
-        newRules
-      );
-
-    return updatedAuthorization;
-  }
-
-  private async extendAuthorizationPolicy(
-    authorization: IAuthorizationPolicy | undefined,
-    accountAdminCredential: ICredentialDefinition
-  ): Promise<IAuthorizationPolicy> {
-    if (!authorization) {
-      throw new EntityNotInitializedException(
-        'Authorization definition not found for account',
-        LogContext.AI_PERSONA_SERVICE
-      );
-    }
-
-    const newRules: IAuthorizationPolicyRuleCredential[] = [];
+    const accountAdminCredential: ICredentialDefinition = {
+      type: AuthorizationCredential.ACCOUNT_ADMIN,
+      resourceID: accountID,
+    };
 
     // Allow hosts (users = self mgmt, org = org admin) to manage resources in their account in a way that cascades
     const accountHostManage =
@@ -141,9 +128,12 @@ export class AiPersonaServiceAuthorizationService {
     accountHostManage.cascade = true;
     newRules.push(accountHostManage);
 
-    return this.authorizationPolicyService.appendCredentialAuthorizationRules(
-      authorization,
-      newRules
-    );
+    const updatedAuthorization =
+      this.authorizationPolicy.appendCredentialAuthorizationRules(
+        authorization,
+        newRules
+      );
+
+    return updatedAuthorization;
   }
 }

--- a/src/services/ai-server/ai-server/ai.server.resolver.mutations.ts
+++ b/src/services/ai-server/ai-server/ai.server.resolver.mutations.ts
@@ -161,7 +161,7 @@ export class AiServerResolverMutations {
 
     const authorizations =
       await this.aiPersonaServiceAuthorizationService.applyAuthorizationPolicy(
-        aiPersonaService,
+        aiPersonaService.id,
         aiServer.authorization
       );
     await this.authorizationPolicyService.saveAll(authorizations);

--- a/src/services/ai-server/ai-server/ai.server.service.authorization.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.authorization.ts
@@ -48,7 +48,7 @@ export class AiServerAuthorizationService {
     for (const aiPersonaService of aiServer.aiPersonaServices) {
       const updatedPersonaAuthorizations =
         await this.aiPersonaServiceAuthorizationService.applyAuthorizationPolicy(
-          aiPersonaService,
+          aiPersonaService.id,
           aiServer.authorization
         );
       updatedAuthorizations.push(...updatedPersonaAuthorizations);

--- a/src/services/ai-server/ai-server/ai.server.service.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.ts
@@ -456,6 +456,41 @@ export class AiServerService {
     return authorization;
   }
 
+  private async getAuthorizationPolicyAiServer(): Promise<IAuthorizationPolicy> {
+    const aiServer = await this.getAiServerOrFail({
+      relations: {
+        authorization: true,
+      },
+    });
+    if (!aiServer || !aiServer.authorization) {
+      throw new EntityNotFoundException(
+        `Unable to find Authorization Policy for AiServer: ${aiServer.id}`,
+        LogContext.AI_SERVER
+      );
+    }
+    const authorization = aiServer.authorization;
+
+    if (!authorization) {
+      throw new EntityNotFoundException(
+        `Unable to find Authorization Policy for AiServer: ${aiServer.id}`,
+        LogContext.AI_SERVER
+      );
+    }
+
+    return authorization;
+  }
+
+  public async resetAuthorizationPolicyOnAiPersonaService(
+    aiPersonaServiceID: string
+  ): Promise<IAuthorizationPolicy[]> {
+    const aiServerAuthorization = await this.getAuthorizationPolicyAiServer();
+
+    return await this.aiPersonaServiceAuthorizationService.applyAuthorizationPolicy(
+      aiPersonaServiceID,
+      aiServerAuthorization
+    );
+  }
+
   public async handleInvokeEngineResult(event: InvokeEngineResult) {
     const resultHandler = event.original.resultHandler;
     const handler = this.INVOKE_ENGINE_RESULT_HANDLERS[resultHandler.action];

--- a/src/services/ai-server/ai-server/ai.server.service.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.ts
@@ -366,7 +366,7 @@ export class AiServerService {
 
     const updatedAuthorizations =
       await this.aiPersonaServiceAuthorizationService.applyAuthorizationPolicy(
-        aiPersonaService,
+        aiPersonaService.id,
         server.authorization
       );
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);


### PR DESCRIPTION
This deals with a logic debt that will need to pick up later, namely that there are two roots for the authorization tree: collaboration server + AI Server.

This PR cascades for now the auth reset on an AI Person through to the related AI Persona Service - but we will later need a better design. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of authorization policies for AI personas and AI persona services, allowing for multiple authorization rules to be applied asynchronously.
- **Bug Fixes**
	- Enhanced error handling when retrieving authorization policies, ensuring more robust responses if policies are missing.
- **Refactor**
	- Streamlined and centralized the logic for applying and resetting authorization policies, resulting in clearer and more maintainable authorization management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->