### PR TITLE
Memo bullets parsing

### DIFF
--- a/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
+++ b/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
@@ -83,7 +83,14 @@ export const yjsStateToMarkdown = (state: Buffer) => {
             child.type.name === 'bulletList' ||
             child.type.name === 'orderedList'
           ) {
-            nestedLists += serializeNode(child, depth + 1);
+            nestedLists += serializeNode(child, depth + 1, child.type.name);
+          } else {
+            // Handle other node types (images, code blocks, etc.) using renderToMarkdown
+            const otherContent = renderToMarkdown({
+              extensions: [StarterKit, ImageExtension, Highlight, Iframe],
+              content: child,
+            }).trim();
+            itemText += otherContent;
           }
         });
 

--- a/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
+++ b/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
@@ -60,14 +60,15 @@ export const yjsStateToMarkdown = (state: Buffer) => {
 
     switch (node.type.name) {
       case 'bulletList':
-      case 'orderedList':
+      case 'orderedList': {
         let listOutput = '';
         node.content.forEach(child => {
           listOutput += serializeNode(child, depth, node.type.name);
         });
         return listOutput;
+      }
 
-      case 'listItem':
+      case 'listItem': {
         let itemText = '';
         let nestedLists = '';
 
@@ -91,6 +92,7 @@ export const yjsStateToMarkdown = (state: Buffer) => {
           ? `${indent}${bullet} ${itemText}\n`
           : `${indent}${bullet}\n`;
         return mainLine + nestedLists;
+      }
 
       default:
         // Use TipTap's default for other node types

--- a/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
+++ b/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
@@ -48,9 +48,63 @@ export const yjsStateToMarkdown = (state: Buffer) => {
   });
   const newDoc = pmDoc.copy(Fragment.fromArray(newContent));
 
-  return renderToMarkdown({
-    extensions: [StarterKit, ImageExtension, /*Link,*/ Highlight, Iframe],
-    content: newDoc,
-    // options,
-  }).trim();
+  // Manually serialize with proper indentation by traversing the tree
+  const serializeNode = (
+    node: ProseMirrorNode,
+    depth = 0,
+    parentType = ''
+  ): string => {
+    // Ordered lists need 4 spaces per level, bullet lists need 2
+    const indentSize = parentType === 'orderedList' ? 4 : 2;
+    const indent = ' '.repeat(depth * indentSize);
+
+    switch (node.type.name) {
+      case 'bulletList':
+      case 'orderedList':
+        let listOutput = '';
+        node.content.forEach(child => {
+          listOutput += serializeNode(child, depth, node.type.name);
+        });
+        return listOutput;
+
+      case 'listItem':
+        let itemText = '';
+        let nestedLists = '';
+
+        node.content.forEach(child => {
+          if (child.type.name === 'paragraph') {
+            const paragraphMarkdown = renderToMarkdown({
+              extensions: [StarterKit, ImageExtension, Highlight, Iframe],
+              content: child,
+            }).trim();
+            itemText += paragraphMarkdown;
+          } else if (
+            child.type.name === 'bulletList' ||
+            child.type.name === 'orderedList'
+          ) {
+            nestedLists += serializeNode(child, depth + 1);
+          }
+        });
+
+        const bullet = parentType === 'orderedList' ? '1.' : '-';
+        const mainLine = itemText
+          ? `${indent}${bullet} ${itemText}\n`
+          : `${indent}${bullet}\n`;
+        return mainLine + nestedLists;
+
+      default:
+        // Use TipTap's default for other node types
+        return renderToMarkdown({
+          extensions: [StarterKit, ImageExtension, Highlight, Iframe],
+          content: node,
+        });
+    }
+  };
+
+  let result = '';
+  newDoc.content.forEach(child => {
+    result += serializeNode(child);
+  });
+
+  return result.trim();
 };


### PR DESCRIPTION
The nested bullets were not rendered correctly for the memo markdown used for preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown list serialization with consistent indentation (ordered lists: 4 spaces per level; unordered lists: 2 spaces).
  * Better handling of nested lists to preserve correct hierarchy and spacing.
  * Trimmed paragraph content inside list items for cleaner output.
  * Falls back to existing rendering for non-list content and preserves handling of empty paragraphs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->