### PR TITLE
Community Updates Notification to include the message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.4.1",
-        "@alkemio/notifications-lib": "0.10.4",
+        "@alkemio/notifications-lib": "0.10.5",
         "@apollo/server": "^4.10.4",
         "@elastic/elasticsearch": "^8.12.2",
         "@golevelup/nestjs-rabbitmq": "^5.3.0",
@@ -232,10 +232,9 @@
       }
     },
     "node_modules/@alkemio/notifications-lib": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.4.tgz",
-      "integrity": "sha512-ekZhCs541k/WC//taFwrwgBhSTYCQRGFxZUS0art/uOBYLw1iLQhS3Hl0uV8/sXQPuPwy0WexNoTXB6MVwaJ4Q==",
-      "license": "EUPL-1.2",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.5.tgz",
+      "integrity": "sha512-uYrK1JK8wcXTcSidvZ900Vf0DGpKFe5qpDAXBiyM/+8R5ne5G5OJhsJ9rXm0bWRYb5Wrl8qtuErAWaCtwAIv5A==",
       "dependencies": {
         "@alkemio/client-lib": "0.34.0"
       },
@@ -15880,9 +15879,9 @@
       "integrity": "sha512-9EW0tOIeDPPaExF4aBpjZ839+NvU0VwGTuFHJu6PGZxVP6ncIcNtVcgi6T7fsONFMeYoZtcS38ZiH8FesCpI5Q=="
     },
     "@alkemio/notifications-lib": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.4.tgz",
-      "integrity": "sha512-ekZhCs541k/WC//taFwrwgBhSTYCQRGFxZUS0art/uOBYLw1iLQhS3Hl0uV8/sXQPuPwy0WexNoTXB6MVwaJ4Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@alkemio/notifications-lib/-/notifications-lib-0.10.5.tgz",
+      "integrity": "sha512-uYrK1JK8wcXTcSidvZ900Vf0DGpKFe5qpDAXBiyM/+8R5ne5G5OJhsJ9rXm0bWRYb5Wrl8qtuErAWaCtwAIv5A==",
       "requires": {
         "@alkemio/client-lib": "0.34.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@alkemio/matrix-adapter-lib": "^0.4.1",
-    "@alkemio/notifications-lib": "0.10.4",
+    "@alkemio/notifications-lib": "0.10.5",
     "@apollo/server": "^4.10.4",
     "@elastic/elasticsearch": "^8.12.2",
     "@golevelup/nestjs-rabbitmq": "^5.3.0",

--- a/src/domain/communication/room/room.resolver.mutations.ts
+++ b/src/domain/communication/room/room.resolver.mutations.ts
@@ -176,7 +176,11 @@ export class RoomResolverMutations {
         );
         break;
       case RoomType.UPDATES:
-        this.roomServiceEvents.processNotificationUpdateSent(room, agentInfo);
+        this.roomServiceEvents.processNotificationUpdateSent(
+          room,
+          message,
+          agentInfo
+        );
         this.roomServiceEvents.processActivityUpdateSent(
           room,
           message,

--- a/src/domain/communication/room/room.service.events.ts
+++ b/src/domain/communication/room/room.service.events.ts
@@ -171,11 +171,13 @@ export class RoomServiceEvents {
 
   public async processNotificationUpdateSent(
     updates: IRoom,
+    lastMessage: IMessage,
     agentInfo: AgentInfo
   ) {
     const notificationInput: NotificationInputUpdateSent = {
       triggeredBy: agentInfo.userID,
       updates: updates,
+      lastMessage: lastMessage,
     };
     await this.notificationAdapter.updateSent(notificationInput);
   }

--- a/src/services/adapters/notification-adapter/dto/notification.dto.input.update.sent.ts
+++ b/src/services/adapters/notification-adapter/dto/notification.dto.input.update.sent.ts
@@ -1,6 +1,8 @@
 import { NotificationInputBase } from './notification.dto.input.base';
 import { IRoom } from '@domain/communication/room/room.interface';
+import { IMessage } from '@domain/communication/message/message.interface';
 
 export interface NotificationInputUpdateSent extends NotificationInputBase {
   updates: IRoom;
+  lastMessage?: IMessage;
 }

--- a/src/services/adapters/notification-adapter/notification.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.adapter.ts
@@ -162,7 +162,8 @@ export class NotificationAdapter {
     const notificationsPayload =
       await this.notificationPayloadBuilder.buildCommunicationUpdateSentNotificationPayload(
         eventData.triggeredBy,
-        eventData.updates
+        eventData.updates,
+        eventData.lastMessage
       );
     this.notificationsClient.emit<number>(event, notificationsPayload);
   }

--- a/src/services/adapters/notification-adapter/notification.payload.builder.ts
+++ b/src/services/adapters/notification-adapter/notification.payload.builder.ts
@@ -459,7 +459,7 @@ export class NotificationPayloadBuilder {
       },
       message: lastMessage?.message,
       ...spacePayload,
-    } as CommunicationUpdateEventPayload & { message?: string };
+    } as CommunicationUpdateEventPayload;
 
     return payload;
   }

--- a/src/services/adapters/notification-adapter/notification.payload.builder.ts
+++ b/src/services/adapters/notification-adapter/notification.payload.builder.ts
@@ -439,7 +439,8 @@ export class NotificationPayloadBuilder {
 
   async buildCommunicationUpdateSentNotificationPayload(
     updateCreatorId: string,
-    updates: IRoom
+    updates: IRoom,
+    lastMessage?: IMessage
   ): Promise<CommunicationUpdateEventPayload> {
     const community =
       await this.communityResolverService.getCommunityFromUpdatesOrFail(
@@ -450,14 +451,15 @@ export class NotificationPayloadBuilder {
       community,
       updateCreatorId
     );
-    const payload: CommunicationUpdateEventPayload = {
+    const payload = {
       update: {
         id: updates.id,
         createdBy: updateCreatorId,
         url: 'not used',
       },
+      message: lastMessage?.message,
       ...spacePayload,
-    };
+    } as CommunicationUpdateEventPayload & { message?: string };
 
     return payload;
   }


### PR DESCRIPTION
Extending the data passed to the notification service with the actual Update content from the Community Updates.
That way, the content could be displayed in the email templates.

The change consumed by the Notification service here: https://github.com/alkem-io/notifications/pull/401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Notifications for room updates now include the latest message content when available, providing more context in update notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->