### PR TITLE
Validates callout template framing type transitions

### DIFF
--- a/src/core/validation/handlers/base/base.handler.ts
+++ b/src/core/validation/handlers/base/base.handler.ts
@@ -104,6 +104,7 @@ import { UpdateUserSettingsNotificationOrganizationInput } from '@domain/communi
 import { CreateUserSettingsNotificationSpaceAdminInput } from '@domain/community/user-settings/dto/user.settings.notification.space.admin.dto.create';
 import { UpdateUserSettingsNotificationSpaceAdminInput } from '@domain/community/user-settings/dto/user.settings.notification.space.admin.dto.update';
 import { UpdateUserSettingsNotificationSpaceInput } from '@domain/community/user-settings/dto/user.settings.notification.space.dto.update';
+import { UpdateCalloutEntityInput } from '@domain/collaboration/callout/dto';
 
 export class BaseHandler extends AbstractHandler {
   public async handle(
@@ -159,6 +160,7 @@ export class BaseHandler extends AbstractHandler {
       UpdateSpaceAboutInput,
       UpdatePostInput,
       UpdateDocumentInput,
+      UpdateCalloutEntityInput,
       UpdateCalloutFramingInput,
       UpdateCalloutContributionDefaultsInput,
       UpdateTemplateInput,

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -202,6 +202,16 @@ export class CalloutFramingService {
       );
     }
     if (calloutFramingData.type) {
+      // Validate framing type transitions for callout templates
+      if (
+        isParentCalloutTemplate &&
+        calloutFramingData.type !== CalloutFramingType.NONE
+      ) {
+        throw new ValidationException(
+          'Callout templates can only transition framing type to NONE. To change to a different framing type, first set it to NONE.',
+          LogContext.COLLABORATION
+        );
+      }
       calloutFraming.type = calloutFramingData.type;
     }
 

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -201,14 +201,19 @@ export class CalloutFramingService {
         calloutFramingData.profile
       );
     }
+
     if (calloutFramingData.type) {
+      const oldType = calloutFraming.type;
+      const newType = calloutFramingData.type;
+
       // Validate framing type transitions for callout templates
       if (
         isParentCalloutTemplate &&
-        calloutFramingData.type !== CalloutFramingType.NONE
+        newType !== oldType &&
+        newType !== CalloutFramingType.NONE
       ) {
         throw new ValidationException(
-          'Callout templates can only transition framing type to NONE. To change to a different framing type, first set it to NONE.',
+          'Callout templates can only transition framing type to NONE.',
           LogContext.COLLABORATION
         );
       }


### PR DESCRIPTION
Adds validation to ensure callout templates can only transition framing type to NONE before changing to another type.
This prevents unexpected behavior and maintains data integrity.

Adds `UpdateCalloutEntityInput` to the base handler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents changing the framing type on parent callout templates to any value other than “None,” returning a clear validation error when such updates are attempted.
  * Extends validation coverage for callout update inputs so invalid or malformed update requests produce consistent validation errors and are rejected before applying changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->