### PR TITLE
feat(room): add validation for room deletion and message handling

### DIFF
--- a/src/domain/collaboration/post/post.service.ts
+++ b/src/domain/collaboration/post/post.service.ts
@@ -63,7 +63,7 @@ export class PostService {
 
   public async deletePost(postId: string): Promise<IPost> {
     const post = await this.getPostOrFail(postId, {
-      relations: { profile: true },
+      relations: { profile: true, comments: true },
     });
     if (post.authorization) {
       await this.authorizationPolicyService.delete(post.authorization);

--- a/src/domain/communication/room-lookup/room.lookup.service.ts
+++ b/src/domain/communication/room-lookup/room.lookup.service.ts
@@ -133,7 +133,7 @@ export class RoomLookupService {
     await this.roomRepository
       .createQueryBuilder()
       .update()
-      .set({ messagesCount: () => 'GREATEST(messagesCount - 1, 0)' })
+      .set({ messagesCount: () => 'GREATEST("messagesCount" - 1, 0)' })
       .where('id = :id', { id: roomId })
       .execute();
   }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the communication and collaboration domain services, focusing on error handling, validation, and query correctness. The most significant changes include enhanced validation for required fields, improved error messages, and a fix for a database query in the room lookup service.

**Validation and Error Handling Improvements:**

* Added validation to ensure `roomID` is provided before deleting a room in `RoomService`, throwing a `ValidationException` if missing.
* Added validation to ensure `senderActorId` is present before deleting a message or removing a reaction, throwing a `ValidationException` if not found, with context-specific error messages. [[1]](diffhunk://#diff-997504dc90f4b4495f718efac4ffe183279701c14c404f961296ea813b876a3bR144-R150) [[2]](diffhunk://#diff-997504dc90f4b4495f718efac4ffe183279701c14c404f961296ea813b876a3bR244-R250)
* Imported `ValidationException` into `room.service.ts` to support the new validation logic.

**Query and Data Handling Fixes:**

* Fixed the SQL query in `RoomLookupService` to correctly decrement the `messagesCount` field using the proper column name syntax.
* Updated `deletePost` in `PostService` to eagerly load the `comments` relation in addition to `profile` when retrieving a post for deletion.

**Other Improvements:**

* Ensured the room ID is captured before removal in `deleteRoom` to prevent issues with TypeORM clearing the entity's ID field after deletion, and used the captured ID in subsequent operations.## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
