### PR TITLE
refactor: make createdBy field optional in document-related classes a…

### DIFF
--- a/src/domain/community/contributor/contributor.service.ts
+++ b/src/domain/community/contributor/contributor.service.ts
@@ -93,7 +93,7 @@ export class ContributorService {
 
   public async ensureAvatarIsStoredInLocalStorageBucket(
     profileID: string,
-    userID: string
+    userID?: string
   ): Promise<IProfile> {
     const profile = await this.profileService.getProfileOrFail(profileID, {
       relations: {

--- a/src/domain/community/organization/organization.service.ts
+++ b/src/domain/community/organization/organization.service.ts
@@ -206,7 +206,7 @@ export class OrganizationService {
       );
     }
 
-    const userID = agentInfo ? agentInfo.userID : '';
+    const userID = agentInfo?.userID;
     await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
       organization.profile.id,
       userID

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -187,7 +187,7 @@ export class VirtualContributorService {
 
     virtualContributor = await this.save(virtualContributor);
 
-    const userID = agentInfo ? agentInfo.userID : '';
+    const userID = agentInfo?.userID;
     await this.contributorService.ensureAvatarIsStoredInLocalStorageBucket(
       virtualContributor.profile.id,
       userID

--- a/src/domain/storage/document/document.entity.ts
+++ b/src/domain/storage/document/document.entity.ts
@@ -23,7 +23,7 @@ export class Document extends AuthorizableEntity implements IDocument {
   // })
   // @JoinColumn()
   @Column('uuid', { nullable: true })
-  createdBy!: string;
+  createdBy?: string;
 
   @ManyToOne(() => StorageBucket, storage => storage.documents, {
     eager: false,

--- a/src/domain/storage/document/document.interface.ts
+++ b/src/domain/storage/document/document.interface.ts
@@ -20,7 +20,7 @@ export abstract class IDocument extends IAuthorizable {
   })
   displayName!: string;
 
-  createdBy!: string;
+  createdBy?: string;
 
   @Field(() => MimeFileType, {
     description: 'Mime type for this Document.',

--- a/src/domain/storage/document/document.service.authorization.ts
+++ b/src/domain/storage/document/document.service.authorization.ts
@@ -58,23 +58,25 @@ export class DocumentAuthorizationService {
 
     const newRules: IAuthorizationPolicyRuleCredential[] = [];
 
-    const manageCreatedDocumentPolicy =
-      this.authorizationPolicyService.createCredentialRule(
-        [
-          AuthorizationPrivilege.CREATE,
-          AuthorizationPrivilege.READ,
-          AuthorizationPrivilege.UPDATE,
-          AuthorizationPrivilege.DELETE,
-        ],
-        [
-          {
-            type: AuthorizationCredential.USER_SELF_MANAGEMENT,
-            resourceID: document.createdBy,
-          },
-        ],
-        CREDENTIAL_RULE_DOCUMENT_CREATED_BY
-      );
-    newRules.push(manageCreatedDocumentPolicy);
+    if (document.createdBy) {
+      const manageCreatedDocumentPolicy =
+        this.authorizationPolicyService.createCredentialRule(
+          [
+            AuthorizationPrivilege.CREATE,
+            AuthorizationPrivilege.READ,
+            AuthorizationPrivilege.UPDATE,
+            AuthorizationPrivilege.DELETE,
+          ],
+          [
+            {
+              type: AuthorizationCredential.USER_SELF_MANAGEMENT,
+              resourceID: document.createdBy,
+            },
+          ],
+          CREDENTIAL_RULE_DOCUMENT_CREATED_BY
+        );
+      newRules.push(manageCreatedDocumentPolicy);
+    }
 
     const updatedAuthorization =
       this.authorizationPolicyService.appendCredentialAuthorizationRules(

--- a/src/domain/storage/document/dto/document.dto.create.ts
+++ b/src/domain/storage/document/dto/document.dto.create.ts
@@ -3,7 +3,7 @@ import { MimeFileType } from '@common/enums/mime.file.type';
 export class CreateDocumentInput {
   displayName!: string;
 
-  createdBy!: string;
+  createdBy?: string;
 
   mimeType!: MimeFileType;
 

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -160,7 +160,7 @@ export class StorageBucketService {
     buffer: Buffer,
     filename: string,
     mimeType: string,
-    userID: string,
+    userID?: string,
     temporaryLocation = false
   ): Promise<IDocument> {
     const storage = await this.getStorageBucketOrFail(storageBucketId, {
@@ -417,7 +417,7 @@ export class StorageBucketService {
   public async ensureAvatarUrlIsDocument(
     avatarURL: string,
     storageBucketId: string,
-    userId: string
+    userId?: string
   ): Promise<IDocument> {
     if (this.documentService.isAlkemioDocumentURL(avatarURL)) {
       const document = await this.documentService.getDocumentFromURL(avatarURL);


### PR DESCRIPTION
<img width="1411" height="52" alt="image" src="https://github.com/user-attachments/assets/bacb3a69-ca3c-4b96-a0d2-8487e35fcc18" />

- This bootstrap error was due to a failed document creation with a `createdBy` of empty string.
- The table expects `createdBy` to be `uuid` or `null`, and an empty string was provided instead.
- Тhe issue was additionally reinforced by the `Document` class declaring `createdBy` as mandatory, while TypeORM defined it as `nullable` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced avatar and document storage workflows to better support scenarios where user identification may not be available. Made user context optional across storage operations, allowing the system to proceed gracefully without disruption when user details are unavailable. Authorization rules are created conditionally based on available data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->