### PR TITLE
allow beta testers to create orgs; allow beta testers to add orgs 

### DIFF
--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -33,6 +33,7 @@ export enum AuthorizationPrivilege {
   ROLESET_ENTRY_ROLE_INVITE = 'roleset-entry-role-invite',
   ROLESET_ENTRY_ROLE_INVITE_ACCEPT = 'roleset-entry-role-invite-accept',
   ROLESET_ENTRY_ROLE_ASSIGN = 'roleset-entry-role-assign', // only for global admins
+  ROLESET_ENTRY_ROLE_ASSIGN_ORGANIZATION = 'roleset-entry-role-assign-organization', // only for global admins
   COMMUNITY_ASSIGN_VC_FROM_ACCOUNT = 'community-assign-vc-from-account', // allow adding a VC as member to a community from an account
   UPDATE_CALLOUT_PUBLISHER = 'update-callout-publisher',
   READ_ABOUT = 'read-about', // access the external about information for an entity

--- a/src/domain/access/role-set/role.set.resolver.mutations.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.ts
@@ -121,6 +121,13 @@ export class RoleSetResolverMutations {
     );
     this.validateRoleSetTypeOrFail(roleSet, [RoleSetType.SPACE]);
 
+    // Check if has **both** grant + assign org privileges
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      roleSet.authorization,
+      AuthorizationPrivilege.ROLESET_ENTRY_ROLE_ASSIGN_ORGANIZATION,
+      `assign organization RoleSet role: ${roleSet.id}`
+    );
     this.authorizationService.grantAccessOrFail(
       agentInfo,
       roleSet.authorization,

--- a/src/domain/access/role-set/role.set.service.authorization.ts
+++ b/src/domain/access/role-set/role.set.service.authorization.ts
@@ -159,6 +159,18 @@ export class RoleSetAuthorizationService {
       );
     newRules.push(globalAdminAddMembers);
 
+    const globalAdminAddOrganizations =
+      this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
+        [AuthorizationPrivilege.ROLESET_ENTRY_ROLE_ASSIGN_ORGANIZATION],
+        [
+          AuthorizationCredential.GLOBAL_ADMIN,
+          AuthorizationCredential.GLOBAL_SUPPORT,
+          AuthorizationCredential.BETA_TESTER,
+        ],
+        'assign-organization-global-admins-beta-testers'
+      );
+    newRules.push(globalAdminAddOrganizations);
+
     //
     const updatedAuthorization =
       this.authorizationPolicyService.appendCredentialAuthorizationRules(

--- a/src/platform/platform/platform.service.authorization.ts
+++ b/src/platform/platform/platform.service.authorization.ts
@@ -280,7 +280,7 @@ export class PlatformAuthorizationService {
         [
           AuthorizationCredential.GLOBAL_ADMIN,
           AuthorizationCredential.GLOBAL_SUPPORT,
-          AuthorizationCredential.SPACE_ADMIN,
+          AuthorizationCredential.BETA_TESTER,
         ],
         CREDENTIAL_RULE_PLATFORM_CREATE_ORGANIZATION
       );

--- a/src/services/api/registration/registration.resolver.mutations.ts
+++ b/src/services/api/registration/registration.resolver.mutations.ts
@@ -101,7 +101,6 @@ export class RegistrationResolverMutations {
   @Mutation(() => IOrganization, {
     description: 'Creates a new Organization on the platform.',
   })
-  @Profiling.api
   async createOrganization(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('organizationData') organizationData: CreateOrganizationInput


### PR DESCRIPTION
added new privilege on roleset for adding orgs directly; new privilege assigned to global admins and beta testers.

check on mutation for adding org checks new privilege AND grant privilege.

privilege to create orgs on platform added to beta testers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new authorization privilege for assigning organization roles, available to global admins, global support, and beta testers.

- **Changes**
  - Updated user roles permitted to create organizations, replacing space admins with beta testers.

- **Other**
  - Removed profiling instrumentation from the organization creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->