### PR TITLE
feat(conversation): enhance migration for USER_VC conversations with …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.131.7",
+  "version": "0.131.8",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/migrations/1764897584127-conversationArchitectureRefactor.ts
+++ b/src/migrations/1764897584127-conversationArchitectureRefactor.ts
@@ -27,7 +27,8 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * This migration:
  * 1. Creates conversation_membership pivot table with FKs
  * 2. Migrates conversation participants to conversation_membership:
- *    A) USER_VC conversations: insert user agent + VC agent
+ *    A) USER_VC conversations (direct virtualContributorID): insert user agent + VC agent
+ *    A') USER_VC conversations (wellKnownVirtualContributor): resolve via platform mapping, insert user agent + VC agent
  *    B) USER_USER pairs (share externalRoomID): merge into one, insert both user agents
  *    C) Standalone USER_USER: insert single user agent
  * 3. Drops legacy conversation columns (type, userID, virtualContributorID, wellKnownVirtualContributor)
@@ -95,6 +96,41 @@ export class ConversationArchitectureRefactor1764897584127
     `);
     console.log(
       `[Migration] 2A: Inserted ${userVcVcResult[1] ?? 0} VC agents for USER_VC conversations`
+    );
+
+    // 2A'. USER_VC conversations using wellKnownVirtualContributor (resolved via platform mapping)
+    // User membership first
+    const wellKnownUserResult = await queryRunner.query(`
+      INSERT INTO conversation_membership ("conversationId", "agentId")
+      SELECT c.id, u."agentId"
+      FROM conversation c
+      JOIN "user" u ON c."userID" = u.id
+      JOIN (
+        SELECT key as wk_name, (value)::uuid as vc_id
+        FROM platform, jsonb_each_text("wellKnownVirtualContributors")
+      ) p ON c."wellKnownVirtualContributor" = p.wk_name
+      WHERE c."virtualContributorID" IS NULL
+        AND c."wellKnownVirtualContributor" IS NOT NULL
+    `);
+    console.log(
+      `[Migration] 2A': Inserted ${wellKnownUserResult[1] ?? 0} user agents for wellKnown USER_VC conversations`
+    );
+
+    // VC membership via wellKnownVirtualContributor
+    const wellKnownVcResult = await queryRunner.query(`
+      INSERT INTO conversation_membership ("conversationId", "agentId")
+      SELECT c.id, vc."agentId"
+      FROM conversation c
+      JOIN (
+        SELECT key as wk_name, (value)::uuid as vc_id
+        FROM platform, jsonb_each_text("wellKnownVirtualContributors")
+      ) p ON c."wellKnownVirtualContributor" = p.wk_name
+      JOIN virtual_contributor vc ON vc.id = p.vc_id
+      WHERE c."virtualContributorID" IS NULL
+        AND c."wellKnownVirtualContributor" IS NOT NULL
+    `);
+    console.log(
+      `[Migration] 2A': Inserted ${wellKnownVcResult[1] ?? 0} VC agents for wellKnown USER_VC conversations`
     );
 
     // 2B. USER_USER pairs: find conversations sharing externalRoomID via their rooms


### PR DESCRIPTION
This pull request updates the migration logic for refactoring the conversation architecture, specifically improving how USER_VC conversations that use a well-known virtual contributor are handled. The changes ensure that these conversations correctly resolve and insert both user and VC agent memberships using platform mappings, which was previously missing.

**Migration logic improvements:**

* Added handling for USER_VC conversations that use `wellKnownVirtualContributor` by resolving the VC via platform mapping and inserting both user and VC agents into the new `conversation_membership` table.
* Clarified migration documentation to distinguish between USER_VC conversations using a direct `virtualContributorID` and those using a `wellKnownVirtualContributor`.## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
[Copilot is generating a summary...]