### PR TITLE
Invalidate space URL when nameID is changed

### DIFF
--- a/src/domain/space/space/space.module.ts
+++ b/src/domain/space/space/space.module.ts
@@ -33,6 +33,7 @@ import { SpaceLicenseService } from './space.service.license';
 import { AccountLookupModule } from '../account.lookup/account.lookup.module';
 import { SpaceAboutModule } from '../space.about/space.about.module';
 import { SpaceLookupModule } from '../space.lookup/space.lookup.module';
+import { UrlGeneratorModule } from '@services/infrastructure/url-generator/url.generator.module';
 
 @Module({
   imports: [
@@ -61,6 +62,7 @@ import { SpaceLookupModule } from '../space.lookup/space.lookup.module';
     SpaceDefaultsModule,
     SpaceLookupModule,
     LicenseModule,
+    UrlGeneratorModule,
     TypeOrmModule.forFeature([Space]),
   ],
   providers: [

--- a/src/domain/space/space/space.resolver.mutations.ts
+++ b/src/domain/space/space/space.resolver.mutations.ts
@@ -150,7 +150,9 @@ export class SpaceResolverMutations {
     @CurrentUser() agentInfo: AgentInfo,
     @Args('updateData') updateData: UpdateSpacePlatformSettingsInput
   ): Promise<ISpace> {
-    let space = await this.spaceService.getSpaceOrFail(updateData.spaceID);
+    let space = await this.spaceService.getSpaceOrFail(updateData.spaceID, {
+      relations: { about: { profile: true } },
+    });
     this.authorizationService.grantAccessOrFail(
       agentInfo,
       space.authorization,

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -27,12 +27,15 @@ import { CalloutsSetType } from '@common/enums/callouts.set.type';
 import { SpaceAbout } from '../space.about';
 import { TagsetTemplate } from '@domain/common/tagset-template';
 import { TagsetType } from '@common/enums/tagset.type';
+import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
+import { UpdateSpacePlatformSettingsInput } from './dto/space.dto.update.platform.settings';
 
 const moduleMocker = new ModuleMocker(global);
 
 describe('SpaceService', () => {
   let service: SpaceService;
   let spaceRepository: Repository<Space>;
+  let urlGeneratorCacheService: UrlGeneratorCacheService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -48,10 +51,155 @@ describe('SpaceService', () => {
 
     service = module.get<SpaceService>(SpaceService);
     spaceRepository = module.get<Repository<Space>>(getRepositoryToken(Space));
+    urlGeneratorCacheService = module.get<UrlGeneratorCacheService>(
+      UrlGeneratorCacheService
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('updateSpacePlatformSettings', () => {
+    it('should invalidate URL cache when nameID is updated for L0 space', async () => {
+      // Arrange
+      const spaceId = 'space-1';
+      const oldNameID = 'old-space-name';
+      const newNameID = 'new-space-name';
+      const subspaceId = 'subspace-1';
+
+      const mockSpace = {
+        id: spaceId,
+        nameID: oldNameID,
+        level: SpaceLevel.L0,
+        levelZeroSpaceID: spaceId,
+      } as Space;
+
+      const mockSubspace = {
+        id: subspaceId,
+        nameID: 'subspace-name',
+        level: SpaceLevel.L1,
+        levelZeroSpaceID: spaceId,
+      } as Space;
+
+      const updateData: UpdateSpacePlatformSettingsInput = {
+        spaceID: spaceId,
+        nameID: newNameID,
+      };
+
+      // Mock the naming service to return empty reserved nameIDs
+      const mockNamingService = {
+        getReservedNameIDsLevelZeroSpaces: jest.fn().mockResolvedValue([]),
+      };
+      service['namingService'] = mockNamingService as any;
+
+      // Mock the repository to return subspaces
+      jest.spyOn(spaceRepository, 'find').mockResolvedValue([mockSubspace]);
+      jest.spyOn(service, 'save').mockResolvedValue(mockSpace);
+
+      // Mock the URL cache service
+      const revokeUrlCacheSpy = jest
+        .spyOn(urlGeneratorCacheService, 'revokeUrlCache')
+        .mockResolvedValue();
+
+      // Act
+      await service.updateSpacePlatformSettings(mockSpace, updateData);
+
+      // Assert
+      expect(mockSpace.nameID).toBe(newNameID);
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(spaceId); // Main space cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(subspaceId); // Subspace cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should invalidate URL cache when nameID is updated for subspace', async () => {
+      // Arrange
+      const parentSpaceId = 'parent-space-1';
+      const subspaceId = 'subspace-1';
+      const childSubspaceId = 'child-subspace-1';
+      const oldNameID = 'old-subspace-name';
+      const newNameID = 'new-subspace-name';
+
+      const mockSubspace = {
+        id: subspaceId,
+        nameID: oldNameID,
+        level: SpaceLevel.L1,
+        levelZeroSpaceID: parentSpaceId,
+      } as Space;
+
+      const mockChildSubspace = {
+        id: childSubspaceId,
+        nameID: 'child-subspace-name',
+        level: SpaceLevel.L2,
+        levelZeroSpaceID: parentSpaceId,
+      } as Space;
+
+      const updateData: UpdateSpacePlatformSettingsInput = {
+        spaceID: subspaceId,
+        nameID: newNameID,
+      };
+
+      // Mock the naming service to return empty reserved nameIDs
+      const mockNamingService = {
+        getReservedNameIDsInLevelZeroSpace: jest.fn().mockResolvedValue([]),
+      };
+      service['namingService'] = mockNamingService as any;
+
+      // Mock the repository to return child subspaces
+      jest
+        .spyOn(spaceRepository, 'find')
+        .mockResolvedValue([mockChildSubspace]);
+      jest.spyOn(service, 'save').mockResolvedValue(mockSubspace);
+
+      // Mock the URL cache service
+      const revokeUrlCacheSpy = jest
+        .spyOn(urlGeneratorCacheService, 'revokeUrlCache')
+        .mockResolvedValue();
+
+      // Act
+      await service.updateSpacePlatformSettings(mockSubspace, updateData);
+
+      // Assert
+      expect(mockSubspace.nameID).toBe(newNameID);
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(subspaceId); // Main subspace cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(childSubspaceId); // Child subspace cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not invalidate URL cache when nameID is not changed', async () => {
+      // Arrange
+      const spaceId = 'space-1';
+      const nameID = 'same-space-name';
+
+      const mockSpace = {
+        id: spaceId,
+        nameID: nameID,
+        level: SpaceLevel.L0,
+        levelZeroSpaceID: spaceId,
+        visibility: SpaceVisibility.ACTIVE,
+      } as Space;
+
+      const updateData: UpdateSpacePlatformSettingsInput = {
+        spaceID: spaceId,
+        visibility: SpaceVisibility.DEMO, // Only changing visibility, not nameID
+      };
+
+      jest.spyOn(service, 'save').mockResolvedValue(mockSpace);
+      jest
+        .spyOn(service, 'updateSpaceVisibilityAllSubspaces' as any)
+        .mockResolvedValue(undefined);
+
+      // Mock the URL cache service
+      const revokeUrlCacheSpy = jest
+        .spyOn(urlGeneratorCacheService, 'revokeUrlCache')
+        .mockResolvedValue();
+
+      // Act
+      await service.updateSpacePlatformSettings(mockSpace, updateData);
+
+      // Assert
+      expect(revokeUrlCacheSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('shouldUpdateAuthorizationPolicy', () => {

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -73,6 +73,11 @@ describe('SpaceService', () => {
         nameID: oldNameID,
         level: SpaceLevel.L0,
         levelZeroSpaceID: spaceId,
+        about: {
+          profile: {
+            id: `profile-${spaceId}`,
+          },
+        },
       } as Space;
 
       const mockSubspace = {
@@ -80,6 +85,11 @@ describe('SpaceService', () => {
         nameID: 'subspace-name',
         level: SpaceLevel.L1,
         levelZeroSpaceID: spaceId,
+        about: {
+          profile: {
+            id: `profile-${subspaceId}`,
+          },
+        },
       } as Space;
 
       const updateData: UpdateSpacePlatformSettingsInput = {
@@ -107,8 +117,8 @@ describe('SpaceService', () => {
 
       // Assert
       expect(mockSpace.nameID).toBe(newNameID);
-      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(spaceId); // Main space cache invalidated
-      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(subspaceId); // Subspace cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(`profile-${spaceId}`); // Main space cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(`profile-${subspaceId}`); // Subspace cache invalidated
       expect(revokeUrlCacheSpy).toHaveBeenCalledTimes(2);
     });
 
@@ -125,6 +135,11 @@ describe('SpaceService', () => {
         nameID: oldNameID,
         level: SpaceLevel.L1,
         levelZeroSpaceID: parentSpaceId,
+        about: {
+          profile: {
+            id: `profile-${subspaceId}`,
+          },
+        },
       } as Space;
 
       const mockChildSubspace = {
@@ -132,6 +147,11 @@ describe('SpaceService', () => {
         nameID: 'child-subspace-name',
         level: SpaceLevel.L2,
         levelZeroSpaceID: parentSpaceId,
+        about: {
+          profile: {
+            id: `profile-${childSubspaceId}`,
+          },
+        },
       } as Space;
 
       const updateData: UpdateSpacePlatformSettingsInput = {
@@ -161,8 +181,10 @@ describe('SpaceService', () => {
 
       // Assert
       expect(mockSubspace.nameID).toBe(newNameID);
-      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(subspaceId); // Main subspace cache invalidated
-      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(childSubspaceId); // Child subspace cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(`profile-${subspaceId}`); // Main subspace cache invalidated
+      expect(revokeUrlCacheSpy).toHaveBeenCalledWith(
+        `profile-${childSubspaceId}`
+      ); // Child subspace cache invalidated
       expect(revokeUrlCacheSpy).toHaveBeenCalledTimes(2);
     });
 

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -458,6 +458,9 @@ export class SpaceService {
       relations: {
         parentSpace: true,
         collaboration: true,
+        about: {
+          profile: true,
+        },
       },
     });
 
@@ -689,8 +692,10 @@ export class SpaceService {
       const oldNameID = space.nameID;
       space.nameID = updateData.nameID;
 
-      // Invalidate URL cache for this space
-      await this.urlGeneratorCacheService.revokeUrlCache(space.id);
+      // Invalidate URL cache for this space's profile
+      await this.urlGeneratorCacheService.revokeUrlCache(
+        space.about.profile.id
+      );
 
       // Invalidate URL cache for all subspaces since their URLs include parent nameIDs
       if (space.level === SpaceLevel.L0) {
@@ -699,10 +704,19 @@ export class SpaceService {
           where: {
             levelZeroSpaceID: space.id,
           },
+          relations: {
+            about: {
+              profile: true,
+            },
+          },
         });
 
         for (const subspace of allSubspaces) {
-          await this.urlGeneratorCacheService.revokeUrlCache(subspace.id);
+          if (subspace.about?.profile?.id) {
+            await this.urlGeneratorCacheService.revokeUrlCache(
+              subspace.about.profile.id
+            );
+          }
         }
 
         this.logger.verbose?.(
@@ -715,10 +729,19 @@ export class SpaceService {
           where: {
             parentSpace: { id: space.id },
           },
+          relations: {
+            about: {
+              profile: true,
+            },
+          },
         });
 
         for (const childSubspace of childSubspaces) {
-          await this.urlGeneratorCacheService.revokeUrlCache(childSubspace.id);
+          if (childSubspace.about?.profile?.id) {
+            await this.urlGeneratorCacheService.revokeUrlCache(
+              childSubspace.about.profile.id
+            );
+          }
         }
 
         this.logger.verbose?.(


### PR DESCRIPTION
- invalidates URL of space.about.profile when nameID is changed
- also invalidates all sub- and sub-sub- spaces nameIDs
- tests added

tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated automatic URL cache invalidation when the nameID of a space or subspace is updated, ensuring that URLs reflect the latest changes.
* **Bug Fixes**
  * Ensured related profile data is loaded when updating space platform settings.
* **Tests**
  * Added tests to verify correct URL cache invalidation behavior when updating space or subspace nameIDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->