### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -7405,6 +7405,18 @@ input UpdateWhiteboardPreviewSettingsInput {
 """The `Upload` scalar type represents a file upload."""
 scalar Upload
 
+type UrlResolverQueryClosestAncestor {
+  discussionId: UUID
+  innovationHubId: UUID
+  innovationPack: UrlResolverQueryResultInnovationPack
+  organizationId: UUID
+  space: UrlResolverQueryResultSpace
+  type: UrlType!
+  url: String!
+  userId: UUID
+  virtualContributor: UrlResolverQueryResultVirtualContributor
+}
+
 type UrlResolverQueryResultCalendar {
   calendarEventId: UUID
   id: UUID!
@@ -7451,14 +7463,22 @@ type UrlResolverQueryResultVirtualContributor {
 }
 
 type UrlResolverQueryResults {
+  closestAncestor: UrlResolverQueryClosestAncestor
   discussionId: UUID
   innovationHubId: UUID
   innovationPack: UrlResolverQueryResultInnovationPack
   organizationId: UUID
   space: UrlResolverQueryResultSpace
+  state: UrlResolverResultState!
   type: UrlType!
   userId: UUID
   virtualContributor: UrlResolverQueryResultVirtualContributor
+}
+
+enum UrlResolverResultState {
+  Forbidden
+  NotFound
+  Resolved
 }
 
 enum UrlType {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 247789 bytes
Snapshot md5: 2fbc32beec3ebf8abaa545f1e2bdcb8b

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced URL resolution queries with new ancestor tracking capabilities for improved context understanding
  * Added comprehensive result state indicators (Forbidden, NotFound, Resolved) providing clearer visibility into URL resolution outcomes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->