### PR TITLE
Increases platform invitation message length

### DIFF
--- a/src/domain/access/invitation.platform/platform.invitation.entity.ts
+++ b/src/domain/access/invitation.platform/platform.invitation.entity.ts
@@ -3,7 +3,7 @@ import { IPlatformInvitation } from './platform.invitation.interface';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import {
   ENUM_LENGTH,
-  MID_TEXT_LENGTH,
+  LONGER_TEXT_LENGTH,
   SMALL_TEXT_LENGTH,
   UUID_LENGTH,
 } from '@common/constants';
@@ -42,7 +42,7 @@ export class PlatformInvitation
   @Column('char', { length: UUID_LENGTH, nullable: false })
   createdBy!: string;
 
-  @Column('varchar', { length: MID_TEXT_LENGTH, nullable: true })
+  @Column('varchar', { length: LONGER_TEXT_LENGTH, nullable: true })
   welcomeMessage?: string;
 
   @Column('boolean', { default: false })

--- a/src/migrations/1748434921732-longerPlatformInvitationMessage.ts
+++ b/src/migrations/1748434921732-longerPlatformInvitationMessage.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LongerPlatformInvitationMessage1748434921732
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `platform_invitation` MODIFY `welcomeMessage` varchar(8192) NULL'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `platform_invitation` MODIFY `welcomeMessage` varchar(255) NULL'
+    );
+  }
+}


### PR DESCRIPTION
Extends the maximum length of the welcome message field
in the platform invitation entity to accommodate longer,
more detailed messages.

Includes a database migration to update the `welcomeMessage`
column in the `platform_invitation` table to varchar(8192).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the maximum length allowed for invitation welcome messages, enabling support for much longer text.
- **Chores**
	- Updated the database to accommodate longer welcome messages in platform invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->