### PR TITLE
Enhances callout authorization for space admins

### DIFF
--- a/src/domain/collaboration/callout/callout.module.ts
+++ b/src/domain/collaboration/callout/callout.module.ts
@@ -22,6 +22,7 @@ import { PostModule } from '../post/post.module';
 import { TemporaryStorageModule } from '@services/infrastructure/temporary-storage/temporary.storage.module';
 import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
 import { ClassificationModule } from '@domain/common/classification/classification.module';
+import { RoleSetModule } from '@domain/access/role-set/role.set.module';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { ClassificationModule } from '@domain/common/classification/classificati
     PostModule,
     ClassificationModule,
     TemporaryStorageModule,
+    RoleSetModule,
     TypeOrmModule.forFeature([Callout]),
   ],
   providers: [


### PR DESCRIPTION
Improves callout authorization by incorporating role sets for space administrators.

This change allows inheriting space admin credentials from parent spaces,
ensuring hierarchical access control for draft callouts. It falls back to the
current space admin if roleSet is not available.

I am drafting this, because I am not sure what is the desired behavior of this (it's clearly intended to have READ only for those roles originally) and there was a bug by giving unauthorized access to DRAFTs before that was resolved last week which lead to another READ bug. I am not sure whether UPDATE has ever been a requirement anywhere.
