### PR TITLE
Sort a-b the platform lib templates

### DIFF
--- a/src/library/library/library.service.ts
+++ b/src/library/library/library.service.ts
@@ -131,7 +131,9 @@ export class LibraryService {
       },
       relations: {
         templatesSet: {
-          templates: true,
+          templates: {
+            profile: true,
+          },
         },
       },
     });
@@ -160,6 +162,14 @@ export class LibraryService {
         templateResults.push(result);
       }
     }
+
+    // Sort templates alphabetically by display name
+    templateResults.sort((a, b) => {
+      const displayNameA = a.template.profile?.displayName || '';
+      const displayNameB = b.template.profile?.displayName || '';
+      return displayNameA.localeCompare(displayNameB);
+    });
+
     return templateResults;
   }
 }


### PR DESCRIPTION
In addition to the templates under templatesSet, the platform templates should also be sorted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Template profiles are now available alongside templates in listed innovation packs (e.g., display names where supported).

* Improvements
  * Templates within listed innovation packs are now sorted alphabetically by display name for easier browsing and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->