### PR TITLE
Add recursive flag to updateTemplateFromSpace mutation

### DIFF
--- a/src/domain/template/template-content-space/template.content.space.interface.ts
+++ b/src/domain/template/template-content-space/template.content.space.interface.ts
@@ -1,6 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { ICollaboration } from '@domain/collaboration/collaboration';
-import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { ILicense } from '@domain/common/license/license.interface';
 import { IAuthorizable } from '@domain/common/entity/authorizable-entity';
 import { ISpaceAbout } from '@domain/space/space.about/space.about.interface';
@@ -24,8 +23,6 @@ export class ITemplateContentSpace extends IAuthorizable {
   collaboration?: ICollaboration;
 
   settings!: ISpaceSettings;
-
-  storageAggregator?: IStorageAggregator;
 
   license?: ILicense;
 }

--- a/src/domain/template/template/dto/template.dto.update.from.space.ts
+++ b/src/domain/template/template/dto/template.dto.update.from.space.ts
@@ -14,4 +14,10 @@ export class UpdateTemplateFromSpaceInput {
     description: 'The Space whose content should be copied to this Template.',
   })
   spaceID!: string;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description: 'Whether to reproduce the hierarchy or just the space.',
+  })
+  recursive?: boolean;
 }

--- a/src/domain/template/template/template.resolver.mutations.ts
+++ b/src/domain/template/template/template.resolver.mutations.ts
@@ -74,6 +74,24 @@ export class TemplateResolverMutations {
                 tagsetTemplateSet: true,
               },
             },
+            subspaces: {
+              collaboration: {
+                innovationFlow: true,
+                calloutsSet: {
+                  callouts: true,
+                  tagsetTemplateSet: true,
+                },
+              },
+              subspaces: {
+                collaboration: {
+                  innovationFlow: true,
+                  calloutsSet: {
+                    callouts: true,
+                    tagsetTemplateSet: true,
+                  },
+                },
+              },
+            },
           },
         },
       }
@@ -97,7 +115,7 @@ export class TemplateResolverMutations {
     const templateUpdated = await this.templateService.updateTemplateFromSpace(
       template,
       updateData,
-      agentInfo.userID
+      agentInfo
     );
 
     const authorizations =


### PR DESCRIPTION
- Removes recursively all subspaces of the template and creates the new ones. Maybe could be done updating the existing the ones if there are but got into lots of trouble trying that
- Also removed `storageAggregator?: IStorageAggregator;` from the contentSpace interface. It was not used and was misleading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional "recursive" setting when updating a template from a space, allowing users to choose whether to reproduce the full hierarchy or just the space.

* **Bug Fixes**
  * Improved handling of subspaces during template updates to ensure accurate recreation of subspace structures.

* **Refactor**
  * Enhanced internal logic for updating templates from spaces, including deeper relation fetching and improved agent information handling. 

* **Chores**
  * Removed an unused property from template content space definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->