### PR TITLE
Fixes for client/#8555 and client/#8594

### DIFF
--- a/src/common/exceptions/relationship.not.found.exception.ts
+++ b/src/common/exceptions/relationship.not.found.exception.ts
@@ -1,8 +1,9 @@
 import { LogContext, AlkemioErrorStatus } from '@common/enums';
 import { BaseException } from './base.exception';
+import { ExceptionDetails } from './exception.details';
 
 export class RelationshipNotFoundException extends BaseException {
-  constructor(error: string, context: LogContext) {
-    super(error, context, AlkemioErrorStatus.RELATION_NOT_LOADED);
+  constructor(error: string, context: LogContext, details?: ExceptionDetails) {
+    super(error, context, AlkemioErrorStatus.RELATION_NOT_LOADED, details);
   }
 }

--- a/src/domain/space/space.defaults/space.defaults.service.ts
+++ b/src/domain/space/space.defaults/space.defaults.service.ts
@@ -66,26 +66,43 @@ export class SpaceDefaultsService {
     }
 
     // Enforce innovation flow settings:
-    if (templateSpaceContent.collaboration?.innovationFlow?.settings) {
-      collaborationData.innovationFlowData.settings.maximumNumberOfStates =
-        templateSpaceContent.collaboration.innovationFlow.settings.maximumNumberOfStates;
-      collaborationData.innovationFlowData.settings.minimumNumberOfStates =
-        templateSpaceContent.collaboration.innovationFlow.settings.minimumNumberOfStates;
+    if (!templateSpaceContent.collaboration?.innovationFlow?.settings) {
+      throw new RelationshipNotFoundException(
+        'Innovation flow settings not found in template',
+        LogContext.TEMPLATES,
+        { templateSpaceContentId: templateSpaceContent.id }
+      );
+    }
+    const { maximumNumberOfStates, minimumNumberOfStates } =
+      templateSpaceContent.collaboration.innovationFlow.settings;
+    if (
+      maximumNumberOfStates < minimumNumberOfStates ||
+      maximumNumberOfStates < 1 ||
+      minimumNumberOfStates < 1
+    ) {
+      throw new ValidationException(
+        `Invalid min (${minimumNumberOfStates})/max (${maximumNumberOfStates}) number of states.`,
+        LogContext.SPACES,
+        { templateSpaceContentId: templateSpaceContent.id }
+      );
     }
 
+    collaborationData.innovationFlowData.settings.maximumNumberOfStates =
+      maximumNumberOfStates;
+    collaborationData.innovationFlowData.settings.minimumNumberOfStates =
+      minimumNumberOfStates;
+
     if (
-      collaborationData.innovationFlowData.states.length >
-      collaborationData.innovationFlowData.settings.maximumNumberOfStates
+      collaborationData.innovationFlowData.states.length > maximumNumberOfStates
     ) {
       collaborationData.innovationFlowData.states =
         collaborationData.innovationFlowData.states.slice(
           0,
-          collaborationData.innovationFlowData.settings.maximumNumberOfStates
+          maximumNumberOfStates
         );
     }
     if (
-      collaborationData.innovationFlowData.states.length <
-      collaborationData.innovationFlowData.settings.minimumNumberOfStates
+      collaborationData.innovationFlowData.states.length < minimumNumberOfStates
     ) {
       throw new ValidationException(
         `Innovation flow must have at least ${collaborationData.innovationFlowData.settings.minimumNumberOfStates} states.`,

--- a/src/domain/space/space.defaults/space.defaults.service.ts
+++ b/src/domain/space/space.defaults/space.defaults.service.ts
@@ -66,21 +66,26 @@ export class SpaceDefaultsService {
     }
 
     // Enforce innovation flow settings:
-    const maxNumberOfStates =
-      templateSpaceContent.collaboration?.innovationFlow?.settings
-        .maximumNumberOfStates ?? Number.MAX_SAFE_INTEGER;
-    const minNumberOfStates =
-      templateSpaceContent.collaboration?.innovationFlow?.settings
-        .minimumNumberOfStates ?? 0;
+    if (templateSpaceContent.collaboration?.innovationFlow?.settings) {
+      collaborationData.innovationFlowData.settings.maximumNumberOfStates =
+        templateSpaceContent.collaboration.innovationFlow.settings.maximumNumberOfStates;
+      collaborationData.innovationFlowData.settings.minimumNumberOfStates =
+        templateSpaceContent.collaboration.innovationFlow.settings.minimumNumberOfStates;
+    }
 
     if (
-      collaborationData.innovationFlowData.states.length > maxNumberOfStates
+      collaborationData.innovationFlowData.states.length >
+      collaborationData.innovationFlowData.settings.maximumNumberOfStates
     ) {
       collaborationData.innovationFlowData.states =
-        collaborationData.innovationFlowData.states.slice(0, maxNumberOfStates);
+        collaborationData.innovationFlowData.states.slice(
+          0,
+          collaborationData.innovationFlowData.settings.maximumNumberOfStates
+        );
     }
     if (
-      collaborationData.innovationFlowData.states.length < minNumberOfStates
+      collaborationData.innovationFlowData.states.length <
+      collaborationData.innovationFlowData.settings.minimumNumberOfStates
     ) {
       throw new ValidationException(
         `Innovation flow must have at least ${collaborationData.innovationFlowData.settings.minimumNumberOfStates} states.`,

--- a/src/domain/template/template-applier/template.applier.resolver.mutations.ts
+++ b/src/domain/template/template-applier/template.applier.resolver.mutations.ts
@@ -15,6 +15,7 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy/author
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { InstrumentResolver } from '@src/apm/decorators';
 import { CalloutsSetAuthorizationService } from '@domain/collaboration/callouts-set/callouts.set.service.authorization';
+import { InnovationFlowAuthorizationService } from '@domain/collaboration/innovation-flow/innovation.flow.service.authorization';
 
 @InstrumentResolver()
 @Resolver()
@@ -23,6 +24,7 @@ export class TemplateApplierResolverMutations {
     private authorizationService: AuthorizationService,
     private collaborationService: CollaborationService,
     private calloutsSetAuthorizationService: CalloutsSetAuthorizationService,
+    private innovationFlowAuthorizationService: InnovationFlowAuthorizationService,
     private templateApplierService: TemplateApplierService,
     private authorizationPolicyService: AuthorizationPolicyService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
@@ -77,6 +79,9 @@ export class TemplateApplierResolverMutations {
         targetCollaboration.id,
         {
           relations: {
+            innovationFlow: {
+              states: true,
+            },
             calloutsSet: {
               callouts: true,
             },
@@ -84,7 +89,10 @@ export class TemplateApplierResolverMutations {
           },
         }
       );
-    if (!targetCollaboration.calloutsSet?.callouts) {
+    if (
+      !targetCollaboration.calloutsSet?.callouts ||
+      !targetCollaboration.innovationFlow
+    ) {
       throw new RelationshipNotFoundException(
         `Unable to retrieve callouts for collaboration: ${targetCollaboration.id}`,
         LogContext.TEMPLATES
@@ -98,6 +106,12 @@ export class TemplateApplierResolverMutations {
           roles: [],
         }
       );
+    updatedAuthorizations.push(
+      ...(await this.innovationFlowAuthorizationService.applyAuthorizationPolicy(
+        targetCollaboration.innovationFlow.id,
+        targetCollaboration.authorization
+      ))
+    );
 
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
     return this.collaborationService.getCollaborationOrFail(


### PR DESCRIPTION
Two issues in one PR.
Both client repository issues:

Can't update flow states after applying an L1 template 
[#8594](https://github.com/alkem-io/server/commit/da82003b4aa9974efaa5072a842a55294d5994b3) Fixed with the changes on `src/domain/template/template-applier/template.applier.resolver.mutations.ts` applies authorizationPolicy to the newly created states with the ones coming and then uses them

[#8549](https://github.com/alkem-io/server/commit/ced0ff901080024e6c80b90e47157f3b31db946d) Fixed with the changes on `src/domain/space/space.defaults/space.defaults.service.ts`
Establishes the flow settings with the ones coming in the template and uses them from there instead of those temporary variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Authorization now covers innovation flows when applying templates, ensuring permissions are validated and updated accordingly.
- Improvements
  - Strict propagation and validation of minimum/maximum state bounds from templates into collaborations.
  - Error handling now includes richer context when relationships or settings are missing.
- Bug Fixes
  - Prevents creation of too many or too few innovation-flow states by enforcing validated bounds.
- Chores
  - Ensured fresh loading of collaboration data before authorization processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->