### PR TITLE
Remove the in-app privilege for beta testers

### DIFF
--- a/docs/Notifications.md
+++ b/docs/Notifications.md
@@ -39,7 +39,6 @@ The `NotificationRecipientsService` determines recipients through:
 1. **Credential Criteria**: Identifies potential recipients based on their roles/credentials
 2. **Notification Settings**: Filters users based on their email/in-app preferences for the specific event
 3. **Authorization Check**: Verifies users have required privileges to receive the notification
-4. **Platform Privileges**: For in-app notifications, checks `RECEIVE_NOTIFICATIONS_IN_APP` privilege
 
 ### 3. Notification Dispatch
 
@@ -340,7 +339,6 @@ The notification system implements a multi-stage filtering process:
 1. **Initial Candidate Selection**: Based on credential criteria (roles/permissions)
 2. **Settings Filter**: Users must have notifications enabled for the specific event type
 3. **Authorization Check**: Users must have required privileges for the specific entity
-4. **Platform Privilege Check**: For in-app notifications, users need `RECEIVE_NOTIFICATIONS_IN_APP` privilege
 
 ### Example Flow for Space Callout Published
 
@@ -364,10 +362,6 @@ emailRecipients = candidates.filter(
 privilegeRequired = AuthorizationPrivilege.RECEIVE_NOTIFICATIONS;
 authPolicy = await getSpaceAuthorizationPolicy(spaceID);
 // Filter users based on privilege
-
-// 4. For in-app: check platform privilege
-platformPolicy = await getPlatformAuthorizationPolicy();
-// Filter users with RECEIVE_NOTIFICATIONS_IN_APP privilege
 ```
 
 ## Best Practices

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -88,8 +88,6 @@ export const CREDENTIAL_RULE_PLATFORM_CREATE_INNOVATION_PACK =
   'credentialRuleTypes-platformCreateInnovationPack';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE =
   'credentialRuleTypes-platformAccessGuidance';
-export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_IN_APP_NOTIFICATIONS =
-  'credentialRuleTypes-platformAccessInAppNotifications';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_DASHBOARD =
   'credentialRuleTypes-platformAccessDashboard';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER =

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -50,8 +50,6 @@ export enum AuthorizationPrivilege {
   RECEIVE_NOTIFICATIONS_ORGANIZATION_ADMIN = 'receive-notifications-organization-admin',
   RECEIVE_NOTIFICATIONS_SPACE_ADMIN = 'receive-notifications-space-admin',
   RECEIVE_NOTIFICATIONS_SPACE_LEAD = 'receive-notifications-space-lead',
-  // Temporary privileges for in-app notifications until rolled out platform wide
-  RECEIVE_NOTIFICATIONS_IN_APP = 'receive-notifications-in-app',
   TRANSFER_RESOURCE_OFFER = 'transfer-resource-offer',
   TRANSFER_RESOURCE_ACCEPT = 'transfer-resource-accept',
   ACCOUNT_LICENSE_MANAGE = 'account-license-manage',

--- a/src/platform/platform/platform.service.authorization.ts
+++ b/src/platform/platform/platform.service.authorization.ts
@@ -13,7 +13,6 @@ import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authoriz
 import {
   CREDENTIAL_RULE_PLATFORM_CREATE_ORGANIZATION,
   CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE,
-  CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_IN_APP_NOTIFICATIONS,
   CREDENTIAL_RULE_TYPES_PLATFORM_ADMINS,
   CREDENTIAL_RULE_TYPES_PLATFORM_AUTH_RESET,
   CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER,
@@ -149,9 +148,6 @@ export class PlatformAuthorizationService {
     authorization: IAuthorizationPolicy
   ): Promise<IAuthorizationPolicy> {
     const credentialRules = this.createPlatformCredentialRules();
-    const credentialRuleInAppNotifications =
-      await this.createCredentialRuleInAppNotifications();
-    credentialRules.push(credentialRuleInAppNotifications);
 
     const credentialRuleInteractiveGuidance =
       await this.createCredentialRuleInteractiveGuidance();
@@ -204,23 +200,6 @@ export class PlatformAuthorizationService {
         [AuthorizationPrivilege.ACCESS_INTERACTIVE_GUIDANCE],
         [userChatGuidanceAccessCredential],
         CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE
-      );
-    userChatGuidanceAccessPrivilegeRule.cascade = false;
-
-    return userChatGuidanceAccessPrivilegeRule;
-  }
-
-  private async createCredentialRuleInAppNotifications(): Promise<IAuthorizationPolicyRuleCredential> {
-    const userChatGuidanceAccessInAppNotifications = {
-      type: AuthorizationCredential.BETA_TESTER,
-      resourceID: '',
-    };
-
-    const userChatGuidanceAccessPrivilegeRule =
-      this.authorizationPolicyService.createCredentialRule(
-        [AuthorizationPrivilege.RECEIVE_NOTIFICATIONS_IN_APP],
-        [userChatGuidanceAccessInAppNotifications],
-        CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_IN_APP_NOTIFICATIONS
       );
     userChatGuidanceAccessPrivilegeRule.cascade = false;
 

--- a/src/services/api/notification-recipients/notification.recipients.service.ts
+++ b/src/services/api/notification-recipients/notification.recipients.service.ts
@@ -112,7 +112,7 @@ export class NotificationRecipientsService {
         privilegeRequired,
         eventData
       );
-    const inAppRecipientsWithEntityPrivilege =
+    const inAppRecipientsWithPrivilege =
       await this.filterRecipientsWithPrivileges(
         inAppRecipientsWithNotificationEnabled,
         privilegeRequired,
@@ -124,24 +124,7 @@ export class NotificationRecipientsService {
       LogContext.NOTIFICATIONS
     );
     this.logger.verbose?.(
-      `[${eventData.eventType}] - 4b. ...and for in-app, of those ${inAppRecipientsWithEntityPrivilege.length} have the required privilege (${privilegeRequired || 'none'})`,
-      LogContext.NOTIFICATIONS
-    );
-    // Filter by whether they have the InApp privilege on platform level
-    const authorizationPolicyForInApp =
-      await this.platformAuthorizationService.getPlatformAuthorizationPolicy();
-    const inAppRecipientsWithPrivilege =
-      inAppRecipientsWithEntityPrivilege.filter(recipient =>
-        this.authorizationService.isAccessGrantedForCredentials(
-          recipient.agent.credentials || [],
-          [],
-          authorizationPolicyForInApp,
-          AuthorizationPrivilege.RECEIVE_NOTIFICATIONS_IN_APP
-        )
-      );
-
-    this.logger.verbose?.(
-      `[${eventData.eventType}] - 4bb. ...and for in-app, of those ${inAppRecipientsWithPrivilege.length} are eligible for in-app notifications`,
+      `[${eventData.eventType}] - 4b. ...and for in-app, of those ${inAppRecipientsWithPrivilege.length} have the required privilege (${privilegeRequired || 'none'})`,
       LogContext.NOTIFICATIONS
     );
 


### PR DESCRIPTION
Removal of the temporary logic for in-app credentials and privilege for beta testers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified in-app notification recipient filtering by removing platform-level privilege checks; recipients are now determined by in-app privileges only.
  - Streamlined authorization flow by removing the dedicated in‑app notifications rule; no changes to other rules.
  - Updated logs to reflect the new recipient calculation.

- Documentation
  - Removed references to platform privilege checks in notification recipient flow and examples to align with current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->