### PR TITLE
Ability to disable user geo location

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -372,6 +372,7 @@ microservices:
 integrations:
   # Different types of geo information like lat, lan, city, country, etc...
   geo:
+    enabled: ${GEO_ENABLED}:false
     # Header used to get the user IP
     header: ${GEO_HEADER}:x-forwarded-for
     rest_endpoint: ${GEO_REST_ENDPOINT}:http://localhost:3000/api/public/rest/geo

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -62,11 +62,7 @@ export class AppController {
     try {
       geo = await this.geoLocationService.getGeo(ip);
     } catch (error: any) {
-      this.logger.error(
-        `Unable to fetch geo location for IP: ${ip} :: ${error?.message}`,
-        error?.stack,
-        LogContext.GEO
-      );
+      throw error;
     }
 
     return geo;

--- a/src/common/exceptions/geo/geo.service.not.available.exception.ts
+++ b/src/common/exceptions/geo/geo.service.not.available.exception.ts
@@ -1,8 +1,16 @@
-import { BaseException } from '@common/exceptions/base.exception';
 import { AlkemioErrorStatus, LogContext } from '@common/enums';
+import { BaseHttpException } from '@common/exceptions/http';
+import { HttpStatus } from '@nestjs/common';
+import { ExceptionDetails } from '@common/exceptions/exception.details';
 
-export class GeoServiceNotAvailableException extends BaseException {
-  constructor(error: string, context: LogContext) {
-    super(error, context, AlkemioErrorStatus.GEO_SERVICE_NOT_AVAILABLE);
+export class GeoServiceNotAvailableException extends BaseHttpException {
+  constructor(error: string, context: LogContext, details?: ExceptionDetails) {
+    super(
+      error,
+      HttpStatus.METHOD_NOT_ALLOWED,
+      context,
+      AlkemioErrorStatus.GEO_SERVICE_NOT_AVAILABLE,
+      details
+    );
   }
 }

--- a/src/common/exceptions/geo/geo.service.not.available.exception.ts
+++ b/src/common/exceptions/geo/geo.service.not.available.exception.ts
@@ -7,7 +7,7 @@ export class GeoServiceNotAvailableException extends BaseHttpException {
   constructor(error: string, context: LogContext, details?: ExceptionDetails) {
     super(
       error,
-      HttpStatus.METHOD_NOT_ALLOWED,
+      HttpStatus.SERVICE_UNAVAILABLE,
       context,
       AlkemioErrorStatus.GEO_SERVICE_NOT_AVAILABLE,
       details

--- a/src/platform/configuration/config/config.service.ts
+++ b/src/platform/configuration/config/config.service.ts
@@ -130,7 +130,8 @@ export class KonfigService {
         endpoint: apm?.endpoint,
       },
       geo: {
-        endpoint: geoConfig?.rest_endpoint,
+        enabled: geoConfig.enabled,
+        endpoint: geoConfig.rest_endpoint,
       },
       storage: {
         file: {

--- a/src/platform/configuration/config/integrations/geo/geo.config.interface.ts
+++ b/src/platform/configuration/config/integrations/geo/geo.config.interface.ts
@@ -2,6 +2,12 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType('Geo')
 export abstract class IGeoConfig {
+  @Field(() => Boolean, {
+    nullable: false,
+    description: 'Is the geo functionality enabled.',
+  })
+  enabled!: boolean;
+
   @Field(() => String, {
     nullable: false,
     description: 'Endpoint where geo information is consumed from.',

--- a/src/services/external/geo-location/geo.location.service.spec.ts
+++ b/src/services/external/geo-location/geo.location.service.spec.ts
@@ -26,6 +26,7 @@ describe('GeoLocationService', () => {
   MockConfigService.useValue = {
     ...MockConfigService.useValue,
     get: () => ({
+      enabled: true,
       service_endpoint: 'mock',
       allowed_calls_to_service: 1,
       allowed_calls_to_service_window: 1,

--- a/src/services/external/geo-location/geo.location.service.ts
+++ b/src/services/external/geo-location/geo.location.service.ts
@@ -106,7 +106,7 @@ export class GeoLocationService {
   }
 
   public getCacheMetadata() {
-    if (this.enabled) {
+    if (!this.enabled) {
       throw new GeoServiceNotAvailableException(
         'Geo location service is disabled',
         LogContext.GEO

--- a/src/services/external/geo-location/geo.location.service.ts
+++ b/src/services/external/geo-location/geo.location.service.ts
@@ -25,6 +25,7 @@ export class GeoLocationService {
   private readonly allowedCallsToService: number;
   private readonly allowedCallsToServiceWindow: number;
   private readonly cacheEntryTtl: number;
+  private readonly disabled: boolean;
 
   constructor(
     @Inject(CACHE_MANAGER)
@@ -38,9 +39,16 @@ export class GeoLocationService {
     this.allowedCallsToService = config.allowed_calls_to_service;
     this.allowedCallsToServiceWindow = config.allowed_calls_to_service_window;
     this.cacheEntryTtl = config.cache_entry_ttl;
+    this.disabled = !config.enabled;
   }
 
   public async getGeo(ip: string): Promise<GeoInformation | undefined> {
+    if (this.disabled) {
+      throw new GeoServiceNotAvailableException(
+        'Geo location service is disabled',
+        LogContext.GEO
+      );
+    }
     const userGeoCached = await this.cacheManager.get<GeoInformation>(ip);
 
     if (userGeoCached) {
@@ -98,6 +106,13 @@ export class GeoLocationService {
   }
 
   public getCacheMetadata() {
+    if (this.disabled) {
+      throw new GeoServiceNotAvailableException(
+        'Geo location service is disabled',
+        LogContext.GEO
+      );
+    }
+
     return this.cacheManager.get<GeoLocationCacheMetadata>(geoServiceCallsKey);
   }
 

--- a/src/services/external/geo-location/geo.location.service.ts
+++ b/src/services/external/geo-location/geo.location.service.ts
@@ -25,7 +25,7 @@ export class GeoLocationService {
   private readonly allowedCallsToService: number;
   private readonly allowedCallsToServiceWindow: number;
   private readonly cacheEntryTtl: number;
-  private readonly disabled: boolean;
+  private readonly enabled: boolean;
 
   constructor(
     @Inject(CACHE_MANAGER)
@@ -39,11 +39,11 @@ export class GeoLocationService {
     this.allowedCallsToService = config.allowed_calls_to_service;
     this.allowedCallsToServiceWindow = config.allowed_calls_to_service_window;
     this.cacheEntryTtl = config.cache_entry_ttl;
-    this.disabled = !config.enabled;
+    this.enabled = config.enabled;
   }
 
   public async getGeo(ip: string): Promise<GeoInformation | undefined> {
-    if (this.disabled) {
+    if (!this.enabled) {
       throw new GeoServiceNotAvailableException(
         'Geo location service is disabled',
         LogContext.GEO
@@ -106,7 +106,7 @@ export class GeoLocationService {
   }
 
   public getCacheMetadata() {
-    if (this.disabled) {
+    if (this.enabled) {
       throw new GeoServiceNotAvailableException(
         'Geo location service is disabled',
         LogContext.GEO

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -158,6 +158,7 @@ export type AlkemioConfig = {
   };
   integrations: {
     geo: {
+      enabled: boolean;
       header: string;
       rest_endpoint: string;
       service_endpoint: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration toggle to enable/disable the Geo integration (default: off; controllable via environment).
  - Exposed an enabled flag in the public configuration so clients can detect Geo availability.

- **Bug Fixes**
  - When Geo is disabled, requests now return a clear service-unavailable error instead of proceeding.
  - Improved error propagation for Geo requests so failures reach callers reliably.

- **Tests**
  - Updated Geo tests to reflect the new enabled configuration flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->