### PR TITLE
chore: bump matrix adapter version to v0.8.4-mapping8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ tmp/prev.schema.graphql
 
 # ignore pychache dirs
 **/__pycache__/
+
+.claude/settings.local.json

--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -355,7 +355,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.4-mapping7
+    image: alkemio/matrix-adapter-go:v0.8.4-mapping8
     platform: linux/amd64
     depends_on:
       - rabbitmq

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -403,7 +403,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.4-mapping7
+    image: alkemio/matrix-adapter-go:v0.8.4-mapping8
     platform: linux/amd64
     depends_on:
       - rabbitmq

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -419,7 +419,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.4-mapping7
+    image: alkemio/matrix-adapter-go:v0.8.4-mapping8
     platform: linux/amd64
     depends_on:
       - rabbitmq

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -414,7 +414,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.4-mapping7
+    image: alkemio/matrix-adapter-go:v0.8.4-mapping8
     platform: linux/amd64
     depends_on:
       - rabbitmq


### PR DESCRIPTION
This pull request updates the `alkemio_dev_matrix_adapter` service across multiple Docker Compose files to use a newer version of the `alkemio/matrix-adapter-go` image. The update moves from version `v0.8.4-mapping7` to `v0.8.4-mapping8`, ensuring consistency and bringing in any improvements or fixes from the new image.

Image version update for matrix adapter:

* Updated the `alkemio_dev_matrix_adapter` service image from `alkemio/matrix-adapter-go:v0.8.4-mapping7` to `v0.8.4-mapping8` in the following files:
  - `quickstart-services.yml`
  - `quickstart-services-ai.yml`
  - `quickstart-services-ai-debug.yml`
  - `quickstart-services-kratos-debug.yml`
## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
This pull request updates the `alkemio_dev_matrix_adapter` service across all quickstart Docker Compose files to use a newer version of the `alkemio/matrix-adapter-go` image. The image is upgraded from version `v0.8.4-mapping7` to `v0.8.4-mapping8`, ensuring consistency and access to the latest changes or fixes in the adapter.

**Docker Compose configuration updates:**

* Updated the `alkemio_dev_matrix_adapter` service image to `alkemio/matrix-adapter-go:v0.8.4-mapping8` in the following files:
  - `quickstart-services.yml`
  - `quickstart-services-ai.yml`
  - `quickstart-services-ai-debug.yml`
  - `quickstart-services-kratos-debug.yml`