### PR TITLE
Subspace tutorials fixes

### DIFF
--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -857,6 +857,7 @@ export class SpaceService {
         community: {
           roleSet: true,
         },
+        parentSpace: true,
       },
     });
 
@@ -887,7 +888,20 @@ export class SpaceService {
 
     // Update the subspace data being passed in to set the storage aggregator to use
     subspaceData.storageAggregatorParent = space.storageAggregator;
-    subspaceData.templatesManagerParent = space.templatesManager;
+
+    let rootTemplatesManager = space.templatesManager;
+    let parentSpace = space.parentSpace;
+    while (!rootTemplatesManager && parentSpace) {
+      parentSpace = await this.getSpaceOrFail(parentSpace.id, {
+        relations: {
+          templatesManager: true,
+          parentSpace: true,
+        },
+      });
+      rootTemplatesManager = parentSpace.templatesManager;
+    }
+
+    subspaceData.templatesManagerParent = rootTemplatesManager;
     subspaceData.level = space.level + 1;
     let subspace = await this.createSpace(subspaceData, agentInfo);
 

--- a/src/migrations/1748424718837-tutorialsFlowState.ts
+++ b/src/migrations/1748424718837-tutorialsFlowState.ts
@@ -1,0 +1,108 @@
+import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
+import { bootstrapSpaceTutorialsCallouts } from '@core/bootstrap/platform-template-definitions/space-tutorials/bootstrap.space.tutorials.callouts';
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TutorialsFlowState1748424718837 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Get the calloutsSetId from the collaboration associated with the platform space tutorials template
+    const [{ calloutsSetId }]: { calloutsSetId: string }[] =
+      await queryRunner.query(
+        `SELECT calloutsSetId FROM collaboration WHERE id = (
+          SELECT collaborationId FROM template WHERE id = (
+            SELECT templateId FROM template_default WHERE templatesManagerId IN (
+              SELECT templatesManagerId FROM platform
+            ) AND type = 'platform-space-tutorials'
+          )
+        )`
+      );
+
+    // Get the callouts of the tutorial
+    const callouts: {
+      id: string;
+      nameId: string;
+      classificationTagsetId: string;
+      currentFlowState: string;
+      currentSortOrder: number;
+    }[] = await queryRunner.query(
+      `
+          SELECT
+            callout.id,
+            callout.nameId,
+            tagset.id AS classificationTagsetId,
+            tagset.tags AS currentFlowState,
+            callout.sortOrder as currentSortOrder
+          FROM callout
+            JOIN tagset ON tagset.classificationID = callout.classificationId AND tagset.name = 'flow-state'
+          WHERE calloutsSetId = ?`,
+      [calloutsSetId]
+    );
+
+    for (const callout of callouts) {
+      // tutorialCallouts are the hardcoded callouts in the bootstrap file
+      const tutorialCallout = this.findTutorialCallout(callout.nameId);
+      if (!tutorialCallout) {
+        console.warn(
+          `No tutorial callout found for nameId: ${callout.nameId}. This callout will be skipped.`
+        );
+        continue;
+      }
+      const { flowState: expectedFlowState, sortOrder: expectedSortOrder } =
+        tutorialCallout;
+
+      if (callout.currentFlowState !== expectedFlowState) {
+        console.log(
+          `Updating flow state for callout: ${callout.id} ${callout.nameId} from ${callout.currentFlowState} to ${expectedFlowState}`
+        );
+        await queryRunner.query(
+          `
+          UPDATE tagset SET tags = ? WHERE id = ?
+        `,
+          [expectedFlowState, callout.classificationTagsetId]
+        );
+      }
+      if (callout.currentSortOrder !== expectedSortOrder) {
+        console.log(
+          `Updating sortOrder for callout: ${callout.id} ${callout.nameId} from ${callout.currentSortOrder} to ${expectedSortOrder}`
+        );
+        await queryRunner.query(
+          `
+          UPDATE callout SET sortOrder = ? WHERE id = ?
+        `,
+          [expectedSortOrder, callout.id]
+        );
+      }
+    }
+  }
+
+  // Get the tutorial callout from the hardcoded bootstrap file
+  private findTutorialCallout(nameId: string) {
+    const tutorialCallout = bootstrapSpaceTutorialsCallouts.find(
+      c => c.nameID === nameId
+    );
+    if (!tutorialCallout) {
+      return undefined;
+    }
+    const classificationTagset = tutorialCallout.classification?.tagsets.find(
+      tagset => tagset.name === TagsetReservedName.FLOW_STATE
+    );
+    if (!classificationTagset) {
+      // This should not happen, the tutorials are hardcoded in that file
+      throw new Error(
+        `No classification tagset found for tutorial callout: ${nameId}`
+      );
+    }
+    const flowState = classificationTagset.tags?.[0];
+    if (!flowState) {
+      throw new Error(
+        `No expected flow state found for tutorial callout: ${nameId}`
+      );
+    }
+
+    return {
+      flowState,
+      sortOrder: tutorialCallout.sortOrder,
+    };
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/services/api/input-creator/input.creator.service.ts
+++ b/src/services/api/input-creator/input.creator.service.ts
@@ -148,6 +148,9 @@ export class InputCreatorService {
         relations: {
           calloutsSet: {
             callouts: {
+              classification: {
+                tagsets: true,
+              },
               framing: {
                 profile: true,
                 whiteboard: {


### PR DESCRIPTION
- Migration to rewrite flowState and sortOrder on the callouts in the tutorials callouts according to the bootstrap hardcoded values.
- There was a different problem creating subspaces L2:
  - Set the default subspace template in the space settings
  - Create a L2 subspace inside another subspace
  - The platform subspace template was used. 
  - Only L0 spaces have a templatesManager. The subspaces have templatesManagerId = null. It was not getting properly the templatesManager, so it was not using the space template. I've made a while loop climbing up to parent space that may be implemented somewhere else in a better way.
  -  (This may need to be fixed in a different way, maybe we can create a migration to make all subspaces to point to the root templates manager) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subspace creation by ensuring the correct templates manager is inherited from the nearest parent space with a templates manager.
  - Enhanced collaboration input building to include classification tagsets for callouts.

- **Chores**
  - Updated tutorial callouts in the database to align their flow state and sort order with the latest configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->