### PR TITLE
Better visibility into the Wingback license process

### DIFF
--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -735,7 +735,7 @@ export class RoleSetService {
               subspaceAdminCredential
             );
           if (!alreadyHasSubspaceAdmin) {
-            await this.agentService.grantCredential({
+            await this.agentService.grantCredentialOrFail({
               agentID: agent.id,
               type: subspaceAdminCredential.type,
               resourceID: subspaceAdminCredential.resourceID,
@@ -755,7 +755,7 @@ export class RoleSetService {
               accountAdminCredential
             );
           if (!alreadyHasAccountAdmin) {
-            await this.agentService.grantCredential({
+            await this.agentService.grantCredentialOrFail({
               agentID: agent.id,
               type: accountAdminCredential.type,
               resourceID: accountAdminCredential.resourceID,
@@ -889,7 +889,7 @@ export class RoleSetService {
       }
     );
     if (!hasInviteeCredential) {
-      await this.agentService.grantCredential({
+      await this.agentService.grantCredentialOrFail({
         agentID: agent.id,
         type: inviteeCredential.type,
         resourceID: inviteeCredential.resourceID,
@@ -1293,7 +1293,7 @@ export class RoleSetService {
 
     const roleCredential = await this.getCredentialForRole(roleSet, roleType);
 
-    return await this.agentService.grantCredential({
+    return await this.agentService.grantCredentialOrFail({
       agentID: agent.id,
       type: roleCredential.type,
       resourceID: roleCredential.resourceID,

--- a/src/domain/agent/agent/agent.service.ts
+++ b/src/domain/agent/agent/agent.service.ts
@@ -187,7 +187,7 @@ export class AgentService {
    * @param grantCredentialData
    * @throws ValidationException If the agent already has a credential of the same type AND resourceID
    */
-  async grantCredential(
+  async grantCredentialOrFail(
     grantCredentialData: GrantCredentialToAgentInput
   ): Promise<IAgent> {
     const { agent, credentials } = await this.getAgentCredentials(

--- a/src/domain/agent/agent/agent.service.ts
+++ b/src/domain/agent/agent/agent.service.ts
@@ -182,6 +182,11 @@ export class AgentService {
     return { agent: agent, credentials: agent.credentials };
   }
 
+  /**
+   *
+   * @param grantCredentialData
+   * @throws ValidationException If the agent already has a credential of the same type AND resourceID
+   */
   async grantCredential(
     grantCredentialData: GrantCredentialToAgentInput
   ): Promise<IAgent> {
@@ -198,8 +203,13 @@ export class AgentService {
         credential.resourceID === grantCredentialData.resourceID
       ) {
         throw new ValidationException(
-          `Agent (${agent.id}) already has assigned credential: ${grantCredentialData.type}`,
-          LogContext.AUTH
+          'Agent already has credential of this type on this resource',
+          LogContext.AUTH,
+          {
+            agentId: agent.id,
+            credentialType: grantCredentialData.type,
+            resourceID: grantCredentialData.resourceID,
+          }
         );
       }
     }

--- a/src/domain/community/user-group/user-group.service.ts
+++ b/src/domain/community/user-group/user-group.service.ts
@@ -167,7 +167,7 @@ export class UserGroupService {
       membershipData.userID
     );
 
-    user.agent = await this.agentService.grantCredential({
+    user.agent = await this.agentService.grantCredentialOrFail({
       agentID: agent.id,
       type: AuthorizationCredential.USER_GROUP_MEMBER,
       resourceID: membershipData.groupID,

--- a/src/domain/community/user/user.service.authorization.ts
+++ b/src/domain/community/user/user.service.authorization.ts
@@ -178,16 +178,16 @@ export class UserAuthorizationService {
     const { user, agent } =
       await this.userLookupService.getUserAndAgent(userID);
 
-    await this.agentService.grantCredential({
+    await this.agentService.grantCredentialOrFail({
       type: AuthorizationCredential.GLOBAL_REGISTERED,
       agentID: agent.id,
     });
-    await this.agentService.grantCredential({
+    await this.agentService.grantCredentialOrFail({
       type: AuthorizationCredential.USER_SELF_MANAGEMENT,
       agentID: agent.id,
       resourceID: userID,
     });
-    await this.agentService.grantCredential({
+    await this.agentService.grantCredentialOrFail({
       type: AuthorizationCredential.ACCOUNT_ADMIN,
       agentID: agent.id,
       resourceID: user.accountID,

--- a/src/domain/space/account/account.service.license.ts
+++ b/src/domain/space/account/account.service.license.ts
@@ -121,7 +121,7 @@ export class AccountLicenseService {
     );
     // grant ACCOUNT_LICENSE_PLUS entitlement to the account agent
     const accountAgent = await this.accountService.getAgentOrFail(accountID);
-    await this.agentService.grantCredential({
+    await this.agentService.grantCredentialOrFail({
       agentID: accountAgent.id,
       type: LicensingCredentialBasedCredentialType.ACCOUNT_LICENSE_PLUS,
       resourceID: accountID,

--- a/src/domain/space/account/account.service.license.ts
+++ b/src/domain/space/account/account.service.license.ts
@@ -121,13 +121,25 @@ export class AccountLicenseService {
     );
     // grant ACCOUNT_LICENSE_PLUS entitlement to the account agent
     const accountAgent = await this.accountService.getAgentOrFail(accountID);
-    await this.agentService.grantCredentialOrFail({
-      agentID: accountAgent.id,
-      type: LicensingCredentialBasedCredentialType.ACCOUNT_LICENSE_PLUS,
-      resourceID: accountID,
-    });
-    // populate the license entitlements
-    await this.applyLicensePolicy(accountID);
+    try {
+      await this.agentService.grantCredentialOrFail({
+        agentID: accountAgent.id,
+        type: LicensingCredentialBasedCredentialType.ACCOUNT_LICENSE_PLUS,
+        resourceID: accountID,
+      });
+      // only populate the license entitlements if the credential was granted successfully
+      await this.applyLicensePolicy(accountID);
+    } catch {
+      // failing is perfectly fine; we have to make sure the credential is granted
+      this.logger.verbose?.(
+        {
+          message: 'Account already has ACCOUNT_LICENSE_PLUS credential',
+          accountId: accountID,
+          agentId: accountAgent.id,
+        },
+        LogContext.ACCOUNT
+      );
+    }
 
     return wingbackCustomerID;
   }

--- a/src/domain/space/account/account.service.ts
+++ b/src/domain/space/account/account.service.ts
@@ -43,6 +43,7 @@ import { CreateCalloutInput } from '@domain/collaboration/callout/dto/callout.dt
 import { PlatformTemplatesService } from '@platform/platform-templates/platform.templates.service';
 import { TemplateDefaultType } from '@common/enums/template.default.type';
 import { IRoleSet } from '@domain/access/role-set';
+import { IAgent } from '@domain/agent';
 
 @InstrumentService()
 @Injectable()
@@ -331,6 +332,24 @@ export class AccountService {
     if (!accounts) return [];
 
     return accounts;
+  }
+
+  public async getAgentOrFail(accountID: string): Promise<IAgent> {
+    const account = await this.getAccountOrFail(accountID, {
+      relations: {
+        agent: true,
+      },
+    });
+
+    if (!account.agent) {
+      throw new EntityNotInitializedException(
+        'Unable to load Agent for Account',
+        LogContext.ACCOUNT,
+        { accountId: accountID }
+      );
+    }
+
+    return account.agent;
   }
 
   public async createVirtualContributorOnAccount(

--- a/src/platform/admin/authorization/admin.authorization.service.ts
+++ b/src/platform/admin/authorization/admin.authorization.service.ts
@@ -87,7 +87,7 @@ export class AdminAuthorizationService {
       grantCredentialData.userID
     );
 
-    user.agent = await this.agentService.grantCredential({
+    user.agent = await this.agentService.grantCredentialOrFail({
       agentID: agent.id,
       type: grantCredentialData.type,
       resourceID: grantCredentialData.resourceID,
@@ -136,7 +136,7 @@ export class AdminAuthorizationService {
         grantCredentialData.organizationID
       );
 
-    organization.agent = await this.agentService.grantCredential({
+    organization.agent = await this.agentService.grantCredentialOrFail({
       agentID: agent.id,
       type: grantCredentialData.type,
       resourceID: grantCredentialData.resourceID,

--- a/src/platform/licensing/credential-based/license-credential-issuer/license.issuer.service.ts
+++ b/src/platform/licensing/credential-based/license-credential-issuer/license.issuer.service.ts
@@ -31,7 +31,7 @@ export class LicenseIssuerService {
     }
     let updatedAgent: IAgent = agent;
     try {
-      updatedAgent = await this.agentService.grantCredential({
+      updatedAgent = await this.agentService.grantCredentialOrFail({
         agentID: agent.id,
         type: licensePlan.licenseCredential,
         resourceID: resourceID,

--- a/src/platform/platform-role/platform.role.resolver.mutations.ts
+++ b/src/platform/platform-role/platform.role.resolver.mutations.ts
@@ -89,7 +89,7 @@ export class PlatformRoleResolverMutations {
         type: LicensingCredentialBasedCredentialType.ACCOUNT_LICENSE_PLUS,
         resourceID: user.accountID,
       };
-      await this.agentService.grantCredential({
+      await this.agentService.grantCredentialOrFail({
         agentID: accountAgent.id,
         ...accountLicenseCredential,
       });


### PR DESCRIPTION
todo: unit tests

- improved the flow around assigning license entitlements, including Wingback
- `ACCOUNT_LICENSE_PLUS` is now granted upon creating a Wingback account
