### PR TITLE
Added delete entity as contribution mutation

### DIFF
--- a/src/domain/collaboration/callout-contribution/callout.contribution.move.resolver.mutations.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.move.resolver.mutations.ts
@@ -1,13 +1,20 @@
+import { WINSTON_MODULE_NEST_PROVIDER, WinstonLogger } from 'nest-winston';
+import { Inject } from '@nestjs/common/decorators';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { InstrumentResolver } from '@src/apm/decorators';
 import { CurrentUser } from '@common/decorators';
-import { AuthorizationPrivilege } from '@common/enums';
+import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
+import { IWhiteboard } from '@domain/common/whiteboard/whiteboard.interface';
+import { IPost } from '@domain/collaboration/post';
+import { ILink } from '@domain/collaboration/link/link.interface';
+import { EntityNotFoundException } from '@common/exceptions';
+import { UUID } from '@domain/common/scalars';
 import { CalloutContributionService } from './callout.contribution.service';
 import { ICalloutContribution } from './callout.contribution.interface';
 import { CalloutContributionMoveService } from './callout.contribution.move.service';
 import { MoveCalloutContributionInput } from './dto/callout.contribution.dto.move';
-import { InstrumentResolver } from '@src/apm/decorators';
 
 @InstrumentResolver()
 @Resolver()
@@ -15,7 +22,8 @@ export class CalloutContributionMoveResolverMutations {
   constructor(
     private authorizationService: AuthorizationService,
     private calloutContributionService: CalloutContributionService,
-    private calloutContributionMoveService: CalloutContributionMoveService
+    private calloutContributionMoveService: CalloutContributionMoveService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: WinstonLogger
   ) {}
 
   @Mutation(() => ICalloutContribution, {
@@ -58,9 +66,117 @@ export class CalloutContributionMoveResolverMutations {
       agentInfo,
       contribution.authorization,
       AuthorizationPrivilege.DELETE,
-      `move contribution: ${contribution.id}`
+      `delete contribution: ${contribution.id}`
     );
 
-    return this.calloutContributionService.delete(contribution.id);
+    const { contribution: deletedContribution } =
+      await this.calloutContributionService.delete(contribution.id);
+
+    return deletedContribution;
+  }
+
+  @Mutation(() => IWhiteboard, {
+    description: 'Deletes the specified Whiteboard.',
+  })
+  async deleteWhiteboardAsContribution(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('ID', { type: () => UUID }) id: string
+  ): Promise<IWhiteboard> {
+    const contribution =
+      await this.calloutContributionService.getContributionByChildIdOrFail(id);
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      contribution.authorization,
+      AuthorizationPrivilege.DELETE,
+      `delete contribution: ${contribution.id}`
+    );
+
+    const { whiteboard } = await this.calloutContributionService.delete(
+      contribution.id
+    );
+
+    if (!whiteboard) {
+      throw new EntityNotFoundException(
+        'Whiteboard not found after deleting the parent Contribution',
+        LogContext.COLLABORATION,
+        {
+          contributionId: contribution.id,
+          whiteboardId: id,
+        }
+      );
+    }
+
+    return whiteboard;
+  }
+
+  @Mutation(() => IPost, {
+    description: 'Deletes the specified Post.',
+  })
+  async deletePostAsContribution(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('ID', { type: () => UUID }) id: string
+  ): Promise<IPost> {
+    const contribution =
+      await this.calloutContributionService.getContributionByChildIdOrFail(id);
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      contribution.authorization,
+      AuthorizationPrivilege.DELETE,
+      `delete contribution: ${contribution.id}`
+    );
+
+    const { post } = await this.calloutContributionService.delete(
+      contribution.id
+    );
+
+    if (!post) {
+      throw new EntityNotFoundException(
+        'Post not found after deleting the parent Contribution',
+        LogContext.COLLABORATION,
+        {
+          contributionId: contribution.id,
+          postId: id,
+        }
+      );
+    }
+
+    return post;
+  }
+
+  @Mutation(() => ILink, {
+    description: 'Deletes the specified Link.',
+  })
+  async deleteLinkAsContribution(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('ID', { type: () => UUID }) id: string
+  ): Promise<ILink> {
+    const contribution =
+      await this.calloutContributionService.getContributionByChildIdOrFail(id);
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      contribution.authorization,
+      AuthorizationPrivilege.DELETE,
+      `link contribution: ${contribution.id}`
+    );
+
+    const { link } = await this.calloutContributionService.delete(
+      contribution.id
+    );
+
+    if (!link) {
+      throw new EntityNotFoundException(
+        'Link not found after deleting the parent Contribution',
+        LogContext.COLLABORATION,
+        {
+          contributionId: contribution.id,
+          postId: id,
+        }
+      );
+    }
+
+    return link;
   }
 }

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -127,7 +127,7 @@ export class CalloutContributionService {
     }
   }
 
-  async delete(contributionID: string): Promise<ICalloutContribution> {
+  async delete(contributionID: string) {
     const contribution = await this.getCalloutContributionOrFail(
       contributionID,
       {
@@ -158,7 +158,12 @@ export class CalloutContributionService {
       contribution as CalloutContribution
     );
     result.id = contributionID;
-    return result;
+    return {
+      contribution: result,
+      whiteboard: contribution.whiteboard,
+      post: contribution.post,
+      link: contribution.link,
+    };
   }
 
   async save(
@@ -255,6 +260,25 @@ export class CalloutContributionService {
     }
 
     return calloutContribution.post;
+  }
+
+  public getContributionByChildIdOrFail(
+    childID: string,
+    relations?: FindOptionsRelations<ICalloutContribution>
+  ): Promise<ICalloutContribution> {
+    return this.contributionRepository.findOneOrFail({
+      where: [
+        { post: { id: childID } },
+        { whiteboard: { id: childID } },
+        { link: { id: childID } },
+      ],
+      relations: {
+        ...relations,
+        post: true,
+        whiteboard: true,
+        link: true,
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
- Created new mutation per supported contribution entity
- The mutation expects a supported entity ID and deletes it and the parent contribution
- Deleting contributions has to be handled by the contribution logic and not the underlying child entity. Otherwise it creates a circular dependency and is not logical domain wise

### Todo
- delete the orphaned contributions