### PR TITLE
Reduced field logging

### DIFF
--- a/src/common/exceptions/base.exception.ts
+++ b/src/common/exceptions/base.exception.ts
@@ -12,14 +12,7 @@ export class BaseException extends GraphQLError {
     public details?: ExceptionDetails,
     public errorId: string = randomUUID()
   ) {
-    super(message, {
-      extensions: {
-        code: code.toLocaleString(),
-        context,
-        errorId,
-        details,
-      },
-    });
+    super(message);
     this.name = this.constructor.name;
   }
 }

--- a/src/core/error-handling/graphql.exception.filter.ts
+++ b/src/core/error-handling/graphql.exception.filter.ts
@@ -14,7 +14,8 @@ export class GraphqlExceptionFilter implements GqlExceptionFilter {
   catch(exception: BaseException, host: ArgumentsHost) {
     const httpArguments = host.switchToHttp();
     const ctx = httpArguments.getNext<IGraphQLContext>();
-    const userID = ctx.req.user.userID || 'unknown';
+    const userID =
+      exception.details?.userId ?? ctx.req.user.userID ?? 'unknown';
     exception.details = {
       ...exception.details,
       userId: userID,
@@ -27,7 +28,12 @@ export class GraphqlExceptionFilter implements GqlExceptionFilter {
     /* the logger will handle the passed exception by iteration over all it's fields
      * you can provide additional data in the stack and context
      */
-    this.logger.error(exception, secondParam, thirdParam);
+    const loggableException = {
+      ...exception,
+      stack: String(exception.stack),
+      extensions: undefined, // we do not need it
+    };
+    this.logger.error(loggableException, secondParam, thirdParam);
     // something needs to be returned so the default ExceptionsHandler is not triggered
     if (process.env.NODE_ENV === 'production') {
       // return a new error with only the message and the id

--- a/src/core/error-handling/http.exception.filter.ts
+++ b/src/core/error-handling/http.exception.filter.ts
@@ -53,7 +53,11 @@ export class HttpExceptionFilter implements ExceptionFilter {
     /* the logger will handle the passed exception by iteration over all it's fields
      * you can provide additional data in the stack and context
      */
-    this.logger.error(exception, secondParam, thirdParam);
+    const loggableException = {
+      ...exception,
+      stack: String(exception.stack),
+    };
+    this.logger.error(loggableException, secondParam, thirdParam);
 
     response.status(status).json({
       statusCode: status,

--- a/src/core/error-handling/unhandled.exception.filter.ts
+++ b/src/core/error-handling/unhandled.exception.filter.ts
@@ -22,7 +22,10 @@ export class UnhandledExceptionFilter implements ExceptionFilter {
     /* add values that you want to include as additional data
      e.g. secondParam = { code: '123' };
     */
-    const secondParam = { stack: exception.stack, errorId: randomUUID() };
+    const secondParam = {
+      stack: String(exception.stack),
+      errorId: randomUUID(),
+    };
     const thirdParam = 'UnhandledException';
     /* the logger will handle the passed exception by iteration over all it's fields
      * you can provide additional data in the stack and context
@@ -61,10 +64,10 @@ export class UnhandledExceptionFilter implements ExceptionFilter {
       }
       // if not in PROD, return everything
       return new GraphQLError(exception.message, {
+        originalError: exception,
         extensions: {
-          ...exception,
-          stack: exception.stack,
-          message: undefined, // do not repeat the message
+          errorId: secondParam.errorId,
+          code: AlkemioErrorStatus.UNSPECIFIED,
         },
       });
     }

--- a/src/domain/space/space/space.resolver.queries.ts
+++ b/src/domain/space/space/space.resolver.queries.ts
@@ -11,8 +11,6 @@ import { SpaceFilterInput } from '@services/infrastructure/space-filter/dto/spac
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { InstrumentResolver } from '@src/apm/decorators';
 import { RestrictedSpaceNames } from '@common/enums/restricted.space.names';
-import { BaseException } from '@common/exceptions/base.exception';
-import { AlkemioErrorStatus, LogContext } from '@common/enums';
 
 @InstrumentResolver()
 @Resolver()
@@ -64,15 +62,6 @@ export class SpaceResolverQueries {
     description: 'Get the list of restricted space names.',
   })
   restrictedSpaceNames(): string[] {
-    throw new BaseException(
-      'test',
-      LogContext.SPACES,
-      AlkemioErrorStatus.ACCOUNT_NOT_FOUND,
-      {
-        field1: 'a',
-        field2: 'b',
-      }
-    );
     return RestrictedSpaceNames;
   }
 }

--- a/src/domain/space/space/space.resolver.queries.ts
+++ b/src/domain/space/space/space.resolver.queries.ts
@@ -11,6 +11,8 @@ import { SpaceFilterInput } from '@services/infrastructure/space-filter/dto/spac
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { InstrumentResolver } from '@src/apm/decorators';
 import { RestrictedSpaceNames } from '@common/enums/restricted.space.names';
+import { BaseException } from '@common/exceptions/base.exception';
+import { AlkemioErrorStatus, LogContext } from '@common/enums';
 
 @InstrumentResolver()
 @Resolver()
@@ -62,6 +64,15 @@ export class SpaceResolverQueries {
     description: 'Get the list of restricted space names.',
   })
   restrictedSpaceNames(): string[] {
+    throw new BaseException(
+      'test',
+      LogContext.SPACES,
+      AlkemioErrorStatus.ACCOUNT_NOT_FOUND,
+      {
+        field1: 'a',
+        field2: 'b',
+      }
+    );
     return RestrictedSpaceNames;
   }
 }


### PR DESCRIPTION
- reduced the data that is being logged
- The data in `extensions` was duplicated and already extended in the exception itself
- This reduces disc usage and we are mapping the correct fields in Elasticsearch so no more conflicts occur
- stack HAS to be string now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL error responses now return only code and errorId; stack traces and extended metadata are no longer exposed.
  * Standardized user identification in error details for more consistent error context across requests.
  * Sanitized error handling ensures stack traces are serialized when surfaced in non-GraphQL contexts.

* **Refactor**
  * restrictedSpaceNames query now returns an error instead of a list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->