### PR TITLE
feat: add Alkemio server URL and identity resolve path to configurati…

### DIFF
--- a/.build/synapse/homeserver.yaml
+++ b/.build/synapse/homeserver.yaml
@@ -229,7 +229,8 @@ oidc_providers:
       config:
         # Use email localpart (before @) as Matrix user ID (FR-005)
         # Supports all Kratos authentication methods: password, LinkedIn, Microsoft, GitHub
-        localpart_template: "{{ user.email.split('@')[0] }}"
+#        localpart_template: "{{ user.email.split('@')[0] }}"
+        localpart_template: "{{ user.alkemio_user_id }}"
         # Display name from Kratos traits.name.first and traits.name.last (FR-007)
         display_name_template: "{{ user.given_name }} {{ user.family_name }}"
         # Email from Kratos traits.email (FR-007)

--- a/.env.docker
+++ b/.env.docker
@@ -48,7 +48,8 @@ OIDC_KRATOS_ADMIN_URL=http://kratos:4434
 OIDC_KRATOS_PUBLIC_URL=http://kratos:4433
 # OIDC_KRATOS_BROWSER_URL=http://localhost:3000/ory/kratos/public
 OIDC_WEB_BASE_URL=http://localhost:3000
-
+OIDC_ALKEMIO_SERVER_URL=http://host.docker.internal:4000
+OIDC_ALKEMIO_IDENTITY_RESOLVE_PATH=/rest/internal/identity/resolve
 
 EMAIL_SMTP_HOST=mailslurper
 EMAIL_MULTI_PROVIDER_STRATEGY=no-fallback

--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -212,6 +212,8 @@ services:
       - OIDC_KRATOS_PUBLIC_URL
       - OIDC_KRATOS_BROWSER_URL=http://localhost:3000/ory/kratos/public
       - OIDC_WEB_BASE_URL=http://localhost:3000
+      - OIDC_ALKEMIO_SERVER_URL
+      - OIDC_ALKEMIO_IDENTITY_RESOLVE_PATH
     networks:
       - alkemio_dev_net
     ports:

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -211,6 +211,8 @@ services:
       - OIDC_KRATOS_PUBLIC_URL
       - OIDC_KRATOS_BROWSER_URL=http://localhost:3000/ory/kratos/public
       - OIDC_WEB_BASE_URL=http://localhost:3000
+      - OIDC_ALKEMIO_SERVER_URL
+      - OIDC_ALKEMIO_IDENTITY_RESOLVE_PATH
     networks:
       - alkemio_dev_net
     ports:

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -228,6 +228,8 @@ services:
       - OIDC_KRATOS_PUBLIC_URL
       - OIDC_KRATOS_BROWSER_URL=http://localhost:3000/ory/kratos/public
       - OIDC_WEB_BASE_URL=http://localhost:3000
+      - OIDC_ALKEMIO_SERVER_URL
+      - OIDC_ALKEMIO_IDENTITY_RESOLVE_PATH
     networks:
       - alkemio_dev_net
     ports:

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -223,6 +223,8 @@ services:
       - OIDC_KRATOS_PUBLIC_URL
       - OIDC_KRATOS_BROWSER_URL=http://localhost:3000/ory/kratos/public
       - OIDC_WEB_BASE_URL=http://localhost:3000
+      - OIDC_ALKEMIO_SERVER_URL
+      - OIDC_ALKEMIO_IDENTITY_RESOLVE_PATH
     networks:
       - alkemio_dev_net
     ports:


### PR DESCRIPTION
This pull request updates the OIDC configuration to support integration with Alkemio identity services. The main changes include switching the user ID template to use `alkemio_user_id` and adding new environment variables for the Alkemio server and identity resolution path. These updates are reflected across multiple service configuration files to ensure consistent environment setup.

**OIDC configuration updates:**

* Changed the `localpart_template` in `.build/synapse/homeserver.yaml` to use `user.alkemio_user_id` instead of extracting the local part from the email address.

**Environment variable additions:**

* Added `OIDC_ALKEMIO_SERVER_URL` and `OIDC_ALKEMIO_IDENTITY_RESOLVE_PATH` to `.env.docker` for Alkemio integration.

**Service environment propagation:**

* Included the new Alkemio environment variables in the `services` section of `quickstart-services.yml`, `quickstart-services-ai.yml`, `quickstart-services-ai-debug.yml`, and `quickstart-services-kratos-debug.yml` to ensure all services have access to the updated configuration. [[1]](diffhunk://#diff-01e1178df16632cd0c7ac44c98314a1561debb20010e4c4145ba91d13b65f359R226-R227) [[2]](diffhunk://#diff-a8adb3d9bf60e525421fdfd4cfd36336b548b87db7287de5c49274b2ea353df5R214-R215) [[3]](diffhunk://#diff-173caa8e83eb3884333d039392b5da98e7141a4c8f49eb6fc0d4324f18cdc30bR215-R216) [[4]](diffhunk://#diff-7675f100a586a43aa45fc07cbf1b282970a71c11f5e505ee5f708917ca66a757R231-R232)…on files

## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
