### PR TITLE
Reduces log verbosity for collaboration checks

### DIFF
--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -263,14 +263,7 @@ export class ActivityFeedService {
         );
         readableCollaborationIds.push(collaboration.id);
       } catch {
-        this.logger?.verbose?.(
-          {
-            message: 'User is not able to read collaboration',
-            userID: agentInfo.userID,
-            collaborationID: collaboration.id,
-          },
-          LogContext.ACTIVITY_FEED
-        );
+        // User is not able to read collaboration - this is not uncommon
       }
 
       try {

--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -263,7 +263,7 @@ export class ActivityFeedService {
         );
         readableCollaborationIds.push(collaboration.id);
       } catch {
-        this.logger?.warn(
+        this.logger?.verbose?.(
           {
             message: 'User is not able to read collaboration',
             userID: agentInfo.userID,


### PR DESCRIPTION
Decreases the log level from warn to verbose when a user is unable to read a collaboration.

This change reduces the noise in the logs by only logging these events at a more detailed verbosity level, as they are not necessarily indicative of a problem.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed warning logs for inaccessible collaborations so access-failure cases no longer produce warnings, reducing noisy diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->