### PR TITLE
update logo url and tweak some emails contents

### DIFF
--- a/.build/ory/kratos/courier-templates/recovery/invalid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/recovery/invalid/email.body.gotmpl
@@ -8,11 +8,12 @@ If this was you, check if you signed up using a different address.
 <p>
 If this was not you, please ignore this email.
 <p>
+<b>The Alkemio Team</b>
+<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
 <p>
-<b>Team Alkemio</b>
-<br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/recovery/valid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/recovery/valid/email.body.gotmpl
@@ -6,10 +6,12 @@ Alternatively, you can also cut and paste the following URL into your browser:
 <p>
 <em>{{ .RecoveryURL }}</em>
 <p>
-<b>Team Alkemio</b>
+<b>The Alkemio Team</b>
 <br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
+<p>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/recovery/valid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/recovery/valid/email.body.plaintext.gotmpl
@@ -6,4 +6,4 @@ please recover access to your account by clicking the following link:
 
 Team Alkemio
 website: https://alkem.io
-"Enabling society to collaborate. Building a better future, together"
+"Enabling society to collaborate. Building a better future, together."

--- a/.build/ory/kratos/courier-templates/recovery_code/invalid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/recovery_code/invalid/email.body.gotmpl
@@ -8,11 +8,12 @@ If this was you, check if you signed up using a different address.
 <p>
 If this was not you, please ignore this email.
 <p>
+<b>The Alkemio Team</b>
+<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
 <p>
-<b>Team Alkemio</b>
-<br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/recovery_code/invalid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/recovery_code/invalid/email.body.plaintext.gotmpl
@@ -10,4 +10,4 @@ If this was not you, please ignore this email.
 
 Team Alkemio
 website: https://alkem.io
-"Enabling society to collaborate. Building a better future, together"
+"Enabling society to collaborate. Building a better future, together."

--- a/.build/ory/kratos/courier-templates/recovery_code/valid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/recovery_code/valid/email.body.gotmpl
@@ -1,11 +1,17 @@
 Alkemio Account Recovery
 <p>
-please recover access to your account by entering the following code: {{ .RecoveryCode }}.
 <p>
-<b>Team Alkemio</b>
+Please recover access to your account by entering the following code: <b>{{ .RecoveryCode }}</b>.
+
+{{ .RecoveryURL }}
+
+<p>
+<b>The Alkemio Team</b>
 <br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
+<p>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/recovery_code/valid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/recovery_code/valid/email.body.plaintext.gotmpl
@@ -4,4 +4,4 @@ please recover access to your account by entering the following code: {{ .Recove
 
 Team Alkemio
 website: https://alkem.io
-"Enabling society to collaborate. Building a better future, together"
+"Enabling society to collaborate. Building a better future, together."

--- a/.build/ory/kratos/courier-templates/verification/invalid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification/invalid/email.body.gotmpl
@@ -4,11 +4,12 @@ If this was you, check if you signed up using a different address.
 <p>
 If this was not you, please ignore this email.
 <p>
+<b>The Alkemio Team</b>
+<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
 <p>
-<b>Team Alkemio</b>
-<br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/verification/invalid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification/invalid/email.body.plaintext.gotmpl
@@ -8,4 +8,4 @@ If this was not you, please ignore this email.
 
 Team Alkemio
 website: https://alkem.io
-"Enabling society to collaborate. Building a better future, together"
+"Enabling society to collaborate. Building a better future, together."

--- a/.build/ory/kratos/courier-templates/verification/valid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification/valid/email.body.gotmpl
@@ -1,19 +1,19 @@
 Thank you for signing up for Alkemio!
 <p>
 <p>
-For security reasons, please verify your email address by clicking on
-<a href="{{ .VerificationURL }}">this link.</a>
-<p>
-Alternatively, you can also cut and paste the following URL into your browser:
+For security reasons, please verify your email address by clicking on <a href="{{ .VerificationURL }}">this link.</a>
+or you can also cut and paste the following URL into your browser, with the following verification code <em>{{ .VerificationCode }}</em>
 <p>
 <em>{{ .VerificationURL }}</em>
 <p>
-Good luck connecting and collaborating!
+Enjoy connecting and collaborating!
 <p>
-<b>Team Alkemio</b>
+<b>The Alkemio Team</b>
 <br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
+<p>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/verification/valid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification/valid/email.body.gotmpl
@@ -2,7 +2,7 @@ Thank you for signing up for Alkemio!
 <p>
 <p>
 For security reasons, please verify your email address by clicking on <a href="{{ .VerificationURL }}">this link.</a>
-or you can also cut and paste the following URL into your browser, with the following verification code <em>{{ .VerificationCode }}</em>
+or you can also cut and paste the following URL into your browser:
 <p>
 <em>{{ .VerificationURL }}</em>
 <p>

--- a/.build/ory/kratos/courier-templates/verification/valid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification/valid/email.body.plaintext.gotmpl
@@ -8,5 +8,5 @@ Good luck connecting and collaborating!
 
 Team Alkemio
 website: https://alkem.io
-"Enabling society to collaborate. Building a better future, together"
+"Enabling society to collaborate. Building a better future, together."
 

--- a/.build/ory/kratos/courier-templates/verification_code/invalid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification_code/invalid/email.body.gotmpl
@@ -4,11 +4,12 @@ If this was you, check if you signed up using a different address.
 <p>
 If this was not you, please ignore this email.
 <p>
+<b>The Alkemio Team</b>
+<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
 <p>
-<b>Team Alkemio</b>
-<br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/verification_code/invalid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification_code/invalid/email.body.plaintext.gotmpl
@@ -8,4 +8,4 @@ If this was not you, please ignore this email.
 
 Team Alkemio
 website: https://alkem.io
-"Enabling society to collaborate. Building a better future, together"
+"Enabling society to collaborate. Building a better future, together."

--- a/.build/ory/kratos/courier-templates/verification_code/valid/email.body.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification_code/valid/email.body.gotmpl
@@ -1,21 +1,20 @@
 Thank you for signing up for Alkemio!
 <p>
 <p>
-For security reasons, please verify your email address by entering the following code:
-<em>{{ .VerificationCode }}</em>
+For security reasons, please verify your email address by clicking on <b><a target="_blank" href="{{ .VerificationURL }}">this link.</a></b>
 <p>
-Alternatively, you can verify your email address by clicking on
-<a href="{{ .VerificationURL }}">this link.</a>
-or you can also cut and paste the following URL into your browser:
+Or you can also cut and paste the following URL into your browser, with the following verification code <em>{{ .VerificationCode }}</em>
 <p>
 <em>{{ .VerificationURL }}</em>
 <p>
-Good luck connecting and collaborating!
+Enjoy connecting and collaborating!
 <p>
-<b>Team Alkemio</b>
+<b>The Alkemio Team</b>
 <br>
-<b>website</b>: <a href="https://alkem.io">https://alkem.io</a>
-<br>
-<a href="https://alkem.io"><img src="https://alkem.io/uploads/logos/alkemio-logo.svg" width="120"></a>
-<br>
+<b>website</b>: <a target="_blank" href="https://alkem.io">https://alkem.io</a>
+<p>
+<p>
+<a target="_blank" href="https://alkem.io"><img src="https://alkem.io/logo.png" width="120" ></a>
+<p>
+<p>
 <i>Enabling society to collaborate. Building a better future, together.</i>

--- a/.build/ory/kratos/courier-templates/verification_code/valid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification_code/valid/email.body.plaintext.gotmpl
@@ -1,4 +1,3 @@
------  verification code valid plaintext
 Thank you for signing up for Alkemio!
 
 For security reasons, please verify your email address by entering the following code:

--- a/.build/ory/kratos/courier-templates/verification_code/valid/email.body.plaintext.gotmpl
+++ b/.build/ory/kratos/courier-templates/verification_code/valid/email.body.plaintext.gotmpl
@@ -1,3 +1,4 @@
+-----  verification code valid plaintext
 Thank you for signing up for Alkemio!
 
 For security reasons, please verify your email address by entering the following code:


### PR DESCRIPTION
Fixes: https://github.com/alkem-io/alkemio/issues/1558

Expected result:
**Notes:** _logo is there obviously :D; margins in the footer are slightly different; all auth flow related templates should have the same footer._
![image](https://github.com/user-attachments/assets/84aa0af2-be5c-4ae0-ad5a-40e7f9cc831a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Improved formatting and spacing in email templates for account recovery and verification notifications, including updated paragraph breaks and enhanced clarity.
	- Updated team signature to "The Alkemio Team" and standardized logo image and website link formatting, ensuring links open in new tabs.
	- Minor punctuation and typographic corrections in plain text email templates.
- **New Features**
	- Added clickable recovery and verification links in relevant email templates, providing users with direct access for account actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->