### PR TITLE
fix: change default APM log level from `trace` to `warn`

### DIFF
--- a/src/apm/apm.ts
+++ b/src/apm/apm.ts
@@ -24,7 +24,7 @@ export const apmAgent = process.env.APM_ENDPOINT
        *
        * Related to: https://github.com/alkem-io/server/issues/5127
        */
-      logLevel: (process.env.APM_LOG_LEVEL as any) ?? 'trace',
+      logLevel: (process.env.APM_LOG_LEVEL as any) ?? 'warn',
       /**
        * Specify the sampling rate to use when deciding whether to trace a request.
        * This must be a value between 0.0 and 1.0, where 1.0 means 100% of requests are traced.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * APM default logging level changed from trace to warn when environment variable is not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->