### PR TITLE
Fix missing messageDetails breaks the In-app notification query

### DIFF
--- a/src/common/exceptions/base.exception.ts
+++ b/src/common/exceptions/base.exception.ts
@@ -16,6 +16,8 @@ export class BaseException extends GraphQLError {
       extensions: {
         // this needs to be set, since graphql automatically chooses a default code
         code: String(code),
+        errorId,
+        details,
       },
     });
     this.name = this.constructor.name;

--- a/src/platform/in-app-notification-payload/field-resolvers/platform/in.app.notification.payload.platform.global.role.change.resolver.fields.ts
+++ b/src/platform/in-app-notification-payload/field-resolvers/platform/in.app.notification.payload.platform.global.role.change.resolver.fields.ts
@@ -4,17 +4,10 @@ import { Loader } from '@core/dataloader/decorators';
 import { InAppNotificationPayloadPlatformGlobalRoleChange } from '@platform/in-app-notification-payload/dto/platform/notification.in.app.payload.platform.global.role.change';
 import { IUser } from '@domain/community/user/user.interface';
 import { UserLoaderCreator } from '@core/dataloader/creators/loader.creators/user.loader.creator';
-import { LoggerService } from '@nestjs/common';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { Inject } from '@nestjs/common';
-import { LogContext } from '@common/enums/logging.context';
 
 @Resolver(() => InAppNotificationPayloadPlatformGlobalRoleChange)
 export class InAppNotificationPayloadPlatformGlobalRoleChangeResolverFields {
-  constructor(
-    @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService
-  ) {}
+  constructor() {}
 
   @ResolveField(() => IUser, {
     nullable: true,
@@ -26,18 +19,7 @@ export class InAppNotificationPayloadPlatformGlobalRoleChangeResolverFields {
     @Loader(UserLoaderCreator, { resolveToNull: true })
     loader: ILoader<IUser | null>
   ): Promise<IUser | null> {
-    try {
-      return await loader.load(payload.userID);
-    } catch {
-      this.logger.warn(
-        'User not found for platform global role change notification.',
-        LogContext.NOTIFICATIONS,
-        {
-          userId: payload.userID,
-        }
-      );
-      return null;
-    }
+    return await loader.load(payload.userID);
   }
 
   @ResolveField(() => String, {

--- a/src/platform/in-app-notification-payload/field-resolvers/space/in.app.notification.payload.space.collaboration.callout.post.comment.resolver.fields.ts
+++ b/src/platform/in-app-notification-payload/field-resolvers/space/in.app.notification.payload.space.collaboration.callout.post.comment.resolver.fields.ts
@@ -8,10 +8,17 @@ import { MessageDetails } from '@domain/communication/message.details/message.de
 import { MessageDetailsService } from '@domain/communication/message.details/message.details.service';
 import { ICallout } from '@domain/collaboration/callout/callout.interface';
 import { CalloutLoaderCreator } from '@core/dataloader/creators';
+import { LogContext } from '@common/enums/logging.context';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { Inject, LoggerService } from '@nestjs/common';
 
 @Resolver(() => InAppNotificationPayloadSpaceCollaborationCalloutPostComment)
 export class InAppNotificationPayloadSpaceCollaborationCalloutPostCommentResolverFields {
-  constructor(private messageDetailsService: MessageDetailsService) {}
+  constructor(
+    private messageDetailsService: MessageDetailsService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
+  ) {}
 
   @ResolveField(() => ISpace, {
     nullable: true,
@@ -47,9 +54,23 @@ export class InAppNotificationPayloadSpaceCollaborationCalloutPostCommentResolve
     @Parent()
     payload: InAppNotificationPayloadSpaceCollaborationCalloutPostComment
   ): Promise<MessageDetails | null> {
-    return await this.messageDetailsService.getMessageDetails(
-      payload.roomID,
-      payload.messageID
-    );
+    try {
+      return await this.messageDetailsService.getMessageDetails(
+        payload.roomID,
+        payload.messageID
+      );
+    } catch (error) {
+      this.logger.error(
+        {
+          messageId: payload.messageID,
+          roomId: payload.roomID,
+          msg: 'BROKEN_NOTIFICATION_PAYLOAD',
+          name: InAppNotificationPayloadSpaceCollaborationCalloutPostComment.name,
+        },
+        (error as Error)?.stack,
+        LogContext.IN_APP_NOTIFICATION
+      );
+      return null;
+    }
   }
 }

--- a/src/platform/in-app-notification-payload/field-resolvers/user/in.app.notification.payload.user.message.room.resolver.fields.ts
+++ b/src/platform/in-app-notification-payload/field-resolvers/user/in.app.notification.payload.user.message.room.resolver.fields.ts
@@ -1,3 +1,4 @@
+import { LogContext } from '@common/enums/logging.context';
 import { UserLoaderCreator } from '@core/dataloader/creators';
 import { Loader } from '@core/dataloader/decorators/data.loader.decorator';
 import { ILoader } from '@core/dataloader/loader.interface';
@@ -38,9 +39,23 @@ export class InAppNotificationPayloadUserMessageRoomResolverFields {
     @Parent()
     payload: InAppNotificationPayloadUserMessageRoom
   ): Promise<MessageDetails | null> {
-    return await this.messageDetailsService.getMessageDetails(
-      payload.roomID,
-      payload.messageID
-    );
+    try {
+      return await this.messageDetailsService.getMessageDetails(
+        payload.roomID,
+        payload.messageID
+      );
+    } catch (error) {
+      this.logger.error(
+        {
+          messageId: payload.messageID,
+          roomId: payload.roomID,
+          msg: 'BROKEN_NOTIFICATION_PAYLOAD',
+          name: InAppNotificationPayloadUserMessageRoom.name,
+        },
+        (error as Error)?.stack,
+        LogContext.IN_APP_NOTIFICATION
+      );
+      return null;
+    }
   }
 }


### PR DESCRIPTION
_target release/21_

In case of a missing message entity:
- don't throw and block the in-app query;
- log error with relevant information

In addition, the base error were extended to provide errorId and details. ⚠️
