### PR TITLE
Fix attribution for SPACE_JOINED contribution events

### DIFF
--- a/src/domain/access/role-set/role.set.service.events.ts
+++ b/src/domain/access/role-set/role.set.service.events.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { NotificationAdapter } from '@services/adapters/notification-adapter/notification.adapter';
 import { ContributionReporterService } from '@services/external/elasticsearch/contribution-reporter';
+import { AuthorDetails } from '@services/external/elasticsearch/types';
 import { ActivityInputMemberJoined } from '@services/adapters/activity-adapter/dto/activity.dto.input.member.joined';
 import { ActivityAdapter } from '@services/adapters/activity-adapter/activity.adapter';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { IRoleSet } from './role.set.interface';
 import { IContributor } from '@domain/community/contributor/contributor.interface';
+import { Organization } from '@domain/community/organization/organization.entity';
+import { User } from '@domain/community/user/user.entity';
+import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
 import { SpaceLevel } from '@common/enums/space.level';
 import { RoleSetMembershipException } from '@common/exceptions/role.set.membership.exception';
 import { LogContext } from '@common/enums';
@@ -66,6 +70,8 @@ export class RoleSetEventsService {
     );
 
     // Record the contribution events
+    const joiningContributor =
+      this.resolveAuthorDetailsFromContributor(newContributor);
     switch (space.level) {
       case SpaceLevel.L0: {
         this.contributionReporter.spaceJoined(
@@ -74,10 +80,7 @@ export class RoleSetEventsService {
             name: communityDisplayName,
             space: levelZeroSpaceID,
           },
-          {
-            id: agentInfo.userID,
-            email: agentInfo.email,
-          }
+          joiningContributor
         );
         break;
       }
@@ -89,10 +92,7 @@ export class RoleSetEventsService {
             name: communityDisplayName,
             space: levelZeroSpaceID,
           },
-          {
-            id: agentInfo.userID,
-            email: agentInfo.email,
-          }
+          joiningContributor
         );
         break;
       }
@@ -102,5 +102,35 @@ export class RoleSetEventsService {
           LogContext.ROLES
         );
     }
+  }
+
+  private resolveAuthorDetailsFromContributor(
+    contributor: IContributor
+  ): AuthorDetails {
+    if (contributor instanceof User) {
+      return {
+        id: contributor.id,
+        email: contributor.email,
+      };
+    }
+
+    if (contributor instanceof Organization) {
+      return {
+        id: contributor.id,
+        email: contributor.contactEmail ?? '',
+      };
+    }
+
+    if (contributor instanceof VirtualContributor) {
+      return {
+        id: contributor.id,
+        email: '',
+      };
+    }
+
+    return {
+      id: contributor.id,
+      email: '',
+    };
   }
 }

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
@@ -50,7 +50,7 @@ export class ContributionReporterService {
         id: contribution.id,
         name: contribution.name,
         author: details.id,
-        space: contribution.id,
+        space: contribution.space,
       },
       details
     );


### PR DESCRIPTION
## Summary
- ensure SPACE_JOINED events record the correct space identifier in Elasticsearch
- emit space/subspace join contribution events with the actual joining contributor as author
- add an explicit author-details resolver for users, organizations, and virtual contributors

## Testing
- not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected contribution tracking to accurately capture space information.

* **Improvements**
  * Enhanced author data resolution for contributions, ensuring consistent reporting across different contributor types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->