### PR TITLE
Assign space members for read access to VC

### DIFF
--- a/src/domain/community/virtual-contributor/virtual.contributor.resolver.mutations.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.resolver.mutations.ts
@@ -1,7 +1,7 @@
 import { Inject, LoggerService } from '@nestjs/common';
 import { Args, Resolver, Mutation, ObjectType } from '@nestjs/graphql';
 import { VirtualContributorService } from './virtual.contributor.service';
-import { CurrentUser, Profiling } from '@src/common/decorators';
+import { CurrentUser } from '@src/common/decorators';
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { AuthorizationService } from '@core/authorization/authorization.service';
@@ -34,7 +34,6 @@ export class VirtualContributorResolverMutations {
   @Mutation(() => IVirtualContributor, {
     description: 'Updates the specified VirtualContributor.',
   })
-  @Profiling.api
   async updateVirtualContributor(
     @CurrentUser() agentInfo: AgentInfo,
     @Args('virtualContributorData')

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -35,7 +35,8 @@ export class VirtualContributorAuthorizationService {
   ) {}
 
   async applyAuthorizationPolicy(
-    virtualInput: IVirtualContributor
+    virtualInput: IVirtualContributor,
+    accountSpaceMemberCredentials: ICredentialDefinition[]
   ): Promise<IAuthorizationPolicy[]> {
     const virtual = await this.virtualService.getVirtualContributorOrFail(
       virtualInput.id,
@@ -71,7 +72,7 @@ export class VirtualContributorAuthorizationService {
     const credentialCriteriasWithAccessToVC =
       await this.getCredentialsWithVisibilityOfVirtualContributor(
         virtual.searchVisibility,
-        accountAdminCredential
+        accountSpaceMemberCredentials
       );
 
     virtual.authorization = this.resetToBaseVirtualContributorAuthorization(
@@ -140,7 +141,7 @@ export class VirtualContributorAuthorizationService {
 
   private async getCredentialsWithVisibilityOfVirtualContributor(
     searchVisibility: SearchVisibility,
-    accountAdminCredential?: ICredentialDefinition
+    accountSpaceMemberCredentials: ICredentialDefinition[]
   ): Promise<ICredentialDefinition[]> {
     const credentialCriteriasWithAccess: ICredentialDefinition[] = [];
 
@@ -154,8 +155,8 @@ export class VirtualContributorAuthorizationService {
 
       case SearchVisibility.ACCOUNT:
         // ACCOUNT visibility: only accessible within the scope of the account
-        if (accountAdminCredential) {
-          credentialCriteriasWithAccess.push(accountAdminCredential);
+        if (accountSpaceMemberCredentials.length > 0) {
+          credentialCriteriasWithAccess.push(...accountSpaceMemberCredentials);
         }
         break;
 

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.authorization.ts
@@ -58,12 +58,12 @@ export class VirtualContributorAuthorizationService {
       !virtual.profile ||
       !virtual.agent ||
       !virtual.aiPersona ||
-      !virtual.knowledgeBase ||
-      !virtual.account
+      !virtual.knowledgeBase
     )
       throw new RelationshipNotFoundException(
-        `Unable to load entities for virtual: ${virtual.id} `,
-        LogContext.COMMUNITY
+        'Unable to load entities for VC',
+        LogContext.COMMUNITY,
+        { virtualContributorID: virtual.id }
       );
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
     const accountAdminCredential: ICredentialDefinition = {
@@ -246,8 +246,9 @@ export class VirtualContributorAuthorizationService {
   private getAccountSpaceMemberCredentials(account: IAccount) {
     if (!account.spaces) {
       throw new RelationshipNotFoundException(
-        `Unable to load Account with spaces to get members: ${account.id} `,
-        LogContext.ACCOUNT
+        'Unable to load Account with spaces to get membership credentials',
+        LogContext.ACCOUNT,
+        { accountID: account.id }
       );
     }
     const accountMemberCredentials: ICredentialDefinition[] = [];

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -114,24 +114,6 @@ export class AccountAuthorizationService {
     return updatedAuthorizations;
   }
 
-  private getAccountSpaceMemberCredentials(account: IAccount) {
-    if (!account.spaces) {
-      throw new RelationshipNotFoundException(
-        `Unable to load Account with spaces to get members: ${account.id} `,
-        LogContext.ACCOUNT
-      );
-    }
-    const accountMemberCredentials: ICredentialDefinition[] = [];
-    for (const space of account.spaces) {
-      const spaceMemberCredential: ICredentialDefinition = {
-        type: AuthorizationCredential.SPACE_MEMBER,
-        resourceID: space.id,
-      };
-      accountMemberCredentials.push(spaceMemberCredential);
-    }
-    return accountMemberCredentials;
-  }
-
   public async getClonedAccountAuthExtendedForChildEntities(
     account: IAccount
   ): Promise<IAuthorizationPolicy> {
@@ -202,13 +184,10 @@ export class AccountAuthorizationService {
       );
     updatedAuthorizations.push(...storageAggregatorAuthorizations);
 
-    const accountSpaceMemberCredentials =
-      this.getAccountSpaceMemberCredentials(account);
     for (const vc of account.virtualContributors) {
       const updatedVcAuthorizations =
         await this.virtualContributorAuthorizationService.applyAuthorizationPolicy(
-          vc,
-          accountSpaceMemberCredentials
+          vc
         );
       updatedAuthorizations.push(...updatedVcAuthorizations);
     }


### PR DESCRIPTION
Added in method to get all space member credentials for an Account. 
Use that instead of the AccountAdmin credential when policy is Account access. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Virtual Contributor visibility is now determined per space, providing more precise, space-aware access across an account.

- Bug Fixes
  - Stronger validation preventing access when no valid space membership exists; clearer error reporting when required space relationships are missing.
  - Improved consistency in credential handling for ACCOUNT-level visibility.

- Chores
  - Removed internal performance profiling from an update mutation (no user-facing impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->