### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -4270,7 +4270,7 @@ type Mutation {
   """Updates a Tagset on a Classification."""
   updateClassificationTagset(updateData: UpdateClassificationSelectTagsetValueInput!): Tagset!
   """
-  Updates a Collaboration, including InnovationFlow states, using the Space content from the specified Template.
+  Updates a Collaboration using the Space content from the specified Template. Behavior depends on parameter combinations: (1) Flow Only: deleteExistingCallouts=false, addCallouts=false - updates only InnovationFlow states; (2) Add Posts: deleteExistingCallouts=false, addCallouts=true - keeps existing and adds template callouts; (3) Replace All: deleteExistingCallouts=true, addCallouts=true - deletes existing then adds template callouts; (4) Delete Only: deleteExistingCallouts=true, addCallouts=false - deletes existing callouts and updates InnovationFlow states. Execution order: delete (if requested) → update flow states (always) → add (if requested).
   """
   updateCollaborationFromSpaceTemplate(updateData: UpdateCollaborationFromSpaceTemplateInput!): Collaboration!
   """Updates the CommunityGuidelines."""
@@ -6892,6 +6892,10 @@ input UpdateCollaborationFromSpaceTemplateInput {
   addCallouts: Boolean = false
   """ID of the Collaboration to be updated"""
   collaborationID: UUID!
+  """
+  Delete existing Callouts before applying template. When combined with addCallouts=true, enables Replace All behavior.
+  """
+  deleteExistingCallouts: Boolean = false
   """
   The Space Template whose Collaboration that will be used for updates to the target Collaboration
   """


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 254121 bytes
Snapshot md5: 24a0d2e0e7c0adfeeb32cc3e9dee6189

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to selectively remove existing callouts when updating collaboration from space templates.

* **Documentation**
  * Enhanced documentation clarifying the execution order for space template updates: delete existing callouts, update flow states, then add new callouts. Documented all parameter combination behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->