### PR TITLE
Adds worktree management skill

### DIFF
--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,16 +1,52 @@
 ---
-description: Create a git worktree for parallel work
+description: Create or remove a git worktree for parallel work
 arguments:
+  - name: action
+    description: Action to perform - "create" (default) or "remove"
+    required: false
   - name: branch
     description: Branch name to create or check out (e.g. "feature-auth", "fix-db-connection")
     required: true
   - name: base
-    description: Base branch to create from (e.g. "main", "develop"). Defaults to current branch.
+    description: Base branch to create from (e.g. "main", "develop"). Defaults to current branch. Only used with create.
     required: false
 ---
 
-Create a worktree at `../$REPO_NAME-$ARGUMENTS.branch` for branch `$ARGUMENTS.branch`.
+## Create (default action)
 
-If the branch doesn't exist, create it from `$ARGUMENTS.base` (or current branch if not specified).
+If action is "create" or not specified:
 
-After creation, tell me to run `cd ../$REPO_NAME-$ARGUMENTS.branch && claude` in a new tmux pane.
+1. Create a worktree at `../$REPO_NAME-$ARGUMENTS.branch` for branch `$ARGUMENTS.branch`
+2. If the branch doesn't exist, create it from `$ARGUMENTS.base` (or current branch if not specified)
+3. Automatically open a new tmux pane with Claude:
+```bash
+tmux split-window -h "cd ../$REPO_NAME-$ARGUMENTS.branch && claude"
+```
+
+## Remove
+
+If action is "remove":
+
+1. **Ask user for confirmation** before proceeding with removal using AskUserQuestion tool:
+   - Question: "Remove worktree and close tmux pane for branch '$ARGUMENTS.branch'?"
+   - Options: "Yes, remove" / "No, cancel"
+
+2. If confirmed, **FIRST** find and close any tmux pane running in that worktree directory (must happen BEFORE removing worktree):
+```bash
+tmux list-panes -a -F '#{pane_id} #{pane_current_path}' | grep "$REPO_NAME-$ARGUMENTS.branch" | awk '{print $1}' | xargs -I{} tmux kill-pane -t {}
+```
+
+3. **THEN** remove the worktree:
+```bash
+git worktree remove "../$REPO_NAME-$ARGUMENTS.branch"
+```
+
+4. **Ask user if they want to delete the branch** using AskUserQuestion tool:
+   - Question: "Also delete the local branch '$ARGUMENTS.branch'?"
+   - Options: "Yes, delete branch" / "No, keep branch"
+
+5. If confirmed, delete the branch:
+```bash
+git branch -d $ARGUMENTS.branch
+```
+   If the branch has unmerged changes and user still wants to delete, use `-D` instead.

--- a/.claude/skills/worktree.md
+++ b/.claude/skills/worktree.md
@@ -1,24 +1,33 @@
 # Worktree Management
 
-When asked to work on multiple things simultaneously or create a worktree:
+When asked to work on multiple things simultaneously or create/remove a worktree:
 
+## Create worktree
 1. Create worktrees in sibling directories using the pattern `../{repo-name}-{branch}`
 2. If the branch doesn't exist, create it with `git worktree add -b`
-3. After creating, remind the user to open a new terminal/tmux pane and run `claude` there
+3. Automatically open a new tmux pane with Claude running in that worktree
+
+## Remove worktree
+1. Find and kill any tmux pane whose current directory is the worktree
+2. Remove the worktree with `git worktree remove`
 
 ## Commands reference
 ```bash
-# New worktree from existing branch
-git worktree add ../alkemio-{branch} {branch}
+# New worktree from existing branch + open tmux pane
+git worktree add ../repo-{branch} {branch}
+tmux split-window -h "cd ../repo-{branch} && claude"
 
-# New worktree with new branch
-git worktree add -b {branch} ../alkemio-{branch}
+# New worktree with new branch + open tmux pane
+git worktree add -b {branch} ../repo-{branch}
+tmux split-window -h "cd ../repo-{branch} && claude"
 
 # List worktrees
 git worktree list
 
-# Cleanup
-git worktree remove ../alkemio-{branch}
+# Close tmux pane and remove worktree
+worktree_path=$(realpath "../repo-{branch}")
+tmux list-panes -a -F '#{pane_id} #{pane_current_path}' | grep "$worktree_path" | awk '{print $1}' | xargs -I{} tmux kill-pane -t {}
+git worktree remove ../repo-{branch}
 ```
 
 ## Naming convention


### PR DESCRIPTION
### Describe the background of your pull request

This pull request introduces a new skill to manage Git worktrees. It allows users to create and remove worktrees, simplifying parallel work on different branches.

### Additional context

The worktree skill automates the process of creating and removing worktrees, including:
- Creating worktrees in sibling directories.
- Creating new branches if they don't exist.
- Opening a new tmux pane in the worktree directory.
- Removing the worktree and closing the corresponding tmux pane.
- Optionally deleting the associated branch.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "remove" action to the worktree command, enabling both creation and removal of worktrees
  * Automatic tmux pane management now handles workspace setup and teardown seamlessly

* **Documentation**
  * Enhanced documentation with detailed, multi-step workflows for creating and removing worktrees
  * Clarified argument usage and behavior in command reference

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->