### PR TITLE
Add level filter to `PlatformAdminService.getAllSpaces`

### DIFF
--- a/src/platform-admin/admin/platform.admin.service.ts
+++ b/src/platform-admin/admin/platform.admin.service.ts
@@ -48,6 +48,7 @@ export class PlatformAdminService {
       where: {
         visibility: visibilities?.length ? In(visibilities) : undefined,
         id: IDs?.length ? In(IDs) : undefined,
+        level: SpaceLevel.L0,        
       },
       order: { createdDate: sort },
     });

--- a/src/platform-admin/admin/platform.admin.service.ts
+++ b/src/platform-admin/admin/platform.admin.service.ts
@@ -21,6 +21,7 @@ import { LibraryService } from '@library/library/library.service';
 import { Injectable } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { EntityManager, In } from 'typeorm';
+import { SpaceLevel } from '@common/enums/space.level';
 
 @Injectable()
 export class PlatformAdminService {


### PR DESCRIPTION
`PlatformAdminService.getAllSpaces` was returning all spaces which was not the expected behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Platform admin space filtering updated to ensure administrators see only top-level (Level 0) spaces, improving accuracy of space listings and reducing clutter.
  * Visibility and ID filters reinforced so space results better reflect intended administrative scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->