### PR TITLE
Delete default CG

### DIFF
--- a/src/migrations/1759497165260-removeDefaultCommunityGuidelinesCopy.ts
+++ b/src/migrations/1759497165260-removeDefaultCommunityGuidelinesCopy.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const TARGET_DISPLAY_NAME = 'Professional Networking Community Name';
+const TARGET_DESCRIPTION = 'Please fill out the community guidelines here';
+// markdown field adds '\n' at the end of the strings
+const TARGET_DESCRIPTION_WITH_NEWLINE =
+  'Please fill out the community guidelines here\n';
+const TARGET_DESCRIPTION_WITH_CRLF =
+  'Please fill out the community guidelines here\r\n';
+
+export class RemoveDefaultCommunityGuidelinesCopy1759497165260
+  implements MigrationInterface
+{
+  name = 'RemoveDefaultCommunityGuidelinesCopy1759497165260';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`profile\` p
+                INNER JOIN \`community_guidelines\` g ON g.\`profileId\` = p.\`id\`
+            SET
+                p.\`displayName\` = CASE WHEN p.\`displayName\` = ? THEN '' ELSE p.\`displayName\` END,
+                p.\`description\` = CASE WHEN p.\`description\` IN (?, ?, ?) THEN '' ELSE p.\`description\` END
+            WHERE p.\`displayName\` = ? OR p.\`description\` IN (?, ?, ?)`,
+      [
+        TARGET_DISPLAY_NAME,
+        TARGET_DESCRIPTION,
+        TARGET_DESCRIPTION_WITH_NEWLINE,
+        TARGET_DESCRIPTION_WITH_CRLF,
+        TARGET_DISPLAY_NAME,
+        TARGET_DESCRIPTION,
+        TARGET_DESCRIPTION_WITH_NEWLINE,
+        TARGET_DESCRIPTION_WITH_CRLF,
+      ]
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
As part of the SpaceTemplates, we've set some default titles and descriptions to the CG templates. 
This results in unwanted behaviour in multiple places.

The fix is to update all default text to empty strings.

The migration covers all CG profiles, both for spaces and templates.
The description has a couple of variations because the MD string has a new line at the end (sometimes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleans up profiles where community guidelines fields were auto-filled with default copy, preventing duplicated or unintended text from appearing.
* **Chores**
  * Runs a one-time data migration to normalize community guidelines fields by clearing out default placeholder content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->