### PR TITLE
Filter out unsupported inAppNotifications

### DIFF
--- a/src/services/adapters/notification-in-app-adapter/notification.in.app.adapter.ts
+++ b/src/services/adapters/notification-in-app-adapter/notification.in.app.adapter.ts
@@ -10,6 +10,14 @@ import { IInAppNotificationPayload } from '@platform/in-app-notification-payload
 
 @Injectable()
 export class NotificationInAppAdapter {
+  private static readonly SUPPORTED_IN_APP_NOTIFICATION_TYPES: NotificationEvent[] =
+    [
+      NotificationEvent.USER_MENTIONED,
+      NotificationEvent.SPACE_COLLABORATION_CALLOUT_PUBLISHED,
+      NotificationEvent.SPACE_ADMIN_COMMUNITY_NEW_MEMBER,
+      NotificationEvent.USER_SPACE_COMMUNITY_JOINED,
+    ];
+
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
@@ -24,6 +32,19 @@ export class NotificationInAppAdapter {
     receiverIDs: string[],
     payload: IInAppNotificationPayload
   ) {
+    // Filter out unsupported notification types
+    if (
+      !NotificationInAppAdapter.SUPPORTED_IN_APP_NOTIFICATION_TYPES.includes(
+        type
+      )
+    ) {
+      this.logger.verbose?.(
+        `Skipping in-app notification of type ${type} as it's not in the supported list`,
+        LogContext.IN_APP_NOTIFICATION
+      );
+      return;
+    }
+
     if (receiverIDs.length === 0) {
       this.logger.error(
         'Received in-app notification with no receiver IDs, skipping storage.',


### PR DESCRIPTION
Note the target branch - release/30

**The Issue**
We have the filter for supported in-apps passed by the client in the query.
However, on subscription update, the in-apps are not filtered.

**The fix**
Filter out non-supported in-app events on the server.

**The Why**
We have one client. Let's filter all supported types in one place and avoid sending redundant events. 
I'd suggest removing the filter from the client (next release). 