### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -4304,7 +4304,11 @@ type Mutation {
   updateUserSettings(settingsData: UpdateUserSettingsInput!): User!
   """Updates the specified VirtualContributor."""
   updateVirtualContributor(virtualContributorData: UpdateVirtualContributorInput!): VirtualContributor!
-  """Updates one of the Setting on an Organization"""
+  """
+  Updates platform-level settings of a VirtualContributor (platform admins only).
+  """
+  updateVirtualContributorPlatformSettings(settingsData: UpdateVirtualContributorPlatformSettingsInput!): VirtualContributor!
+  """Updates one of the Setting on an Virtual Contributor"""
   updateVirtualContributorSettings(settingsData: UpdateVirtualContributorSettingsInput!): VirtualContributor!
   """Updates the image URI for the specified Visual."""
   updateVisual(updateData: UpdateVisualInput!): Visual!
@@ -7381,6 +7385,20 @@ input UpdateVirtualContributorInput {
   searchVisibility: SearchVisibility
 }
 
+input UpdateVirtualContributorPlatformSettingsEntityInput {
+  """
+  Enable or disable the editing of the prompt graph for this Virtual Contributor.
+  """
+  promptGraphEditingEnabled: Boolean!
+}
+
+input UpdateVirtualContributorPlatformSettingsInput {
+  """Platform-level settings to apply to this Virtual Contributor."""
+  settings: UpdateVirtualContributorPlatformSettingsEntityInput!
+  """ID of the Virtual Contributor to update."""
+  virtualContributorID: UUID!
+}
+
 input UpdateVirtualContributorSettingsEntityInput {
   """"""
   privacy: UpdateVirtualContributorSettingsPrivacyInput
@@ -7824,6 +7842,10 @@ type VirtualContributor implements Contributor {
   modelCard: VirtualContributorModelCard!
   """A name identifier of the Contributor, unique within a given scope."""
   nameID: NameID!
+  """
+  Platform-level settings of this Virtual Contributor, modifiable only by platform admins.
+  """
+  platformSettings: VirtualContributorPlatformSettings!
   """The profile for this Virtual."""
   profile: Profile!
   """Prompt graph definition for this Virtual Contributor."""
@@ -7891,6 +7913,13 @@ type VirtualContributorModelCardFlag {
   enabled: Boolean!
   """The name of the Model Card Entry flag"""
   name: VirtualContributorModelCardEntryFlagName!
+}
+
+type VirtualContributorPlatformSettings {
+  """
+  Enable or disable the editing of the prompt graph for this Virtual Contributor.
+  """
+  promptGraphEditingEnabled: Boolean!
 }
 
 type VirtualContributorSettings {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 249152 bytes
Snapshot md5: ae1f36ebf660649cd7110863ab7026e8

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive platform settings management for Virtual Contributors. Administrators can now use a new API mutation to update platform-level configurations, including the ability to control prompt graph editing permissions. These settings are now accessible as a queryable field on Virtual Contributor profiles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->