### PR TITLE
Enables multiple authentication methods for users

### DIFF
--- a/src/common/enums/authentication.type.ts
+++ b/src/common/enums/authentication.type.ts
@@ -3,6 +3,7 @@ import { registerEnumType } from '@nestjs/graphql';
 export enum AuthenticationType {
   LINKEDIN = 'linkedin',
   MICROSOFT = 'microsoft',
+  GITHUB = 'github',
   EMAIL = 'email',
   UNKNOWN = 'unknown',
 }

--- a/src/domain/community/user/dto/roles.dto.authentication.result.ts
+++ b/src/domain/community/user/dto/roles.dto.authentication.result.ts
@@ -5,7 +5,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 export class UserAuthenticationResult {
   @Field(() => [AuthenticationType], {
     description:
-      'The Authentication Methods used for this User. One of email, linkedin, microsoft, or unknown',
+      'The Authentication Methods used for this User. One of email, linkedin, microsoft, github or unknown',
     nullable: false,
   })
   methods!: AuthenticationType[];

--- a/src/domain/community/user/dto/roles.dto.authentication.result.ts
+++ b/src/domain/community/user/dto/roles.dto.authentication.result.ts
@@ -3,12 +3,12 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class UserAuthenticationResult {
-  @Field(() => AuthenticationType, {
+  @Field(() => [AuthenticationType], {
     description:
-      'The Authentication Method used for this User. One of email, linkedin, microsoft, or unknown',
+      'The Authentication Methods used for this User. One of email, linkedin, microsoft, or unknown',
     nullable: false,
   })
-  method!: AuthenticationType;
+  methods!: AuthenticationType[];
 
   @Field(() => Date, {
     description: 'When the Kratos Account for the user was created',

--- a/src/domain/community/user/user.resolver.fields.ts
+++ b/src/domain/community/user/user.resolver.fields.ts
@@ -1,4 +1,4 @@
-import { AuthorizationAgentPrivilege, CurrentUser } from '@common/decorators';
+import { CurrentUser } from '@common/decorators';
 import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { IAgent } from '@domain/agent/agent';
@@ -243,14 +243,14 @@ export class UserResolverFields {
       AuthorizationPrivilege.PLATFORM_ADMIN
     );
     const result: UserAuthenticationResult = {
-      method: AuthenticationType.UNKNOWN,
+      methods: [AuthenticationType.UNKNOWN],
       createdAt: undefined,
       authenticatedAt: undefined,
     };
     if (isCurrentUser || platformAccessGranted) {
       const identity = await this.kratosService.getIdentityByEmail(user.email);
       if (identity) {
-        result.method =
+        result.methods =
           await this.kratosService.getAuthenticationTypeFromIdentity(identity);
         result.createdAt = await this.kratosService.getCreatedAt(identity);
         result.authenticatedAt =

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -215,23 +215,27 @@ export class KratosService {
    * - If the identity has password credentials, it returns `AuthenticationType.EMAIL`.
    * - If none of the above conditions are met, it returns `AuthenticationType.UNKNOWN`.
    */
-  public mapAuthenticationType(identity: Identity): AuthenticationType {
+  public mapAuthenticationType(identity: Identity): AuthenticationType[] {
+    const authTypes: AuthenticationType[] = [];
     if (identity.credentials) {
       if (identity.credentials.oidc) {
         const identifiers = identity.credentials.oidc.identifiers;
-        if (!identifiers) return AuthenticationType.UNKNOWN;
+        if (!identifiers) return [AuthenticationType.UNKNOWN];
         const identifier = identifiers[0];
-        if (!identifier) return AuthenticationType.UNKNOWN;
+        if (!identifier) return [AuthenticationType.UNKNOWN];
         if (identifier.startsWith('microsoft'))
-          return AuthenticationType.MICROSOFT;
+          authTypes.push(AuthenticationType.MICROSOFT);
         if (identifier.startsWith('linkedin'))
-          return AuthenticationType.LINKEDIN;
-      } else {
-        if (identity.credentials.password) return AuthenticationType.EMAIL;
+          authTypes.push(AuthenticationType.LINKEDIN);
+        if (identifier.startsWith('github'))
+          authTypes.push(AuthenticationType.GITHUB);
+      }
+      if (identity.credentials.password) {
+        authTypes.push(AuthenticationType.EMAIL);
       }
     }
 
-    return AuthenticationType.UNKNOWN;
+    return authTypes;
   }
 
   /**
@@ -481,9 +485,9 @@ export class KratosService {
    */
   public async getAuthenticationTypeFromIdentity(
     identity: Identity
-  ): Promise<AuthenticationType> {
+  ): Promise<AuthenticationType[]> {
     if (!identity) {
-      return AuthenticationType.UNKNOWN;
+      return [AuthenticationType.UNKNOWN];
     }
 
     return this.mapAuthenticationType(identity);

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -206,36 +206,39 @@ export class KratosService {
    * Maps the provided identity to an authentication type.
    *
    * @param identity - The identity object containing credentials.
-   * @returns The corresponding authentication type based on the identity's credentials.
+   * @returns The corresponding authentication types based on the identity's credentials.
    *
    * The function checks the following conditions in order:
    * - If the identity has OIDC credentials, it examines the identifiers:
-   *   - If the identifier starts with 'microsoft', it returns `AuthenticationType.MICROSOFT`.
-   *   - If the identifier starts with 'linkedin', it returns `AuthenticationType.LINKEDIN`.
-   * - If the identity has password credentials, it returns `AuthenticationType.EMAIL`.
-   * - If none of the above conditions are met, it returns `AuthenticationType.UNKNOWN`.
+   *   - If the identifier starts with 'microsoft', it adds `AuthenticationType.MICROSOFT`.
+   *   - If the identifier starts with 'linkedin', it adds `AuthenticationType.LINKEDIN`.
+   *   - If the identifier starts with 'github', it adds `AuthenticationType.GITHUB`.
+   * - If the identity has password credentials, it adds `AuthenticationType.EMAIL`.
+   * - If none of the above conditions are met, it adds `AuthenticationType.UNKNOWN`.
    */
   public mapAuthenticationType(identity: Identity): AuthenticationType[] {
-    const authTypes: AuthenticationType[] = [];
-    if (identity.credentials) {
-      if (identity.credentials.oidc) {
-        const identifiers = identity.credentials.oidc.identifiers;
-        if (!identifiers) return [AuthenticationType.UNKNOWN];
-        const identifier = identifiers[0];
-        if (!identifier) return [AuthenticationType.UNKNOWN];
-        if (identifier.startsWith('microsoft'))
-          authTypes.push(AuthenticationType.MICROSOFT);
-        if (identifier.startsWith('linkedin'))
-          authTypes.push(AuthenticationType.LINKEDIN);
-        if (identifier.startsWith('github'))
-          authTypes.push(AuthenticationType.GITHUB);
-      }
-      if (identity.credentials.password) {
-        authTypes.push(AuthenticationType.EMAIL);
-      }
+    if (!identity?.credentials) {
+      return [AuthenticationType.UNKNOWN];
     }
 
-    return authTypes;
+    const authTypes: AuthenticationType[] = [];
+    const oidcIdentifiers = identity.credentials.oidc?.identifiers;
+    const identifier = oidcIdentifiers?.[0];
+
+    if (identifier) {
+      if (identifier.startsWith('microsoft'))
+        authTypes.push(AuthenticationType.MICROSOFT);
+      if (identifier.startsWith('linkedin'))
+        authTypes.push(AuthenticationType.LINKEDIN);
+      if (identifier.startsWith('github'))
+        authTypes.push(AuthenticationType.GITHUB);
+    }
+
+    if (identity.credentials.password) {
+      authTypes.push(AuthenticationType.EMAIL);
+    }
+
+    return authTypes.length ? authTypes : [AuthenticationType.UNKNOWN];
   }
 
   /**


### PR DESCRIPTION
Allows users to authenticate with multiple identity providers
(e.g., LinkedIn, Microsoft, GitHub, Email).

Changes the `UserAuthenticationResult` to return an array of
`AuthenticationType` to support multiple authentication methods.

resolves #5294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User accounts now report multiple authentication methods (array) instead of a single method, improving accuracy in profile and API responses.
  * Added GitHub as a recognized authentication method alongside email, LinkedIn, and Microsoft.
  * Authentication details now default to “unknown” when data is unavailable to provide consistent feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->