### PR TITLE
remove test mode for direct messages

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -298,8 +298,6 @@ communications:
       ssl: ${SYNAPSE_DB_SSL}:false
   discussions:
     enabled: ${COMMUNICATIONS_DISCUSSIONS_ENABLED}:true
-  direct_message_rooms:
-    enabled: ${COMMUNICATIONS_DIRECT_MESSAGE_ROOMS_ENABLED}:false
 
 
 ## storage ##

--- a/src/services/adapters/communication-adapter/communication.adapter.ts
+++ b/src/services/adapters/communication-adapter/communication.adapter.ts
@@ -72,7 +72,6 @@ export class CommunicationAdapter {
   private readonly enabled = false;
   private readonly timeout: number;
   private readonly retries: number;
-  public directMessageRoomsEnabled: boolean;
 
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
@@ -84,8 +83,6 @@ export class CommunicationAdapter {
     this.enabled = communications?.enabled;
     this.timeout = +communications?.matrix?.connection_timeout * 1000;
     this.retries = +communications?.matrix?.connection_retries;
-    this.directMessageRoomsEnabled =
-      communications?.direct_message_rooms?.enabled;
   }
 
   async sendMessageToRoom(


### PR DESCRIPTION
The flag that was set was only for testing purposes until the client was updated with direct messaging support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed direct message rooms configuration and related direct messaging functionality.
  * Removed associated communication adapter properties and code paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->