### PR TITLE
Updates matrix adapter image version

### DIFF
--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -195,7 +195,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.6.0
+    image: alkemio/matrix-adapter:v0.6.1
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -237,7 +237,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.6.0
+    image: alkemio/matrix-adapter:v0.6.1
     platform: linux/x86_64
     environment:
       - RABBITMQ_HOST

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -253,7 +253,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.6.0
+    image: alkemio/matrix-adapter:v0.6.1
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -243,7 +243,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter:v0.6.0
+    image: alkemio/matrix-adapter:v0.6.1
     platform: linux/x86_64
     depends_on:
       - rabbitmq


### PR DESCRIPTION
Updates the matrix adapter image version to v0.6.1 in all relevant quickstart configurations.
This ensures that the latest version of the matrix adapter is used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the matrix-adapter service to use the latest image version (v0.6.1) across all quickstart configuration files. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->