### PR TITLE
Fix GA receiving notifications for all community applications

### DIFF
--- a/src/services/api/notification-recipients/notification.recipients.service.ts
+++ b/src/services/api/notification-recipients/notification.recipients.service.ts
@@ -342,10 +342,6 @@ export class NotificationRecipientsService {
       case NotificationEvent.SPACE_ADMIN_COMMUNITY_APPLICATION: {
         privilegeRequired = AuthorizationPrivilege.RECEIVE_NOTIFICATIONS_ADMIN;
         credentialCriteria = this.getSpaceAdminCredentialCriteria(spaceID);
-        credentialCriteria.push({
-          type: AuthorizationCredential.GLOBAL_ADMIN,
-          resourceID: '',
-        });
         break;
       }
       case NotificationEvent.SPACE_LEAD_COMMUNICATION_MESSAGE: {


### PR DESCRIPTION
Now the GA was excluded from the logic, and these notifications will continue to be sent to the space admin members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted credential requirements for community application events to ensure appropriate access control levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->