### PR TITLE
Sorting the templates alphabetically 

### DIFF
--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -620,6 +620,11 @@ export class TemplateService {
       relations: {
         profile: true,
       },
+      order: {
+        profile: {
+          displayName: 'ASC',
+        },
+      },
     });
   }
 
@@ -636,6 +641,11 @@ export class TemplateService {
       },
       relations: {
         profile: true,
+      },
+      order: {
+        profile: {
+          displayName: 'ASC',
+        },
       },
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Templates within a template set are now consistently sorted by the associated profile’s display name (A–Z), eliminating unpredictable ordering across views and sessions.
  * Applies to all template lists within a set, including type-filtered views, ensuring deterministic results across refreshes and pagination for easier browsing and comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->