### PR TITLE
Migration - fixing mismatch of inApp categories

### DIFF
--- a/src/migrations/1756372316381-fixInAppCategory.ts
+++ b/src/migrations/1756372316381-fixInAppCategory.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixInAppCategory1756372316381 implements MigrationInterface {
+  name = 'FixInAppCategory1756372316381';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // fix baseline
+    await queryRunner.query(
+      `DROP INDEX \`IDX_c3eee1b0c21294874daec15ad5\` ON \`callout_framing\``
+    );
+
+    // Update all the categories to match the NotificationEventCategory values
+    await queryRunner.query(
+      `UPDATE \`in_app_notification\` SET \`category\` = 'space_member' WHERE \`category\` = 'space-member'`
+    );
+    await queryRunner.query(
+      `UPDATE \`in_app_notification\` SET \`category\` = 'space_admin' WHERE \`category\` = 'space-admin'`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
+ one line from migration:generate to fix the baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized in-app notification categories for consistency across the app, preventing missing or misfiled items in category views and filters.
  * Resolves cases where “space-member” and “space-admin” notifications appeared under separate or incorrect categories.
* **Chores**
  * Performed database maintenance to streamline notification handling and improve overall reliability.
  * Behind-the-scenes optimizations to support more consistent categorization without user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->