### PR TITLE
No Kibana errors for identity routes

### DIFF
--- a/src/common/enums/url.path.base.ts
+++ b/src/common/enums/url.path.base.ts
@@ -20,6 +20,16 @@ export enum UrlPathBase {
   // Flow routes
   CREATE_SPACE = 'create-space',
 
+  // Identity routes
+  LOGIN = 'login',
+  LOGOUT = 'logout',
+  REGISTRATION = 'registration',
+  SIGN_UP = 'sign_up',
+  VERIFY = 'verify',
+  RECOVERY = 'recovery',
+  REQUIRED = 'required',
+  ERROR = 'error',
+
   // Legacy routes
   LANDING = 'landing', // Legacy route that redirects to Welcome site
   IDENTITY = 'identity', // Legacy route that's not used anymore but is decided to be reserved

--- a/src/common/enums/url.type.ts
+++ b/src/common/enums/url.type.ts
@@ -22,6 +22,14 @@ export enum UrlType {
   UNKNOWN = 'unknown',
   NOT_AUTHORIZED = 'not-authorized',
   FLOW = 'flow',
+  LOGIN = 'login',
+  LOGOUT = 'logout',
+  REGISTRATION = 'registration',
+  SIGN_UP = 'sign_up',
+  VERIFY = 'verify',
+  RECOVERY = 'recovery',
+  REQUIRED = 'required',
+  ERROR = 'error',
 }
 
 registerEnumType(UrlType, {

--- a/src/services/api/url-resolver/url.resolver.service.ts
+++ b/src/services/api/url-resolver/url.resolver.service.ts
@@ -98,11 +98,12 @@ export class UrlResolverService {
         );
       } catch (error: any) {
         throw new UrlResolverException(
-          `Unable to resolve URL: ${url}`,
+          'Unable to resolve URL',
           LogContext.URL_RESOLVER,
           {
             message: error?.message,
             originalException: error,
+            url,
           }
         );
       }
@@ -114,11 +115,12 @@ export class UrlResolverService {
       return await this.populateSpaceInternalResult(result, agentInfo);
     } catch (error: any) {
       throw new UrlResolverException(
-        `Unable to resolve URL: ${url}`,
+        'Unable to resolve URL',
         LogContext.URL_RESOLVER,
         {
           message: error?.message,
           originalException: error,
+          url,
         }
       );
     }
@@ -226,10 +228,46 @@ export class UrlResolverService {
         }
         return result;
       }
+      case UrlPathBase.LOGIN: {
+        result.type = UrlType.LOGIN;
+        return result;
+      }
+      case UrlPathBase.LOGOUT: {
+        result.type = UrlType.LOGOUT;
+        return result;
+      }
+      case UrlPathBase.REGISTRATION: {
+        result.type = UrlType.REGISTRATION;
+        return result;
+      }
+      case UrlPathBase.SIGN_UP: {
+        result.type = UrlType.SIGN_UP;
+        return result;
+      }
+      case UrlPathBase.VERIFY: {
+        result.type = UrlType.VERIFY;
+        return result;
+      }
+      case UrlPathBase.RECOVERY: {
+        result.type = UrlType.RECOVERY;
+        return result;
+      }
+      case UrlPathBase.REQUIRED: {
+        result.type = UrlType.REQUIRED;
+        return result;
+      }
+      case UrlPathBase.ERROR: {
+        result.type = UrlType.ERROR;
+        return result;
+      }
     }
     throw new ValidationException(
-      `Unknown base route (${baseRoute}), from URL: ${url}`,
-      LogContext.URL_RESOLVER
+      'Unknown base route',
+      LogContext.URL_RESOLVER,
+      {
+        baseRoute,
+        url,
+      }
     );
   }
 
@@ -340,8 +378,11 @@ export class UrlResolverService {
 
     if (!innovationHubNameID) {
       throw new ValidationException(
-        `Unable to resolve innovation hub from URL: ${urlPath}`,
-        LogContext.URL_RESOLVER
+        'Unable to resolve innovation hub from URL',
+        LogContext.URL_RESOLVER,
+        {
+          urlPath,
+        }
       );
     }
 


### PR DESCRIPTION
Add the identity routes to the URL resolver logic to prevent redundant errors. 
The client sometimes sends requests because of an issue between rerenders and routing.


 Updated err messages to be unique, the URL part was moved to the details object. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional identity-related URL paths, including login, logout, registration, sign up, verify, recovery, required, and error routes.

* **Bug Fixes**
  * Improved error messages for URL resolution, providing clearer and more consistent feedback with relevant context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->