### PR TITLE
Markdown Tables

### DIFF
--- a/src/domain/common/memo/conversion/markdown.schema.ts
+++ b/src/domain/common/memo/conversion/markdown.schema.ts
@@ -214,6 +214,40 @@ export const markdownSchema = new Schema({
         },
       ],
     },
+    table: {
+      content: 'tableRow+',
+      tableRole: 'table',
+      isolating: true,
+      group: 'block',
+      parseDOM: [{ tag: 'table' }],
+    },
+    tableRow: {
+      content: '(tableCell | tableHeader)*',
+      tableRole: 'row',
+      parseDOM: [{ tag: 'tr' }],
+    },
+    tableCell: {
+      content: 'block+',
+      tableRole: 'cell',
+      isolating: true,
+      attrs: {
+        colspan: { default: 1 },
+        rowspan: { default: 1 },
+        colwidth: { default: null },
+      },
+      parseDOM: [{ tag: 'td' }],
+    },
+    tableHeader: {
+      content: 'block+',
+      tableRole: 'header_cell',
+      isolating: true,
+      attrs: {
+        colspan: { default: 1 },
+        rowspan: { default: 1 },
+        colwidth: { default: null },
+      },
+      parseDOM: [{ tag: 'th' }],
+    },
   },
   marks: {
     link: {

--- a/src/domain/common/memo/conversion/markdown.schema.ts
+++ b/src/domain/common/memo/conversion/markdown.schema.ts
@@ -222,7 +222,7 @@ export const markdownSchema = new Schema({
       parseDOM: [{ tag: 'table' }],
     },
     tableRow: {
-      content: '(tableCell | tableHeader)*',
+      content: '(tableCell | tableHeader)+',
       tableRole: 'row',
       parseDOM: [{ tag: 'tr' }],
     },

--- a/src/domain/common/memo/conversion/markdown.to.yjs.v2.state.ts
+++ b/src/domain/common/memo/conversion/markdown.to.yjs.v2.state.ts
@@ -59,6 +59,26 @@ const parserRules: MarkdownParser['tokens'] = {
   list_item: { block: 'listItem' },
   hardbreak: { node: 'hardBreak' },
 
+  // Tables
+  table: { block: 'table' },
+  thead: { ignore: true },
+  tbody: { ignore: true },
+  tr: { block: 'tableRow' },
+  th: {
+    block: 'tableHeader',
+    getAttrs: (token: Token) => ({
+      colspan: Number(token.attrGet('colspan') || 1),
+      rowspan: Number(token.attrGet('rowspan') || 1),
+    }),
+  },
+  td: {
+    block: 'tableCell',
+    getAttrs: (token: Token) => ({
+      colspan: Number(token.attrGet('colspan') || 1),
+      rowspan: Number(token.attrGet('rowspan') || 1),
+    }),
+  },
+
   // Inline Nodes
   image: {
     node: 'image',


### PR DESCRIPTION
## Summary
Adds Tables syntax to the Markdown Parser for the memos handling.

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown now supports tables with rows, header cells and regular cells.
  * Cells can include colspan, rowspan and column-width hints for richer layouts.
  * Table structures are parsed and rendered correctly, improving fidelity when converting or editing markdown tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->