### PR TITLE
feat: update constitution to version 2.0.0

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -2,14 +2,14 @@
 
 <!--
 Sync Impact Report
-Version change: 0.0.0 → 1.0.0 (initial full definition)
-Modified principles: (initial creation)
-Added sections: Core Principles, Architecture Standards, Engineering Workflow, Governance
+Version change: 1.0.0 → 2.0.0 (re-balanced observability + testing principles)
+Modified principles: 5. Observability & Operational Readiness (clarified signal expectations), 6. Code Quality with Pragmatic Testing (risk-based guidance)
+Added sections: (none)
 Removed sections: (none)
 Templates requiring updates:
- - .specify/templates/plan-template.md (Constitution Check gates) ✅
+ - .specify/templates/plan-template.md (Constitution Check alignment) ✅
+ - .specify/templates/tasks-template.md (testing guidance note) ✅
  - .specify/templates/spec-template.md (no changes required) ✅
- - .specify/templates/tasks-template.md (no changes required) ✅
 Deferred TODOs: None
 -->
 
@@ -37,11 +37,11 @@ State changes MUST propagate through domain services emitting events (synchronou
 
 ### 5. Observability & Operational Readiness
 
-Every new module MUST define: structured log contexts, key metrics, and at least one meaningful health indicator if applicable. Logs use contextual IDs (request, correlation, entity). Silent failure paths are forbidden. Feature flags and license checks MUST log decision points at debug level. Performance-sensitive queries require an inline comment explaining chosen optimization.
+Every new module MUST define structured log contexts and describe the operational signals we actively consume. Instrument only what our observability stack ingests today—do not add orphaned Prometheus metrics or unused dashboards. Health indicators are required only when the module exposes an externally consumed surface; otherwise document why a lightweight runtime check or log hook suffices. Logs use contextual IDs (request, correlation, entity). Silent failure paths are forbidden. Feature flags and license checks MUST log decision points at debug level. Performance-sensitive queries require an inline comment explaining the chosen optimization.
 
 ### 6. Code Quality with Pragmatic Testing
 
-Minimum test expectations: unit tests for orchestration services (DO NOT unit test CRUD operations on AggregateRoots) AND integration tests for cross-module interactions or persistence mapping of new aggregates. Snapshot or superficial tests are discouraged unless asserting schema output. 100% coverage is NOT required; tests MUST defend invariants and contracts. Failure to justify absence of tests for non-trivial logic blocks the PR.
+Tests exist to defend domain invariants and observable behaviors that matter. Use a risk-based approach: add unit or integration tests when they deliver real signal, skip trivial pass-through coverage, and call out deliberate omissions in the PR when automation is unnecessary. Snapshot or superficial tests are discouraged unless asserting schema output. 100% coverage is NOT required; tests MUST stay maintainable and purposeful. Placeholder or “future we’ll fix it” tests are forbidden.
 
 ### 7. API Consistency & Evolution Discipline
 
@@ -100,4 +100,4 @@ Enforcement:
 - Automated lint / CI may enforce schema stability, module boundaries, and logging context presence.
 - Manual review ensures domain purity & testing adequacy.
 
-**Version**: 1.0.0 | **Ratified**: 2025-10-04 | **Last Amended**: 2025-10-04
+**Version**: 2.0.0 | **Ratified**: 2025-10-04 | **Last Amended**: 2025-11-11

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -17,21 +17,23 @@
   the iteration process.
 -->
 
-**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
-**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
-**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
-**Project Type**: [single/web/mobile - determines source structure]  
-**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
-**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Project Type**: [single/web/mobile - determines source structure]
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]
 **Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
 ## Constitution Check
 
 _GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 
-[Gates determined based on constitution file]
+- Confirm changes keep core business rules inside `src/domain` and use application layers only for orchestration (Principle 1).
+- Describe the observability signals the feature will rely on (logs, alerts, existing dashboards) without inventing unused metrics (Principle 5).
+- Outline meaningful automated tests or explain, in the PR checklist, why automation is unnecessary for low-risk work (Principle 6).
 
 ## Project Structure
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -7,7 +7,7 @@ description: 'Task list template for feature implementation'
 **Input**: Design documents from `/specs/[###-feature-name]/`
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
-**Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.
+**Tests**: The examples below include test tasks. Tests are OPTIONAL - include them only when they provide real signal per Constitution Principle 6 or when explicitly requested in the feature specification.
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 


### PR DESCRIPTION
This pull request updates the engineering constitution and associated templates to clarify and strengthen expectations around observability and pragmatic testing. The most significant changes are refinements to principles 5 and 6, ensuring that new features instrument only useful operational signals and that testing is risk-based and purposeful. Related templates have been updated to align with these new standards.

**Constitution Principle refinements:**

* Principle 5 (Observability & Operational Readiness): Now requires modules to instrument only signals actively consumed by the observability stack and to avoid adding unused metrics or dashboards. Health indicators are required only for externally exposed modules, with alternatives documented for internal modules.
* Principle 6 (Code Quality with Pragmatic Testing): Emphasizes a risk-based approach to testing, focusing on defending domain invariants and observable behaviors, and forbids superficial or placeholder tests. Deliberate omissions must be justified in the PR.

**Template updates for workflow alignment:**

* [`plan-template.md`](diffhunk://#diff-accfd2eb19a2dc49a924d5a0a2f638a751f0eef1d1f4ab71335de9f4e63cc357L34-R36): Updated constitution check gates to require explicit description of observability signals and meaningful automated tests or rationale for omissions.
* [`tasks-template.md`](diffhunk://#diff-56152ad2de4c68e0527f11093eef614e1e4c1796a1f18e863561f8cff3590df3L10-R10): Clarified that test tasks should be included only when they provide real signal per the updated testing principle or are explicitly requested.

**Meta/documentation updates:**

* Constitution version bumped from 1.0.0 to 2.0.0, with ratification and amendment dates updated. [[1]](diffhunk://#diff-68da6d0a6818ee87101f0e2220e30cfa038e7deeb68c2a35344636db6d6da2bcL5-L12) [[2]](diffhunk://#diff-68da6d0a6818ee87101f0e2220e30cfa038e7deeb68c2a35344636db6d6da2bcL103-R103)

## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Governance constitution updated to v2.0.0 with refined observability and testing principles emphasizing risk-based approaches and actionable metrics.
  * Planning and task templates reorganized for clarity, with enhanced guidance on constitution alignment, observable behaviors, and meaningful test coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->