### PR TITLE
recalculate entitlements on change to base plan

### DIFF
--- a/src/domain/space/account/account.resolver.mutations.ts
+++ b/src/domain/space/account/account.resolver.mutations.ts
@@ -361,7 +361,13 @@ export class AccountResolverMutations {
         account.baselineLicensePlan,
         updateData
       );
-    return await this.accountService.save(account);
+    await this.accountService.save(account);
+
+    const accountLicenses = await this.accountLicenseService.applyLicensePolicy(
+      account.id
+    );
+    await this.licenseService.saveAll(accountLicenses);
+    return await this.accountService.getAccountOrFail(account.id);
   }
 
   @Mutation(() => IInnovationHub, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When changing an account’s baseline license plan, license policies are now refreshed and licenses are updated immediately, eliminating stale or inconsistent license data.
  * The account information returned after the change now reflects the latest license state, improving accuracy in the UI and downstream workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->