### PR TITLE
Add BlueSky and remove twitter from users' references

### DIFF
--- a/src/domain/community/contributor/contributor.defaults.ts
+++ b/src/domain/community/contributor/contributor.defaults.ts
@@ -1,4 +1,4 @@
-export const userDefaults: any = {
+export const contributorDefaults: any = {
   references: [
     {
       name: 'linkedin',

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -62,7 +62,7 @@ import { organizationApplicationForm } from './definitions/organization.role.app
 import { RoleSetContributorType } from '@common/enums/role.set.contributor.type';
 import { RoleSetType } from '@common/enums/role.set.type';
 import { CreateReferenceInput } from '@domain/common/reference';
-import { userDefaults } from '../user/user.defaults';
+import { contributorDefaults } from '../contributor/contributor.defaults';
 
 @Injectable()
 export class OrganizationService {
@@ -625,7 +625,7 @@ export class OrganizationService {
 
   private getDefaultContributorProfileReferences(): CreateReferenceInput[] {
     const references: CreateReferenceInput[] = [];
-    const referenceTemplates = userDefaults.references; // Reuse userDefaults.references
+    const referenceTemplates = contributorDefaults.references;
 
     if (referenceTemplates) {
       for (const referenceTemplate of referenceTemplates) {

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -61,6 +61,8 @@ import { RoleName } from '@common/enums/role.name';
 import { organizationApplicationForm } from './definitions/organization.role.application.form';
 import { RoleSetContributorType } from '@common/enums/role.set.contributor.type';
 import { RoleSetType } from '@common/enums/role.set.type';
+import { CreateReferenceInput } from '@domain/common/reference';
+import { userDefaults } from '../user/user.defaults';
 
 @Injectable()
 export class OrganizationService {
@@ -118,6 +120,10 @@ export class OrganizationService {
       await this.storageAggregatorService.createStorageAggregator(
         StorageAggregatorType.ORGANIZATION
       );
+
+    organizationData.profileData.referencesData =
+      this.getDefaultContributorProfileReferences();
+
     organization.profile = await this.profileService.createProfile(
       organizationData.profileData,
       ProfileType.ORGANIZATION,
@@ -615,5 +621,22 @@ export class OrganizationService {
       base,
       reservedNameIDs
     );
+  }
+
+  private getDefaultContributorProfileReferences(): CreateReferenceInput[] {
+    const references: CreateReferenceInput[] = [];
+    const referenceTemplates = userDefaults.references; // Reuse userDefaults.references
+
+    if (referenceTemplates) {
+      for (const referenceTemplate of referenceTemplates) {
+        references.push({
+          name: referenceTemplate.name,
+          uri: referenceTemplate.uri,
+          description: referenceTemplate.description,
+        });
+      }
+    }
+
+    return references;
   }
 }

--- a/src/domain/community/user/user.defaults.ts
+++ b/src/domain/community/user/user.defaults.ts
@@ -3,7 +3,6 @@ export const userDefaults: any = {
     {
       name: 'linkedin',
       description: 'User profile on LinkedIn',
-
       uri: '',
     },
     {
@@ -12,8 +11,8 @@ export const userDefaults: any = {
       uri: '',
     },
     {
-      name: 'twitter',
-      description: 'User profile on Twitter',
+      name: 'bsky',
+      description: 'User profile on BlueSky',
       uri: '',
     },
   ],

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -44,7 +44,7 @@ import { validateEmail } from '@common/utils';
 import { RoleSetRoleSelectionCredentials } from '../../access/role-set/dto/role.set.dto.role.selection.credentials';
 import { RoleSetRoleWithParentCredentials } from '../../access/role-set/dto/role.set.dto.role.with.parent.credentials';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
-import { userDefaults } from './user.defaults';
+import { contributorDefaults } from '../contributor/contributor.defaults';
 import { UsersQueryArgs } from './dto/users.query.args';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
@@ -274,7 +274,7 @@ export class UserService {
       result.referencesData = [];
     }
     // Get the template to populate with
-    const referenceTemplates = userDefaults.references;
+    const referenceTemplates = contributorDefaults.references;
     if (referenceTemplates) {
       for (const referenceTemplate of referenceTemplates) {
         const existingRef = result.referencesData?.find(

--- a/src/migrations/1747925999514-AddBlueSkyRefToUserProfiles.ts
+++ b/src/migrations/1747925999514-AddBlueSkyRefToUserProfiles.ts
@@ -1,9 +1,10 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 import { randomUUID } from 'crypto';
 
-export class AddBlueSkyRefToUserProfiles1747925999514 implements MigrationInterface {
-
-    public async up(queryRunner: QueryRunner): Promise<void> {
+export class AddBlueSkyRefToUserProfiles1747925999514
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
     // Define the new reference
     const bskyReference = {
       name: 'bsky',
@@ -60,11 +61,5 @@ export class AddBlueSkyRefToUserProfiles1747925999514 implements MigrationInterf
     `);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
-    // Remove the "bsky" reference from all profiles
-    await queryRunner.query(`
-      DELETE FROM reference
-      WHERE name = 'bsky'
-    `);
-  }
+  public async down(queryRunner: QueryRunner): Promise<void> {}
 }

--- a/src/migrations/1747925999514-AddBlueSkyRefToUserProfiles.ts
+++ b/src/migrations/1747925999514-AddBlueSkyRefToUserProfiles.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+export class AddBlueSkyRefToUserProfiles1747925999514 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+    // Define the new reference
+    const bskyReference = {
+      name: 'bsky',
+      description: 'User profile on BlueSky',
+      uri: '',
+    };
+
+    // Fetch all users and their profiles
+    const usersWithProfiles = await queryRunner.query(`
+      SELECT u.id AS userId, p.id AS profileId
+      FROM user u
+      INNER JOIN profile p ON u.profileId = p.id
+    `);
+
+    // Iterate through each user and check if the "bsky" reference exists
+    for (const user of usersWithProfiles) {
+      const existingReferences = await queryRunner.query(
+        `
+        SELECT name
+        FROM reference
+        WHERE profileId = ?
+      `,
+        [user.profileId]
+      );
+
+      // Check if the "bsky" reference already exists
+      const hasBskyReference = existingReferences.some(
+        (ref: any) => ref.name === bskyReference.name
+      );
+
+      // If "bsky" reference does not exist, add it
+      if (!hasBskyReference) {
+        await queryRunner.query(
+          `
+          INSERT INTO reference (id, profileId, version, name, description, uri, createdDate, updatedDate)
+          VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())
+        `,
+          [
+            randomUUID(),
+            user.profileId,
+            '1',
+            bskyReference.name,
+            bskyReference.description,
+            bskyReference.uri,
+          ]
+        );
+      }
+    }
+
+    // Remove all "twitter" references where the URI is empty
+    await queryRunner.query(`
+      DELETE FROM reference
+      WHERE name = 'twitter' AND (uri IS NULL OR uri = '')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove the "bsky" reference from all profiles
+    await queryRunner.query(`
+      DELETE FROM reference
+      WHERE name = 'bsky'
+    `);
+  }
+}

--- a/src/migrations/1747995647235-AddSocialReferencesToOrganizationProfiles.ts
+++ b/src/migrations/1747995647235-AddSocialReferencesToOrganizationProfiles.ts
@@ -1,0 +1,74 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+export class AddSocialReferencesToOrganizationProfiles1747995647235
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Define the new references
+    const referencesToAdd = [
+      { name: 'bsky', description: 'Organization profile on BlueSky', uri: '' },
+      {
+        name: 'github',
+        description: 'Organization profile on GitHub',
+        uri: '',
+      },
+      {
+        name: 'linkedin',
+        description: 'Organization profile on LinkedIn',
+        uri: '',
+      },
+    ];
+
+    // Fetch all organization profiles
+    const organizationProfiles = await queryRunner.query(`
+      SELECT o.id AS organizationId, p.id AS profileId
+      FROM organization o
+      INNER JOIN profile p ON o.profileId = p.id
+    `);
+
+    // Iterate through each organization profile
+    for (const org of organizationProfiles) {
+      const existingReferences = await queryRunner.query(
+        `
+        SELECT name
+        FROM reference
+        WHERE profileId = ?
+      `,
+        [org.profileId]
+      );
+
+      // Add missing references
+      for (const ref of referencesToAdd) {
+        const hasReference = existingReferences.some(
+          (existingRef: any) => existingRef.name === ref.name
+        );
+
+        if (!hasReference) {
+          await queryRunner.query(
+            `
+            INSERT INTO reference (id, profileId, version, name, description, uri, createdDate, updatedDate)
+            VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())
+          `,
+            [
+              randomUUID(), // Generate a random UUID for the reference ID
+              org.profileId,
+              '1', // Version
+              ref.name,
+              ref.description,
+              ref.uri,
+            ]
+          );
+        }
+      }
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove the added references ('bsky', 'github', 'linkedin') from all organization profiles
+    await queryRunner.query(`
+      DELETE FROM reference
+      WHERE name IN ('bsky', 'github', 'linkedin')
+    `);
+  }
+}


### PR DESCRIPTION
As part of the task, we need to:
- Remove not used Twitter references.
- Add BluSky as the default social option instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added BlueSky as a default social media reference for user and organization profiles.
	- Organization profiles now include default social references for BlueSky, GitHub, and LinkedIn upon creation.

- **Bug Fixes**
	- Removed empty or null Twitter references from user profiles.

- **Chores**
	- Updated naming and references to ensure consistency across user and contributor profile defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->