### PR TITLE
Home space pin settings

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -5566,6 +5566,8 @@ type UserSettings {
   communication: UserSettingsCommunication!
   """The date at which the entity was created."""
   createdDate: DateTime!
+  """The home space settings for this User."""
+  homeSpace: UserSettingsHomeSpace!
   """The ID of the entity"""
   id: UUID!
   """The notification settings for this User."""
@@ -5579,6 +5581,13 @@ type UserSettings {
 type UserSettingsCommunication {
   """Allow Users to send messages to this User."""
   allowOtherUsersToSendMessages: Boolean!
+}
+
+type UserSettingsHomeSpace {
+  """Automatically redirect to home space instead of the dashboard."""
+  autoRedirect: Boolean!
+  """The ID of the Space to use as home. Null if not set."""
+  spaceID: String
 }
 
 type UserSettingsNotification {
@@ -7835,10 +7844,19 @@ input UpdateUserSettingsCommunicationInput {
 input UpdateUserSettingsEntityInput {
   """Settings related to this users Communication preferences."""
   communication: UpdateUserSettingsCommunicationInput
+  """Settings related to Home Space."""
+  homeSpace: UpdateUserSettingsHomeSpaceInput
   """Settings related to this users Notifications preferences."""
   notification: UpdateUserSettingsNotificationInput
   """Settings related to Privacy."""
   privacy: UpdateUserSettingsPrivacyInput
+}
+
+input UpdateUserSettingsHomeSpaceInput {
+  """Automatically redirect to home space instead of the dashboard."""
+  autoRedirect: Boolean
+  """The ID of the Space to use as home. Set to null to clear."""
+  spaceID: UUID
 }
 
 input UpdateUserSettingsInput {

--- a/src/domain/community/user-settings/dto/user.settings.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.create.ts
@@ -4,6 +4,7 @@ import { Type } from 'class-transformer';
 import { CreateUserSettingsPrivacyInput } from './user.settings.privacy.dto.create';
 import { CreateUserSettingsCommunicationInput } from './user.settings.communications.dto.create';
 import { CreateUserSettingsNotificationInput } from './user.settings.notification.dto.create';
+import { CreateUserSettingsHomeSpaceInput } from './user.settings.home.space.dto.create';
 
 @InputType()
 export class CreateUserSettingsInput {
@@ -30,4 +31,12 @@ export class CreateUserSettingsInput {
   @ValidateNested()
   @Type(() => CreateUserSettingsNotificationInput)
   notification?: CreateUserSettingsNotificationInput;
+
+  @Field(() => CreateUserSettingsHomeSpaceInput, {
+    nullable: true,
+    description: 'Settings related to Home Space.',
+  })
+  @ValidateNested()
+  @Type(() => CreateUserSettingsHomeSpaceInput)
+  homeSpace?: CreateUserSettingsHomeSpaceInput;
 }

--- a/src/domain/community/user-settings/dto/user.settings.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.update.ts
@@ -4,6 +4,7 @@ import { UpdateUserSettingsCommunicationInput } from './user.settings.communicat
 import { ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { UpdateUserSettingsNotificationInput } from './user.settings.notification.dto.update';
+import { UpdateUserSettingsHomeSpaceInput } from './user.settings.home.space.dto.update';
 
 @InputType()
 export class UpdateUserSettingsEntityInput {
@@ -30,4 +31,12 @@ export class UpdateUserSettingsEntityInput {
   @ValidateNested()
   @Type(() => UpdateUserSettingsNotificationInput)
   notification?: UpdateUserSettingsNotificationInput;
+
+  @Field(() => UpdateUserSettingsHomeSpaceInput, {
+    nullable: true,
+    description: 'Settings related to Home Space.',
+  })
+  @ValidateNested()
+  @Type(() => UpdateUserSettingsHomeSpaceInput)
+  homeSpace?: UpdateUserSettingsHomeSpaceInput;
 }

--- a/src/domain/community/user-settings/dto/user.settings.home.space.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.home.space.dto.create.ts
@@ -1,9 +1,10 @@
+import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { Field, InputType } from '@nestjs/graphql';
 import { IsBoolean, IsOptional, IsUUID } from 'class-validator';
 
 @InputType()
 export class CreateUserSettingsHomeSpaceInput {
-  @Field(() => String, {
+  @Field(() => UUID, {
     nullable: true,
     description: 'The ID of the Space to use as home.',
   })

--- a/src/domain/community/user-settings/dto/user.settings.home.space.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.home.space.dto.create.ts
@@ -1,0 +1,21 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsOptional, IsUUID } from 'class-validator';
+
+@InputType()
+export class CreateUserSettingsHomeSpaceInput {
+  @Field(() => String, {
+    nullable: true,
+    description: 'The ID of the Space to use as home.',
+  })
+  @IsOptional()
+  @IsUUID()
+  spaceID?: string | null;
+
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      'Automatically redirect to home space instead of the dashboard.',
+  })
+  @IsBoolean()
+  autoRedirect!: boolean;
+}

--- a/src/domain/community/user-settings/dto/user.settings.home.space.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.home.space.dto.update.ts
@@ -1,0 +1,22 @@
+import { UUID } from '@domain/common/scalars/scalar.uuid';
+import { Field, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+@InputType()
+export class UpdateUserSettingsHomeSpaceInput {
+  @Field(() => UUID, {
+    nullable: true,
+    description: 'The ID of the Space to use as home. Set to null to clear.',
+  })
+  @IsOptional()
+  spaceID?: string | null;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Automatically redirect to home space instead of the dashboard.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  autoRedirect?: boolean;
+}

--- a/src/domain/community/user-settings/user.settings.entity.ts
+++ b/src/domain/community/user-settings/user.settings.entity.ts
@@ -4,6 +4,7 @@ import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { IUserSettingsPrivacy } from './user.settings.privacy.interface';
 import { IUserSettingsCommunication } from './user.settings.communications.interface';
 import { IUserSettingsNotification } from './user.settings.notification.interface';
+import { IUserSettingsHomeSpace } from './user.settings.home.space.interface';
 
 @Entity()
 export class UserSettings extends AuthorizableEntity implements IUserSettings {
@@ -15,4 +16,7 @@ export class UserSettings extends AuthorizableEntity implements IUserSettings {
 
   @Column('jsonb', { nullable: false })
   notification!: IUserSettingsNotification;
+
+  @Column('jsonb', { nullable: false })
+  homeSpace!: IUserSettingsHomeSpace;
 }

--- a/src/domain/community/user-settings/user.settings.home.space.interface.ts
+++ b/src/domain/community/user-settings/user.settings.home.space.interface.ts
@@ -1,0 +1,17 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('UserSettingsHomeSpace')
+export abstract class IUserSettingsHomeSpace {
+  @Field(() => String, {
+    nullable: true,
+    description: 'The ID of the Space to use as home. Null if not set.',
+  })
+  spaceID?: string | null;
+
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      'Automatically redirect to home space instead of the dashboard.',
+  })
+  autoRedirect!: boolean;
+}

--- a/src/domain/community/user-settings/user.settings.home.space.validation.service.ts
+++ b/src/domain/community/user-settings/user.settings.home.space.validation.service.ts
@@ -1,0 +1,60 @@
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
+import { AgentInfo } from '@core/authentication.agent.info/agent.info';
+import { groupCredentialsByEntity } from '@services/api/roles/util/group.credentials.by.entity';
+import { ValidationException } from '@common/exceptions';
+import { LogContext } from '@common/enums/logging.context';
+
+@Injectable()
+export class UserSettingsHomeSpaceValidationService {
+  constructor(
+    private spaceLookupService: SpaceLookupService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
+  ) {}
+
+  /**
+   * Validates that the user has access to the specified space.
+   * @throws ValidationException if user doesn't have access or space doesn't exist
+   */
+  async validateSpaceAccess(
+    spaceID: string,
+    agentInfo: AgentInfo
+  ): Promise<void> {
+    // First verify space exists
+    await this.spaceLookupService.getSpaceOrFail(spaceID);
+
+    // Check user has credentials for this space
+    const credentialMap = groupCredentialsByEntity(agentInfo.credentials);
+    const userSpaces = credentialMap.get('spaces');
+
+    if (!userSpaces || !userSpaces.has(spaceID)) {
+      throw new ValidationException(
+        'User does not have access to the specified space',
+        LogContext.COMMUNITY,
+        { spaceID }
+      );
+    }
+  }
+
+  /**
+   * Checks if user still has access to their home space.
+   * Returns false if space doesn't exist or user lost access.
+   */
+  async isHomeSpaceValid(
+    spaceID: string | null | undefined,
+    agentInfo: AgentInfo
+  ): Promise<boolean> {
+    if (!spaceID) {
+      return false;
+    }
+
+    try {
+      await this.validateSpaceAccess(spaceID, agentInfo);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/domain/community/user-settings/user.settings.interface.ts
+++ b/src/domain/community/user-settings/user.settings.interface.ts
@@ -3,6 +3,7 @@ import { IUserSettingsPrivacy } from './user.settings.privacy.interface';
 import { IUserSettingsCommunication } from './user.settings.communications.interface';
 import { IAuthorizable } from '@domain/common/entity/authorizable-entity';
 import { IUserSettingsNotification } from './user.settings.notification.interface';
+import { IUserSettingsHomeSpace } from './user.settings.home.space.interface';
 
 @ObjectType('UserSettings')
 export class IUserSettings extends IAuthorizable {
@@ -23,4 +24,10 @@ export class IUserSettings extends IAuthorizable {
     description: 'The notification settings for this User.',
   })
   notification!: IUserSettingsNotification;
+
+  @Field(() => IUserSettingsHomeSpace, {
+    nullable: false,
+    description: 'The home space settings for this User.',
+  })
+  homeSpace!: IUserSettingsHomeSpace;
 }

--- a/src/domain/community/user-settings/user.settings.module.ts
+++ b/src/domain/community/user-settings/user.settings.module.ts
@@ -4,13 +4,24 @@ import { UserSettings } from './user.settings.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { UserSettingsAuthorizationService } from './user.settings.service.authorization';
+import { UserSettingsHomeSpaceValidationService } from './user.settings.home.space.validation.service';
+import { SpaceLookupModule } from '@domain/space/space.lookup/space.lookup.module';
 
 @Module({
   imports: [
     AuthorizationPolicyModule,
+    SpaceLookupModule,
     TypeOrmModule.forFeature([UserSettings]),
   ],
-  providers: [UserSettingsService, UserSettingsAuthorizationService],
-  exports: [UserSettingsService, UserSettingsAuthorizationService],
+  providers: [
+    UserSettingsService,
+    UserSettingsAuthorizationService,
+    UserSettingsHomeSpaceValidationService,
+  ],
+  exports: [
+    UserSettingsService,
+    UserSettingsAuthorizationService,
+    UserSettingsHomeSpaceValidationService,
+  ],
 })
 export class UserSettingsModule {}

--- a/src/domain/community/user-settings/user.settings.service.ts
+++ b/src/domain/community/user-settings/user.settings.service.ts
@@ -7,7 +7,10 @@ import { NotificationSettingInput } from './dto/notification.setting.input';
 import { UserSettings } from './user.settings.entity';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
-import { EntityNotFoundException } from '@common/exceptions/entity.not.found.exception';
+import {
+  EntityNotFoundException,
+  ValidationException,
+} from '@common/exceptions';
 import { LogContext } from '@common/enums/logging.context';
 import { FindOneOptions, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -28,6 +31,7 @@ export class UserSettingsService {
       communication: settingsData.communication,
       privacy: settingsData.privacy,
       notification: settingsData.notification,
+      homeSpace: settingsData.homeSpace,
     });
     settings.authorization = new AuthorizationPolicy(
       AuthorizationPolicyType.USER_SETTINGS
@@ -204,6 +208,29 @@ export class UserSettingsService {
         settings.notification.virtualContributor.adminSpaceCommunityInvitation,
         notificationVcData.adminSpaceCommunityInvitation
       );
+    }
+
+    if (updateData.homeSpace) {
+      // Note: spaceID can be explicitly set to null to clear
+      if (updateData.homeSpace.spaceID !== undefined) {
+        settings.homeSpace.spaceID = updateData.homeSpace.spaceID;
+
+        // If clearing spaceID, also disable autoRedirect
+        if (settings.homeSpace.spaceID === null) {
+          settings.homeSpace.autoRedirect = false;
+        }
+      }
+
+      if (updateData.homeSpace.autoRedirect !== undefined) {
+        // Validation: cannot enable autoRedirect without a spaceID
+        if (updateData.homeSpace.autoRedirect && !settings.homeSpace.spaceID) {
+          throw new ValidationException(
+            'Cannot enable auto-redirect without a home space set',
+            LogContext.COMMUNITY
+          );
+        }
+        settings.homeSpace.autoRedirect = updateData.homeSpace.autoRedirect;
+      }
     }
 
     return settings;

--- a/src/domain/community/user/user.resolver.spec.ts
+++ b/src/domain/community/user/user.resolver.spec.ts
@@ -13,6 +13,7 @@ import { MockNotificationsService } from '@test/mocks/notifications.service.mock
 import { MockNotificationPlatformAdapter } from '@test/mocks/notification.platform.adapter.service.mock';
 import { MockPlatformAuthorizationService } from '@test/mocks/platform.authorization.service.mock';
 import { MockEntityManagerProvider } from '@test/mocks';
+import { MockUserSettingsHomeSpaceValidationService } from '@test/mocks/user.settings.home.space.validation.service.mock';
 
 describe('UserResolver', () => {
   let resolver: UserResolverQueries;
@@ -30,6 +31,7 @@ describe('UserResolver', () => {
         MockPlatformAuthorizationService,
         MockCommunicationAdapter,
         MockUserAuthorizationService,
+        MockUserSettingsHomeSpaceValidationService,
         MockNotificationPlatformAdapter,
         MockNotificationsService,
         MockEntityManagerProvider,

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -303,6 +303,10 @@ export class UserService {
           adminSpaceCommunityInvitation: { email: true, inApp: true },
         },
       },
+      homeSpace: {
+        spaceID: null,
+        autoRedirect: false,
+      },
     };
     return settings;
   }

--- a/src/migrations/1768490929721-AddHomeSpaceToUserSettings.ts
+++ b/src/migrations/1768490929721-AddHomeSpaceToUserSettings.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddHomeSpaceToUserSettings1768490929721
+  implements MigrationInterface
+{
+  name = 'AddHomeSpaceToUserSettings1768490929721';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "homeSpace" jsonb NOT NULL DEFAULT '{"spaceID": null, "autoRedirect": false}'`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN "homeSpace"`
+    );
+  }
+}

--- a/test/data/user.settings.mock.ts
+++ b/test/data/user.settings.mock.ts
@@ -128,5 +128,9 @@ export const userSettingsData: { userSettings: IUserSettings } = {
         },
       },
     },
+    homeSpace: {
+      spaceID: null,
+      autoRedirect: false,
+    },
   },
 };

--- a/test/mocks/user.settings.home.space.validation.service.mock.ts
+++ b/test/mocks/user.settings.home.space.validation.service.mock.ts
@@ -1,0 +1,13 @@
+import { UserSettingsHomeSpaceValidationService } from '@domain/community/user-settings/user.settings.home.space.validation.service';
+import { ValueProvider } from '@nestjs/common';
+import { PublicPart } from '../utils/public-part';
+
+export const MockUserSettingsHomeSpaceValidationService: ValueProvider<
+  PublicPart<UserSettingsHomeSpaceValidationService>
+> = {
+  provide: UserSettingsHomeSpaceValidationService,
+  useValue: {
+    validateSpaceAccess: jest.fn(),
+    isHomeSpaceValid: jest.fn(),
+  },
+};


### PR DESCRIPTION
Extend user's settings with home space pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can set a preferred home space in their settings.
  * Added an auto-redirect option to navigate to the home space instead of the dashboard.
  * Home-space settings can be created and updated via user settings management.
  * The system validates that users have access to the space they set as home.

* **Chores**
  * Database schema updated to store home-space settings with a default value and migration.

* **Tests**
  * Added mocks and test adjustments for home-space validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->