### PR TITLE
Handle Callouts and Posts when sending conversation history for VC invocation

### DIFF
--- a/src/domain/communication/room/room.entity.ts
+++ b/src/domain/communication/room/room.entity.ts
@@ -5,6 +5,7 @@ import { RoomType } from '@common/enums/room.type';
 import { VcInteraction } from '../vc-interaction/vc.interaction.entity';
 import { ENUM_LENGTH } from '@common/constants';
 import { Callout } from '@domain/collaboration/callout/callout.entity';
+import { Post } from '@domain/collaboration/post/post.entity';
 
 @Entity()
 export class Room extends AuthorizableEntity implements IRoom {
@@ -32,6 +33,9 @@ export class Room extends AuthorizableEntity implements IRoom {
 
   @OneToOne(() => Callout, callout => callout.comments)
   callout!: Callout;
+
+  @OneToOne(() => Post, post => post.comments)
+  post!: Post;
 
   constructor(displayName: string, type: RoomType) {
     super();

--- a/src/domain/communication/room/room.entity.ts
+++ b/src/domain/communication/room/room.entity.ts
@@ -32,10 +32,10 @@ export class Room extends AuthorizableEntity implements IRoom {
   vcInteractions?: VcInteraction[];
 
   @OneToOne(() => Callout, callout => callout.comments)
-  callout!: Callout;
+  callout?: Callout;
 
   @OneToOne(() => Post, post => post.comments)
-  post!: Post;
+  post?: Post;
 
   constructor(displayName: string, type: RoomType) {
     super();

--- a/src/services/ai-server/ai-server/ai.server.service.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.ts
@@ -304,9 +304,20 @@ export class AiServerService {
       }
     }
     if (includeEntityContents) {
-      const entity = await this.roomControllerService.getRoomEntityOrFail(
-        roomDetails.roomID
-      );
+      let entity = null;
+      try {
+        entity = await this.roomControllerService.getRoomEntityOrFail(
+          roomDetails.roomID
+        );
+      } catch (error: any) {
+        this.logger?.error(
+          { message: 'Error getting post/callout for room', error },
+          error.stack,
+          LogContext.AI_SERVER
+        );
+        return messages;
+      }
+
       let entityContent: string | undefined = '';
       if (entity instanceof Callout) {
         entityContent = entity?.framing?.profile?.description;

--- a/src/services/ai-server/ai-server/ai.server.service.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.ts
@@ -245,8 +245,7 @@ export class AiServerService {
         )
       );
 
-      //NOTE this should not be needed but untill we start using the callout contents in the
-      //expert engine better skip it
+      //NOTE this should not be needed when we start using the callout/post contents  in all engines
       const includeEntityContents = [
         AiPersonaEngine.LIBRA_FLOW,
         AiPersonaEngine.EXPERT,

--- a/src/services/ai-server/ai-server/ai.server.service.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.ts
@@ -247,7 +247,7 @@ export class AiServerService {
 
       //NOTE this should not be needed but untill we start using the callout contents in the
       //expert engine better skip it
-      const includeEntry = [
+      const includeEntityContents = [
         AiPersonaEngine.LIBRA_FLOW,
         AiPersonaEngine.EXPERT,
       ].includes(personaService.engine);
@@ -255,7 +255,7 @@ export class AiServerService {
       history = await this.getLastNInteractionMessages(
         invocationInput.resultHandler.roomDetails,
         historyLimit,
-        includeEntry
+        includeEntityContents
       );
     }
 
@@ -266,7 +266,7 @@ export class AiServerService {
     roomDetails: RoomDetails,
     // interactionID: string | undefined,
     limit: number = 100,
-    includeEntry = false
+    includeEntityContents = false
   ): Promise<InteractionMessage[]> {
     let roomMessages: IMessage[] = [];
     // const room = await this.roomControllerService.getRoomOrFail(roomDetails.roomID);
@@ -298,26 +298,26 @@ export class AiServerService {
       });
 
       if (
-        (includeEntry && messages.length === limit - 1) ||
-        (!includeEntry && messages.length === limit)
+        (includeEntityContents && messages.length === limit - 1) ||
+        (!includeEntityContents && messages.length === limit)
       ) {
         break;
       }
     }
-    if (includeEntry) {
-      const entry = await this.roomControllerService.getRoomCalloutOrFail(
+    if (includeEntityContents) {
+      const entity = await this.roomControllerService.getRoomEntityOrFail(
         roomDetails.roomID
       );
-      let entryContent: string | undefined = '';
-      if (entry instanceof Callout) {
-        entryContent = entry?.framing?.profile?.description;
+      let entityContent: string | undefined = '';
+      if (entity instanceof Callout) {
+        entityContent = entity?.framing?.profile?.description;
       }
-      if (entry instanceof Post) {
-        entryContent = entry?.profile?.description;
+      if (entity instanceof Post) {
+        entityContent = entity?.profile?.description;
       }
-      if (entryContent) {
+      if (entityContent) {
         messages.unshift({
-          content: entryContent,
+          content: entityContent,
           role: MessageSenderRole.HUMAN,
         });
       }

--- a/src/services/room-integration/room.controller.service.ts
+++ b/src/services/room-integration/room.controller.service.ts
@@ -23,13 +23,26 @@ export class RoomControllerService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  public async getRoomCalloutOrFail(roomID: string): Promise<Callout | Post> {
+  public async getRoomEntityOrFail(
+    roomID: string
+    // undefined should not be needed bevause of the throw below but Typescript complains
+  ): Promise<Callout | Post | undefined> {
     const room = await this.roomLookupService.getRoomOrFail(roomID, {
       relations: {
         callout: { framing: { profile: true } },
         post: { profile: true },
       },
     });
+    if (!room.callout && !room.post) {
+      this.logger.error(
+        `Room with ID ${roomID} does not have a callout or post.`,
+        LogContext.COMMUNICATION
+      );
+      throw new Error(
+        `Room with ID ${roomID} does not have a callout or post.`
+      );
+    }
+
     return room.callout || room.post;
   }
 

--- a/src/services/room-integration/room.controller.service.ts
+++ b/src/services/room-integration/room.controller.service.ts
@@ -23,17 +23,15 @@ export class RoomControllerService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  public async getRoomEntityOrFail(
-    roomID: string
-    // undefined should not be needed bevause of the throw below but Typescript complains
-  ): Promise<Callout | Post | undefined> {
+  public async getRoomEntityOrFail(roomID: string): Promise<Callout | Post> {
     const room = await this.roomLookupService.getRoomOrFail(roomID, {
       relations: {
         callout: { framing: { profile: true } },
         post: { profile: true },
       },
     });
-    if (!room.callout && !room.post) {
+    const entity = room.callout || room.post;
+    if (!entity) {
       this.logger.error(
         `Room with ID ${roomID} does not have a callout or post.`,
         LogContext.COMMUNICATION
@@ -43,7 +41,7 @@ export class RoomControllerService {
       );
     }
 
-    return room.callout || room.post;
+    return entity;
   }
 
   public async getMessages(roomID: string) {

--- a/src/services/room-integration/room.controller.service.ts
+++ b/src/services/room-integration/room.controller.service.ts
@@ -1,5 +1,7 @@
 import { LogContext } from '@common/enums';
 import { MutationType } from '@common/enums/subscriptions';
+import { Callout } from '@domain/collaboration/callout/callout.entity';
+import { Post } from '@domain/collaboration/post/post.entity';
 import { RoomLookupService } from '@domain/communication/room-lookup/room.lookup.service';
 import { VcInteractionService } from '@domain/communication/vc-interaction/vc.interaction.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
@@ -21,12 +23,16 @@ export class RoomControllerService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  public async getRoomCalloutOrFail(roomID: string) {
+  public async getRoomCalloutOrFail(roomID: string): Promise<Callout | Post> {
     const room = await this.roomLookupService.getRoomOrFail(roomID, {
-      relations: { callout: { framing: { profile: true } } },
+      relations: {
+        callout: { framing: { profile: true } },
+        post: { profile: true },
+      },
     });
-    return room.callout;
+    return room.callout || room.post;
   }
+
   public async getMessages(roomID: string) {
     const room = await this.getRoomOrFail(roomID);
     return await this.roomLookupService.getMessages(room);

--- a/src/services/room-integration/room.controller.service.ts
+++ b/src/services/room-integration/room.controller.service.ts
@@ -24,6 +24,14 @@ export class RoomControllerService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
+  /**
+   * Retrieves the Callout or Post entity associated with the given room ID.
+   * Throws EntityNotFoundException if neither entity is found.
+   *
+   * @param {string} roomID - The unique identifier of the room.
+   * @returns {Promise<Callout | Post>} The associated Callout or Post entity.
+   * @throws {EntityNotFoundException} If the room does not have a callout or post.
+   */
   public async getRoomEntityOrFail(roomID: string): Promise<Callout | Post> {
     const room = await this.roomLookupService.getRoomOrFail(roomID, {
       relations: {
@@ -33,16 +41,12 @@ export class RoomControllerService {
     });
     const entity = room.callout || room.post;
     if (!entity) {
-      this.logger.error(
-        `Room with ID ${roomID} does not have a callout or post.`,
-        LogContext.COMMUNICATION
-      );
       throw new EntityNotFoundException(
-        `Room with ID ${roomID} does not have a callout or post.`,
-        LogContext.COMMUNICATION
+        'Room with ID does not have a callout or post.',
+        LogContext.COMMUNICATION,
+        { roomID }
       );
     }
-
     return entity;
   }
 

--- a/src/services/room-integration/room.controller.service.ts
+++ b/src/services/room-integration/room.controller.service.ts
@@ -1,7 +1,7 @@
 import { LogContext } from '@common/enums';
 import { MutationType } from '@common/enums/subscriptions';
-import { Callout } from '@domain/collaboration/callout/callout.entity';
 import { Post } from '@domain/collaboration/post/post.entity';
+import { Callout } from '@domain/collaboration/callout/callout.entity';
 import { RoomLookupService } from '@domain/communication/room-lookup/room.lookup.service';
 import { VcInteractionService } from '@domain/communication/vc-interaction/vc.interaction.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
@@ -13,6 +13,7 @@ import {
 
 import { SubscriptionPublishService } from '@services/subscriptions/subscription-service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { EntityNotFoundException } from '@common/exceptions';
 
 @Injectable()
 export class RoomControllerService {
@@ -36,8 +37,9 @@ export class RoomControllerService {
         `Room with ID ${roomID} does not have a callout or post.`,
         LogContext.COMMUNICATION
       );
-      throw new Error(
-        `Room with ID ${roomID} does not have a callout or post.`
+      throw new EntityNotFoundException(
+        `Room with ID ${roomID} does not have a callout or post.`,
+        LogContext.COMMUNICATION
       );
     }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rooms can link to a Post in addition to a Callout.
  * AI assistant now includes room entry content (Callout or Post) to enrich initial conversation context.

* **Bug Fixes**
  * Restores missing context for rooms lacking a Callout by falling back to Post content.
  * Prevents crashes when fetching room entry content, preserving partial history on errors.

* **Refactor**
  * Unified entry handling so Callouts and Posts are treated uniformly for context building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->