### PR TITLE
Filter out Memo when creating space template

### DIFF
--- a/src/services/api/input-creator/input.creator.service.ts
+++ b/src/services/api/input-creator/input.creator.service.ts
@@ -128,9 +128,14 @@ export class InputCreatorService {
         LogContext.INPUT_CREATOR
       );
     }
+    // we do not support having memo callouts in the template
+    // https://github.com/alkem-io/collaborative-document-service/issues/4
+    const filteredCallouts = calloutsSet.callouts.filter(
+      callout => callout.framing.type !== 'memo'
+    );
 
     const calloutInputs: CreateCalloutInput[] = [];
-    for (const callout of calloutsSet.callouts) {
+    for (const callout of filteredCallouts) {
       calloutInputs.push(
         await this.buildCreateCalloutInputFromCallout(callout.id)
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of callouts by excluding those with a framing type of "memo" from further actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->