### PR TITLE
fixes to the conversation PR

### DIFF
--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -181,6 +181,8 @@ services:
         fi
 
   oidc-service:
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_oidc_service
     image: docker.io/alkemio/oidc-service:v0.7.1
     platform: linux/amd64

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -180,6 +180,8 @@ services:
         fi
 
   oidc-service:
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_oidc_service
     image: docker.io/alkemio/oidc-service:v0.7.1
     platform: linux/amd64

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -197,6 +197,8 @@ services:
         fi
 
   oidc-service:
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_oidc_service
     image: docker.io/alkemio/oidc-service:v0.7.1
     platform: linux/amd64

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -217,6 +217,8 @@ services:
         fi
 
   oidc-service:
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_oidc_service
     image: docker.io/alkemio/oidc-service:v0.7.1
     platform: linux/amd64

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -105,3 +105,5 @@ export const CREDENTIAL_RULE_TYPES_FORUM_CONTRIBUTE =
   'credentialRuleTypes-forumContribute';
 export const CREDENTIAL_RULE_TYPES_FORUM_CREATE_DISCUSSION =
   'credentialRuleTypes-forumCreateDiscussion';
+export const CREDENTIAL_RULE_TYPES_MESSAGING_CREATE_CONVERSATION =
+  'credentialRuleTypes-messagingCreateConversation';

--- a/src/common/exceptions/user/user.registered.exception.ts
+++ b/src/common/exceptions/user/user.registered.exception.ts
@@ -1,12 +1,18 @@
 import { LogContext, AlkemioErrorStatus } from '@common/enums';
 import { BaseException } from '../base.exception';
+import { ExceptionDetails } from '../exception.details';
 
 export class UserAlreadyRegisteredException extends BaseException {
   constructor(
     error: string,
     context = LogContext.COMMUNITY,
-    code?: AlkemioErrorStatus
+    details?: ExceptionDetails
   ) {
-    super(error, context, code ?? AlkemioErrorStatus.USER_ALREADY_REGISTERED);
+    super(
+      error,
+      context,
+      AlkemioErrorStatus.USER_ALREADY_REGISTERED,
+      details
+    );
   }
 }

--- a/src/domain/communication/messaging/messaging.service.authorization.spec.ts
+++ b/src/domain/communication/messaging/messaging.service.authorization.spec.ts
@@ -50,6 +50,13 @@ describe('MessagingAuthorizationService', () => {
   beforeEach(async () => {
     const mockAuthorizationPolicyService = {
       inheritParentAuthorization: jest.fn(),
+      createCredentialRuleUsingTypesOnly: jest.fn().mockReturnValue({
+        name: 'credentialRuleTypes-messagingCreateConversation',
+        cascade: false,
+        grantedPrivileges: ['CREATE'],
+        criterias: [],
+      }),
+      appendCredentialAuthorizationRules: jest.fn().mockImplementation(auth => auth),
       saveAll: jest.fn(),
     };
 
@@ -198,6 +205,32 @@ describe('MessagingAuthorizationService', () => {
         conversationAuthorizationService.applyAuthorizationPolicy
       ).not.toHaveBeenCalled();
       expect(result).toHaveLength(1); // Only the set authorization
+    });
+
+    it('should grant CREATE privilege to registered users for creating conversations', async () => {
+      messagingService.getMessagingOrFail.mockResolvedValue(mockMessaging);
+      authorizationPolicyService.inheritParentAuthorization.mockReturnValue(
+        mockMessaging.authorization as IAuthorizationPolicy
+      );
+      conversationAuthorizationService.applyAuthorizationPolicy.mockResolvedValue(
+        [{ id: 'conv-auth-1' } as IAuthorizationPolicy]
+      );
+
+      await service.applyAuthorizationPolicy(
+        mockMessaging,
+        mockParentAuthorization
+      );
+
+      expect(
+        authorizationPolicyService.createCredentialRuleUsingTypesOnly
+      ).toHaveBeenCalledWith(
+        ['create'],
+        ['global-registered'],
+        'credentialRuleTypes-messagingCreateConversation'
+      );
+      expect(
+        authorizationPolicyService.appendCredentialAuthorizationRules
+      ).toHaveBeenCalled();
     });
   });
 });

--- a/src/domain/communication/messaging/messaging.service.authorization.ts
+++ b/src/domain/communication/messaging/messaging.service.authorization.ts
@@ -4,6 +4,11 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy/author
 import { ConversationAuthorizationService } from '../conversation/conversation.service.authorization';
 import { IMessaging } from './messaging.interface';
 import { MessagingService } from './messaging.service';
+import {
+  AuthorizationCredential,
+  AuthorizationPrivilege,
+} from '@common/enums';
+import { CREDENTIAL_RULE_TYPES_MESSAGING_CREATE_CONVERSATION } from '@common/constants';
 
 @Injectable()
 export class MessagingAuthorizationService {
@@ -34,6 +39,24 @@ export class MessagingAuthorizationService {
       this.authorizationPolicyService.inheritParentAuthorization(
         messaging.authorization,
         parentAuthorization
+      );
+
+    // Allow registered users to create conversations
+    // Note: Before the refactor (8f8887ce3), each user had their own conversationsSet
+    // which inherited from their user authorization. Now with platform-owned messaging,
+    // we need to explicitly grant CREATE to registered users.
+    const createConversationRule =
+      this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
+        [AuthorizationPrivilege.CREATE],
+        [AuthorizationCredential.GLOBAL_REGISTERED],
+        CREDENTIAL_RULE_TYPES_MESSAGING_CREATE_CONVERSATION
+      );
+    createConversationRule.cascade = false;
+
+    messaging.authorization =
+      this.authorizationPolicyService.appendCredentialAuthorizationRules(
+        messaging.authorization,
+        [createConversationRule]
       );
 
     updatedAuthorizations.push(messaging.authorization);

--- a/src/domain/communication/messaging/messaging.service.ts
+++ b/src/domain/communication/messaging/messaging.service.ts
@@ -224,11 +224,12 @@ export class MessagingService {
    * @returns The platform messaging
    */
   public async getPlatformMessaging(): Promise<IMessaging> {
-    // Query the platform and load the messaging relation
+    // Query the platform and load the messaging relation with authorization
     const platform = await this.entityManager
       .getRepository('Platform')
       .createQueryBuilder('platform')
       .leftJoinAndSelect('platform.messaging', 'messaging')
+      .leftJoinAndSelect('messaging.authorization', 'authorization')
       .getOne();
 
     if (!platform) {

--- a/src/domain/community/user-authentication-link/user.authentication.link.module.ts
+++ b/src/domain/community/user-authentication-link/user.authentication.link.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '@domain/community/user/user.entity';
 import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
 import { UserAuthenticationLinkService } from './user.authentication.link.service';
+import { KratosModule } from '@services/infrastructure/kratos/kratos.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), UserLookupModule],
+  imports: [TypeOrmModule.forFeature([User]), UserLookupModule, KratosModule],
   providers: [UserAuthenticationLinkService],
   exports: [UserAuthenticationLinkService],
 })

--- a/src/domain/community/user-authentication-link/user.authentication.link.service.spec.ts
+++ b/src/domain/community/user-authentication-link/user.authentication.link.service.spec.ts
@@ -27,6 +27,10 @@ describe('UserAuthenticationLinkService', () => {
       save: jest.fn(async user => user),
     };
 
+    const kratosService = {
+      getIdentityById: jest.fn(),
+    };
+
     const logger: LoggerService & {
       log: jest.Mock;
       verbose: jest.Mock;
@@ -42,10 +46,11 @@ describe('UserAuthenticationLinkService', () => {
     const service = new UserAuthenticationLinkService(
       userLookupService as any,
       userRepository as any,
+      kratosService as any,
       logger
     );
 
-    return { service, userLookupService, userRepository, logger };
+    return { service, userLookupService, userRepository, kratosService, logger };
   };
 
   it('returns existing user matched by authentication ID', async () => {
@@ -82,8 +87,8 @@ describe('UserAuthenticationLinkService', () => {
     expect(result?.user.authenticationID).toBe('auth-123');
   });
 
-  it('logs mismatch and returns conflict outcome when conflictMode is log', async () => {
-    const { service, userLookupService, logger } = createService();
+  it('logs mismatch and returns conflict outcome when conflictMode is log and old identity exists', async () => {
+    const { service, userLookupService, kratosService, logger } = createService();
 
     const existingUser = {
       id: 'user-3',
@@ -94,6 +99,8 @@ describe('UserAuthenticationLinkService', () => {
 
     userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
     userLookupService.getUserByEmail.mockResolvedValue(existingUser);
+    // Old identity still exists in Kratos
+    kratosService.getIdentityById.mockResolvedValue({ id: 'other-auth' });
 
     const result = await service.resolveExistingUser(createAgentInfo(), {
       conflictMode: 'log',
@@ -101,14 +108,15 @@ describe('UserAuthenticationLinkService', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Authentication ID mismatch'),
+      expect.any(String),
       LogContext.AUTH
     );
     expect(result?.outcome).toBe(UserAuthenticationLinkOutcome.CONFLICT);
     expect(result?.user.authenticationID).toBe('other-auth');
   });
 
-  it('throws when mismatch occurs and conflictMode is error', async () => {
-    const { service, userLookupService } = createService();
+  it('throws when mismatch occurs and conflictMode is error and old identity exists', async () => {
+    const { service, userLookupService, kratosService } = createService();
 
     const existingUser = {
       id: 'user-4',
@@ -119,6 +127,8 @@ describe('UserAuthenticationLinkService', () => {
 
     userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
     userLookupService.getUserByEmail.mockResolvedValue(existingUser);
+    // Old identity still exists in Kratos
+    kratosService.getIdentityById.mockResolvedValue({ id: 'other-auth' });
 
     await expect(
       service.resolveExistingUser(createAgentInfo(), {
@@ -127,8 +137,35 @@ describe('UserAuthenticationLinkService', () => {
     ).rejects.toBeInstanceOf(UserAlreadyRegisteredException);
   });
 
+  it('allows relinking when old authentication ID no longer exists in Kratos', async () => {
+    const { service, userLookupService, kratosService, userRepository, logger } = createService();
+
+    const existingUser = {
+      id: 'user-relink',
+      email: 'user@example.com',
+      authenticationID: 'stale-auth',
+      agent: { credentials: [] },
+    };
+
+    userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
+    userLookupService.getUserByEmail.mockResolvedValue(existingUser);
+    // Old identity no longer exists in Kratos
+    kratosService.getIdentityById.mockResolvedValue(undefined);
+
+    const result = await service.resolveExistingUser(createAgentInfo());
+
+    expect(kratosService.getIdentityById).toHaveBeenCalledWith('stale-auth');
+    expect(logger.verbose).toHaveBeenCalledWith(
+      expect.stringContaining('no longer exists in Kratos'),
+      LogContext.AUTH
+    );
+    expect(userRepository.save).toHaveBeenCalled();
+    expect(result?.outcome).toBe(UserAuthenticationLinkOutcome.LINKED);
+    expect(result?.user.authenticationID).toBe('auth-123');
+  });
+
   it('prefers email lookup when requested even if authentication ID belongs to another user', async () => {
-    const { service, userLookupService, logger } = createService();
+    const { service, userLookupService, kratosService, logger } = createService();
 
     const conflictingUser = {
       id: 'user-5',
@@ -147,6 +184,8 @@ describe('UserAuthenticationLinkService', () => {
       conflictingUser
     );
     userLookupService.getUserByEmail.mockResolvedValue(emailUser);
+    // This test doesn't reach the Kratos check since authenticationID is null
+    kratosService.getIdentityById.mockResolvedValue(undefined);
 
     const result = await service.resolveExistingUser(createAgentInfo(), {
       conflictMode: 'log',
@@ -157,6 +196,7 @@ describe('UserAuthenticationLinkService', () => {
     expect(result?.outcome).toBe(UserAuthenticationLinkOutcome.CONFLICT);
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Authentication ID already linked'),
+      expect.any(String),
       LogContext.AUTH
     );
   });

--- a/src/domain/community/user-authentication-link/user.authentication.link.service.ts
+++ b/src/domain/community/user-authentication-link/user.authentication.link.service.ts
@@ -7,6 +7,7 @@ import { User } from '@domain/community/user/user.entity';
 import { LogContext } from '@common/enums';
 import { UserAlreadyRegisteredException } from '@common/exceptions';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { KratosService } from '@services/infrastructure/kratos/kratos.service';
 import {
   UserAuthenticationLinkConflictMode,
   UserAuthenticationLinkMatch,
@@ -21,6 +22,7 @@ export class UserAuthenticationLinkService {
     private readonly userLookupService: UserLookupService,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    private readonly kratosService: KratosService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
   ) {}
@@ -92,18 +94,37 @@ export class UserAuthenticationLinkService {
       existingByEmail.authenticationID &&
       existingByEmail.authenticationID !== authId
     ) {
-      const message = `Authentication ID mismatch for user ${existingByEmail.id}: existing ${existingByEmail.authenticationID}, incoming ${authId}`;
-      this.logger.error?.(message, LogContext.AUTH);
-      if (conflictMode === 'error') {
-        throw new UserAlreadyRegisteredException(
-          `User with email: ${email} already registered`
+      // Check if the existing authenticationID is still valid in Kratos
+      const existingKratosIdentity = await this.kratosService.getIdentityById(
+        existingByEmail.authenticationID
+      );
+
+      if (existingKratosIdentity) {
+        // Old identity still exists - this is a real conflict
+        this.logger.error?.(
+          'Authentication ID mismatch: user already linked to different identity',
+          new Error().stack,
+          LogContext.AUTH
         );
+        if (conflictMode === 'error') {
+          throw new UserAlreadyRegisteredException(
+            'User already registered with different authentication ID',
+            LogContext.AUTH,
+            { email, existingAuthId: existingByEmail.authenticationID, incomingAuthId: authId }
+          );
+        }
+        return {
+          user: existingByEmail,
+          matchedBy: UserAuthenticationLinkMatch.EMAIL,
+          outcome: UserAuthenticationLinkOutcome.CONFLICT,
+        };
       }
-      return {
-        user: existingByEmail,
-        matchedBy: UserAuthenticationLinkMatch.EMAIL,
-        outcome: UserAuthenticationLinkOutcome.CONFLICT,
-      };
+
+      // Old identity no longer exists in Kratos - allow relinking
+      this.logger.verbose?.(
+        `Old authentication ID ${existingByEmail.authenticationID} no longer exists in Kratos, allowing relink to ${authId}`,
+        LogContext.AUTH
+      );
     }
 
     const availability = await this.checkAuthenticationIdAvailability(
@@ -155,11 +176,16 @@ export class UserAuthenticationLinkService {
       await this.userLookupService.getUserByAuthenticationID(authenticationId);
 
     if (existingUser && existingUser.id !== currentUserId) {
-      const message = `Authentication ID already linked to user ${existingUser.id}`;
-      this.logger.error?.(message, LogContext.AUTH);
+      this.logger.error?.(
+        'Authentication ID already linked to another user',
+        new Error().stack,
+        LogContext.AUTH
+      );
       if (conflictMode === 'error') {
         throw new UserAlreadyRegisteredException(
-          'Kratos identity already linked to another user'
+          'Kratos identity already linked to another user',
+          LogContext.AUTH,
+          { existingUserId: existingUser.id, authenticationId }
         );
       }
       return false;

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -356,7 +356,9 @@ export class UserService {
     return result;
   }
 
-  async createUserFromAgentInfo(agentInfo: AgentInfo): Promise<IUser> {
+  async createOrLinkUserFromAgentInfo(
+    agentInfo: AgentInfo
+  ): Promise<{ user: IUser; isNew: boolean }> {
     // Extra check that there is valid data + no user with the email
     const email = agentInfo.email;
     if (!email || email.length === 0) {
@@ -371,7 +373,7 @@ export class UserService {
       });
 
     if (resolvedUser) {
-      return resolvedUser.user;
+      return { user: resolvedUser.user, isNew: false };
     }
 
     const userData: CreateUserInput = {
@@ -389,7 +391,8 @@ export class UserService {
       },
     };
 
-    return await this.createUser(userData, agentInfo);
+    const user = await this.createUser(userData, agentInfo);
+    return { user, isNew: true };
   }
 
   async clearAuthenticationIDForUser(user: IUser): Promise<IUser> {

--- a/src/platform-admin/domain/user/authentication-id-backfill/authentication-id-backfill.service.ts
+++ b/src/platform-admin/domain/user/authentication-id-backfill/authentication-id-backfill.service.ts
@@ -126,8 +126,8 @@ export class AdminAuthenticationIDBackfillService {
       const agentInfo = this.buildAgentInfo(identity, user.email);
 
       try {
-        const updatedUser =
-          await this.userService.createUserFromAgentInfo(agentInfo);
+        const { user: updatedUser } =
+          await this.userService.createOrLinkUserFromAgentInfo(agentInfo);
         if (updatedUser.id !== user.id) {
           outcome.skipped += 1;
           this.logger.warn?.(

--- a/src/services/api/registration/registration.service.ts
+++ b/src/services/api/registration/registration.service.ts
@@ -22,12 +22,18 @@ import { RoleName } from '@common/enums/role.name';
 import { OrganizationLookupService } from '@domain/community/organization-lookup/organization.lookup.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
 import { RelationshipNotFoundException } from '@common/exceptions';
+import { UserAuthorizationService } from '@domain/community/user/user.service.authorization';
+import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
+import { NotificationPlatformAdapter } from '@services/adapters/notification-adapter/notification.platform.adapter';
+import { NotificationInputPlatformUserRegistered } from '@services/adapters/notification-adapter/dto/platform/notification.dto.input.platform.user.registered';
 
 export class RegistrationService {
   constructor(
     private accountService: AccountService,
     private authorizationPolicyService: AuthorizationPolicyService,
     private userService: UserService,
+    private userAuthorizationService: UserAuthorizationService,
+    private accountAuthorizationService: AccountAuthorizationService,
     private organizationLookupService: OrganizationLookupService,
     private organizationService: OrganizationService,
     private platformInvitationService: PlatformInvitationService,
@@ -35,6 +41,7 @@ export class RegistrationService {
     private invitationService: InvitationService,
     private applicationService: ApplicationService,
     private roleSetService: RoleSetService,
+    private notificationPlatformAdapter: NotificationPlatformAdapter,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
@@ -46,17 +53,73 @@ export class RegistrationService {
       );
     }
 
-    if (agentInfo.authenticationID) {
+    const { user, isNew } =
+      await this.userService.createOrLinkUserFromAgentInfo(agentInfo);
+
+    if (!isNew) {
+      // User was linked - no finalization needed, they already have credentials
       this.logger.verbose?.(
-        'Received Kratos authentication ID for registration flow',
+        `Existing user ${user.id} linked to authentication ID`,
         LogContext.AUTH
       );
+      return user;
     }
-    // If a user has a valid session, and hence email / names etc set, then they can create a User profile
-    const user = await this.userService.createUserFromAgentInfo(agentInfo);
 
+    // New user - finalize registration
     await this.assignUserToOrganizationByDomain(user);
-    return user;
+    const finalizedUser = await this.finalizeUserRegistration(user);
+
+    return finalizedUser;
+  }
+
+  /**
+   * Finalizes user registration by applying authorization and processing pending invitations.
+   * This should be called after user entity creation, regardless of the creation path.
+   */
+  public async finalizeUserRegistration(user: IUser): Promise<IUser> {
+    // Grant essential credentials to the user
+    const userWithCredentials =
+      await this.userAuthorizationService.grantCredentialsAllUsersReceive(
+        user.id
+      );
+
+    // Apply and save user authorization policy
+    const userAuthorizations =
+      await this.userAuthorizationService.applyAuthorizationPolicy(
+        userWithCredentials.id
+      );
+    await this.authorizationPolicyService.saveAll(userAuthorizations);
+
+    // Apply and save account authorization policy
+    const userAccount = await this.userService.getAccount(userWithCredentials);
+    const accountAuthorizations =
+      await this.accountAuthorizationService.applyAuthorizationPolicy(
+        userAccount
+      );
+    await this.authorizationPolicyService.saveAll(accountAuthorizations);
+
+    // Process any pending invitations for this user
+    await this.processPendingInvitations(userWithCredentials);
+
+    // Send notification that user profile was created
+    await this.sendUserCreatedNotification(userWithCredentials);
+
+    this.logger.verbose?.(
+      `Finalized registration for user: ${user.id}`,
+      LogContext.AUTH
+    );
+
+    return userWithCredentials;
+  }
+
+  private async sendUserCreatedNotification(user: IUser): Promise<void> {
+    const notificationInput: NotificationInputPlatformUserRegistered = {
+      triggeredBy: user.id,
+      userID: user.id,
+    };
+    await this.notificationPlatformAdapter.platformUserProfileCreated(
+      notificationInput
+    );
   }
 
   async assignUserToOrganizationByDomain(user: IUser): Promise<boolean> {

--- a/test/mocks/user.service.mock.ts
+++ b/test/mocks/user.service.mock.ts
@@ -6,7 +6,7 @@ export const MockUserService: ValueProvider<PublicPart<UserService>> = {
   provide: UserService,
   useValue: {
     createUser: jest.fn(),
-    createUserFromAgentInfo: jest.fn(),
+    createOrLinkUserFromAgentInfo: jest.fn(),
     deleteUser: jest.fn(),
     save: jest.fn(),
     getUserOrFail: jest.fn(),


### PR DESCRIPTION
This pull request introduces several improvements and fixes across authentication, authorization, and service configuration. The most significant changes include enhanced user authentication linking logic with Kratos identity checks, explicit granting of messaging conversation creation privileges to registered users, and updates to Docker Compose service files to support host networking. Below are the most important changes grouped by theme:

**Authentication and User Linking Enhancements:**

* The `UserAuthenticationLinkService` now checks with Kratos to determine if an old authentication ID still exists before deciding whether to allow relinking a user to a new authentication ID. If the old ID no longer exists, relinking is permitted; otherwise, a conflict is logged or an exception is thrown depending on the conflict mode. Logging and exception details have been improved to provide more context. [[1]](diffhunk://#diff-864e6570c7cef247eeab30e6bf438be4818005e593a8f202171a4e27a2a16e51L95-R113) [[2]](diffhunk://#diff-864e6570c7cef247eeab30e6bf438be4818005e593a8f202171a4e27a2a16e51R123-R129) [[3]](diffhunk://#diff-864e6570c7cef247eeab30e6bf438be4818005e593a8f202171a4e27a2a16e51L158-R188) [[4]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124R30-R33) [[5]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124R49-R53) [[6]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124L85-R91) [[7]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124R102-R119) [[8]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124R130-R131) [[9]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124R140-R168) [[10]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124R187-R188) [[11]](diffhunk://#diff-cce5b75eba51ad448b09f88fd3b939c8ea974bf9910af8bb06d37808ba8be124R199) [[12]](diffhunk://#diff-62b8f6e92272d6d724bae94b77fce384d023e2c7c4fcdc8aea4d9e8b09d2bb12R6-R9) [[13]](diffhunk://#diff-864e6570c7cef247eeab30e6bf438be4818005e593a8f202171a4e27a2a16e51R10) [[14]](diffhunk://#diff-864e6570c7cef247eeab30e6bf438be4818005e593a8f202171a4e27a2a16e51R25) [[15]](diffhunk://#diff-25b41e1bf6b0d42f785ecab4a65e7129142aa96fe16b6733ad0371b506e6b2edR3-R16)

**Authorization and Privileges:**

* Registered users are now explicitly granted the `CREATE` privilege for creating messaging conversations via a new credential rule type (`credentialRuleTypes-messagingCreateConversation`). This is enforced in `MessagingAuthorizationService` and covered by new and updated tests. [[1]](diffhunk://#diff-e6f7dc41d3c87039307a526a0bcd45dcaf5c8344ee5fba23004d148a6cf02ab0R108-R109) [[2]](diffhunk://#diff-66fc3a81d1d1b2fd634a4cdfaad050cb32c9ad7064b086e29618fd3b772cbbf5R7-R11) [[3]](diffhunk://#diff-66fc3a81d1d1b2fd634a4cdfaad050cb32c9ad7064b086e29618fd3b772cbbf5R44-R61) [[4]](diffhunk://#diff-bfbe44eb4b58e3e7655bfe8a6c0efa00fe83db970e7ce259435093f9f2fc115eR53-R59) [[5]](diffhunk://#diff-bfbe44eb4b58e3e7655bfe8a6c0efa00fe83db970e7ce259435093f9f2fc115eR209-R234)

**Service Configuration (Docker Compose):**

* Added `extra_hosts` configuration for `oidc-service` in all relevant Docker Compose files to map `host.docker.internal` to `host-gateway`, improving container-to-host network communication. [[1]](diffhunk://#diff-01e1178df16632cd0c7ac44c98314a1561debb20010e4c4145ba91d13b65f359R220-R221) [[2]](diffhunk://#diff-7675f100a586a43aa45fc07cbf1b282970a71c11f5e505ee5f708917ca66a757R200-R201) [[3]](diffhunk://#diff-173caa8e83eb3884333d039392b5da98e7141a4c8f49eb6fc0d4324f18cdc30bR184-R185) [[4]](diffhunk://#diff-a8adb3d9bf60e525421fdfd4cfd36336b548b87db7287de5c49274b2ea353df5R183-R184)

**Messaging Service Improvements:**

* The `getPlatformMessaging` method now loads the `authorization` relation along with the messaging entity, ensuring authorization data is readily available.

**Testing and Naming Consistency:**

* Test descriptions and mocks have been updated for clarity and to reflect the new authentication linking logic and service method names. [[1]](diffhunk://#diff-3f92ebaac27eb1d326d50884ca148186b0f58f3508aa9af5d8b641aca7948224L52-R52) [[2]](diffhunk://#diff-3f92ebaac27eb1d326d50884ca148186b0f58f3508aa9af5d8b641aca7948224L105-R105)refactor: move messaging credential rule constant to common constants

Rename CREDENTIAL_RULE_MESSAGING_CREATE_CONVERSATION to CREDENTIAL_RULE_TYPES_MESSAGING_CREATE_CONVERSATION and move to src/common/constants/authorization/credential.rule.types.constants.ts to follow existing codebase conventions.

fix: improve exception handling and logging in user auth linking

- Update UserAlreadyRegisteredException to support structured details parameter
- Fix logger.error calls to use 3-arg signature (message, stack, context)
- Remove dynamic data from exception messages, use details property instead
- Return finalized user from registerNewUser to reflect credential updates
- Update tests to expect new logger signature

fix: grant CREATE privilege to registered users on platform messaging

After the conversation consolidation refactor (8f8887ce3), the authorization model changed from user-owned conversationsSet to platform-owned messaging. This broke conversation creation for regular users since they no longer inherited CREATE from their own entity.

- Add credential rule granting CREATE to GLOBAL_REGISTERED users
- Load authorization relation in getPlatformMessaging query
- Add test for new credential rule

Note: Requires authorizationPolicyResetOnPlatform mutation after deploy.

fix: skip finalization for linked users, rename createOrLinkUserFromAgentInfo

When linking an existing user to a Kratos identity, skip finalization (credential granting, authorization, notifications) since the user already has everything set up from their original creation.

Changes:
- Rename createUserFromAgentInfo → createOrLinkUserFromAgentInfo (clearer intent: method either creates or links)
- Return { user, isNew } to indicate if user was created or linked
- registerNewUser only calls finalizeUserRegistration when isNew=true
- Linked users (isNew=false) return immediately

This fixes the "Agent already has credential" error when linking bootstrap-created users like admin@alkem.io.

fix: allow relinking when old Kratos identity no longer exists

When a user has a different authenticationID stored, check with Kratos if the old identity still exists before failing. If the old identity is stale (deleted from Kratos), allow relinking to the new authID.

This handles cases where a user's Kratos identity was deleted and recreated, allowing them to link to their existing Alkemio account.

Changes:
- Add KratosService dependency to UserAuthenticationLinkService
- Check getIdentityById before rejecting authID mismatch
- If old identity gone, log and proceed with relinking
- Add test for relinking scenario

fix: converge user creation paths to ensure authorization is applied

All three user creation paths (GraphQL self-registration, GraphQL admin, REST identity-resolve) now follow the same finalization logic via `finalizeUserRegistration()` in RegistrationService.

This fixes a bug where users created via the REST identity-resolve endpoint were missing authorization policies (empty credentialRules), causing "AuthorizationPolicy without credential rules" errors.

Changes:
- Move authorization logic from resolver to RegistrationService
- Add `finalizeUserRegistration()` method that handles:
  - Granting essential credentials (GLOBAL_REGISTERED)
  - Applying user authorization policy
  - Applying account authorization policy
  - Processing pending invitations
  - Sending user created notification
- Remove duplicate `processCreatedUser()` and `userCreatedEvents()` from resolver

## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced user registration process with streamlined authorization and credential setup.
  * Improved authentication ID conflict detection to distinguish between stale and active conflicts.

* **Bug Fixes**
  * Better error handling for duplicate authentication scenarios with detailed exception context.

* **Improvements**
  * Platform now sends user creation notifications as part of the registration finalization flow.
  * Refined authentication link resolution to support seamless user account linking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->