### PR TITLE
`platform.spaces` to return spaces sorted by created date desc

### DIFF
--- a/src/domain/space/space/dto/space.args.query.spaces.ts
+++ b/src/domain/space/space/dto/space.args.query.spaces.ts
@@ -8,5 +8,5 @@ export class SpacesQueryArgs extends IDsQueryArgs {
     nullable: true,
     description: 'Return Spaces matching the provided filter.',
   })
-  filter!: SpaceFilterInput;
+  filter?: SpaceFilterInput;
 }

--- a/src/platform-admin/admin/platform.admin.service.ts
+++ b/src/platform-admin/admin/platform.admin.service.ts
@@ -20,7 +20,8 @@ import { InnovationPacksInput } from '@library/library/dto/library.dto.innovatio
 import { LibraryService } from '@library/library/library.service';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
-import { EntityManager } from 'typeorm';
+import { EntityManager, In } from 'typeorm';
+import { SpaceLevel } from '@common/enums/space.level';
 
 @Injectable()
 export class PlatformAdminService {
@@ -34,13 +35,24 @@ export class PlatformAdminService {
     private libraryService: LibraryService
   ) {}
 
-  public async getAllInnovationHubs(): Promise<IInnovationHub[]> {
-    const innovationHubs = await this.entityManager.find(InnovationHub, {});
-    return innovationHubs;
+  public getAllInnovationHubs(): Promise<IInnovationHub[]> {
+    return this.entityManager.find(InnovationHub);
   }
 
-  public async getAllSpaces(args: SpacesQueryArgs): Promise<ISpace[]> {
-    return this.spaceService.getSpacesSorted(args);
+  public getAllSpaces(
+    args: SpacesQueryArgs,
+    sort: 'ASC' | 'DESC' = 'DESC'
+  ): Promise<ISpace[]> {
+    const visibilities = args?.filter?.visibilities;
+    const IDs = args?.IDs;
+    return this.spaceService.getAllSpaces({
+      where: {
+        visibility: !!visibilities ? In(visibilities) : undefined,
+        id: !!IDs ? In(IDs) : undefined,
+        level: SpaceLevel.L0,
+      },
+      order: { createdDate: sort },
+    });
   }
 
   public async getAllInnovationPacks(

--- a/src/platform-admin/admin/platform.admin.service.ts
+++ b/src/platform-admin/admin/platform.admin.service.ts
@@ -21,7 +21,6 @@ import { LibraryService } from '@library/library/library.service';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { EntityManager, In } from 'typeorm';
-import { SpaceLevel } from '@common/enums/space.level';
 
 @Injectable()
 export class PlatformAdminService {

--- a/src/platform-admin/admin/platform.admin.service.ts
+++ b/src/platform-admin/admin/platform.admin.service.ts
@@ -47,9 +47,8 @@ export class PlatformAdminService {
     const IDs = args?.IDs;
     return this.spaceService.getAllSpaces({
       where: {
-        visibility: !!visibilities ? In(visibilities) : undefined,
-        id: !!IDs ? In(IDs) : undefined,
-        level: SpaceLevel.L0,
+        visibility: visibilities?.length ? In(visibilities) : undefined,
+        id: IDs?.length ? In(IDs) : undefined,
       },
       order: { createdDate: sort },
     });

--- a/src/services/infrastructure/space-filter/dto/space.filter.dto.input.ts
+++ b/src/services/infrastructure/space-filter/dto/space.filter.dto.input.ts
@@ -8,5 +8,5 @@ export class SpaceFilterInput {
     description:
       'Return Spaces with a Visibility matching one of the provided types.',
   })
-  visibilities!: SpaceVisibility[];
+  visibilities?: SpaceVisibility[];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting to the Spaces list: choose ASC or DESC by creation date (defaults to newest first).
  * Spaces can now be queried without mandatory filters; visibility and ID filters are optional and applied only when provided.
  * GraphQL inputs for spaces and visibility are more flexible, accepting undefined values where they were previously required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->