### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -102,6 +102,7 @@ type ActivityCreatedSubscriptionResult {
 enum ActivityEventType {
   CALENDAR_EVENT_CREATED
   CALLOUT_LINK_CREATED
+  CALLOUT_MEMO_CREATED
   CALLOUT_POST_COMMENT
   CALLOUT_POST_CREATED
   CALLOUT_PUBLISHED
@@ -253,6 +254,34 @@ type ActivityLogEntryCalloutLinkCreated implements ActivityLogEntry {
   id: UUID!
   """The Link that was created."""
   link: Link!
+  """The display name of the parent"""
+  parentDisplayName: String!
+  """The Space where the activity happened"""
+  space: Space
+  """The user that triggered this Activity."""
+  triggeredBy: User!
+  """The event type for this Activity."""
+  type: ActivityEventType!
+}
+
+type ActivityLogEntryCalloutMemoCreated implements ActivityLogEntry {
+  """The Callout in which the Memo was created."""
+  callout: Callout!
+  """
+  Indicates if this Activity happened on a child Collaboration. Child results can be included via the "includeChild" parameter.
+  """
+  child: Boolean!
+  """
+  The id of the Collaboration entity within which the Activity was generated.
+  """
+  collaborationID: UUID!
+  """The timestamp for the Activity."""
+  createdDate: DateTime!
+  """The text details for this Activity."""
+  description: String!
+  id: UUID!
+  """The Memo that was created."""
+  memo: Memo!
   """The display name of the parent"""
   parentDisplayName: String!
   """The Space where the activity happened"""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 245038 bytes
Snapshot md5: 2ccc81655db3a1095d25162a6f8c5301

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity logging now tracks memo creation within callouts as distinct event types, providing enhanced visibility into collaboration and memo-related activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->