### PR TITLE
Enables subspace ordering within a space

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4529,7 +4529,7 @@ type RelayPaginatedSpace {
   """The settings for this Space."""
   settings: SpaceSettings!
   """The sorting order for this Space within its parent."""
-  sortOrder: Float!
+  sortOrder: Int!
   """The StorageAggregator in use by this Space"""
   storageAggregator: StorageAggregator!
   """The subscriptions active for this Space."""
@@ -4964,7 +4964,7 @@ type Space {
   """The settings for this Space."""
   settings: SpaceSettings!
   """The sorting order for this Space within its parent."""
-  sortOrder: Float!
+  sortOrder: Int!
   """The StorageAggregator in use by this Space"""
   storageAggregator: StorageAggregator!
   """The subscriptions active for this Space."""

--- a/schema.graphql
+++ b/schema.graphql
@@ -3690,6 +3690,10 @@ type Mutation {
   updateSpacePlatformSettings(updateData: UpdateSpacePlatformSettingsInput!): Space!
   """Updates one of the Setting on a Space"""
   updateSpaceSettings(settingsData: UpdateSpaceSettingsInput!): Space!
+  """
+  Update the sortOrder field of the supplied Subspaces to increase as per the order that they are provided in.
+  """
+  updateSubspacesSortOrder(sortOrderData: UpdateSubspacesSortOrderInput!): [Space!]!
   """Updates the specified Tagset."""
   updateTagset(updateData: UpdateTagsetInput!): Tagset!
   """Updates the specified Template."""
@@ -4524,6 +4528,8 @@ type RelayPaginatedSpace {
   platformAccess: PlatformRolesAccess!
   """The settings for this Space."""
   settings: SpaceSettings!
+  """The sorting order for this Space within its parent."""
+  sortOrder: Float!
   """The StorageAggregator in use by this Space"""
   storageAggregator: StorageAggregator!
   """The subscriptions active for this Space."""
@@ -4957,6 +4963,8 @@ type Space {
   platformAccess: PlatformRolesAccess!
   """The settings for this Space."""
   settings: SpaceSettings!
+  """The sorting order for this Space within its parent."""
+  sortOrder: Float!
   """The StorageAggregator in use by this Space"""
   storageAggregator: StorageAggregator!
   """The subscriptions active for this Space."""
@@ -7752,6 +7760,12 @@ input UpdateSpaceSettingsPrivacyInput {
   allowPlatformSupportAsAdmin: Boolean
   """"""
   mode: SpacePrivacyMode
+}
+
+input UpdateSubspacesSortOrderInput {
+  spaceID: UUID!
+  """The IDs of the subspaces to update the sort order on"""
+  subspaceIDs: [UUID!]!
 }
 
 input UpdateTagsetInput {

--- a/src/domain/space/space/dto/space.dto.update.subspaces.sort.order.ts
+++ b/src/domain/space/space/dto/space.dto.update.subspaces.sort.order.ts
@@ -1,0 +1,15 @@
+import { UUID } from '@domain/common/scalars';
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateSubspacesSortOrderInput {
+  @Field(() => UUID, { nullable: false })
+  spaceID!: string;
+
+  @Field(() => [UUID], {
+    name: 'subspaceIDs',
+    description: 'The IDs of the subspaces to update the sort order on',
+    nullable: false,
+  })
+  subspaceIDs!: string[];
+}

--- a/src/domain/space/space/index.ts
+++ b/src/domain/space/space/index.ts
@@ -1,5 +1,6 @@
 export * from './dto/space.dto.update';
 export * from './dto/space.dto.delete';
 export * from './dto/space.dto.create';
+export * from './dto/space.dto.update.subspaces.sort.order';
 export * from '../space.defaults/definitions/space.community.roles';
 export * from '../space.defaults/definitions/space.community.role.application.form';

--- a/src/domain/space/space/sort.spaces.by.activity.spec.ts
+++ b/src/domain/space/space/sort.spaces.by.activity.spec.ts
@@ -56,6 +56,7 @@ const createTestSpace = (id: string): ISpace => {
     platformRolesAccess: {
       roles: [],
     },
+    sortOrder: 0,
     createdDate: new Date(),
     updatedDate: new Date(),
     about: {

--- a/src/domain/space/space/space.entity.ts
+++ b/src/domain/space/space/space.entity.ts
@@ -101,6 +101,9 @@ export class Space extends AuthorizableEntity implements ISpace {
   @Column('int', { nullable: false })
   level!: SpaceLevel;
 
+  @Column('int', { nullable: false })
+  sortOrder!: number;
+
   @Column('varchar', {
     length: ENUM_LENGTH,
     nullable: false,

--- a/src/domain/space/space/space.interface.ts
+++ b/src/domain/space/space/space.interface.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 import { IAgent } from '@domain/agent/agent/agent.interface';
 import { ICollaboration } from '@domain/collaboration/collaboration';
 import { ICommunity } from '@domain/community/community';
@@ -61,7 +61,7 @@ export class ISpace extends IAuthorizable {
   })
   levelZeroSpaceID!: string;
 
-  @Field(() => Number, {
+  @Field(() => Int, {
     nullable: false,
     description: 'The sorting order for this Space within its parent.',
   })

--- a/src/domain/space/space/space.interface.ts
+++ b/src/domain/space/space/space.interface.ts
@@ -61,6 +61,12 @@ export class ISpace extends IAuthorizable {
   })
   levelZeroSpaceID!: string;
 
+  @Field(() => Number, {
+    nullable: false,
+    description: 'The sorting order for this Space within its parent.',
+  })
+  sortOrder!: number;
+
   templatesManager?: ITemplatesManager;
   license?: ILicense;
 }

--- a/src/domain/space/space/space.resolver.mutations.ts
+++ b/src/domain/space/space/space.resolver.mutations.ts
@@ -2,7 +2,11 @@ import { Inject } from '@nestjs/common';
 import { Resolver, Args, Mutation } from '@nestjs/graphql';
 import { CurrentUser } from '@src/common/decorators';
 import { SpaceService } from './space.service';
-import { DeleteSpaceInput, UpdateSpaceInput } from '@domain/space/space';
+import {
+  DeleteSpaceInput,
+  UpdateSpaceInput,
+  UpdateSubspacesSortOrderInput,
+} from '@domain/space/space';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
@@ -236,5 +240,25 @@ export class SpaceResolverMutations {
     );
 
     return newSubspace;
+  }
+
+  @Mutation(() => [ISpace], {
+    description:
+      'Update the sortOrder field of the supplied Subspaces to increase as per the order that they are provided in.',
+  })
+  async updateSubspacesSortOrder(
+    @CurrentUser() agentInfo: AgentInfo,
+    @Args('sortOrderData') sortOrderData: UpdateSubspacesSortOrderInput
+  ): Promise<ISpace[]> {
+    const space = await this.spaceService.getSpaceOrFail(sortOrderData.spaceID);
+
+    this.authorizationService.grantAccessOrFail(
+      agentInfo,
+      space.authorization,
+      AuthorizationPrivilege.UPDATE,
+      `update subspaces sort order on space: ${space.id}`
+    );
+
+    return this.spaceService.updateSubspacesSortOrder(space, sortOrderData);
   }
 }

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -515,6 +515,7 @@ const getSubspacesMock = (
       nameID: `challenge-${spaceId}.${i}`,
       settings: spaceSettings,
       levelZeroSpaceID: spaceId,
+      sortOrder: i,
       platformRolesAccess: {
         roles: [],
       },
@@ -639,6 +640,7 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
       nameID: `subsubspace-${subsubspaceId}.${i}`,
       settings: spaceSettings,
       levelZeroSpaceID: subsubspaceId,
+      sortOrder: i,
       platformRolesAccess: {
         roles: [],
       },
@@ -769,6 +771,7 @@ const getSpaceMock = ({
     nameID: `space-${id}`,
     settings: settings,
     levelZeroSpaceID: '',
+    sortOrder: 0,
     platformRolesAccess: {
       roles: [],
     },

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1031,9 +1031,7 @@ export class SpaceService {
       index++;
     }
 
-    await Promise.all(
-      modifiedSubspaces.map(async subspace => await this.save(subspace))
-    );
+    await this.spaceRepository.save(modifiedSubspaces);
 
     return subspacesInOrder;
   }

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1,3 +1,4 @@
+import { keyBy } from 'lodash';
 import { LogContext } from '@common/enums';
 import {
   EntityNotFoundException,
@@ -17,6 +18,7 @@ import { Space } from './space.entity';
 import { ISpace } from './space.interface';
 import { UpdateSpaceInput } from './dto/space.dto.update';
 import { CreateSubspaceInput } from './dto/space.dto.create.subspace';
+import { UpdateSubspacesSortOrderInput } from './dto/space.dto.update.subspaces.sort.order';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { limitAndShuffle } from '@common/utils/limitAndShuffle';
 import { SpacesQueryArgs } from './dto/space.args.query.spaces';
@@ -134,6 +136,7 @@ export class SpaceService {
     const space: ISpace = Space.create(spaceData);
     // default to demo space
     space.visibility = SpaceVisibility.ACTIVE;
+    space.sortOrder = 0;
 
     space.authorization = new AuthorizationPolicy(
       AuthorizationPolicyType.SPACE
@@ -970,14 +973,69 @@ export class SpaceService {
       args?.shuffle
     );
 
-    // Sort the subspaces base on their display name
-    const sortedSubspaces = limitAndShuffled.sort((a, b) =>
-      a.about.profile.displayName.toLowerCase() >
-      b.about.profile.displayName.toLowerCase()
-        ? 1
-        : -1
-    );
+    // Sort the subspaces based on sortOrder, with displayName as tiebreaker
+    const sortedSubspaces = limitAndShuffled.sort((a, b) => {
+      if (a.sortOrder !== b.sortOrder) {
+        return a.sortOrder - b.sortOrder;
+      }
+      return a.about.profile.displayName
+        .toLowerCase()
+        .localeCompare(b.about.profile.displayName.toLowerCase());
+    });
     return sortedSubspaces;
+  }
+
+  public async updateSubspacesSortOrder(
+    space: ISpace,
+    sortOrderData: UpdateSubspacesSortOrderInput
+  ): Promise<ISpace[]> {
+    const spaceLoaded = await this.getSpaceOrFail(space.id, {
+      relations: { subspaces: true },
+    });
+
+    const allSubspaces = spaceLoaded.subspaces;
+    if (!allSubspaces) {
+      throw new EntityNotFoundException(
+        'Space not initialized, no subspaces',
+        LogContext.SPACES,
+        { spaceId: space.id }
+      );
+    }
+
+    const subspacesByID = keyBy(allSubspaces, 'id');
+
+    const sortOrders = sortOrderData.subspaceIDs
+      .map(subspaceId => subspacesByID[subspaceId]?.sortOrder)
+      .filter(sortOrder => sortOrder !== undefined);
+
+    const minimumSortOrder = sortOrders.length > 0 ? Math.min(...sortOrders) : 0;
+    const modifiedSubspaces: ISpace[] = [];
+
+    const subspacesInOrder: ISpace[] = [];
+    let index = 1;
+    for (const subspaceID of sortOrderData.subspaceIDs) {
+      const subspace = subspacesByID[subspaceID];
+      if (!subspace) {
+        throw new EntityNotFoundException(
+          'Subspace not found within parent Space',
+          LogContext.SPACES,
+          { subspaceId: subspaceID, parentSpaceId: space.id }
+        );
+      }
+      subspacesInOrder.push(subspace);
+      const newSortOrder = minimumSortOrder + index;
+      if (subspace.sortOrder !== newSortOrder) {
+        subspace.sortOrder = newSortOrder;
+        modifiedSubspaces.push(subspace);
+      }
+      index++;
+    }
+
+    await Promise.all(
+      modifiedSubspaces.map(async subspace => await this.save(subspace))
+    );
+
+    return subspacesInOrder;
   }
 
   async getSubscriptions(spaceInput: ISpace): Promise<ISpaceSubscription[]> {
@@ -1056,6 +1114,7 @@ export class SpaceService {
           roleSet: true,
         },
         parentSpace: true,
+        subspaces: true,
       },
     });
 
@@ -1130,6 +1189,14 @@ export class SpaceService {
       agentInfo,
       space.platformRolesAccess
     );
+
+    // Calculate sortOrder for new subspace (appears first = lowest sortOrder)
+    if (space.subspaces && space.subspaces.length > 0) {
+      subspace.sortOrder =
+        Math.min(...space.subspaces.map(s => s.sortOrder), 0) - 1;
+    } else {
+      subspace.sortOrder = 0;
+    }
 
     subspace = await this.addSubspaceToSpace(space, subspace);
     subspace = await this.save(subspace);

--- a/src/migrations/1768479624225-AddSortOrderToSpace.ts
+++ b/src/migrations/1768479624225-AddSortOrderToSpace.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSortOrderToSpace1768479624225 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add sortOrder column with default value of 0
+    await queryRunner.query(
+      `ALTER TABLE "space" ADD "sortOrder" integer NOT NULL DEFAULT 0`
+    );
+
+    // Set initial sortOrder values for existing subspaces based on creation order
+    // Each subspace within a parent gets sequential sortOrder starting from 1
+    await queryRunner.query(`
+      WITH ranked_subspaces AS (
+        SELECT
+          id,
+          "parentSpaceId",
+          ROW_NUMBER() OVER (
+            PARTITION BY "parentSpaceId"
+            ORDER BY "createdDate" ASC
+          ) as rn
+        FROM space
+        WHERE "parentSpaceId" IS NOT NULL
+      )
+      UPDATE space
+      SET "sortOrder" = ranked_subspaces.rn
+      FROM ranked_subspaces
+      WHERE space.id = ranked_subspaces.id
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "space" DROP COLUMN "sortOrder"`);
+  }
+}

--- a/src/services/api/roles/roles.service.spec.ts
+++ b/src/services/api/roles/roles.service.spec.ts
@@ -261,6 +261,7 @@ const getSpaceRoleResultMock = ({
       rowId: parseInt(id),
       nameID: `space-${id}`,
       levelZeroSpaceID: '',
+      sortOrder: 0,
       about: {
         id,
         profile: {

--- a/test/data/space.mock.ts
+++ b/test/data/space.mock.ts
@@ -130,6 +130,7 @@ export const spaceData: { space: ISpace } = {
     level: SpaceLevel.L0,
     visibility: SpaceVisibility.ACTIVE,
     levelZeroSpaceID: '00655835-4d15-4546-801e-1ab80ac3078a',
+    sortOrder: 0,
     createdDate: new Date('2024-01-01T00:00:00.000Z'),
     updatedDate: new Date('2024-01-01T00:00:00.000Z'),
     // Add a minimal settings mock for ISpace


### PR DESCRIPTION
### Describe the background of your pull request

This pull request introduces a `sortOrder` field to the `Space` entity, allowing subspaces to be ordered within their parent space. It also adds an API endpoint to update the sort order of multiple subspaces simultaneously. This feature enables users to define the order in which subspaces are displayed, enhancing the user experience when navigating complex space hierarchies.

### Additional context

This change introduces a new `UpdateSubspacesSortOrderInput` and the corresponding resolver and service methods.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can reorder subspaces within a parent space; subspaces are displayed by explicit sort order, then name.
  * Spaces now expose a sort-order attribute; new subspaces receive an initial sort position on creation.

* **Chores**
  * Database migration added to persist and initialize sort order for existing spaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->