### PR TITLE
Fix typos in QA docs

### DIFF
--- a/docs/QA.md
+++ b/docs/QA.md
@@ -63,7 +63,7 @@ To run only one test from a test file
 
 ## Update user password secret for Travis CI
 
-In order to be able to update the user secret (used in automation tests) for Travi CI configuration, the following steps, should be perforemed:
+In order to be able to update the user secret (used in automation tests) for Travis CI configuration, the following steps, should be performed:
 
 - Install `ruby`
   ```sh


### PR DESCRIPTION
## Summary
- fix Travis CI typo in QA documentation
- correct spelling of "performed"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880e3f2a02c8330ac0e2b94a33057fb