### PR TITLE
Conversations optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.132.0",
+  "version": "0.132.1",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/core/dataloader/creators/loader.creators/collaboration/contributor.by.agent.id.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/collaboration/contributor.by.agent.id.loader.creator.ts
@@ -1,0 +1,69 @@
+import { SYSTEM_ACTOR_IDS } from '@common/constants/system.actor.ids';
+import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import { ILoader } from '@core/dataloader/loader.interface';
+import { IContributor } from '@domain/community/contributor/contributor.interface';
+import { Organization } from '@domain/community/organization';
+import { User } from '@domain/community/user/user.entity';
+import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { isUUID } from 'class-validator';
+import DataLoader from 'dataloader';
+import { EntityManager, In } from 'typeorm';
+
+/**
+ * DataLoader creator for batching contributor lookups by agent ID.
+ * This prevents N+1 queries when resolving message senders and reaction senders.
+ * Queries User, Organization, and VirtualContributor entities in parallel.
+ */
+@Injectable()
+export class ContributorByAgentIdLoaderCreator
+  implements DataLoaderCreator<IContributor | null>
+{
+  constructor(@InjectEntityManager() private manager: EntityManager) {}
+
+  public create(): ILoader<IContributor | null> {
+    return new DataLoader<string, IContributor | null>(
+      async agentIds => this.batchLoadByAgentIds(agentIds),
+      { cache: true, name: 'ContributorByAgentIdLoader' }
+    );
+  }
+
+  private async batchLoadByAgentIds(
+    agentIds: readonly string[]
+  ): Promise<(IContributor | null)[]> {
+    // Filter out system actors and invalid UUIDs
+    const validIds = [...agentIds].filter(
+      id => !SYSTEM_ACTOR_IDS.has(id) && isUUID(id)
+    );
+
+    if (validIds.length === 0) {
+      return agentIds.map(() => null);
+    }
+
+    // Parallel batch queries for all contributor types
+    const [users, orgs, vcs] = await Promise.all([
+      this.manager.find(User, {
+        where: { agent: { id: In(validIds) } },
+        relations: { agent: true, profile: true },
+      }),
+      this.manager.find(Organization, {
+        where: { agent: { id: In(validIds) } },
+        relations: { agent: true, profile: true },
+      }),
+      this.manager.find(VirtualContributor, {
+        where: { agent: { id: In(validIds) } },
+        relations: { agent: true, profile: true },
+      }),
+    ]);
+
+    // Map by agent ID for O(1) lookup
+    const byAgentId = new Map<string, IContributor>();
+    for (const u of users) if (u.agent) byAgentId.set(u.agent.id, u);
+    for (const o of orgs) if (o.agent) byAgentId.set(o.agent.id, o);
+    for (const vc of vcs) if (vc.agent) byAgentId.set(vc.agent.id, vc);
+
+    // Return in input order
+    return agentIds.map(id => byAgentId.get(id) ?? null);
+  }
+}

--- a/src/core/dataloader/creators/loader.creators/conversation/conversation.memberships.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/conversation/conversation.memberships.loader.creator.ts
@@ -1,0 +1,52 @@
+import { EntityManager, In } from 'typeorm';
+import DataLoader from 'dataloader';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import { ILoader } from '@core/dataloader/loader.interface';
+import { ConversationMembership } from '@domain/communication/conversation-membership/conversation.membership.entity';
+import { IConversationMembership } from '@domain/communication/conversation-membership/conversation.membership.interface';
+
+/**
+ * DataLoader creator for batching conversation membership lookups.
+ * This prevents N+1 queries when resolving conversation type, user, and virtualContributor fields.
+ * Batches membership queries across multiple conversations in a single database call.
+ */
+@Injectable()
+export class ConversationMembershipsLoaderCreator
+  implements DataLoaderCreator<IConversationMembership[]>
+{
+  constructor(@InjectEntityManager() private manager: EntityManager) {}
+
+  public create(): ILoader<IConversationMembership[]> {
+    return new DataLoader<string, IConversationMembership[]>(
+      async conversationIds => this.batchLoadMemberships(conversationIds),
+      { cache: true, name: 'ConversationMembershipsLoader' }
+    );
+  }
+
+  private async batchLoadMemberships(
+    conversationIds: readonly string[]
+  ): Promise<IConversationMembership[][]> {
+    if (conversationIds.length === 0) {
+      return [];
+    }
+
+    const memberships = await this.manager.find(ConversationMembership, {
+      where: { conversationId: In([...conversationIds]) },
+      relations: { agent: true },
+    });
+
+    // Group by conversation ID for O(1) lookup
+    const grouped = new Map<string, IConversationMembership[]>();
+    for (const id of conversationIds) {
+      grouped.set(id, []);
+    }
+    for (const membership of memberships) {
+      grouped.get(membership.conversationId)?.push(membership);
+    }
+
+    // Return in input order
+    return conversationIds.map(id => grouped.get(id) ?? []);
+  }
+}

--- a/src/core/dataloader/creators/loader.creators/conversation/conversation.memberships.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/conversation/conversation.memberships.loader.creator.ts
@@ -33,8 +33,17 @@ export class ConversationMembershipsLoaderCreator
     }
 
     const memberships = await this.manager.find(ConversationMembership, {
+      loadEagerRelations: false,
       where: { conversationId: In([...conversationIds]) },
       relations: { agent: true },
+      select: {
+        conversationId: true,
+        agentId: true,
+        agent: {
+          id: true,
+          type: true,
+        },
+      },
     });
 
     // Group by conversation ID for O(1) lookup

--- a/src/core/dataloader/creators/loader.creators/index.ts
+++ b/src/core/dataloader/creators/loader.creators/index.ts
@@ -25,6 +25,8 @@ export * from './collaboration/collaboration.callouts.set.loader.creator';
 export * from './collaboration/knowledge.base.callouts.set.loader.creator';
 export * from './collaboration/contributor.by.agent.id.loader.creator';
 
+export * from './conversation/conversation.memberships.loader.creator';
+
 export * from './space/space.collaboration.loader.creator';
 export * from './space/space.about.loader.creator';
 export * from './space/space.community.loader.creator';

--- a/src/core/dataloader/creators/loader.creators/index.ts
+++ b/src/core/dataloader/creators/loader.creators/index.ts
@@ -23,6 +23,7 @@ export * from './account/account.loader.creator';
 export * from './collaboration/collaboration.timeline.loader.creator';
 export * from './collaboration/collaboration.callouts.set.loader.creator';
 export * from './collaboration/knowledge.base.callouts.set.loader.creator';
+export * from './collaboration/contributor.by.agent.id.loader.creator';
 
 export * from './space/space.collaboration.loader.creator';
 export * from './space/space.about.loader.creator';

--- a/src/domain/communication/conversation/conversation.resolver.fields.ts
+++ b/src/domain/communication/conversation/conversation.resolver.fields.ts
@@ -46,8 +46,6 @@ export class ConversationResolverFields {
     return await this.conversationService.getRoom(conversation.id);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('type', () => CommunicationConversationType, {
     nullable: false,
     description:
@@ -55,7 +53,9 @@ export class ConversationResolverFields {
   })
   async type(
     @Parent() conversation: IConversation,
-    @Loader(ConversationMembershipsLoaderCreator)
+    @Loader(ConversationMembershipsLoaderCreator, {
+      checkParentPrivilege: AuthorizationPrivilege.READ,
+    })
     convoMembershipsLoader: ILoader<IConversationMembership[]>
   ): Promise<CommunicationConversationType> {
     const memberships = await convoMembershipsLoader.load(conversation.id);
@@ -63,8 +63,6 @@ export class ConversationResolverFields {
     return this.conversationService.inferConversationType(memberships);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('user', () => IUser, {
     nullable: true,
     description:
@@ -75,7 +73,10 @@ export class ConversationResolverFields {
     @CurrentUser() agentInfo: AgentInfo,
     @Loader(ConversationMembershipsLoaderCreator)
     convoMembershipsLoader: ILoader<IConversationMembership[]>,
-    @Loader(ContributorByAgentIdLoaderCreator, { resolveToNull: true })
+    @Loader(ContributorByAgentIdLoaderCreator, {
+      resolveToNull: true,
+      checkParentPrivilege: AuthorizationPrivilege.READ,
+    })
     contributorByAgentLoader: ILoader<IContributor | null>
   ): Promise<IUser | null> {
     // Check for pre-resolved value (used in subscription events for personalized delivery)
@@ -101,8 +102,6 @@ export class ConversationResolverFields {
     return contributor as IUser | null;
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('virtualContributor', () => IVirtualContributor, {
     nullable: true,
     description:
@@ -112,7 +111,10 @@ export class ConversationResolverFields {
     @Parent() conversation: IConversation,
     @Loader(ConversationMembershipsLoaderCreator)
     convoMembershipsLoader: ILoader<IConversationMembership[]>,
-    @Loader(ContributorByAgentIdLoaderCreator, { resolveToNull: true })
+    @Loader(ContributorByAgentIdLoaderCreator, {
+      resolveToNull: true,
+      checkParentPrivilege: AuthorizationPrivilege.READ,
+    })
     contributorByAgentLoader: ILoader<IContributor | null>
   ): Promise<IVirtualContributor | null> {
     // Check for pre-resolved value (used in subscription events)

--- a/src/domain/communication/conversation/conversation.resolver.fields.ts
+++ b/src/domain/communication/conversation/conversation.resolver.fields.ts
@@ -1,10 +1,5 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { LoggerService } from '@nestjs/common';
-import { Inject, UseGuards } from '@nestjs/common/decorators';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { AuthorizationAgentPrivilege, CurrentUser } from '@common/decorators';
-import { AuthorizationPrivilege } from '@common/enums';
-import { GraphqlGuard } from '@core/authorization';
+import { CurrentUser } from '@common/decorators';
 import { IRoom } from '@domain/communication/room/room.interface';
 import { ConversationService } from './conversation.service';
 import { IConversation } from './conversation.interface';
@@ -24,14 +19,8 @@ import { IContributor } from '@domain/community/contributor/contributor.interfac
 
 @Resolver(() => IConversation)
 export class ConversationResolverFields {
-  constructor(
-    @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService,
-    private readonly conversationService: ConversationService
-  ) {}
+  constructor(private readonly conversationService: ConversationService) {}
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('room', () => IRoom, {
     nullable: true,
     description: 'The room for this Conversation.',
@@ -46,8 +35,6 @@ export class ConversationResolverFields {
     return await this.conversationService.getRoom(conversation.id);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('type', () => CommunicationConversationType, {
     nullable: false,
     description:
@@ -63,8 +50,6 @@ export class ConversationResolverFields {
     return this.conversationService.inferConversationType(memberships);
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('user', () => IUser, {
     nullable: true,
     description:
@@ -101,8 +86,6 @@ export class ConversationResolverFields {
     return contributor as IUser | null;
   }
 
-  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
-  @UseGuards(GraphqlGuard)
   @ResolveField('virtualContributor', () => IVirtualContributor, {
     nullable: true,
     description:

--- a/src/domain/communication/conversation/conversation.resolver.fields.ts
+++ b/src/domain/communication/conversation/conversation.resolver.fields.ts
@@ -46,6 +46,8 @@ export class ConversationResolverFields {
     return await this.conversationService.getRoom(conversation.id);
   }
 
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
   @ResolveField('type', () => CommunicationConversationType, {
     nullable: false,
     description:
@@ -53,9 +55,7 @@ export class ConversationResolverFields {
   })
   async type(
     @Parent() conversation: IConversation,
-    @Loader(ConversationMembershipsLoaderCreator, {
-      checkParentPrivilege: AuthorizationPrivilege.READ,
-    })
+    @Loader(ConversationMembershipsLoaderCreator)
     convoMembershipsLoader: ILoader<IConversationMembership[]>
   ): Promise<CommunicationConversationType> {
     const memberships = await convoMembershipsLoader.load(conversation.id);
@@ -63,6 +63,8 @@ export class ConversationResolverFields {
     return this.conversationService.inferConversationType(memberships);
   }
 
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
   @ResolveField('user', () => IUser, {
     nullable: true,
     description:
@@ -73,10 +75,7 @@ export class ConversationResolverFields {
     @CurrentUser() agentInfo: AgentInfo,
     @Loader(ConversationMembershipsLoaderCreator)
     convoMembershipsLoader: ILoader<IConversationMembership[]>,
-    @Loader(ContributorByAgentIdLoaderCreator, {
-      resolveToNull: true,
-      checkParentPrivilege: AuthorizationPrivilege.READ,
-    })
+    @Loader(ContributorByAgentIdLoaderCreator, { resolveToNull: true })
     contributorByAgentLoader: ILoader<IContributor | null>
   ): Promise<IUser | null> {
     // Check for pre-resolved value (used in subscription events for personalized delivery)
@@ -102,6 +101,8 @@ export class ConversationResolverFields {
     return contributor as IUser | null;
   }
 
+  @AuthorizationAgentPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
   @ResolveField('virtualContributor', () => IVirtualContributor, {
     nullable: true,
     description:
@@ -111,10 +112,7 @@ export class ConversationResolverFields {
     @Parent() conversation: IConversation,
     @Loader(ConversationMembershipsLoaderCreator)
     convoMembershipsLoader: ILoader<IConversationMembership[]>,
-    @Loader(ContributorByAgentIdLoaderCreator, {
-      resolveToNull: true,
-      checkParentPrivilege: AuthorizationPrivilege.READ,
-    })
+    @Loader(ContributorByAgentIdLoaderCreator, { resolveToNull: true })
     contributorByAgentLoader: ILoader<IContributor | null>
   ): Promise<IVirtualContributor | null> {
     // Check for pre-resolved value (used in subscription events)

--- a/src/domain/communication/conversation/conversation.service.ts
+++ b/src/domain/communication/conversation/conversation.service.ts
@@ -426,30 +426,28 @@ export class ConversationService {
    * without loading full user/virtualContributor entities. Agent type is eagerly loaded
    * by the memberships query, avoiding N+1 queries.
    * Enforces exactly at most 2 members per conversation (per spec clarification).
-   * @param conversationId - UUID of the conversation
    * @returns USER_USER if both are users, USER_VC if one is a VC
    * @throws ValidationException if conversation doesn't have exactly 2 members
+   * @param memberships
    */
   async inferConversationType(
-    conversationId: string
+    memberships: IConversationMembership[]
   ): Promise<CommunicationConversationType> {
-    const members = await this.getConversationMembers(conversationId);
-
-    if (members.length > 2) {
+    if (memberships.length > 2) {
       throw new ValidationException(
         'Conversation must have exactly 2 members',
         LogContext.COMMUNICATION,
         {
           details: {
-            conversationId,
-            memberCount: members.length,
+            conversationId: memberships[0]?.conversationId,
+            memberCount: memberships.length,
           },
         }
       );
     }
 
     // Check if any agent is a virtual contributor using agent.type field
-    const hasVC = members.some(
+    const hasVC = memberships.some(
       m => m.agent.type === AgentType.VIRTUAL_CONTRIBUTOR
     );
 

--- a/src/domain/communication/conversation/conversation.service.ts
+++ b/src/domain/communication/conversation/conversation.service.ts
@@ -320,8 +320,10 @@ export class ConversationService {
   }
 
   /**
-   * Get all members of a conversation via the pivot table.   * Performance: Queries are limited to 2 members per conversation by domain constraint.
-   * Consider DataLoader batching for GraphQL resolvers when querying multiple conversations.   * @param conversationId - UUID of the conversation
+   * Get all members of a conversation via the pivot table.
+   * Performance: Queries are limited to 2 members per conversation by domain constraint.
+   * Consider DataLoader batching for GraphQL resolvers when querying multiple conversations.
+   * @param conversationId - UUID of the conversation
    * @returns Array of conversation memberships with agent relationships loaded
    */
   async getConversationMembers(

--- a/src/domain/communication/conversation/conversation.service.ts
+++ b/src/domain/communication/conversation/conversation.service.ts
@@ -329,10 +329,17 @@ export class ConversationService {
   async getConversationMembers(
     conversationId: string
   ): Promise<IConversationMembership[]> {
-    return await this.conversationMembershipRepository.find({
+    return this.conversationMembershipRepository.find({
+      loadEagerRelations: false,
       where: { conversationId },
-      relations: {
-        agent: true,
+      relations: { agent: true },
+      select: {
+        conversationId: true,
+        agentId: true,
+        agent: {
+          id: true,
+          type: true,
+        },
       },
     });
   }

--- a/src/domain/communication/message.reaction/message.reaction.resolver.fields.ts
+++ b/src/domain/communication/message.reaction/message.reaction.resolver.fields.ts
@@ -34,7 +34,7 @@ export class MessageReactionResolverFields {
     // Look up contributor by agent ID - reactions are only from users per schema
     const sender = await loader.load(messageReaction.sender);
 
-    if (!sender === null) {
+    if (sender === null) {
       this.logger?.warn(
         {
           message:

--- a/src/domain/communication/message.reaction/message.reaction.resolver.fields.ts
+++ b/src/domain/communication/message.reaction/message.reaction.resolver.fields.ts
@@ -1,18 +1,19 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { LogContext } from '@common/enums/logging.context';
-import { EntityNotFoundException } from '@common/exceptions';
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER, WinstonLogger } from 'nest-winston';
-import { IMessageReaction } from './message.reaction.interface';
-import { ContributorLookupService } from '@services/infrastructure/contributor-lookup/contributor.lookup.service';
+import { Loader } from '@core/dataloader/decorators/data.loader.decorator';
+import { ILoader } from '@core/dataloader/loader.interface';
+import { IContributor } from '@domain/community/contributor/contributor.interface';
 import { IUser } from '@domain/community/user/user.interface';
+import { ContributorByAgentIdLoaderCreator } from '@core/dataloader/creators/loader.creators';
+import { IMessageReaction } from './message.reaction.interface';
 
 @Resolver(() => IMessageReaction)
 export class MessageReactionResolverFields {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: WinstonLogger,
-    private contributorLookupService: ContributorLookupService
+    private readonly logger: WinstonLogger
   ) {}
 
   @ResolveField('sender', () => IUser, {
@@ -20,7 +21,9 @@ export class MessageReactionResolverFields {
     description: 'The user that reacted',
   })
   async sender(
-    @Parent() messageReaction: IMessageReaction
+    @Parent() messageReaction: IMessageReaction,
+    @Loader(ContributorByAgentIdLoaderCreator, { resolveToNull: true })
+    loader: ILoader<IContributor | null>
   ): Promise<IUser | null> {
     // sender contains the agent ID (actorId from the communication adapter)
     const senderAgentId = messageReaction.sender;
@@ -28,31 +31,21 @@ export class MessageReactionResolverFields {
       return null;
     }
 
-    try {
-      // Look up contributor by agent ID - reactions are only from users per schema
-      const sender =
-        await this.contributorLookupService.getContributorByAgentId(
-          senderAgentId,
-          { relations: { profile: true } }
-        );
+    // Look up contributor by agent ID - reactions are only from users per schema
+    const sender = await loader.load(messageReaction.sender);
 
-      // Return as IUser (schema constraint: reactions only from users)
-      return sender as IUser | null;
-    } catch (e: unknown) {
-      if (e instanceof EntityNotFoundException) {
-        this.logger?.warn(
-          {
-            message:
-              'Sender unable to be resolved when resolving message reaction.',
-            senderAgentId,
-            messageReactionId: messageReaction.id,
-          },
-          LogContext.COMMUNICATION
-        );
-        return null;
-      } else {
-        throw e;
-      }
+    if (!sender === null) {
+      this.logger?.warn(
+        {
+          message:
+            'Sender unable to be resolved when resolving message reaction.',
+          senderAgentId,
+          messageReactionId: messageReaction.id,
+        },
+        LogContext.COMMUNICATION
+      );
     }
+    // Return as IUser (schema constraint: reactions only from users)
+    return sender as IUser | null;
   }
 }

--- a/src/domain/communication/message/message.resolver.fields.ts
+++ b/src/domain/communication/message/message.resolver.fields.ts
@@ -1,18 +1,18 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { IMessage } from './message.interface';
 import { LogContext } from '@common/enums/logging.context';
-import { EntityNotFoundException } from '@common/exceptions';
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER, WinstonLogger } from 'nest-winston';
 import { IContributor } from '@domain/community/contributor/contributor.interface';
-import { ContributorLookupService } from '@services/infrastructure/contributor-lookup/contributor.lookup.service';
+import { ContributorByAgentIdLoaderCreator } from '@core/dataloader/creators/loader.creators';
+import { Loader } from '@core/dataloader/decorators/data.loader.decorator';
+import { ILoader } from '@core/dataloader/loader.interface';
 
 @Resolver(() => IMessage)
 export class MessageResolverFields {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: WinstonLogger,
-    private contributorLookupService: ContributorLookupService
+    private readonly logger: WinstonLogger
   ) {}
 
   @ResolveField('sender', () => IContributor, {
@@ -20,36 +20,29 @@ export class MessageResolverFields {
     description: 'The User or Virtual Contributor that created this Message',
   })
   async sender(
-    @Parent() message: IMessage
-  ): Promise<IContributor | null | never> {
+    @Parent() message: IMessage,
+    @Loader(ContributorByAgentIdLoaderCreator, { resolveToNull: true })
+    loader: ILoader<IContributor | null>
+  ): Promise<IContributor | null> {
     // sender contains the agent ID (actorId from the communication adapter)
     const senderAgentId = message.sender;
     if (!senderAgentId) {
       return null;
     }
 
-    try {
-      const sender =
-        await this.contributorLookupService.getContributorByAgentId(
-          senderAgentId,
-          { relations: { profile: true } }
-        );
+    const sender = await loader.load(message.sender);
 
-      return sender;
-    } catch (e: unknown) {
-      if (e instanceof EntityNotFoundException) {
-        this.logger?.warn(
-          {
-            message: 'Sender unable to be resolved when resolving message.',
-            senderAgentId,
-            messageId: message.id,
-          },
-          LogContext.COMMUNICATION
-        );
-        return null;
-      } else {
-        throw e;
-      }
+    if (!sender) {
+      this.logger?.warn(
+        {
+          message: 'Sender unable to be resolved when resolving message.',
+          senderAgentId,
+          messageId: message.id,
+        },
+        LogContext.COMMUNICATION
+      );
     }
+
+    return sender;
   }
 }

--- a/src/domain/communication/messaging/messaging.service.ts
+++ b/src/domain/communication/messaging/messaging.service.ts
@@ -397,6 +397,7 @@ export class MessagingService {
       // Eager-load room — the query already joins conversations,
       // just add the room relation to eliminate N queries
       .leftJoinAndSelect('conversation.room', 'room')
+      .leftJoinAndSelect('room.authorization', 'roomAuthorization')
       .where('membership.agentId = :agentId', { agentId })
       .andWhere('conversation.messagingId = :messagingId', { messagingId });
 

--- a/src/domain/communication/messaging/messaging.service.ts
+++ b/src/domain/communication/messaging/messaging.service.ts
@@ -394,6 +394,9 @@ export class MessagingService {
       .createQueryBuilder('membership')
       .innerJoinAndSelect('membership.conversation', 'conversation')
       .leftJoinAndSelect('conversation.authorization', 'authorization')
+      // Eager-load room — the query already joins conversations,
+      // just add the room relation to eliminate N queries
+      .leftJoinAndSelect('conversation.room', 'room')
       .where('membership.agentId = :agentId', { agentId })
       .andWhere('conversation.messagingId = :messagingId', { messagingId });
 


### PR DESCRIPTION
- Added a couple of data loaders to reduce the amount of db hits
- Optimized some queries to fetch less data, with less joins
- Authorization is now implicitly handled since conversations are only accessible via me.conversations where users can only retrieve their own  conversations. The dataloaders will batch properly without guard interference. 