### PR TITLE
fix: handle dataAccessMode, interactionModes, bodyOfKnowledgeType and bodyOfKnowledgeDescription in updateVirtualContributor

### DIFF
--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -318,6 +318,29 @@ export class VirtualContributorService {
         virtualContributorData.knowledgeBaseData.profile?.description;
     }
 
+    if (
+      virtualContributorData.bodyOfKnowledgeType &&
+      virtualContributorData.bodyOfKnowledgeType !== virtual.bodyOfKnowledgeType
+    ) {
+      virtual.bodyOfKnowledgeType = virtualContributorData.bodyOfKnowledgeType;
+    }
+
+    if (
+      virtualContributorData.dataAccessMode &&
+      virtualContributorData.dataAccessMode !== virtual.dataAccessMode
+    ) {
+      virtual.dataAccessMode = virtualContributorData.dataAccessMode;
+    }
+
+    if (virtualContributorData.interactionModes) {
+      virtual.interactionModes = virtualContributorData.interactionModes;
+    }
+
+    if (typeof virtualContributorData.bodyOfKnowledgeDescription === 'string') {
+      virtual.bodyOfKnowledgeDescription =
+        virtualContributorData.bodyOfKnowledgeDescription;
+    }
+
     return await this.save(virtual);
   }
 


### PR DESCRIPTION
These fields were defined in UpdateVirtualContributorInput but not actually applied when updating a VirtualContributor entity.
