### PR TITLE
Configures AWS CLI based on environment region

### DIFF
--- a/.scripts/backups/restore_latest_backup.sh
+++ b/.scripts/backups/restore_latest_backup.sh
@@ -67,7 +67,7 @@ check_and_install_dependencies() {
 configure_aws_cli() {
     AWS_CONFIG_FILE=~/.aws/config
 
-    # Determine region based on environment (will be set later)
+    # Region parameter passed from caller
     local region="$1"
 
     if [[ -f "$AWS_CONFIG_FILE" ]]; then

--- a/.scripts/backups/restore_latest_backup.sh
+++ b/.scripts/backups/restore_latest_backup.sh
@@ -110,8 +110,8 @@ s3 =
   endpoint_url = $endpoint_url
   max_concurrent_requests = 100
   max_queue_size = 1000
-  multipart_threshold = 50 MB
-  multipart_chunksize = 10 MB
+  multipart_threshold = 50MB
+  multipart_chunksize = 10MB
 s3api =
   endpoint_url = $endpoint_url
 EOL


### PR DESCRIPTION
Updates the AWS CLI configuration to be region-aware.
It determines the appropriate region based on the environment
(production uses fr-par, others use nl-ams) and configures the
AWS CLI with the correct region and endpoint URL. This ensures
that backups are stored and restored from the correct S3 bucket.
Also, updates S3 bucket name for production environment.

- tested OK locally + already ran a set of backups on PROD that write to the new bucket
- I have kept the old bucket policy and re-applied it to the new one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Region-aware AWS setup driven by environment (e.g., prod -> Paris) and displayed during setup.
  - Requires and loads a .env file, failing with a clear error if missing.
  - Prompts before overwriting an existing local backup file.
- Improvements
  - AWS configuration now uses region-specific endpoints and service names; clearer AWS setup messages.
  - Smarter latest backup selection: filters by database for MySQL; no DB filter for Postgres.
  - Production S3 bucket/path renamed to Paris region naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->