### PR TITLE
[Notifications] UserID in the recipient logic 

### DIFF
--- a/src/services/adapters/notification-adapter/notification.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.adapter.ts
@@ -135,7 +135,8 @@ export class NotificationAdapter {
     const event = NotificationEvent.USER_COMMENT_REPLY;
     const recipients = await this.getNotificationRecipientsUser(
       event,
-      eventData
+      eventData,
+      eventData.commentOwnerID
     );
 
     try {
@@ -193,7 +194,8 @@ export class NotificationAdapter {
     const event = NotificationEvent.USER_MESSAGE_RECIPIENT;
     const recipients = await this.getNotificationRecipientsUser(
       event,
-      eventData
+      eventData,
+      eventData.receiverID
     );
     // Emit the events to notify others
     const payload =
@@ -233,7 +235,8 @@ export class NotificationAdapter {
     const event = NotificationEvent.USER_MENTION;
     const recipients = await this.getNotificationRecipientsUser(
       event,
-      eventData
+      eventData,
+      eventData.mentionedEntityID
     );
     // Emit the events to notify others
     const payload =
@@ -302,9 +305,10 @@ export class NotificationAdapter {
 
   private async getNotificationRecipientsUser(
     event: NotificationEvent,
-    eventData: NotificationInputBase
+    eventData: NotificationInputBase,
+    userID?: string
   ): Promise<NotificationRecipientResult> {
-    return this.getNotificationRecipients(event, eventData);
+    return this.getNotificationRecipients(event, eventData, undefined, userID);
   }
 
   private async getNotificationRecipientsOrganization(
@@ -318,13 +322,15 @@ export class NotificationAdapter {
   public async getNotificationRecipients(
     event: NotificationEvent,
     eventData: NotificationInputBase,
-    entityID?: string
+    entityID?: string,
+    userID?: string
   ): Promise<NotificationRecipientResult> {
     this.logEventTriggered(eventData, event);
 
     const recipients = await this.notificationsRecipientsService.getRecipients({
       eventType: event,
       entityID,
+      userID,
     });
     return recipients;
   }

--- a/src/services/adapters/notification-adapter/notification.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.adapter.ts
@@ -329,7 +329,7 @@ export class NotificationAdapter {
 
     const recipients = await this.notificationsRecipientsService.getRecipients({
       eventType: event,
-      entityID,
+      spaceID: entityID,
       userID,
     });
     return recipients;

--- a/src/services/adapters/notification-adapter/notification.platform.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.platform.adapter.ts
@@ -160,7 +160,8 @@ export class NotificationPlatformAdapter {
     const event = NotificationEvent.PLATFORM_USER_PROFILE_CREATED;
     const recipients = await this.getNotificationRecipientsPlatform(
       event,
-      eventData
+      eventData,
+      eventData.userID
     );
 
     const payload =
@@ -254,8 +255,14 @@ export class NotificationPlatformAdapter {
 
   private async getNotificationRecipientsPlatform(
     event: NotificationEvent,
-    eventData: NotificationInputBase
+    eventData: NotificationInputBase,
+    userID?: string
   ): Promise<NotificationRecipientResult> {
-    return this.notificationAdapter.getNotificationRecipients(event, eventData);
+    return this.notificationAdapter.getNotificationRecipients(
+      event,
+      eventData,
+      undefined,
+      userID
+    );
   }
 }

--- a/src/services/adapters/notification-adapter/notification.space.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.space.adapter.ts
@@ -438,7 +438,8 @@ export class NotificationSpaceAdapter {
     const recipients = await this.getNotificationRecipientsSpace(
       event,
       eventData,
-      space.id
+      space.id,
+      eventData.invitedContributorID
     );
 
     const payload =
@@ -732,12 +733,14 @@ export class NotificationSpaceAdapter {
   private async getNotificationRecipientsSpace(
     event: NotificationEvent,
     eventData: NotificationInputBase,
-    spaceID: string
+    spaceID: string,
+    userID?: string
   ): Promise<NotificationRecipientResult> {
     return this.notificationAdapter.getNotificationRecipients(
       event,
       eventData,
-      spaceID
+      spaceID,
+      userID
     );
   }
 }

--- a/src/services/api/notification-recipients/dto/notification.recipients.dto.input.ts
+++ b/src/services/api/notification-recipients/dto/notification.recipients.dto.input.ts
@@ -12,16 +12,15 @@ export class NotificationRecipientsInput {
 
   @Field(() => UUID, {
     nullable: true,
-    description:
-      'The ID of the entity to retrieve the recipients for. This could be a Space, Organization etc, and is specific to the event type.',
-  })
-  entityID?: string;
-
-  @Field(() => UUID, {
-    nullable: true,
     description: 'The ID of the User that triggered the event.',
   })
   triggeredBy?: string;
+
+  @Field(() => UUID, {
+    nullable: true,
+    description: 'The ID of the space to retrieve the recipients for.',
+  })
+  spaceID?: string;
 
   @Field(() => UUID, {
     nullable: true,
@@ -29,4 +28,10 @@ export class NotificationRecipientsInput {
       'The ID of the specific user recipient for user-related notifications (e.g., invitations, mentions).',
   })
   userID?: string;
+
+  @Field(() => UUID, {
+    nullable: true,
+    description: 'The ID of the Organization to use to determine recipients.',
+  })
+  organizationID?: string;
 }

--- a/src/services/api/notification-recipients/dto/notification.recipients.dto.input.ts
+++ b/src/services/api/notification-recipients/dto/notification.recipients.dto.input.ts
@@ -22,4 +22,11 @@ export class NotificationRecipientsInput {
     description: 'The ID of the User that triggered the event.',
   })
   triggeredBy?: string;
+
+  @Field(() => UUID, {
+    nullable: true,
+    description:
+      'The ID of the specific user recipient for user-related notifications (e.g., invitations, mentions).',
+  })
+  userID?: string;
 }

--- a/src/services/api/notification-recipients/notification.recipients.service.ts
+++ b/src/services/api/notification-recipients/notification.recipients.service.ts
@@ -43,7 +43,7 @@ export class NotificationRecipientsService {
     const { privilegeRequired, credentialCriteria } =
       this.getPrivilegeRequiredCredentialCriteria(
         eventData.eventType,
-        eventData.entityID,
+        eventData.spaceID,
         eventData.userID
       );
 
@@ -110,7 +110,7 @@ export class NotificationRecipientsService {
       const privilege = privilegeRequired;
       const authorizationPolicy = await this.getAuthorizationPolicy(
         eventData.eventType,
-        eventData.entityID,
+        eventData.spaceID,
         eventData.userID
       );
       recipientsWithPrivilege =
@@ -236,7 +236,8 @@ export class NotificationRecipientsService {
 
   private getPrivilegeRequiredCredentialCriteria(
     eventType: NotificationEvent,
-    entityID?: string,
+    spaceID?: string,
+    organizationID?: string,
     userID?: string
   ): {
     privilegeRequired: AuthorizationPrivilege | undefined;
@@ -276,12 +277,13 @@ export class NotificationRecipientsService {
       case NotificationEvent.ORGANIZATION_MESSAGE_RECIPIENT:
       case NotificationEvent.ORGANIZATION_MENTIONED: {
         privilegeRequired = AuthorizationPrivilege.RECEIVE_NOTIFICATIONS_ADMIN;
-        credentialCriteria = this.getOrganizationCredentialCriteria(entityID);
+        credentialCriteria =
+          this.getOrganizationCredentialCriteria(organizationID);
         break;
       }
       case NotificationEvent.SPACE_COMMUNITY_APPLICATION_ADMIN: {
         privilegeRequired = AuthorizationPrivilege.RECEIVE_NOTIFICATIONS_ADMIN;
-        credentialCriteria = this.getSpaceCredentialCriteria(entityID);
+        credentialCriteria = this.getSpaceCredentialCriteria(spaceID);
         credentialCriteria.push({
           type: AuthorizationCredential.GLOBAL_ADMIN,
           resourceID: '',
@@ -292,7 +294,7 @@ export class NotificationRecipientsService {
       case NotificationEvent.SPACE_COMMUNITY_NEW_MEMBER_ADMIN:
       case NotificationEvent.SPACE_COLLABORATION_POST_CREATED_ADMIN: {
         privilegeRequired = AuthorizationPrivilege.RECEIVE_NOTIFICATIONS_ADMIN;
-        credentialCriteria = this.getSpaceCredentialCriteria(entityID);
+        credentialCriteria = this.getSpaceCredentialCriteria(spaceID);
         break;
       }
       case NotificationEvent.SPACE_COMMUNICATION_UPDATE:
@@ -301,7 +303,7 @@ export class NotificationRecipientsService {
       case NotificationEvent.SPACE_COLLABORATION_WHITEBOARD_CREATED:
       case NotificationEvent.SPACE_COLLABORATION_CALLOUT_PUBLISHED: {
         privilegeRequired = AuthorizationPrivilege.RECEIVE_NOTIFICATIONS;
-        credentialCriteria = this.getSpaceCredentialCriteria(entityID);
+        credentialCriteria = this.getSpaceCredentialCriteria(spaceID);
         break;
       }
       case NotificationEvent.PLATFORM_FORUM_DISCUSSION_COMMENT:
@@ -310,17 +312,13 @@ export class NotificationRecipientsService {
       case NotificationEvent.USER_COMMENT_REPLY:
       case NotificationEvent.SPACE_COLLABORATION_POST_COMMENT_CREATED: {
         privilegeRequired = AuthorizationPrivilege.RECEIVE_NOTIFICATIONS;
-        // Use userID if provided, otherwise fall back to entityID for backward compatibility
-        const targetUserID = userID || entityID;
-        credentialCriteria = this.getUserSelfCriteria(targetUserID);
+        credentialCriteria = this.getUserSelfCriteria(userID);
         break;
       }
       case NotificationEvent.SPACE_COMMUNITY_INVITATION_USER_PLATFORM:
       case NotificationEvent.SPACE_COMMUNITY_INVITATION_USER: {
         // For direct user invitations, no privilege check is needed - just check if the user exists and has notifications enabled
-        // Use userID if provided, otherwise fall back to entityID for backward compatibility
-        const targetUserID = userID || entityID;
-        credentialCriteria = this.getUserSelfCriteria(targetUserID);
+        credentialCriteria = this.getUserSelfCriteria(userID);
         break;
       }
     }


### PR DESCRIPTION
Adding userID to the recipient logic as the entityID is insufficient for some of the notifications.
