### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -4323,6 +4323,10 @@ type Mutation {
   updateSpacePlatformSettings(updateData: UpdateSpacePlatformSettingsInput!): Space!
   """Updates one of the Setting on a Space"""
   updateSpaceSettings(settingsData: UpdateSpaceSettingsInput!): Space!
+  """
+  Update the sortOrder field of the supplied Subspaces to increase as per the order that they are provided in.
+  """
+  updateSubspacesSortOrder(sortOrderData: UpdateSubspacesSortOrderInput!): [Space!]!
   """Updates the specified Tagset."""
   updateTagset(updateData: UpdateTagsetInput!): Tagset!
   """Updates the specified Template."""
@@ -5401,6 +5405,8 @@ type RelayPaginatedSpace {
   platformAccess: PlatformRolesAccess!
   """The settings for this Space."""
   settings: SpaceSettings!
+  """The sorting order for this Space within its parent."""
+  sortOrder: Int!
   """The StorageAggregator in use by this Space"""
   storageAggregator: StorageAggregator!
   """The subscriptions active for this Space."""
@@ -6132,6 +6138,8 @@ type Space {
   platformAccess: PlatformRolesAccess!
   """The settings for this Space."""
   settings: SpaceSettings!
+  """The sorting order for this Space within its parent."""
+  sortOrder: Int!
   """The StorageAggregator in use by this Space"""
   storageAggregator: StorageAggregator!
   """The subscriptions active for this Space."""
@@ -7257,6 +7265,12 @@ input UpdateSpaceSettingsPrivacyInput {
   allowPlatformSupportAsAdmin: Boolean
   """"""
   mode: SpacePrivacyMode
+}
+
+input UpdateSubspacesSortOrderInput {
+  spaceID: UUID!
+  """The IDs of the subspaces to update the sort order on"""
+  subspaceIDs: [UUID!]!
 }
 
 input UpdateTagsetInput {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 253396 bytes
Snapshot md5: ee4008781cb45b1fe3e7cb07581d7cf7

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch reordering capability for subspaces within a parent space.
  * Spaces now display their sort order within the parent hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->