### PR TITLE
Delete notifications on leaving a community

### DIFF
--- a/src/domain/access/role-set/role.set.module.ts
+++ b/src/domain/access/role-set/role.set.module.ts
@@ -24,6 +24,7 @@ import { ContributionReporterModule } from '@services/external/elasticsearch/con
 import { ActivityAdapterModule } from '@services/adapters/activity-adapter/activity.adapter.module';
 import { LifecycleModule } from '@domain/common/lifecycle/lifecycle.module';
 import { CommunityCommunicationModule } from '@domain/community/community-communication/community.communication.module';
+import { InAppNotificationModule } from '@platform/in-app-notification/in.app.notification.module';
 import { RoleSetResolverFieldsPublic } from './role.set.resolver.fields.public';
 import { LicenseModule } from '@domain/common/license/license.module';
 import { RoleSetLicenseService } from './role.set.service.license';
@@ -63,6 +64,7 @@ import { RoleSetResolverMutationsMembership } from './role.set.resolver.mutation
     ActivityAdapterModule,
     LifecycleModule,
     CommunityCommunicationModule,
+    InAppNotificationModule,
     TypeOrmModule.forFeature([RoleSet]),
     RoleSetCacheModule,
   ],

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1111,15 +1111,28 @@ export class RoleSetService {
             user
           );
 
-          // Clean up notifications for this user in this space
+          // Clean up notifications for this user in this space and all descendant spaces (L1, L2, etc.)
           const space =
             await this.communityResolverService.getSpaceForRoleSetOrFail(
               roleSet.id
             );
+
+          // Delete notifications from the current space
           await this.inAppNotificationService.deleteAllForReceiverInSpace(
             userID,
             space.id
           );
+
+          // Also delete notifications from all descendant spaces (L1, L2, etc.)
+          // since user is automatically removed from those as well
+          const descendantSpaceIDs =
+            await this.spaceLookupService.getAllDescendantSpaceIDs(space.id);
+          if (descendantSpaceIDs.length > 0) {
+            await this.inAppNotificationService.deleteAllForReceiverInSpaces(
+              userID,
+              descendantSpaceIDs
+            );
+          }
         }
         break;
       }
@@ -1177,16 +1190,28 @@ export class RoleSetService {
       validatePolicyLimits
     );
 
-    // Clean up notifications for this organization when removed from space
+    // Clean up notifications for this organization when removed from space and all descendant spaces
     if (roleSet.type === RoleSetType.SPACE && roleType === RoleName.MEMBER) {
       const space =
         await this.communityResolverService.getSpaceForRoleSetOrFail(
           roleSet.id
         );
+
+      // Delete notifications from the current space
       await this.inAppNotificationService.deleteAllForContributorOrganizationInSpace(
         organizationID,
         space.id
       );
+
+      // Also delete notifications from all descendant spaces (L1, L2, etc.)
+      const descendantSpaceIDs =
+        await this.spaceLookupService.getAllDescendantSpaceIDs(space.id);
+      if (descendantSpaceIDs.length > 0) {
+        await this.inAppNotificationService.deleteAllForContributorOrganizationInSpaces(
+          organizationID,
+          descendantSpaceIDs
+        );
+      }
     }
 
     return organization;
@@ -1211,16 +1236,28 @@ export class RoleSetService {
       validatePolicyLimits
     );
 
-    // Clean up notifications for this VC when removed from space
+    // Clean up notifications for this VC when removed from space and all descendant spaces
     if (roleSet.type === RoleSetType.SPACE && roleType === RoleName.MEMBER) {
       const space =
         await this.communityResolverService.getSpaceForRoleSetOrFail(
           roleSet.id
         );
+
+      // Delete notifications from the current space
       await this.inAppNotificationService.deleteAllForContributorVcInSpace(
         virtualContributorID,
         space.id
       );
+
+      // Also delete notifications from all descendant spaces (L1, L2, etc.)
+      const descendantSpaceIDs =
+        await this.spaceLookupService.getAllDescendantSpaceIDs(space.id);
+      if (descendantSpaceIDs.length > 0) {
+        await this.inAppNotificationService.deleteAllForContributorVcInSpaces(
+          virtualContributorID,
+          descendantSpaceIDs
+        );
+      }
     }
 
     return virtualContributor;

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1144,12 +1144,9 @@ export class RoleSetService {
           );
         }
 
-        // Clean up notifications for this user in this organization
-        if (
-          roleType === RoleName.MEMBER ||
-          roleType === RoleName.ADMIN ||
-          roleType === RoleName.OWNER
-        ) {
+        // Clean up notifications only when user is completely removed (MEMBER role)
+        // If only ADMIN or OWNER is removed, user still has access as MEMBER
+        if (roleType === RoleName.MEMBER) {
           const adminCredential = await this.getCredentialDefinitionForRole(
             roleSet,
             RoleName.ADMIN

--- a/src/domain/space/space.lookup/space.lookup.service.ts
+++ b/src/domain/space/space.lookup/space.lookup.service.ts
@@ -246,20 +246,30 @@ export class SpaceLookupService {
   }
 
   /**
-   * Recursively gets all descendant space IDs for a given space.
+   * Gets all descendant space IDs for a given space.
    * This includes direct subspaces (L1) and their subspaces (L2), etc.
    * Uses Set for deduplication and includes safety guards against circular references.
    * @param spaceID The parent space ID
-   * @param visited Set of already visited space IDs to prevent circular references
-   * @param maxDepth Maximum recursion depth (default 10 to prevent stack overflow)
-   * @param currentDepth Current recursion depth
    * @returns Array of all descendant space IDs
    */
-  async getAllDescendantSpaceIDs(
+  async getAllDescendantSpaceIDs(spaceID: string): Promise<string[]> {
+    return this.getAllDescendantSpaceIDsRecursive(spaceID, new Set(), 10, 0);
+  }
+
+  /**
+   * Private recursive implementation for getting descendant space IDs.
+   * Internal parameters are hidden from public API to prevent bypassing safety mechanisms.
+   * @param spaceID The current space ID to process
+   * @param visited Set of already visited space IDs to prevent circular references
+   * @param maxDepth Maximum recursion depth (10 to prevent stack overflow)
+   * @param currentDepth Current recursion depth
+   * @returns Array of descendant space IDs from this branch
+   */
+  private async getAllDescendantSpaceIDsRecursive(
     spaceID: string,
-    visited: Set<string> = new Set(),
-    maxDepth: number = 10,
-    currentDepth: number = 0
+    visited: Set<string>,
+    maxDepth: number,
+    currentDepth: number
   ): Promise<string[]> {
     // Safety guard: prevent infinite recursion
     if (currentDepth >= maxDepth) {
@@ -299,7 +309,7 @@ export class SpaceLookupService {
       descendantIDs.add(subspace.id);
 
       // Recursively get subspaces of this subspace
-      const childDescendants = await this.getAllDescendantSpaceIDs(
+      const childDescendants = await this.getAllDescendantSpaceIDsRecursive(
         subspace.id,
         visited,
         maxDepth,

--- a/src/domain/space/space.lookup/space.lookup.service.ts
+++ b/src/domain/space/space.lookup/space.lookup.service.ts
@@ -274,8 +274,9 @@ export class SpaceLookupService {
     // Safety guard: prevent infinite recursion
     if (currentDepth >= maxDepth) {
       this.logger.warn(
-        `Max recursion depth (${maxDepth}) reached for space ${spaceID}`,
-        LogContext.SPACES
+        'Max recursion depth reached for space',
+        LogContext.SPACES,
+        { maxDepth, spaceID }
       );
       return [];
     }
@@ -283,8 +284,9 @@ export class SpaceLookupService {
     // Safety guard: prevent circular references
     if (visited.has(spaceID)) {
       this.logger.warn(
-        `Circular reference detected for space ${spaceID}`,
-        LogContext.SPACES
+        'Circular reference detected for space',
+        LogContext.SPACES,
+        { spaceID }
       );
       return [];
     }

--- a/src/platform/in-app-notification/in.app.notification.service.ts
+++ b/src/platform/in-app-notification/in.app.notification.service.ts
@@ -304,6 +304,46 @@ export class InAppNotificationService {
     await this.inAppNotificationRepo.delete({ messageID });
   }
 
+  public async deleteAllForReceiverInSpace(
+    receiverID: string,
+    spaceID: string
+  ): Promise<void> {
+    await this.inAppNotificationRepo.delete({
+      receiverID,
+      spaceID,
+    });
+  }
+
+  public async deleteAllForReceiverInOrganization(
+    receiverID: string,
+    organizationID: string
+  ): Promise<void> {
+    await this.inAppNotificationRepo.delete({
+      receiverID,
+      organizationID,
+    });
+  }
+
+  public async deleteAllForContributorVcInSpace(
+    contributorVcID: string,
+    spaceID: string
+  ): Promise<void> {
+    await this.inAppNotificationRepo.delete({
+      contributorVcID,
+      spaceID,
+    });
+  }
+
+  public async deleteAllForContributorOrganizationInSpace(
+    contributorOrganizationID: string,
+    spaceID: string
+  ): Promise<void> {
+    await this.inAppNotificationRepo.delete({
+      contributorOrganizationID,
+      spaceID,
+    });
+  }
+
   /**
    * Extracts core entity IDs from the notification event for FK population.
    * Only core entities (whose deletion should cascade delete the notification) are extracted.

--- a/src/platform/in-app-notification/in.app.notification.service.ts
+++ b/src/platform/in-app-notification/in.app.notification.service.ts
@@ -314,6 +314,27 @@ export class InAppNotificationService {
     });
   }
 
+  /**
+   * Deletes all notifications for a receiver in multiple spaces.
+   * This is used when a user is removed from a parent space to clean up
+   * notifications from all child spaces (L1, L2, etc.).
+   * @param receiverID The user ID
+   * @param spaceIDs Array of space IDs
+   */
+  public async deleteAllForReceiverInSpaces(
+    receiverID: string,
+    spaceIDs: string[]
+  ): Promise<void> {
+    if (spaceIDs.length === 0) {
+      return;
+    }
+
+    await this.inAppNotificationRepo.delete({
+      receiverID,
+      spaceID: In(spaceIDs),
+    });
+  }
+
   public async deleteAllForReceiverInOrganization(
     receiverID: string,
     organizationID: string
@@ -334,6 +355,27 @@ export class InAppNotificationService {
     });
   }
 
+  /**
+   * Deletes all notifications for a Virtual Contributor in multiple spaces.
+   * This is used when a VC is removed from a parent space to clean up
+   * notifications from all child spaces (L1, L2, etc.).
+   * @param contributorVcID The Virtual Contributor ID
+   * @param spaceIDs Array of space IDs
+   */
+  public async deleteAllForContributorVcInSpaces(
+    contributorVcID: string,
+    spaceIDs: string[]
+  ): Promise<void> {
+    if (spaceIDs.length === 0) {
+      return;
+    }
+
+    await this.inAppNotificationRepo.delete({
+      contributorVcID,
+      spaceID: In(spaceIDs),
+    });
+  }
+
   public async deleteAllForContributorOrganizationInSpace(
     contributorOrganizationID: string,
     spaceID: string
@@ -341,6 +383,27 @@ export class InAppNotificationService {
     await this.inAppNotificationRepo.delete({
       contributorOrganizationID,
       spaceID,
+    });
+  }
+
+  /**
+   * Deletes all notifications for an Organization in multiple spaces.
+   * This is used when an Organization is removed from a parent space to clean up
+   * notifications from all child spaces (L1, L2, etc.).
+   * @param contributorOrganizationID The Organization ID
+   * @param spaceIDs Array of space IDs
+   */
+  public async deleteAllForContributorOrganizationInSpaces(
+    contributorOrganizationID: string,
+    spaceIDs: string[]
+  ): Promise<void> {
+    if (spaceIDs.length === 0) {
+      return;
+    }
+
+    await this.inAppNotificationRepo.delete({
+      contributorOrganizationID,
+      spaceID: In(spaceIDs),
     });
   }
 


### PR DESCRIPTION
- Delete in-app notifications after leaving a community. All contributor types.
- Delete the in-app notifications from the sub communities.
- ⚠️ the comments/mention in-apps are not deleted as they don't have spaceID relation. However, they are not breaking the notification inbox, only lead to 404, which is not that critical IMHO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * In-app notifications are now automatically purged when users, organizations, or VCs are removed, including across descendant spaces and additional removal paths to prevent stale alerts.
  * Cleanup actions are scoped to the relevant space, organization, or VC context for accurate pruning.

* **New Features**
  * Multi-space deletion utilities for targeted notification removal.
  * Descendant-space traversal to identify and clean notifications across full space hierarchies.

* **Chores**
  * Notification handling integrated into role management module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->