### PR TITLE
Adds ratelimiting configurations

### DIFF
--- a/.build/synapse/homeserver.yaml
+++ b/.build/synapse/homeserver.yaml
@@ -274,3 +274,112 @@ report_stats: false
 
 # Suppress key server warning
 suppress_key_server_warning: true
+
+## Ratelimiting ##
+
+# Ratelimiting settings for client actions (registration, login, messaging).
+#
+# Each ratelimiting configuration is made of two parameters:
+#   - per_second: number of requests a client can send per second.
+#   - burst_count: number of requests a client can send before being throttled.
+#
+# Synapse currently uses the following configurations:
+#   - one for messages that ratelimits sending based on the account the client
+#     is using
+#   - one for registration that ratelimits registration requests based on the
+#     client's IP address.
+#   - one for login that ratelimits login requests based on the client's IP
+#     address.
+#   - one for login that ratelimits login requests based on the account the
+#     client is attempting to log into.
+#   - one for login that ratelimits login requests based on the account the
+#     client is attempting to log into, based on the amount of failed login
+#     attempts for this account.
+#   - one for ratelimiting redactions by room admins. If this is not explicitly
+#     set then it uses the same ratelimiting as per rc_message. This is useful
+#     to allow room admins to deal with abuse quickly.
+#   - two for ratelimiting number of rooms a user can join, "local" for when
+#     users are joining rooms the server is already in (this is cheap) vs
+#     "remote" for when users are trying to join rooms not on the server (which
+#     can be more expensive)
+#   - one for ratelimiting how often a user or IP can attempt to validate a 3PID.
+#   - two for ratelimiting how often invites can be sent in a room or to a
+#     specific user.
+#
+# The defaults are as shown below.
+#
+
+rc_message:
+  per_second: 10
+  burst_count: 30
+#
+rc_registration:
+  per_second: 10
+  burst_count: 30
+#
+rc_login:
+  address:
+    per_second: 10
+    burst_count: 30
+  account:
+    per_second: 10
+    burst_count: 30
+  failed_attempts:
+    per_second: 2
+    burst_count: 3
+#
+rc_admin_redaction:
+  per_second: 5
+  burst_count: 50
+#
+rc_joins:
+  local:
+    per_second: 5
+    burst_count: 10
+  remote:
+    per_second: 1
+    burst_count: 10
+#
+rc_3pid_validation:
+  per_second: 1
+  burst_count: 5
+#
+rc_invites:
+  per_room:
+    per_second: 5
+    burst_count: 10
+  per_user:
+    per_second: 5
+    burst_count: 5
+
+# Ratelimiting settings for incoming federation
+#
+# The rc_federation configuration is made up of the following settings:
+#   - window_size: window size in milliseconds
+#   - sleep_limit: number of federation requests from a single server in
+#     a window before the server will delay processing the request.
+#   - sleep_delay: duration in milliseconds to delay processing events
+#     from remote servers by if they go over the sleep limit.
+#   - reject_limit: maximum number of concurrent federation requests
+#     allowed from a single server
+#   - concurrent: number of federation requests to concurrently process
+#     from a single server
+#
+# The defaults are as shown below.
+#
+#rc_federation:
+#  window_size: 1000
+#  sleep_limit: 10
+#  sleep_delay: 500
+#  reject_limit: 50
+#  concurrent: 3
+
+# Target outgoing federation transaction frequency for sending read-receipts,
+# per-room.
+#
+# If we end up trying to send out more read-receipts, they will get buffered up
+# into fewer transactions.
+#
+#federation_rr_transactions_per_room_per_second: 50
+
+


### PR DESCRIPTION
Introduces ratelimiting settings for various client actions like messaging, registration, login, and room joins.
Also includes settings for federation traffic and outgoing read-receipts.
This helps to protect the homeserver from abuse and ensure fair resource allocation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comprehensive rate-limiting configuration for server operations including messages, registrations, logins, room joins, and invitations with configurable per-second and burst thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->