### PR TITLE
Do not send notifications to yourself

### DIFF
--- a/src/services/adapters/notification-adapter/notification.platform.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.platform.adapter.ts
@@ -144,17 +144,23 @@ export class NotificationPlatformAdapter {
       recipient => recipient.id !== eventData.triggeredBy
     );
 
-    // build notification payload
-    const payload =
-      await this.notificationExternalAdapter.buildPlatformForumCommentCreatedOnDiscussionPayload(
+    if (emailRecipientsWithoutCommenter.length > 0) {
+      // build notification payload
+      const payload =
+        await this.notificationExternalAdapter.buildPlatformForumCommentCreatedOnDiscussionPayload(
+          event,
+          eventData.commentSent.sender,
+          emailRecipientsWithoutCommenter,
+          eventData.discussion,
+          eventData.commentSent
+        );
+
+      // send notification event
+      this.notificationExternalAdapter.sendExternalNotifications(
         event,
-        eventData.commentSent.sender,
-        emailRecipientsWithoutCommenter,
-        eventData.discussion,
-        eventData.commentSent
+        payload
       );
-    // send notification event
-    this.notificationExternalAdapter.sendExternalNotifications(event, payload);
+    }
 
     // Send in-app notifications
     const inAppRecipientsWithoutCommenter = recipients.inAppRecipients.filter(

--- a/src/services/adapters/notification-adapter/notification.platform.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.platform.adapter.ts
@@ -139,12 +139,17 @@ export class NotificationPlatformAdapter {
       eventData.userID
     );
 
+    // Filter out the commenter from email recipients
+    const emailRecipientsWithoutCommenter = recipients.emailRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+
     // build notification payload
     const payload =
       await this.notificationExternalAdapter.buildPlatformForumCommentCreatedOnDiscussionPayload(
         event,
         eventData.commentSent.sender,
-        recipients.emailRecipients,
+        emailRecipientsWithoutCommenter,
         eventData.discussion,
         eventData.commentSent
       );
@@ -152,7 +157,10 @@ export class NotificationPlatformAdapter {
     this.notificationExternalAdapter.sendExternalNotifications(event, payload);
 
     // Send in-app notifications
-    const inAppReceiverIDs = recipients.inAppRecipients.map(
+    const inAppRecipientsWithoutCommenter = recipients.inAppRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+    const inAppReceiverIDs = inAppRecipientsWithoutCommenter.map(
       recipient => recipient.id
     );
     if (inAppReceiverIDs.length > 0) {

--- a/src/services/adapters/notification-adapter/notification.space.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.space.adapter.ts
@@ -69,18 +69,26 @@ export class NotificationSpaceAdapter {
       space.id
     );
 
+    // Filter out the publisher from email recipients
+    const emailRecipientsWithoutPublisher = recipients.emailRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+
     const payload =
       await this.notificationExternalAdapter.buildSpaceCollaborationCalloutPublishedPayload(
         event,
         eventData.triggeredBy,
-        recipients.emailRecipients,
+        emailRecipientsWithoutPublisher,
         space,
         eventData.callout
       );
     this.notificationExternalAdapter.sendExternalNotifications(event, payload);
 
     // Send in-app notifications
-    const inAppReceiverIDs = recipients.inAppRecipients.map(
+    const inAppRecipientsWithoutPublisher = recipients.inAppRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+    const inAppReceiverIDs = inAppRecipientsWithoutPublisher.map(
       recipient => recipient.id
     );
     if (inAppReceiverIDs.length > 0) {
@@ -261,11 +269,16 @@ export class NotificationSpaceAdapter {
       space.id
     );
 
+    // Filter out the creator from email recipients
+    const emailRecipientsWithoutCreator = recipients.emailRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+
     const payload =
       await this.notificationExternalAdapter.buildSpaceCollaborationCreatedPayload(
         event,
         eventData.triggeredBy,
-        recipients.emailRecipients,
+        emailRecipientsWithoutCreator,
         space,
         eventData
       );
@@ -273,7 +286,10 @@ export class NotificationSpaceAdapter {
     this.notificationExternalAdapter.sendExternalNotifications(event, payload);
 
     // Send in-app notifications
-    const inAppReceiverIDs = recipients.inAppRecipients.map(
+    const inAppRecipientsWithoutCreator = recipients.inAppRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+    const inAppReceiverIDs = inAppRecipientsWithoutCreator.map(
       recipient => recipient.id
     );
     if (inAppReceiverIDs.length > 0) {
@@ -302,11 +318,17 @@ export class NotificationSpaceAdapter {
       space.id
     );
 
+    // Filter out the creator from admin email recipients
+    const adminEmailRecipientsWithoutCreator =
+      adminRecipients.emailRecipients.filter(
+        recipient => recipient.id !== eventData.triggeredBy
+      );
+
     const adminPayload =
       await this.notificationExternalAdapter.buildSpaceCollaborationCreatedPayload(
         adminEvent,
         eventData.triggeredBy,
-        adminRecipients.emailRecipients,
+        adminEmailRecipientsWithoutCreator,
         space,
         eventData
       );
@@ -316,7 +338,11 @@ export class NotificationSpaceAdapter {
     );
 
     // Send admin in-app notifications
-    const adminInAppReceiverIDs = adminRecipients.inAppRecipients.map(
+    const adminInAppRecipientsWithoutCreator =
+      adminRecipients.inAppRecipients.filter(
+        recipient => recipient.id !== eventData.triggeredBy
+      );
+    const adminInAppReceiverIDs = adminInAppRecipientsWithoutCreator.map(
       recipient => recipient.id
     );
     if (adminInAppReceiverIDs.length > 0) {
@@ -447,7 +473,10 @@ export class NotificationSpaceAdapter {
     this.notificationExternalAdapter.sendExternalNotifications(event, payload);
 
     // Send in-app notifications
-    const inAppReceiverIDs = recipients.inAppRecipients.map(
+    const inAppRecipientsWithoutSender = recipients.inAppRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+    const inAppReceiverIDs = inAppRecipientsWithoutSender.map(
       recipient => recipient.id
     );
     if (inAppReceiverIDs.length > 0) {
@@ -671,13 +700,19 @@ export class NotificationSpaceAdapter {
       eventData,
       space.id
     );
-    if (recipients.emailRecipients.length > 0) {
+
+    // Filter out the sender from email recipients
+    const emailRecipientsWithoutSender = recipients.emailRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+
+    if (emailRecipientsWithoutSender.length > 0) {
       // Emit the events to notify others
       const payloadRecipients =
         await this.notificationExternalAdapter.buildSpaceCommunicationMessageDirectNotificationPayload(
           eventRecipientsAdmins,
           eventData.triggeredBy,
-          recipients.emailRecipients,
+          emailRecipientsWithoutSender,
           space,
           eventData.message
         );
@@ -688,7 +723,10 @@ export class NotificationSpaceAdapter {
     }
 
     // Send in-app notifications
-    const inAppReceiverIDs = recipients.inAppRecipients.map(
+    const inAppRecipientsWithoutSender = recipients.inAppRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+    const inAppReceiverIDs = inAppRecipientsWithoutSender.map(
       recipient => recipient.id
     );
     if (inAppReceiverIDs.length > 0) {

--- a/src/services/adapters/notification-adapter/notification.user.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.user.adapter.ts
@@ -186,12 +186,17 @@ export class NotificationUserAdapter {
       eventData.userID
     );
 
-    if (recipients.emailRecipients.length > 0) {
+    // Filter out the sender from email recipients (in case user mentions themselves)
+    const emailRecipientsWithoutSender = recipients.emailRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+
+    if (emailRecipientsWithoutSender.length > 0) {
       const payload =
         await this.notificationExternalAdapter.buildUserMentionNotificationPayload(
           event,
           eventData.triggeredBy,
-          recipients.emailRecipients,
+          emailRecipientsWithoutSender,
           eventData.userID,
           messageDetails
         );
@@ -203,7 +208,10 @@ export class NotificationUserAdapter {
     }
 
     // In-app notification
-    const inAppReceiverIDs = recipients.inAppRecipients.map(
+    const inAppRecipientsWithoutSender = recipients.inAppRecipients.filter(
+      recipient => recipient.id !== eventData.triggeredBy
+    );
+    const inAppReceiverIDs = inAppRecipientsWithoutSender.map(
       recipient => recipient.id
     );
     if (inAppReceiverIDs.length > 0) {
@@ -280,12 +288,16 @@ export class NotificationUserAdapter {
     );
 
     try {
-      if (recipients.emailRecipients.length > 0) {
+      // Filter out the sender from email recipients
+      const emailRecipientsWithoutSender = recipients.emailRecipients.filter(
+        recipient => recipient.id !== eventData.triggeredBy
+      );
+      if (emailRecipientsWithoutSender.length > 0) {
         const payload =
           await this.notificationExternalAdapter.buildUserCommentReplyPayload(
             event,
             eventData.triggeredBy,
-            recipients.emailRecipients,
+            emailRecipientsWithoutSender,
             eventData,
             messageDetails
           );
@@ -297,7 +309,10 @@ export class NotificationUserAdapter {
       }
 
       // In-app notification
-      const inAppReceiverIDs = recipients.inAppRecipients.map(
+      const inAppRecipientsWithoutSender = recipients.inAppRecipients.filter(
+        recipient => recipient.id !== eventData.triggeredBy
+      );
+      const inAppReceiverIDs = inAppRecipientsWithoutSender.map(
         recipient => recipient.id
       );
       if (inAppReceiverIDs.length > 0) {


### PR DESCRIPTION
## Complete Summary of Notification Filtering Changes

Successfully applied filtering to prevent users from receiving notifications for their own actions across all applicable notification methods.

### Impact:

Users will now have a much cleaner notification experience without receiving duplicate notifications about their own actions for:

- Creating posts/contributions
- Publishing callouts
- Adding comments
- Replying to comments
- Mentioning themselves
- Sending messages
- Forum participation

All changes maintain backward compatibility and follow the existing codebase patterns! 🎉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users no longer receive email or in-app notifications about their own actions (posts, comments, mentions, replies, or space activity).
  * Notification filtering is now applied consistently across forum, space, and user notification flows so only other participants are notified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->