### PR TITLE
Compose bump

### DIFF
--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -234,7 +234,7 @@ services:
     build:
       context: '../virtual-contributor-engine-guidance'
       dockerfile: ../virtual-contributor-engine-guidance/Dockerfile
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
        - /dev/shm:/dev/shm
@@ -273,7 +273,7 @@ services:
   #   build:
   #     context: '../virtual-contributor-engine-community-manager'
   #     dockerfile: ../virtual-contributor-engine-community-manager/Dockerfile
-  #   platform: linux/x86_64
+  #   platform: linux/amd64
   #   restart: always
   #   volumes:
   #      - /dev/shm:/dev/shm
@@ -308,7 +308,7 @@ services:
     build:
       dockerfile: ../virtual-contributor-ingest-space/Dockerfile
       context: '../virtual-contributor-ingest-space/'
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
        - /dev/shm:/dev/shm
@@ -350,7 +350,7 @@ services:
     build:
       dockerfile: ../virtual-contributor-engine-expert//Dockerfile
       context: '../virtual-contributor-engine-expert/'
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -205,7 +205,7 @@ services:
     container_name: alkemio_dev_notifications
     hostname: notifications
     image: alkemio/notifications:v0.23.2
-    platform: linux/x86_64
+    platform: linux/amd64
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -238,7 +238,7 @@ services:
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
     image: alkemio/matrix-adapter:v0.6.1
-    platform: linux/x86_64
+    platform: linux/amd64
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER
@@ -275,7 +275,7 @@ services:
     container_name: alkemio_dev_whiteboard_collaboration
     hostname: whiteboard-collaboration
     image: alkemio/whiteboard-collaboration-service:v0.5.0
-    platform: linux/x86_64
+    platform: linux/amd64
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -296,7 +296,7 @@ services:
     container_name: alkemio_dev_file_service
     hostname: file-service
     image: alkemio/file-service:v0.1.2
-    platform: linux/x86_64
+    platform: linux/amd64
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -336,7 +336,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_engine_guidance
     hostname: virtual-contributor-engine-guidance
     image: alkemio/virtual-contributor-engine-guidance:v0.9.1
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -382,7 +382,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_engine_community_manager
     hostname: virtual-contributor-engine-community-manager
     image: alkemio/virtual-contributor-engine-community-manager:v0.1.4
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -417,7 +417,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_engine_expert
     hostname: virtual-contributor-engine-expert
     image: alkemio/virtual-contributor-engine-expert:v0.13.0
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -462,7 +462,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_ingest_website
     hostname: virtual-contributor-ingest-website
     image: alkemio/virtual-contributor-ingest-website:v0.1.1
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -507,7 +507,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_engine_libra_flow
     hostname: virtual-contributor-engine-libra-flow
     image: alkemio/virtual-contributor-engine-libra-flow:v0.1.0
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -556,7 +556,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_ingest_space
     hostname: virtual-contributor-ingest-space
     image: alkemio/virtual-contributor-ingest-space:v0.13.0
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -601,7 +601,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_engine_generic
     hostname: virtual-contributor-engine-generic
     image: alkemio/virtual-contributor-engine-generic:v0.5.0
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -633,7 +633,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_engine_openai_assistant
     hostname: virtual-contributor-engine-openai-assistant
     image: alkemio/virtual-contributor-engine-openai-assistant:v0.3.0
-    platform: linux/x86_64
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -204,7 +204,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_notifications
     hostname: notifications
-    image: alkemio/notifications:v0.23.3
+    image: alkemio/notifications:v0.23.4
     platform: linux/amd64
     depends_on:
       rabbitmq:

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -294,7 +294,7 @@ services:
   whiteboard-collaboration:
     container_name: alkemio_dev_whiteboard_collaboration
     hostname: whiteboard-collaboration
-    image: alkemio/whiteboard-collaboration-service:v0.6.0
+    image: alkemio/whiteboard-collaboration-service:v0.6.1
     platform: linux/amd64
     depends_on:
       rabbitmq:
@@ -339,7 +339,7 @@ services:
   collaborative-document:
     container_name: alkemio_dev_collaborative-document
     hostname: collaborative-document
-    image: svetoslavpetkov23/collaborative-document-service:v0.0.3
+    image: alkemio/collaborative-document-service:v0.0.1
     platform: linux/amd64
     depends_on:
       rabbitmq:

--- a/src/core/authentication/authentication.service.ts
+++ b/src/core/authentication/authentication.service.ts
@@ -48,7 +48,7 @@ export class AuthenticationService {
         opts.authorization,
         opts.cookie
       );
-    } catch (e) {
+    } catch {
       return this.agentInfoService.createAnonymousAgentInfo();
     }
 


### PR DESCRIPTION
this update includes:
- bumped service versions
- Compose has moved to a standardized platform naming: `linux/x86_64` -> `linux/amd64`
- fixed minor lint issue 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated container platform to linux/amd64 for multiple AI-related services to improve compatibility on common architectures.
  - Upgraded service images: Notifications to v0.23.4, Whiteboard Collaboration to v0.6.1, and Collaborative Document to the official alkemio image v0.0.1 for stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->