### PR TITLE
Fix port description typo

### DIFF
--- a/docs/Running.md
+++ b/docs/Running.md
@@ -51,7 +51,7 @@ sudo bash ./.scripts/bootstrap_synapse.sh
 - Finally, ports available on localhost:
   - 4000 (alkemio server),
   - 3306 (MySQL database)
-  - 8888 (traefik dashobard)
+  - 8888 (traefik dashboard)
   - 3000 (alkemio client)
   - 8008 (synapse server)
   - 4436 (mailslurper UI)


### PR DESCRIPTION
## Summary
- fix typo in Running docs

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_6880e3d5b1108330afb300db956f0413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the description of the Traefik dashboard port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->