### PR TITLE
[Search] Filter out posts from DRAFT callouts

### DIFF
--- a/src/services/api/search/result/search.result.service.ts
+++ b/src/services/api/search/result/search.result.service.ts
@@ -803,7 +803,7 @@ export class SearchResultService {
       .filter((x): x is PostParents => !!x)
       .filter(
         postParent =>
-          postParent.callout.settings.visibility !== CalloutVisibility.DRAFT
+          postParent.callout?.settings?.visibility !== CalloutVisibility.DRAFT
       );
   }
 

--- a/src/services/api/search/result/search.result.service.ts
+++ b/src/services/api/search/result/search.result.service.ts
@@ -17,6 +17,7 @@ import {
   AuthorizationPrivilege,
   LogContext,
 } from '@common/enums';
+import { CalloutVisibility } from '@common/enums/callout.visibility';
 import { IUser } from '@domain/community/user/user.interface';
 import { IOrganization, Organization } from '@domain/community/organization';
 import { Post } from '@domain/collaboration/post';
@@ -688,6 +689,9 @@ export class SearchResultService {
       },
       select: {
         id: true,
+        settings: {
+          visibility: true,
+        },
         contributions: {
           id: true,
           post: {
@@ -796,7 +800,11 @@ export class SearchResultService {
           space,
         };
       })
-      .filter((x): x is PostParents => !!x);
+      .filter((x): x is PostParents => !!x)
+      .filter(
+        postParent =>
+          postParent.callout.settings.visibility !== CalloutVisibility.DRAFT
+      );
   }
 
   private async getUsersInSpace(spaceId: string): Promise<string[]> {


### PR DESCRIPTION
Simple fix to filter out all posts whose parent visibility is 'draft'. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now exclude draft callouts, preventing unpublished items from appearing.
  * Parent-post handling updated to consistently respect callout visibility, reducing misleading or incomplete results.
  * Improves overall relevance and trustworthiness of search by filtering non-public content from final results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->