### PR TITLE
Space creation - use about information from the template

### DIFF
--- a/src/domain/space/space.defaults/space.defaults.service.ts
+++ b/src/domain/space/space.defaults/space.defaults.service.ts
@@ -160,7 +160,9 @@ export class SpaceDefaultsService {
           relations: {
             contentSpace: {
               collaboration: true,
-              about: true,
+              about: {
+                profile: true,
+              },
             },
           },
         }

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1258,17 +1258,21 @@ export class SpaceService {
     templateSpaceContent: ITemplateContentSpace,
     spaceData: CreateSpaceInput
   ): CreateSpaceAboutInput {
+    const templateAbout = templateSpaceContent.about;
+    if (!templateAbout || !templateAbout.profile) {
+      return spaceData.about;
+    }
+
     return {
-      why: templateSpaceContent.about.why,
-      who: templateSpaceContent.about.who,
+      why: spaceData.about.why || templateAbout.why,
+      who: spaceData.about.who || templateAbout.who,
       profileData: {
         ...spaceData.about.profileData,
         description:
           spaceData.about.profileData.description ||
-          templateSpaceContent.about.profile.description,
+          templateAbout.profile.description,
         tagline:
-          spaceData.about.profileData.tagline ||
-          templateSpaceContent.about.profile.tagline,
+          spaceData.about.profileData.tagline || templateAbout.profile.tagline,
       },
       // TODO: add the rest of the fields from the template (gather them on tmpl creation first)
     };


### PR DESCRIPTION
- [x] Apply the available 'About' information from the template on space creation.
- Additional fields to be obtained on Space Template creation (visuals, guidelines, tags, etc) To be extracted in another sotry.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved space creation by automatically merging template "About" information with user-provided details, ensuring key fields are preserved or enhanced based on available data.  
  - Enhanced template reloading to fetch more detailed "About" profile information within space content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->