### PR TITLE
fix: align room selection with synapse-migrator to preserve Matrix al…

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@alkemio/matrix-adapter-lib": "0.8.4-mapping5",
+    "@alkemio/matrix-adapter-lib": "0.8.4-mapping8",
     "@alkemio/notifications-lib": "0.12.2",
     "@apollo/server": "^4.10.4",
     "@elastic/elasticsearch": "^8.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@alkemio/matrix-adapter-lib':
-        specifier: 0.8.4-mapping5
-        version: 0.8.4-mapping5
+        specifier: 0.8.4-mapping8
+        version: 0.8.4-mapping8
       '@alkemio/notifications-lib':
         specifier: 0.12.2
         version: 0.12.2(@types/express@4.17.23)
@@ -367,8 +367,8 @@ packages:
     resolution: {integrity: sha512-Gd7gsI/RLjDgTO42pgcewsirbAr0WCj6Gktiq0pjV1N2ZGSf1dBOEIhMCX+wHPoekCY0qs4EY1puYwBxi8/PQA==}
     engines: {node: '>=16.15.0', npm: '>=8.5.5'}
 
-  '@alkemio/matrix-adapter-lib@0.8.4-mapping5':
-    resolution: {integrity: sha512-f01q42+sGP6WQQBeE746DQzv9T7kidEf7th6MQLvchQCvueW5cIwApwBwA4tvw2KfiJgI/u6ng89sMC/vgiaFQ==}
+  '@alkemio/matrix-adapter-lib@0.8.4-mapping8':
+    resolution: {integrity: sha512-mVrdwVHyVwjiJ1upr1bVL9fg5fkvkX/v9nI2G/hiKFXHDXCUy4nriXLdz5F2wQ1dWo7G0NdHIlndVUibO29ptA==}
     engines: {node: '>=22.x', pnpm: '>=9.x'}
 
   '@alkemio/notifications-lib@0.12.2':
@@ -6180,7 +6180,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@alkemio/matrix-adapter-lib@0.8.4-mapping5': {}
+  '@alkemio/matrix-adapter-lib@0.8.4-mapping8': {}
 
   '@alkemio/notifications-lib@0.12.2(@types/express@4.17.23)':
     dependencies:

--- a/src/migrations/1764897584127-conversationArchitectureRefactor.ts
+++ b/src/migrations/1764897584127-conversationArchitectureRefactor.ts
@@ -106,7 +106,7 @@ export class ConversationArchitectureRefactor1764897584127
           c."userID",
           r.id as room_id,
           r."externalRoomID",
-          ROW_NUMBER() OVER (PARTITION BY r."externalRoomID" ORDER BY c.id) as rn
+          ROW_NUMBER() OVER (PARTITION BY r."externalRoomID" ORDER BY r.id) as rn
         FROM conversation c
         JOIN room r ON c."roomId" = r.id
         WHERE c."virtualContributorID" IS NULL
@@ -137,7 +137,7 @@ export class ConversationArchitectureRefactor1764897584127
         SELECT
           c.id as conv_id,
           r."externalRoomID",
-          ROW_NUMBER() OVER (PARTITION BY r."externalRoomID" ORDER BY c.id) as rn
+          ROW_NUMBER() OVER (PARTITION BY r."externalRoomID" ORDER BY r.id) as rn
         FROM conversation c
         JOIN room r ON c."roomId" = r.id
         WHERE c."virtualContributorID" IS NULL
@@ -169,7 +169,7 @@ export class ConversationArchitectureRefactor1764897584127
           c.id as conv_id,
           r.id as room_id,
           r."externalRoomID",
-          ROW_NUMBER() OVER (PARTITION BY r."externalRoomID" ORDER BY c.id) as rn
+          ROW_NUMBER() OVER (PARTITION BY r."externalRoomID" ORDER BY r.id) as rn
         FROM conversation c
         JOIN room r ON c."roomId" = r.id
         WHERE c."virtualContributorID" IS NULL


### PR DESCRIPTION
This pull request updates the `@alkemio/matrix-adapter-lib` dependency to a newer version and refines the ordering logic in a database migration to improve consistency. The most important changes are grouped below:

**Dependency Updates:**

* Upgraded `@alkemio/matrix-adapter-lib` from version `0.8.4-mapping5` to `0.8.4-mapping8` in `package.json` and `pnpm-lock.yaml` to ensure the project uses the latest features and fixes from the library. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L61-R61) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL370-R371) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6183-R6183)

**Database Migration Improvements:**

* Updated the SQL queries in `1764897584127-conversationArchitectureRefactor.ts` to use `ORDER BY r.id` instead of `ORDER BY c.id` in the `ROW_NUMBER()` window function. This change ensures that row numbering is consistent and based on the room's ID rather than the conversation's ID, which can help prevent subtle bugs in migrations involving room and conversation relationships. [[1]](diffhunk://#diff-6da88d5dc8daea4da1e976828a1f0f4ce1d9f74118648deaecbf319ed54665f0L109-R109) [[2]](diffhunk://#diff-6da88d5dc8daea4da1e976828a1f0f4ce1d9f74118648deaecbf319ed54665f0L140-R140) [[3]](diffhunk://#diff-6da88d5dc8daea4da1e976828a1f0f4ce1d9f74118648deaecbf319ed54665f0L172-R172)## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
[Copilot is generating a summary...]