### PR TITLE
Fix not-saved visuals on create space

### DIFF
--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -77,14 +77,14 @@ export class SpaceAboutService {
         storageAggregator
       );
 
-    spaceAbout = await this.save(spaceAbout);
-
     // add the visuals
     await this.profileService.addVisualsOnProfile(
       spaceAbout.profile,
       spaceAboutData.profileData.visuals,
       [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
     );
+
+    spaceAbout = await this.save(spaceAbout);
     return this.getSpaceAboutOrFail(spaceAbout.id);
   }
 


### PR DESCRIPTION
- After the changes in #5230  we had a mistake and Visuals were not saved together with the Space
- @techsmyth [has replaced a call to](https://github.com/alkem-io/server/pull/5230/files#diff-a4db59c8e9fce1926bf2a30e51ade3c44c51aedf4c9d0701a2c6d14c0d67a3c1) `return await this.spaceAboutRepository.save(spaceAbout);` with a call to `this.save` (that does the same) + `getSpaceAboutOrFail(spaceAbout.id);` not sure why that change but it's working well.
- The only problem was that we needed to add the visuals before the `this.save()` otherwise they don't get saved to the db any time. 
Just moved the line down