### PR TITLE
Fix readme URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to the Alkemio Server! This server is the heart of the Alkemio Platform,
 
 [![Build Status](https://api.travis-ci.com/alkem-io/server.svg?branch=develop)](https://travis-ci.com/github/alkem-io/server)
 [![Coverage Status](https://coveralls.io/repos/github/alkem-io/server/badge.svg?branch=develop)](https://coveralls.io/github/alkem-io/server?branch=develop)
-![Docker Image CI](https://github.com/alkem-io/Server/workflows/Docker%20Image%20CI/badge.svg?branch=develop)
+![Docker Image CI](https://github.com/alkem-io/server/actions/workflows/build-release-docker-hub.yml/badge.svg)
 
 A high level overview of the Design of the Alkemio Server is shown below.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://alkemio.org/" target="blank"><img src="https://alkemio.org/uploads/logos/alkemio-logo.svg" width="400" alt="Alkemio Logo" /></a>
+  <a href="https://alkemio.org/" target="blank"><img src="https://alkem.io/logo.png" width="400" alt="Alkemio Logo" /></a>
 </p>
 <p align="center"><i>Empowering society. The platform to succeed in working on challenges, together.</i></p>
 


### PR DESCRIPTION
Fixing the broken logo and the DockerHub status. Please, double-check the second one.

<img width="1001" height="324" alt="image" src="https://github.com/user-attachments/assets/9c7876fe-7321-4230-b0e3-b686cdfd38ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Documentation**
  * Updated the README to use a new source URL for the Alkemio logo image in the header section.
  * Updated the Docker Image CI badge URL in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->