### PR TITLE
VC BoK ID optional

### DIFF
--- a/src/domain/community/virtual-contributor/virtual.contributor.entity.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.entity.ts
@@ -45,7 +45,7 @@ export class VirtualContributor
   aiPersonaID!: string;
 
   @Column('varchar', { nullable: true, length: SMALL_TEXT_LENGTH })
-  bodyOfKnowledgeID!: string;
+  bodyOfKnowledgeID?: string;
 
   @Column('json', { nullable: true, transformer: PromptGraphTransformer })
   promptGraphDefinition?: PromptGraphDefinition;

--- a/src/domain/community/virtual-contributor/virtual.contributor.interface.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.interface.ts
@@ -103,9 +103,9 @@ export class IVirtualContributor
   bodyOfKnowledgeDescription?: string;
 
   @Field(() => UUID, {
-    nullable: false,
+    nullable: true,
     description:
       'The ID of the body of knowledge used by this Virtual Contributor.',
   })
-  bodyOfKnowledgeID!: string;
+  bodyOfKnowledgeID?: string;
 }

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -437,8 +437,25 @@ export class VirtualContributorService {
       LogContext.VIRTUAL_CONTRIBUTOR
     );
 
+    // no refresh needed for these types
+    if (
+      [
+        VirtualContributorBodyOfKnowledgeType.NONE,
+        VirtualContributorBodyOfKnowledgeType.OTHER,
+      ].includes(virtualContributor.bodyOfKnowledgeType)
+    ) {
+      return Promise.resolve(false);
+    }
+
+    if (!virtualContributor.bodyOfKnowledgeID) {
+      throw new ValidationException(
+        `Virtual Contributor Body of Knowledge ID missing: ${virtualContributor.id}`,
+        LogContext.VIRTUAL_CONTRIBUTOR
+      );
+    }
+
     return this.aiServerAdapter.refreshBodyOfKnowledge(
-      virtualContributor.bodyOfKnowledgeID ?? '',
+      virtualContributor.bodyOfKnowledgeID,
       virtualContributor.bodyOfKnowledgeType,
       virtualContributor.aiPersonaID
     );

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -438,7 +438,7 @@ export class VirtualContributorService {
     );
 
     return this.aiServerAdapter.refreshBodyOfKnowledge(
-      virtualContributor.bodyOfKnowledgeID,
+      virtualContributor.bodyOfKnowledgeID ?? '',
       virtualContributor.bodyOfKnowledgeType,
       virtualContributor.aiPersonaID
     );


### PR DESCRIPTION
Please note that for External VC, we're passing an empty string to the ingest. It should not be an issue, as this option is not available for the External VCs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents errors when a virtual contributor lacks a bodyOfKnowledge ID by validating inputs and skipping refresh for unsupported knowledge types, improving stability.

- New Features
  - The bodyOfKnowledgeID field is now optional/nullable in the API, allowing creation and use of virtual contributors without this value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->