### PR TITLE
Sent only one notification on a comment with mention

### DIFF
--- a/src/domain/communication/room/room.resolver.mutations.ts
+++ b/src/domain/communication/room/room.resolver.mutations.ts
@@ -89,6 +89,11 @@ export class RoomResolverMutations {
     );
     const threadID = message.id;
 
+    // Extract user IDs from mentions to avoid double notifications
+    const mentionedUserIDs = mentions
+      .filter(m => m.contributorType === 'user')
+      .map(m => m.contributorID);
+
     switch (room.type) {
       case RoomType.POST: {
         const { post, callout, contribution } =
@@ -109,7 +114,8 @@ export class RoomResolverMutations {
           contribution,
           room,
           message,
-          agentInfo
+          agentInfo,
+          mentionedUserIDs
         );
 
         this.roomServiceEvents.processActivityPostComment(
@@ -219,7 +225,8 @@ export class RoomResolverMutations {
             callout,
             room,
             message,
-            agentInfo
+            agentInfo,
+            mentionedUserIDs
           );
         }
         break;

--- a/src/domain/communication/room/room.service.events.ts
+++ b/src/domain/communication/room/room.service.events.ts
@@ -61,7 +61,8 @@ export class RoomServiceEvents {
     callout: ICallout,
     room: IRoom,
     message: IMessage,
-    agentInfo: AgentInfo
+    agentInfo: AgentInfo,
+    mentionedUserIDs?: string[]
   ) {
     // Send the notification
     const notificationInput: NotificationInputCollaborationCalloutComment = {
@@ -69,6 +70,7 @@ export class RoomServiceEvents {
       callout,
       comments: room,
       commentSent: message,
+      mentionedUserIDs,
     };
     await this.notificationSpaceAdapter.spaceCollaborationCalloutComment(
       notificationInput
@@ -81,7 +83,8 @@ export class RoomServiceEvents {
     contribution: ICalloutContribution,
     room: IRoom,
     message: IMessage,
-    agentInfo: AgentInfo
+    agentInfo: AgentInfo,
+    mentionedUserIDs?: string[]
   ) {
     // Send the notification
     const notificationInput: NotificationInputCollaborationCalloutPostContributionComment =
@@ -92,6 +95,7 @@ export class RoomServiceEvents {
         contribution,
         room,
         commentSent: message,
+        mentionedUserIDs,
       };
     await this.notificationSpaceAdapter.spaceCollaborationCalloutPostContributionComment(
       notificationInput

--- a/src/services/adapters/notification-adapter/dto/space/notification.dto.input.space.collaboration.callout.comment.ts
+++ b/src/services/adapters/notification-adapter/dto/space/notification.dto.input.space.collaboration.callout.comment.ts
@@ -8,4 +8,5 @@ export interface NotificationInputCollaborationCalloutComment
   callout: ICallout;
   comments: IRoom;
   commentSent: IMessage;
+  mentionedUserIDs?: string[];
 }

--- a/src/services/adapters/notification-adapter/dto/space/notification.dto.input.space.collaboration.callout.post.contribution.comment.ts
+++ b/src/services/adapters/notification-adapter/dto/space/notification.dto.input.space.collaboration.callout.post.contribution.comment.ts
@@ -12,4 +12,5 @@ export interface NotificationInputCollaborationCalloutPostContributionComment
   contribution: ICalloutContribution;
   room: IRoom;
   commentSent: IMessage;
+  mentionedUserIDs?: string[];
 }

--- a/src/services/adapters/notification-adapter/notification.space.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.space.adapter.ts
@@ -423,9 +423,11 @@ export class NotificationSpaceAdapter {
       space.id
     );
 
-    // Filter out the sender
+    // Filter out the sender AND users who were already mentioned (to avoid double notifications)
     const recipientsWithoutSender = recipients.emailRecipients.filter(
-      recipient => recipient.id !== eventData.triggeredBy
+      recipient =>
+        recipient.id !== eventData.triggeredBy &&
+        !eventData.mentionedUserIDs?.includes(recipient.id)
     );
     // ALSO only send to the creator of the post
     const recipientCreator = recipientsWithoutSender.filter(
@@ -449,10 +451,13 @@ export class NotificationSpaceAdapter {
     }
 
     // Send in-app notifications
-    // get the creator but only if it not the sender
+    // get the creator but only if it not the sender AND not already mentioned
     const inAppReceiverCreators = recipients.inAppRecipients
       .filter(
-        r => r.id === eventData.post.createdBy && r.id !== eventData.triggeredBy
+        r =>
+          r.id === eventData.post.createdBy &&
+          r.id !== eventData.triggeredBy &&
+          !eventData.mentionedUserIDs?.includes(r.id)
       )
       .map(r => r.id);
 
@@ -497,8 +502,11 @@ export class NotificationSpaceAdapter {
       space.id
     );
     // build notification payload
+    // Filter out sender AND users who were already mentioned (to avoid double notifications)
     const emailRecipientsWithoutSender = recipients.emailRecipients.filter(
-      recipient => recipient.id !== eventData.triggeredBy
+      recipient =>
+        recipient.id !== eventData.triggeredBy &&
+        !eventData.mentionedUserIDs?.includes(recipient.id)
     );
     const payload =
       await this.notificationExternalAdapter.buildSpaceCollaborationCalloutCommentPayload(
@@ -512,8 +520,11 @@ export class NotificationSpaceAdapter {
     this.notificationExternalAdapter.sendExternalNotifications(event, payload);
 
     // Send in-app notifications
+    // Filter out sender AND users who were already mentioned (to avoid double notifications)
     const inAppRecipientsWithoutSender = recipients.inAppRecipients.filter(
-      recipient => recipient.id !== eventData.triggeredBy
+      recipient =>
+        recipient.id !== eventData.triggeredBy &&
+        !eventData.mentionedUserIDs?.includes(recipient.id)
     );
     const inAppReceiverIDs = inAppRecipientsWithoutSender.map(
       recipient => recipient.id


### PR DESCRIPTION
In case a comment is posted and the notification receiver is mentioned, don't send the comment notification.
Mention one is already sent. 
Applies to both in-app and email.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery to eliminate duplicate notifications when users are mentioned in messages, comments, and discussions across collaborative spaces and callouts. Mentioned users now receive notifications only once per mention event, reducing notification redundancy and enhancing the overall user experience for participants actively engaged in collaborative discussions and contributions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->