### PR TITLE
Handles empty country and city values

### DIFF
--- a/src/domain/common/location/location.service.ts
+++ b/src/domain/common/location/location.service.ts
@@ -115,6 +115,15 @@ export class LocationService {
     if (location.geoLocation.isValid) {
       return location.geoLocation;
     }
+
+    if (location.country === '' && location.city === '') {
+      // If both country and city are empty, we cannot update the geoLocation.
+      // In the ideal case the data should not be updated on query; to be discussed.
+      location.geoLocation.longitude = 0;
+      location.geoLocation.latitude = 0;
+      return location.geoLocation;
+    }
+
     if (!this.hasValidLocationDataForGeoLocation(location)) {
       // If no valid location data is available, we cannot update the geoLocation.
       return location.geoLocation;

--- a/src/domain/common/location/location.service.ts
+++ b/src/domain/common/location/location.service.ts
@@ -119,8 +119,8 @@ export class LocationService {
     if (location.country === '' && location.city === '') {
       // If both country and city are empty, we cannot update the geoLocation.
       // In the ideal case the data should not be updated on query; to be discussed.
-      location.geoLocation.longitude = 0;
-      location.geoLocation.latitude = 0;
+      location.geoLocation.longitude = undefined;
+      location.geoLocation.latitude = undefined;
       return location.geoLocation;
     }
 


### PR DESCRIPTION
Ensures that the geoLocation is not updated when both the country and city are empty.

Sets the longitude and latitude to 0 in this scenario to prevent incorrect data from being saved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty country and city fields in location data to prevent invalid geolocation updates. When both fields are empty, the system now clears longitude and latitude values immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->