### PR TITLE
Fix missing tags when using Space TMPL more than once

### DIFF
--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -257,11 +257,11 @@ export class SpaceAboutService {
   }
 
   /**
-   * Merges two sets of tagsets, combining tags for tagsets with the same name.
+   * Merges two sets of tagsets, ensuring deep copies are created for template tagsets.
    *
    * @param inputTagsets - The tagsets provided in the input.
    * @param templateTagsets - The tagsets from the template.
-   * @returns An array of merged tagsets with combined tags.
+   * @returns An array of merged tagsets with combined tags, ensuring new entities for template tagsets.
    */
   private mergeTagsets(
     inputTagsets: CreateTagsetInput[] | undefined,
@@ -273,8 +273,12 @@ export class SpaceAboutService {
 
     const combinedTagsets = [
       ...(inputTagsets || []),
-      ...(templateTagsets || []),
+      ...(templateTagsets || []).map(tagset => ({
+        name: tagset.name,
+        tags: [...tagset.tags],
+      })),
     ];
+
     const tagsetMap = new Map<string, { name: string; tags: Set<string> }>();
 
     combinedTagsets.forEach(tagset => {


### PR DESCRIPTION
The issue was that the merged tags were not deep copied and the one-to-one relation of the existing tagsets was preserved. 

This also fixed the issue - when a user add tags on L1/L2 creation when using a template, the tags from the spaceContent were not preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tagset merging to prevent unintended sharing of tag references, ensuring tagsets remain distinct after merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->