### PR TITLE
Fix callouts in subspaces in the template not being created on subspaces when using a template

### DIFF
--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -245,6 +245,7 @@ export class SpaceService {
             },
           },
           collaborationData: {
+            addCallouts: spaceData.collaborationData.addCallouts,
             calloutsSetData: {},
           },
         };


### PR DESCRIPTION
There was a flag not being mapped properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subspaces created from templates now inherit the "add callouts" setting from the parent space, ensuring consistent collaboration features across all subspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->