### PR TITLE
fix: converge user creation paths to ensure authorization is applied

### DIFF
--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -105,3 +105,5 @@ export const CREDENTIAL_RULE_TYPES_FORUM_CONTRIBUTE =
   'credentialRuleTypes-forumContribute';
 export const CREDENTIAL_RULE_TYPES_FORUM_CREATE_DISCUSSION =
   'credentialRuleTypes-forumCreateDiscussion';
+export const CREDENTIAL_RULE_TYPES_MESSAGING_CREATE_CONVERSATION =
+  'credentialRuleTypes-messagingCreateConversation';

--- a/src/common/exceptions/user/user.registered.exception.ts
+++ b/src/common/exceptions/user/user.registered.exception.ts
@@ -1,12 +1,18 @@
 import { LogContext, AlkemioErrorStatus } from '@common/enums';
 import { BaseException } from '../base.exception';
+import { ExceptionDetails } from '../exception.details';
 
 export class UserAlreadyRegisteredException extends BaseException {
   constructor(
     error: string,
     context = LogContext.COMMUNITY,
-    code?: AlkemioErrorStatus
+    details?: ExceptionDetails
   ) {
-    super(error, context, code ?? AlkemioErrorStatus.USER_ALREADY_REGISTERED);
+    super(
+      error,
+      context,
+      AlkemioErrorStatus.USER_ALREADY_REGISTERED,
+      details
+    );
   }
 }

--- a/src/domain/communication/messaging/messaging.service.authorization.spec.ts
+++ b/src/domain/communication/messaging/messaging.service.authorization.spec.ts
@@ -51,7 +51,7 @@ describe('MessagingAuthorizationService', () => {
     const mockAuthorizationPolicyService = {
       inheritParentAuthorization: jest.fn(),
       createCredentialRuleUsingTypesOnly: jest.fn().mockReturnValue({
-        name: 'messaging-create-conversation',
+        name: 'credentialRuleTypes-messagingCreateConversation',
         cascade: false,
         grantedPrivileges: ['CREATE'],
         criterias: [],
@@ -226,7 +226,7 @@ describe('MessagingAuthorizationService', () => {
       ).toHaveBeenCalledWith(
         ['create'],
         ['global-registered'],
-        'messaging-create-conversation'
+        'credentialRuleTypes-messagingCreateConversation'
       );
       expect(
         authorizationPolicyService.appendCredentialAuthorizationRules

--- a/src/domain/communication/messaging/messaging.service.authorization.ts
+++ b/src/domain/communication/messaging/messaging.service.authorization.ts
@@ -8,12 +8,10 @@ import {
   AuthorizationCredential,
   AuthorizationPrivilege,
 } from '@common/enums';
+import { CREDENTIAL_RULE_TYPES_MESSAGING_CREATE_CONVERSATION } from '@common/constants';
 
 @Injectable()
 export class MessagingAuthorizationService {
-  private static readonly CREDENTIAL_RULE_MESSAGING_CREATE_CONVERSATION =
-    'messaging-create-conversation';
-
   constructor(
     private readonly authorizationPolicyService: AuthorizationPolicyService,
     private readonly messagingService: MessagingService,
@@ -51,7 +49,7 @@ export class MessagingAuthorizationService {
       this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
         [AuthorizationPrivilege.CREATE],
         [AuthorizationCredential.GLOBAL_REGISTERED],
-        MessagingAuthorizationService.CREDENTIAL_RULE_MESSAGING_CREATE_CONVERSATION
+        CREDENTIAL_RULE_TYPES_MESSAGING_CREATE_CONVERSATION
       );
     createConversationRule.cascade = false;
 

--- a/src/domain/communication/messaging/messaging.service.ts
+++ b/src/domain/communication/messaging/messaging.service.ts
@@ -224,11 +224,12 @@ export class MessagingService {
    * @returns The platform messaging
    */
   public async getPlatformMessaging(): Promise<IMessaging> {
-    // Query the platform and load the messaging relation
+    // Query the platform and load the messaging relation with authorization
     const platform = await this.entityManager
       .getRepository('Platform')
       .createQueryBuilder('platform')
       .leftJoinAndSelect('platform.messaging', 'messaging')
+      .leftJoinAndSelect('messaging.authorization', 'authorization')
       .getOne();
 
     if (!platform) {

--- a/src/domain/community/user-authentication-link/user.authentication.link.module.ts
+++ b/src/domain/community/user-authentication-link/user.authentication.link.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '@domain/community/user/user.entity';
 import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
 import { UserAuthenticationLinkService } from './user.authentication.link.service';
+import { KratosModule } from '@services/infrastructure/kratos/kratos.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), UserLookupModule],
+  imports: [TypeOrmModule.forFeature([User]), UserLookupModule, KratosModule],
   providers: [UserAuthenticationLinkService],
   exports: [UserAuthenticationLinkService],
 })

--- a/src/domain/community/user-authentication-link/user.authentication.link.service.spec.ts
+++ b/src/domain/community/user-authentication-link/user.authentication.link.service.spec.ts
@@ -108,6 +108,7 @@ describe('UserAuthenticationLinkService', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Authentication ID mismatch'),
+      expect.any(String),
       LogContext.AUTH
     );
     expect(result?.outcome).toBe(UserAuthenticationLinkOutcome.CONFLICT);
@@ -195,6 +196,7 @@ describe('UserAuthenticationLinkService', () => {
     expect(result?.outcome).toBe(UserAuthenticationLinkOutcome.CONFLICT);
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Authentication ID already linked'),
+      expect.any(String),
       LogContext.AUTH
     );
   });

--- a/src/domain/community/user-authentication-link/user.authentication.link.service.spec.ts
+++ b/src/domain/community/user-authentication-link/user.authentication.link.service.spec.ts
@@ -27,6 +27,10 @@ describe('UserAuthenticationLinkService', () => {
       save: jest.fn(async user => user),
     };
 
+    const kratosService = {
+      getIdentityById: jest.fn(),
+    };
+
     const logger: LoggerService & {
       log: jest.Mock;
       verbose: jest.Mock;
@@ -42,10 +46,11 @@ describe('UserAuthenticationLinkService', () => {
     const service = new UserAuthenticationLinkService(
       userLookupService as any,
       userRepository as any,
+      kratosService as any,
       logger
     );
 
-    return { service, userLookupService, userRepository, logger };
+    return { service, userLookupService, userRepository, kratosService, logger };
   };
 
   it('returns existing user matched by authentication ID', async () => {
@@ -82,8 +87,8 @@ describe('UserAuthenticationLinkService', () => {
     expect(result?.user.authenticationID).toBe('auth-123');
   });
 
-  it('logs mismatch and returns conflict outcome when conflictMode is log', async () => {
-    const { service, userLookupService, logger } = createService();
+  it('logs mismatch and returns conflict outcome when conflictMode is log and old identity exists', async () => {
+    const { service, userLookupService, kratosService, logger } = createService();
 
     const existingUser = {
       id: 'user-3',
@@ -94,6 +99,8 @@ describe('UserAuthenticationLinkService', () => {
 
     userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
     userLookupService.getUserByEmail.mockResolvedValue(existingUser);
+    // Old identity still exists in Kratos
+    kratosService.getIdentityById.mockResolvedValue({ id: 'other-auth' });
 
     const result = await service.resolveExistingUser(createAgentInfo(), {
       conflictMode: 'log',
@@ -107,8 +114,8 @@ describe('UserAuthenticationLinkService', () => {
     expect(result?.user.authenticationID).toBe('other-auth');
   });
 
-  it('throws when mismatch occurs and conflictMode is error', async () => {
-    const { service, userLookupService } = createService();
+  it('throws when mismatch occurs and conflictMode is error and old identity exists', async () => {
+    const { service, userLookupService, kratosService } = createService();
 
     const existingUser = {
       id: 'user-4',
@@ -119,6 +126,8 @@ describe('UserAuthenticationLinkService', () => {
 
     userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
     userLookupService.getUserByEmail.mockResolvedValue(existingUser);
+    // Old identity still exists in Kratos
+    kratosService.getIdentityById.mockResolvedValue({ id: 'other-auth' });
 
     await expect(
       service.resolveExistingUser(createAgentInfo(), {
@@ -127,8 +136,35 @@ describe('UserAuthenticationLinkService', () => {
     ).rejects.toBeInstanceOf(UserAlreadyRegisteredException);
   });
 
+  it('allows relinking when old authentication ID no longer exists in Kratos', async () => {
+    const { service, userLookupService, kratosService, userRepository, logger } = createService();
+
+    const existingUser = {
+      id: 'user-relink',
+      email: 'user@example.com',
+      authenticationID: 'stale-auth',
+      agent: { credentials: [] },
+    };
+
+    userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
+    userLookupService.getUserByEmail.mockResolvedValue(existingUser);
+    // Old identity no longer exists in Kratos
+    kratosService.getIdentityById.mockResolvedValue(undefined);
+
+    const result = await service.resolveExistingUser(createAgentInfo());
+
+    expect(kratosService.getIdentityById).toHaveBeenCalledWith('stale-auth');
+    expect(logger.verbose).toHaveBeenCalledWith(
+      expect.stringContaining('no longer exists in Kratos'),
+      LogContext.AUTH
+    );
+    expect(userRepository.save).toHaveBeenCalled();
+    expect(result?.outcome).toBe(UserAuthenticationLinkOutcome.LINKED);
+    expect(result?.user.authenticationID).toBe('auth-123');
+  });
+
   it('prefers email lookup when requested even if authentication ID belongs to another user', async () => {
-    const { service, userLookupService, logger } = createService();
+    const { service, userLookupService, kratosService, logger } = createService();
 
     const conflictingUser = {
       id: 'user-5',
@@ -147,6 +183,8 @@ describe('UserAuthenticationLinkService', () => {
       conflictingUser
     );
     userLookupService.getUserByEmail.mockResolvedValue(emailUser);
+    // This test doesn't reach the Kratos check since authenticationID is null
+    kratosService.getIdentityById.mockResolvedValue(undefined);
 
     const result = await service.resolveExistingUser(createAgentInfo(), {
       conflictMode: 'log',

--- a/src/domain/community/user-authentication-link/user.authentication.link.service.ts
+++ b/src/domain/community/user-authentication-link/user.authentication.link.service.ts
@@ -101,11 +101,16 @@ export class UserAuthenticationLinkService {
 
       if (existingKratosIdentity) {
         // Old identity still exists - this is a real conflict
-        const message = `Authentication ID mismatch for user ${existingByEmail.id}: existing ${existingByEmail.authenticationID}, incoming ${authId}`;
-        this.logger.error?.(message, LogContext.AUTH);
+        this.logger.error?.(
+          'Authentication ID mismatch: user already linked to different identity',
+          new Error().stack,
+          LogContext.AUTH
+        );
         if (conflictMode === 'error') {
           throw new UserAlreadyRegisteredException(
-            `User with email: ${email} already registered`
+            'User already registered with different authentication ID',
+            LogContext.AUTH,
+            { email, existingAuthId: existingByEmail.authenticationID, incomingAuthId: authId }
           );
         }
         return {
@@ -171,11 +176,16 @@ export class UserAuthenticationLinkService {
       await this.userLookupService.getUserByAuthenticationID(authenticationId);
 
     if (existingUser && existingUser.id !== currentUserId) {
-      const message = `Authentication ID already linked to user ${existingUser.id}`;
-      this.logger.error?.(message, LogContext.AUTH);
+      this.logger.error?.(
+        'Authentication ID already linked to another user',
+        new Error().stack,
+        LogContext.AUTH
+      );
       if (conflictMode === 'error') {
         throw new UserAlreadyRegisteredException(
-          'Kratos identity already linked to another user'
+          'Kratos identity already linked to another user',
+          LogContext.AUTH,
+          { existingUserId: existingUser.id, authenticationId }
         );
       }
       return false;

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -356,7 +356,9 @@ export class UserService {
     return result;
   }
 
-  async createUserFromAgentInfo(agentInfo: AgentInfo): Promise<IUser> {
+  async createOrLinkUserFromAgentInfo(
+    agentInfo: AgentInfo
+  ): Promise<{ user: IUser; isNew: boolean }> {
     // Extra check that there is valid data + no user with the email
     const email = agentInfo.email;
     if (!email || email.length === 0) {
@@ -371,7 +373,7 @@ export class UserService {
       });
 
     if (resolvedUser) {
-      return resolvedUser.user;
+      return { user: resolvedUser.user, isNew: false };
     }
 
     const userData: CreateUserInput = {
@@ -389,7 +391,8 @@ export class UserService {
       },
     };
 
-    return await this.createUser(userData, agentInfo);
+    const user = await this.createUser(userData, agentInfo);
+    return { user, isNew: true };
   }
 
   async clearAuthenticationIDForUser(user: IUser): Promise<IUser> {

--- a/src/platform-admin/domain/user/authentication-id-backfill/authentication-id-backfill.service.ts
+++ b/src/platform-admin/domain/user/authentication-id-backfill/authentication-id-backfill.service.ts
@@ -126,8 +126,8 @@ export class AdminAuthenticationIDBackfillService {
       const agentInfo = this.buildAgentInfo(identity, user.email);
 
       try {
-        const updatedUser =
-          await this.userService.createUserFromAgentInfo(agentInfo);
+        const { user: updatedUser } =
+          await this.userService.createOrLinkUserFromAgentInfo(agentInfo);
         if (updatedUser.id !== user.id) {
           outcome.skipped += 1;
           this.logger.warn?.(

--- a/src/services/api/registration/registration.service.ts
+++ b/src/services/api/registration/registration.service.ts
@@ -22,12 +22,18 @@ import { RoleName } from '@common/enums/role.name';
 import { OrganizationLookupService } from '@domain/community/organization-lookup/organization.lookup.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { RelationshipNotFoundException } from '@common/exceptions';
+import { UserAuthorizationService } from '@domain/community/user/user.service.authorization';
+import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
+import { NotificationPlatformAdapter } from '@services/adapters/notification-adapter/notification.platform.adapter';
+import { NotificationInputPlatformUserRegistered } from '@services/adapters/notification-adapter/dto/platform/notification.dto.input.platform.user.registered';
 
 export class RegistrationService {
   constructor(
     private accountService: AccountService,
     private authorizationPolicyService: AuthorizationPolicyService,
     private userService: UserService,
+    private userAuthorizationService: UserAuthorizationService,
+    private accountAuthorizationService: AccountAuthorizationService,
     private organizationLookupService: OrganizationLookupService,
     private organizationService: OrganizationService,
     private platformInvitationService: PlatformInvitationService,
@@ -35,6 +41,7 @@ export class RegistrationService {
     private invitationService: InvitationService,
     private applicationService: ApplicationService,
     private roleSetService: RoleSetService,
+    private notificationPlatformAdapter: NotificationPlatformAdapter,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
@@ -56,7 +63,61 @@ export class RegistrationService {
     const user = await this.userService.createUserFromAgentInfo(agentInfo);
 
     await this.assignUserToOrganizationByDomain(user);
+
+    // Finalize registration: authorization + pending invitations
+    await this.finalizeUserRegistration(user);
+
     return user;
+  }
+
+  /**
+   * Finalizes user registration by applying authorization and processing pending invitations.
+   * This should be called after user entity creation, regardless of the creation path.
+   */
+  public async finalizeUserRegistration(user: IUser): Promise<IUser> {
+    // Grant essential credentials to the user
+    const userWithCredentials =
+      await this.userAuthorizationService.grantCredentialsAllUsersReceive(
+        user.id
+      );
+
+    // Apply and save user authorization policy
+    const userAuthorizations =
+      await this.userAuthorizationService.applyAuthorizationPolicy(
+        userWithCredentials.id
+      );
+    await this.authorizationPolicyService.saveAll(userAuthorizations);
+
+    // Apply and save account authorization policy
+    const userAccount = await this.userService.getAccount(userWithCredentials);
+    const accountAuthorizations =
+      await this.accountAuthorizationService.applyAuthorizationPolicy(
+        userAccount
+      );
+    await this.authorizationPolicyService.saveAll(accountAuthorizations);
+
+    // Process any pending invitations for this user
+    await this.processPendingInvitations(userWithCredentials);
+
+    // Send notification that user profile was created
+    await this.sendUserCreatedNotification(userWithCredentials);
+
+    this.logger.verbose?.(
+      `Finalized registration for user: ${user.id}`,
+      LogContext.AUTH
+    );
+
+    return userWithCredentials;
+  }
+
+  private async sendUserCreatedNotification(user: IUser): Promise<void> {
+    const notificationInput: NotificationInputPlatformUserRegistered = {
+      triggeredBy: user.id,
+      userID: user.id,
+    };
+    await this.notificationPlatformAdapter.platformUserProfileCreated(
+      notificationInput
+    );
   }
 
   async assignUserToOrganizationByDomain(user: IUser): Promise<boolean> {

--- a/src/services/api/registration/registration.service.ts
+++ b/src/services/api/registration/registration.service.ts
@@ -67,9 +67,9 @@ export class RegistrationService {
 
     // New user - finalize registration
     await this.assignUserToOrganizationByDomain(user);
-    await this.finalizeUserRegistration(user);
+    const finalizedUser = await this.finalizeUserRegistration(user);
 
-    return user;
+    return finalizedUser;
   }
 
   /**

--- a/test/mocks/user.service.mock.ts
+++ b/test/mocks/user.service.mock.ts
@@ -6,7 +6,7 @@ export const MockUserService: ValueProvider<PublicPart<UserService>> = {
   provide: UserService,
   useValue: {
     createUser: jest.fn(),
-    createUserFromAgentInfo: jest.fn(),
+    createOrLinkUserFromAgentInfo: jest.fn(),
     deleteUser: jest.fn(),
     save: jest.fn(),
     getUserOrFail: jest.fn(),


### PR DESCRIPTION
All three user creation paths (GraphQL self-registration, GraphQL admin, REST identity-resolve) now follow the same finalization logic via `finalizeUserRegistration()` in RegistrationService.

This fixes a bug where users created via the REST identity-resolve endpoint were missing authorization policies (empty credentialRules), causing "AuthorizationPolicy without credential rules" errors.

Changes:
- Move authorization logic from resolver to RegistrationService
- Add `finalizeUserRegistration()` method that handles:
  - Granting essential credentials (GLOBAL_REGISTERED)
  - Applying user authorization policy
  - Applying account authorization policy
  - Processing pending invitations
  - Sending user created notification
- Remove duplicate `processCreatedUser()` and `userCreatedEvents()` from resolver

## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Registration now uses a single finalize flow that applies authorizations, processes invitations, and returns the finalized user.

* **New Features**
  * Sends a post-registration user-created notification.
  * External identity provider check enables safe relinking when an old identity is missing.
  * Messaging: registered users can create conversations; messaging loads authorization eagerly.

* **Bug Fixes**
  * Avoids false conflicts by permitting relinking when external identity no longer exists.

* **Tests**
  * Updated tests for relinking, identity scenarios, and create-or-link user flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->