### PR TITLE
fix: correct JSON function usage in conversation architecture refactor

### DIFF
--- a/src/migrations/1764897584127-conversationArchitectureRefactor.ts
+++ b/src/migrations/1764897584127-conversationArchitectureRefactor.ts
@@ -107,7 +107,7 @@ export class ConversationArchitectureRefactor1764897584127
       JOIN "user" u ON c."userID" = u.id
       JOIN (
         SELECT key as wk_name, (value)::uuid as vc_id
-        FROM platform, jsonb_each_text("wellKnownVirtualContributors")
+        FROM platform, json_each_text("wellKnownVirtualContributors")
       ) p ON c."wellKnownVirtualContributor" = p.wk_name
       WHERE c."virtualContributorID" IS NULL
         AND c."wellKnownVirtualContributor" IS NOT NULL
@@ -123,7 +123,7 @@ export class ConversationArchitectureRefactor1764897584127
       FROM conversation c
       JOIN (
         SELECT key as wk_name, (value)::uuid as vc_id
-        FROM platform, jsonb_each_text("wellKnownVirtualContributors")
+        FROM platform, json_each_text("wellKnownVirtualContributors")
       ) p ON c."wellKnownVirtualContributor" = p.wk_name
       JOIN virtual_contributor vc ON vc.id = p.vc_id
       WHERE c."virtualContributorID" IS NULL


### PR DESCRIPTION
This pull request makes a small but important change to the SQL migration logic in `src/migrations/1764897584127-conversationArchitectureRefactor.ts`. The change updates the SQL function used to extract key-value pairs from the `wellKnownVirtualContributors` JSON column, ensuring compatibility with the underlying database.

Database compatibility update:

* Replaced usage of `jsonb_each_text` with `json_each_text` in two SQL queries to ensure correct handling of the `wellKnownVirtualContributors` column. [[1]](diffhunk://#diff-6da88d5dc8daea4da1e976828a1f0f4ce1d9f74118648deaecbf319ed54665f0L110-R110) [[2]](diffhunk://#diff-6da88d5dc8daea4da1e976828a1f0f4ce1d9f74118648deaecbf319ed54665f0L126-R126)## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
