### PR TITLE
fix: workaround Matrix power level mismatch for admin moderation actions

### DIFF
--- a/docs/matrix-admin-reflection.md
+++ b/docs/matrix-admin-reflection.md
@@ -1,0 +1,125 @@
+# Matrix Admin Rights Reflection
+
+This document tracks requirements and findings for implementing proper reflection of Alkemio authorization privileges to Matrix room power levels.
+
+## Problem Statement
+
+Alkemio has its own authorization system where users can be granted DELETE privileges on Rooms (and other entities). However, these privileges are not currently reflected in the underlying Matrix server's power level system.
+
+Matrix uses "power levels" to determine what actions users can perform:
+- **Power level 0**: Default user (can send messages)
+- **Power level 50**: Moderator (can kick users, redact messages)
+- **Power level 100**: Admin (full control)
+
+When an Alkemio admin tries to delete another user's message:
+1. Alkemio correctly authorizes the action via its own permission system
+2. The Matrix API call fails because the admin doesn't have moderator power level in Matrix
+3. Current workaround: Impersonate the message sender to delete the message
+
+## Current Workarounds
+
+### 1. Message Deletion (`removeRoomMessage`)
+
+See `src/domain/communication/room/room.service.ts:removeRoomMessage()`
+
+The workaround:
+1. Looks up the original message sender's actorId
+2. Deletes the message AS the sender (impersonation)
+
+### 2. Reaction Removal (`removeReactionToMessage`)
+
+See `src/domain/communication/room/room.service.ts:removeReactionToMessage()`
+
+The workaround:
+1. Looks up the original reaction sender's actorId
+2. Removes the reaction AS the sender (impersonation)
+
+**Note:** Matrix reaction removal semantics may differ from message deletion - needs testing to confirm whether moderators can even remove others' reactions via standard APIs.
+
+**Issues with these approaches:**
+- Audit trail shows sender performed the action, not the admin
+- Doesn't scale to other moderation actions (banning, kicking, etc.)
+- Potential security concerns with impersonation pattern
+
+## Requirements for Proper Implementation
+
+### 1. Power Level Synchronization
+
+When Alkemio grants a user DELETE privilege on a Room, we need to:
+- Update the user's power level in the corresponding Matrix room to moderator (50) or higher
+- Handle this for all room types where message deletion is permitted
+
+### 2. Events/Triggers to Handle
+
+Power level updates should occur when:
+- [ ] User is granted role with DELETE privilege on a room
+- [ ] User is removed from role with DELETE privilege
+- [ ] Room is created (set initial power levels)
+- [ ] Space/subspace admin status changes
+- [ ] Global platform admin status changes
+
+### 3. Affected Operations
+
+Operations that require Matrix moderator rights:
+- [x] Delete/redact messages (`removeRoomMessage`) - **WORKAROUND APPLIED**
+- [x] Remove reactions (`removeReactionToMessage`) - **WORKAROUND APPLIED**
+- [ ] Kick users from rooms (future)
+- [ ] Ban users from rooms (future)
+
+## Findings
+
+<!-- Add findings here as we investigate -->
+
+### Finding 1: [Date - Author]
+
+_Add findings about Matrix power level API, current adapter capabilities, etc._
+
+---
+
+### Finding 2: [Date - Author]
+
+_Add findings about authorization events that could trigger power level updates_
+
+---
+
+## Implementation Considerations
+
+### Option A: Lazy Synchronization
+Update Matrix power levels at the time of the moderation action.
+
+**Pros:**
+- Simpler to implement initially
+- No need to track authorization changes
+
+**Cons:**
+- Additional latency on moderation actions
+- May still fail if Matrix state is inconsistent
+
+### Option B: Eager Synchronization
+Update Matrix power levels whenever Alkemio authorization changes.
+
+**Pros:**
+- Moderation actions work immediately
+- Cleaner separation of concerns
+
+**Cons:**
+- Need to hook into authorization change events
+- More complex to implement
+- Need to handle edge cases (offline Matrix server, etc.)
+
+### Option C: Hybrid Approach
+Eager sync for known admin roles, lazy sync as fallback.
+
+---
+
+## Related Files
+
+- `src/domain/communication/room/room.service.ts` - Room operations with workaround
+- `src/domain/communication/room/room.resolver.mutations.ts` - GraphQL mutations
+- `src/services/adapters/communication-adapter/` - Matrix adapter
+- `src/core/authorization/` - Authorization system
+
+## References
+
+- [Matrix Power Levels Spec](https://spec.matrix.org/latest/client-server-api/#mroompower_levels)
+- [Synapse Admin API](https://matrix-org.github.io/synapse/latest/admin_api/)

--- a/src/domain/communication/room/room.resolver.mutations.ts
+++ b/src/domain/communication/room/room.resolver.mutations.ts
@@ -471,10 +471,12 @@ export class RoomResolverMutations {
       AuthorizationPrivilege.DELETE,
       `room remove message: ${room.id}`
     );
+    // Pass agentInfo.agentID for future use when Matrix admin reflection is implemented
+    // See: docs/matrix-admin-reflection.md
     const messageID = await this.roomService.removeRoomMessage(
       room,
-      agentInfo.agentID,
-      messageData
+      messageData,
+      agentInfo.agentID
     );
     await this.inAppNotificationService.deleteAllByMessageId(messageID);
     await this.roomServiceEvents.processActivityMessageRemoved(
@@ -526,6 +528,8 @@ export class RoomResolverMutations {
       `room remove reaction: ${room.id}`
     );
 
+    // Pass agentInfo.agentID for future use when Matrix admin reflection is implemented
+    // See: docs/matrix-admin-reflection.md
     const isDeleted = await this.roomService.removeReactionToMessage(
       room,
       agentInfo.agentID,

--- a/src/domain/communication/room/room.resolver.mutations.ts
+++ b/src/domain/communication/room/room.resolver.mutations.ts
@@ -532,8 +532,8 @@ export class RoomResolverMutations {
     // See: docs/matrix-admin-reflection.md
     const isDeleted = await this.roomService.removeReactionToMessage(
       room,
-      agentInfo.agentID,
-      reactionData
+      reactionData,
+      agentInfo.agentID
     );
 
     // Subscription will be published by MessageInboxService when Matrix echoes the removal

--- a/src/domain/communication/room/room.service.ts
+++ b/src/domain/communication/room/room.service.ts
@@ -128,7 +128,7 @@ export class RoomService {
   async removeRoomMessage(
     room: IRoom,
     messageData: RoomRemoveMessageInput,
-    _agentId?: string // TODO: Use this once Matrix admin reflection is implemented
+    _agentId: string // TODO: Use this once Matrix admin reflection is implemented
   ): Promise<string> {
     // WORKAROUND: Get the original message sender's actorId - Matrix only allows
     // the sender or room moderators to delete messages. Since we don't yet
@@ -226,20 +226,20 @@ export class RoomService {
    */
   async removeReactionToMessage(
     room: IRoom,
-    _agentId: string, // TODO: Use this once Matrix admin reflection is implemented
-    messageData: RoomRemoveReactionToMessageInput
+    reactionData: RoomRemoveReactionToMessageInput,
+    _agentId: string // TODO: Use this once Matrix admin reflection is implemented
   ): Promise<boolean> {
     // WORKAROUND: Get the original reaction sender's actorId and impersonate them
     const senderActorId =
       await this.communicationAdapter.getReactionSenderActor({
         alkemioRoomId: room.id,
-        reactionId: messageData.reactionID,
+        reactionId: reactionData.reactionID,
       });
 
     await this.communicationAdapter.removeReaction({
       alkemioRoomId: room.id,
       actorId: senderActorId, // TODO: Replace with _agentId once Matrix reflection is implemented
-      reactionId: messageData.reactionID,
+      reactionId: reactionData.reactionID,
     });
 
     return true;


### PR DESCRIPTION
  Alkemio admins with DELETE privilege on rooms cannot delete other users'
  messages/reactions in Matrix because their admin rights aren't reflected
  as Matrix moderator power levels.

  Workaround: impersonate the original sender when deleting messages or
  removing reactions. This allows the action to succeed but shows the
  sender as the actor in Matrix audit logs.

  Changes:
  - removeRoomMessage: lookup message sender and delete as them
  - removeReactionToMessage: lookup reaction sender and remove as them
  - Keep agentId parameter in signatures for future interface stability
  - Add FIXME/TODO comments documenting the temporary nature

  Add docs/matrix-admin-reflection.md to track requirements for proper
  implementation of Matrix power level synchronization.

## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide describing Matrix admin/power-level reflection, requirements, workarounds, triggers, and implementation options for message and reaction handling.

* **Improvements**
  * Updated message and reaction removal flows to better preserve correct sender attribution and handle permission scenarios more reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->