### PR TITLE
Updates matrix-adapter image version

### DIFF
--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -195,7 +195,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.3.1
+    image: alkemio/matrix-adapter:v0.4.7
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -237,7 +237,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.4.5
+    image: alkemio/matrix-adapter:v0.4.7
     platform: linux/x86_64
     environment:
       - RABBITMQ_HOST

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -253,7 +253,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.3.1
+    image: alkemio/matrix-adapter:v0.4.7
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -241,7 +241,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.4.6
+    image: alkemio/matrix-adapter:v0.4.7
     platform: linux/x86_64
     depends_on:
       - rabbitmq


### PR DESCRIPTION
Updates the matrix-adapter image version to v0.4.7 in multiple docker-compose files.

This ensures that the latest version of the matrix-adapter is used across different environments (debug, AI, kratos-debug, and production).
