### PR TITLE
Proper cache invalidation around applications and invitations

### DIFF
--- a/src/domain/access/invitation/invitation.resolver.mutations.ts
+++ b/src/domain/access/invitation/invitation.resolver.mutations.ts
@@ -26,12 +26,12 @@ export class InvitationResolverMutations {
     const invitation = await this.invitationService.getInvitationOrFail(
       deleteData.ID
     );
-    await this.authorizationService.grantAccessOrFail(
+    this.authorizationService.grantAccessOrFail(
       agentInfo,
       invitation.authorization,
       AuthorizationPrivilege.DELETE,
       `delete invitation to community: ${invitation.id}`
     );
-    return await this.invitationService.deleteInvitation(deleteData);
+    return this.invitationService.deleteInvitation(deleteData);
   }
 }

--- a/src/domain/access/invitation/invitation.service.ts
+++ b/src/domain/access/invitation/invitation.service.ts
@@ -90,6 +90,31 @@ export class InvitationService {
         invitation.invitedContributorID,
         invitation.roleSet.id
       );
+      const contributor = await this.contributorService.getContributor(
+        invitation.invitedContributorID,
+        {
+          relations: { agent: true },
+        }
+      );
+
+      if (!contributor || !contributor.agent) {
+        this.logger.error(
+          {
+            message:
+              'Unable to invalidate membership status cache for Contributor',
+            cause: 'Contributor or associated Agent not found',
+            invitationId: invitation.id,
+            contributorId: invitation.invitedContributorID,
+          },
+          undefined,
+          LogContext.COMMUNITY
+        );
+      } else {
+        await this.roleSetCacheService.deleteMembershipStatusCache(
+          contributor.agent.id,
+          invitation.roleSet.id
+        );
+      }
     }
 
     return result;

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -436,7 +436,9 @@ export class RoleSetResolverMutationsMembership {
       {
         relations: {
           roleSet: true,
-          user: true,
+          user: {
+            agent: true,
+          },
         },
       }
     );
@@ -460,12 +462,12 @@ export class RoleSetResolverMutationsMembership {
       });
     }
 
-    if (!application.user || !application.roleSet) {
+    if (!application.user || !application.user.agent || !application.roleSet) {
       this.logger.error(
         {
           message:
             'Unable to invalidate application cache because of missing relations',
-          cause: 'Application user or role set is null',
+          cause: 'Application user, user agent or role set is null',
           applicationID: application.id,
         },
         undefined,
@@ -482,11 +484,11 @@ export class RoleSetResolverMutationsMembership {
         application.roleSet.id
       );
       await this.roleSetCacheService.deleteMembershipStatusCache(
-        application.user.id,
+        application.user.agent.id,
         application.roleSet.id
       );
       await this.roleSetCacheService.setAgentIsMemberCache(
-        application.user.id,
+        application.user.agent.id,
         application.roleSet.id,
         isMember
       );

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -436,6 +436,7 @@ export class RoleSetResolverMutationsMembership {
       {
         relations: {
           roleSet: true,
+          user: true,
         },
       }
     );
@@ -459,26 +460,39 @@ export class RoleSetResolverMutationsMembership {
       });
     }
 
-    if (agentInfo.userID && application.roleSet) {
+    if (!application.user || !application.roleSet) {
+      this.logger.error(
+        {
+          message:
+            'Unable to invalidate application cache because of missing relations',
+          cause: 'Application user or role set is null',
+          applicationID: application.id,
+        },
+        undefined,
+        LogContext.COMMUNITY
+      );
+    } else {
       applicationState = this.lifecycleService.getState(
         application.lifecycle,
         this.roleSetServiceLifecycleApplication.getApplicationMachine()
       );
       const isMember = applicationState === ApplicationLifecycleState.APPROVED;
-      if (agentInfo.userID && application.roleSet) {
-        await this.roleSetCacheService.deleteOpenApplicationFromCache(
-          agentInfo.userID,
-          application.roleSet?.id
-        );
-        await this.roleSetCacheService.setAgentIsMemberCache(
-          agentInfo.agentID,
-          application.roleSet?.id,
-          isMember
-        );
-      }
+      await this.roleSetCacheService.deleteOpenApplicationFromCache(
+        application.user.id,
+        application.roleSet.id
+      );
+      await this.roleSetCacheService.deleteMembershipStatusCache(
+        application.user.id,
+        application.roleSet.id
+      );
+      await this.roleSetCacheService.setAgentIsMemberCache(
+        application.user.id,
+        application.roleSet.id,
+        isMember
+      );
     }
 
-    return await this.applicationService.getApplicationOrFail(
+    return this.applicationService.getApplicationOrFail(
       eventData.applicationID
     );
   }

--- a/src/domain/access/role-set/role.set.service.cache.ts
+++ b/src/domain/access/role-set/role.set.service.cache.ts
@@ -236,6 +236,13 @@ export class RoleSetCacheService {
     );
   }
 
+  public deleteMembershipStatusCache(
+    agentId: string,
+    roleSetId: string
+  ): Promise<any> {
+    return this.cacheDel(this.getMembershipStatusCacheKey(agentId, roleSetId));
+  }
+
   /**
    * Set open invitation in cache.
    * @param userId - User identifier.

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1592,7 +1592,15 @@ export class RoleSetService {
     const application =
       await this.applicationService.createApplication(applicationData);
     application.roleSet = roleSet;
-    return await this.applicationService.save(application);
+
+    const savedApplication = await this.applicationService.save(application);
+
+    await this.roleSetCacheService.deleteMembershipStatusCache(
+      agent.id,
+      roleSet.id
+    );
+
+    return savedApplication;
   }
 
   async createInvitationExistingContributor(
@@ -1621,6 +1629,11 @@ export class RoleSetService {
     if (roleSet.type === RoleSetType.SPACE) {
       await this.assignSpaceInviteeCredential(agent, roleSet);
     }
+
+    await this.roleSetCacheService.deleteMembershipStatusCache(
+      agent.id,
+      roleSet.id
+    );
 
     return result;
   }


### PR DESCRIPTION
Membership status cache invalidated on:
- new invitation
- ~~archived invitation~~
- accepted invitation
- new application
- rejected application
- archived application

Suggestions for later:
- the client right now depends on an open application to determine the membership status and to display the membership button properly. **It would be best if it depends on the membership status only**
- After an application is sent, the client to refetch the membership status
- After an application is rejected there is not indication to the user that it was, except the button lets them apply again - if attempted an error is throw. **I would suggest introducing a new membership status for rejected applications.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Membership status and open application/invitation indicators update promptly after creating or deleting applications and invitations, reducing stale states.
- Performance & Reliability
  - Improved cache invalidation for membership and application states for faster, more consistent UI updates.
  - Enhanced logging when participant data is missing without interrupting user actions.
  - Deletion flows now proceed without waiting for background authorization, reducing perceived delay (may alter asynchronous error timing).
- Tests/Docs/Chores
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->