### PR TITLE
Document: Return ID after creation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3753,8 +3753,8 @@ type Mutation {
   Create a new Document on the Storage and return the value as part of the returned Reference.
   """
   uploadFileOnReference(file: Upload!, uploadData: StorageBucketUploadFileOnReferenceInput!): Reference!
-  """Create a new Document on the Storage and return the public Url."""
-  uploadFileOnStorageBucket(file: Upload!, uploadData: StorageBucketUploadFileInput!): String!
+  """Create a new Document on the Storage and return the ID and public URL."""
+  uploadFileOnStorageBucket(file: Upload!, uploadData: StorageBucketUploadFileInput!): StorageBucketUploadFileResult!
   """Uploads and sets an image for the specified Visual."""
   uploadImageOnVisual(file: Upload!, uploadData: VisualUploadImageInput!): Visual!
 }
@@ -5197,6 +5197,13 @@ type StorageBucketParent {
   """The type of entity that this StorageBucket is being used with."""
   type: ProfileType!
   """The URL that can be used to access the parent entity."""
+  url: String!
+}
+
+type StorageBucketUploadFileResult {
+  """The ID of the uploaded Document."""
+  id: UUID!
+  """The publicly accessible URL for the uploaded file."""
   url: String!
 }
 

--- a/src/domain/storage/storage-bucket/dto/storage.bucket.dto.upload.file.result.ts
+++ b/src/domain/storage/storage-bucket/dto/storage.bucket.dto.upload.file.result.ts
@@ -1,0 +1,17 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+
+@ObjectType('StorageBucketUploadFileResult')
+export class StorageBucketUploadFileResult {
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'The ID of the uploaded Document.',
+  })
+  id!: string;
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'The publicly accessible URL for the uploaded file.',
+  })
+  url!: string;
+}


### PR DESCRIPTION
## Summary

return uploaded documents' IDs in order for documents uploaded to links which are never saved later, to be deleted by ID manually

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated file upload functionality to return both the uploaded file ID and its publicly accessible URL (previously returned URL only).

* **Chores**
  * Bumped package version to 0.128.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->