### PR TITLE
Fix asyncFilter promise handling

### DIFF
--- a/src/common/utils/async.filter.ts
+++ b/src/common/utils/async.filter.ts
@@ -1,14 +1,7 @@
-export const asyncFilter = <T>(
+export const asyncFilter = async <T>(
   originalArray: Array<T>,
   predicate: (value: T) => Promise<boolean>
 ): Promise<Array<T>> => {
-  return new Promise(resolve => {
-    const booleanArr: Array<Promise<boolean>> = [];
-    originalArray.forEach(e => booleanArr.push(predicate(e)));
-
-    Promise.all(booleanArr).then(booleanArr => {
-      const filteredArray = originalArray.filter((e, i) => booleanArr[i]);
-      resolve(filteredArray);
-    });
-  });
+  const results = await Promise.all(originalArray.map(predicate));
+  return originalArray.filter((_, i) => results[i]);
 };


### PR DESCRIPTION
## Summary
- fix asyncFilter utility to handle predicate rejections correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880df9d97a88330b995f8f1e1d0bd82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal logic for asynchronous filtering to enhance code readability and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->