### PR TITLE
Limit the number of InnovationFlowStates when using a template on Space creation

### DIFF
--- a/src/domain/space/space.defaults/space.defaults.service.ts
+++ b/src/domain/space/space.defaults/space.defaults.service.ts
@@ -38,7 +38,8 @@ export class SpaceDefaultsService {
 
   public async createCollaborationInput(
     collaborationData: CreateCollaborationOnSpaceInput,
-    templateSpaceContent: ITemplateContentSpace
+    templateSpaceContent: ITemplateContentSpace,
+    maxNumberOfFlowStates: number | undefined = undefined
   ): Promise<CreateCollaborationOnSpaceInput> {
     const collaborationDataFromTemplate =
       await this.getCreateCollaborationInputFromContentSpace(
@@ -55,6 +56,17 @@ export class SpaceDefaultsService {
       if (collaborationDataFromTemplate) {
         collaborationData.innovationFlowData =
           collaborationDataFromTemplate.innovationFlowData;
+        if (
+          typeof maxNumberOfFlowStates !== 'undefined' &&
+          collaborationData.innovationFlowData
+        ) {
+          // If maxNumberOfFlowStates is provided, limit the number of flow states
+          collaborationData.innovationFlowData.states =
+            collaborationData.innovationFlowData.states.slice(
+              0,
+              maxNumberOfFlowStates
+            );
+        }
       } else {
         throw new ValidationException(
           'No innovation flow data provided',

--- a/src/domain/space/space.defaults/space.defaults.service.ts
+++ b/src/domain/space/space.defaults/space.defaults.service.ts
@@ -66,18 +66,21 @@ export class SpaceDefaultsService {
     }
 
     // Enforce innovation flow settings:
+    const maxNumberOfStates =
+      templateSpaceContent.collaboration?.innovationFlow?.settings
+        .maximumNumberOfStates ?? Number.MAX_SAFE_INTEGER;
+    const minNumberOfStates =
+      templateSpaceContent.collaboration?.innovationFlow?.settings
+        .minimumNumberOfStates ?? 0;
+
     if (
-      collaborationData.innovationFlowData.states.length >
-      collaborationData.innovationFlowData.settings.maximumNumberOfStates
+      collaborationData.innovationFlowData.states.length > maxNumberOfStates
     ) {
-      collaborationData.innovationFlowData.states.slice(
-        0,
-        collaborationData.innovationFlowData.settings.maximumNumberOfStates
-      );
+      collaborationData.innovationFlowData.states =
+        collaborationData.innovationFlowData.states.slice(0, maxNumberOfStates);
     }
     if (
-      collaborationData.innovationFlowData.states.length <
-      collaborationData.innovationFlowData.settings.minimumNumberOfStates
+      collaborationData.innovationFlowData.states.length < minNumberOfStates
     ) {
       throw new ValidationException(
         `Innovation flow must have at least ${collaborationData.innovationFlowData.settings.minimumNumberOfStates} states.`,

--- a/src/domain/space/space.lookup/space.lookup.service.ts
+++ b/src/domain/space/space.lookup/space.lookup.service.ts
@@ -13,6 +13,7 @@ import {
   FindManyOptions,
   FindOneOptions,
   In,
+  Not,
   Repository,
 } from 'typeorm';
 import { ICollaboration } from '@domain/collaboration/collaboration/collaboration.interface';
@@ -99,6 +100,7 @@ export class SpaceLookupService {
       where: {
         nameID: subspaceNameID,
         levelZeroSpaceID: levelZeroSpaceID,
+        level: Not(SpaceLevel.L0),
       },
       ...options,
     });

--- a/src/domain/space/space/dto/space.dto.create.collaboration.ts
+++ b/src/domain/space/space/dto/space.dto.create.collaboration.ts
@@ -16,9 +16,4 @@ export class CreateCollaborationOnSpaceInput extends CreateCollaborationInput {
       'Add callouts from the template to the Collaboration; defaults to true.',
   })
   addCallouts? = true;
-
-  innovationFlowRestrictions?: {
-    minimumNumberOfStates?: number;
-    maximumNumberOfStates?: number;
-  };
 }

--- a/src/domain/space/space/dto/space.dto.create.collaboration.ts
+++ b/src/domain/space/space/dto/space.dto.create.collaboration.ts
@@ -16,4 +16,9 @@ export class CreateCollaborationOnSpaceInput extends CreateCollaborationInput {
       'Add callouts from the template to the Collaboration; defaults to true.',
   })
   addCallouts? = true;
+
+  innovationFlowRestrictions?: {
+    minimumNumberOfStates?: number;
+    maximumNumberOfStates?: number;
+  };
 }

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -125,7 +125,8 @@ export class SpaceService {
   private async createSpace(
     spaceData: CreateSpaceInput,
     templateContentSpaceID: string,
-    agentInfo: AgentInfo
+    agentInfo: AgentInfo,
+    maxNumberOfFlowStates: number | undefined = undefined
   ): Promise<ISpace> {
     const space: ISpace = Space.create(spaceData);
     // default to demo space
@@ -198,7 +199,8 @@ export class SpaceService {
     updatedCollaborationData =
       await this.spaceDefaultsService.createCollaborationInput(
         updatedCollaborationData,
-        templateContentSpace
+        templateContentSpace,
+        maxNumberOfFlowStates
       );
     if (spaceData.collaborationData.addTutorialCallouts) {
       updatedCollaborationData =
@@ -951,7 +953,12 @@ export class SpaceService {
         spaceData.spaceTemplateID
       );
 
-    return await this.createSpace(spaceData, templateContentSpaceID, agentInfo);
+    return await this.createSpace(
+      spaceData,
+      templateContentSpaceID,
+      agentInfo,
+      4
+    );
   }
 
   public async createSubspace(

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -125,8 +125,7 @@ export class SpaceService {
   private async createSpace(
     spaceData: CreateSpaceInput,
     templateContentSpaceID: string,
-    agentInfo: AgentInfo,
-    maxNumberOfFlowStates: number | undefined = undefined
+    agentInfo: AgentInfo
   ): Promise<ISpace> {
     const space: ISpace = Space.create(spaceData);
     // default to demo space
@@ -199,8 +198,7 @@ export class SpaceService {
     updatedCollaborationData =
       await this.spaceDefaultsService.createCollaborationInput(
         updatedCollaborationData,
-        templateContentSpace,
-        maxNumberOfFlowStates
+        templateContentSpace
       );
     if (spaceData.collaborationData.addTutorialCallouts) {
       updatedCollaborationData =
@@ -953,12 +951,12 @@ export class SpaceService {
         spaceData.spaceTemplateID
       );
 
-    return await this.createSpace(
-      spaceData,
-      templateContentSpaceID,
-      agentInfo,
-      4
-    );
+    spaceData.collaborationData.innovationFlowRestrictions = {
+      maximumNumberOfStates: 4,
+      minimumNumberOfStates: 4,
+    };
+
+    return await this.createSpace(spaceData, templateContentSpaceID, agentInfo);
   }
 
   public async createSubspace(


### PR DESCRIPTION
Client is not yet fully ready for having more than 4 tabs on Tabbed Layout. 
I have limited the number of states and that puts all the callouts in the deleted states into the first tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for innovation flow states when creating spaces, ensuring the number of states adheres to defined minimum and maximum limits.
  * Enhanced error handling to provide clearer feedback if innovation flow data or required state counts are missing.

* **Refactor**
  * Streamlined the process for creating spaces and subspaces by updating how template content is handled and validated.
  * Optimized data loading to include specific innovation flow details for better performance.

* **Enhancements**
  * Refined subspace search to exclude top-level spaces, improving result accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->