### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -2849,7 +2849,7 @@ type InAppNotificationPayloadPlatformUser implements InAppNotificationPayload {
 
 type InAppNotificationPayloadPlatformUserMessageRoom implements InAppNotificationPayload {
   """The details of the message."""
-  messageDetails: MessageDetails!
+  messageDetails: MessageDetails
   """The payload type."""
   type: NotificationEventPayload!
   """The User receiver of the message."""
@@ -2885,7 +2885,7 @@ type InAppNotificationPayloadSpaceCollaborationCalloutComment implements InAppNo
   """The Callout that was published."""
   callout: Callout!
   """The details of the message."""
-  messageDetails: MessageDetails!
+  messageDetails: MessageDetails
   """The Space where the comment was made."""
   space: Space!
   """The payload type."""
@@ -2896,7 +2896,7 @@ type InAppNotificationPayloadSpaceCollaborationCalloutPostComment implements InA
   """The Callout that was published."""
   callout: Callout!
   """The details of the message."""
-  messageDetails: MessageDetails!
+  messageDetails: MessageDetails
   """The Space where the comment was made."""
   space: Space!
   """The payload type."""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 245035 bytes
Snapshot md5: 18f693d9b92e99ab03d7db134e3d93e1

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated in-app notification schema to support optional message details for platform messages, collaboration callouts, and comments, enabling notifications to be generated even when detailed message information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->