### PR TITLE
refactor: update repository queries to use findOne

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,9 @@
 {
   "permissions": {
-    "allow": ["Bash(pnpm lint:*)", "Bash(pnpm test:*)"]
+    "allow": [
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm build:*)"
+    ]
   }
 }

--- a/src/library/library/library.service.ts
+++ b/src/library/library/library.service.ts
@@ -31,9 +31,10 @@ export class LibraryService {
   ) {}
 
   async getLibraryOrFail(options?: FindOneOptions<Library>): Promise<ILibrary> {
-    const library = (
-      await this.libraryRepository.find({ take: 1, ...options })
-    )?.[0];
+    const library = await this.libraryRepository.findOne({
+      where: {},
+      ...options,
+    });
     if (!library)
       throw new EntityNotFoundException(
         'No Library found!',

--- a/src/platform/authorization/platform.authorization.policy.service.ts
+++ b/src/platform/authorization/platform.authorization.policy.service.ts
@@ -28,14 +28,12 @@ export class PlatformAuthorizationPolicyService {
   }
 
   public async getPlatformAuthorizationPolicy(): Promise<IAuthorizationPolicy> {
-    const platform = (
-      await this.platformRepository.find({
-        take: 1,
-        relations: {
-          authorization: true,
-        },
-      })
-    )?.[0];
+    const platform = await this.platformRepository.findOne({
+      where: {},
+      relations: {
+        authorization: true,
+      },
+    });
 
     if (!platform || !platform.authorization) {
       throw new EntityNotFoundException(

--- a/src/platform/licensing/credential-based/license-policy/license.policy.service.ts
+++ b/src/platform/licensing/credential-based/license-policy/license.policy.service.ts
@@ -43,9 +43,9 @@ export class LicensePolicyService {
   // in all contexts
   public async getDefaultLicensePolicyOrFail(): Promise<ILicensePolicy> {
     let licensePolicy: ILicensePolicy | null = null;
-    licensePolicy = (
-      await this.entityManager.find(LicensePolicy, { take: 1 })
-    )?.[0];
+    licensePolicy = await this.entityManager.findOne(LicensePolicy, {
+      where: {},
+    });
 
     if (!licensePolicy) {
       throw new EntityNotFoundException(

--- a/src/platform/platform/platform.service.ts
+++ b/src/platform/platform/platform.service.ts
@@ -40,9 +40,10 @@ export class PlatformService {
     options?: FindOneOptions<Platform>
   ): Promise<IPlatform | never> {
     let platform: IPlatform | null = null;
-    platform = (
-      await this.platformRepository.find({ take: 1, ...options })
-    )?.[0];
+    platform = await this.platformRepository.findOne({
+      where: {},
+      ...options,
+    });
 
     if (!platform) {
       throw new EntityNotFoundException(

--- a/src/services/ai-server/ai-server/ai.server.service.ts
+++ b/src/services/ai-server/ai-server/ai.server.service.ts
@@ -360,9 +360,10 @@ export class AiServerService {
     options?: FindOneOptions<AiServer>
   ): Promise<IAiServer | never> {
     let aiServer: IAiServer | null = null;
-    aiServer = (
-      await this.aiServerRepository.find({ take: 1, ...options })
-    )?.[0];
+    aiServer = await this.aiServerRepository.findOne({
+      where: {},
+      ...options,
+    });
 
     if (!aiServer) {
       throw new EntityNotFoundException(


### PR DESCRIPTION
## Summary

- Replace `repository.find({ take: 1 })[0]` with `repository.findOne()` across 5 singleton-entity services to eliminate unnecessary duplicate SQL queries

## Problem

All entities extending `AuthorizableEntity` have an eager-loaded `@OneToOne` relation to `authorization_policy`. When combined with TypeORM's `find({ take: 1 })`, this triggers TypeORM's **two-query pagination-safety strategy**:

1. **Query 1** (DISTINCT subquery): `SELECT DISTINCT "distinctAlias"."Entity_id" FROM (...full query with JOINs...) "distinctAlias" LIMIT 1` — fetches the ID
2. **Query 2**: `SELECT ... FROM entity LEFT JOIN authorization_policy ... WHERE id IN ($1)` — loads the entity by that ID

This two-query pattern exists to safely paginate when JOINs can produce duplicate rows (e.g., `@OneToMany`). However, it's completely unnecessary for these singleton entities with `@OneToOne` relations.

## Solution

Replace `find({ take: 1 })` with `findOne()`, which generates a **single** `SELECT ... LIMIT 1` query directly — no DISTINCT subquery, no second round-trip.

## Affected services

| Service | Method |
|---------|--------|
| `PlatformService` | `getPlatformOrFail()` |
| `PlatformAuthorizationPolicyService` | `getPlatformAuthorizationPolicy()` |
| `LicensePolicyService` | `getDefaultLicensePolicyOrFail()` |
| `AiServerService` | `getAiServerOrFail()` |
| `LibraryService` | `getLibraryOrFail()` |

## Impact

Each of these methods now executes **1 SQL query instead of 2** per call. The `platform` query path (hit on every client page load for configuration) benefits the most.

## Test plan

- [x] Build passes (`pnpm build`)
- [ ] Verify via Elastic APM that the DISTINCT subquery no longer appears for these entities
- [ ] Regression: confirm `platform { configuration }` GraphQL query still returns correct data
- [ ] Test results below
<img width="2469" height="182" alt="image" src="https://github.com/user-attachments/assets/36eda424-a012-4f8c-ac00-9fb50feff48d" />

3 EXPECTED failures
- Upload document > read uploaded file
- Upload document > read uploaded file after related reference is removed
- Upload visual tests > read uploaded visual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal database query patterns across multiple services for improved efficiency.

* **Chores**
  * Updated configuration settings to include additional permission entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->