### PR TITLE
Latest contributions optimization

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,11 @@
 {
   "permissions": {
-    "allow": ["Bash(pnpm lint:*)", "Bash(pnpm test:*)"]
+    "allow": [
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm test:*)",
+      "Bash(npx biome check:*)",
+      "Bash(npx biome:*)",
+      "Bash(npx vitest:*)"
+    ]
   }
 }

--- a/src/domain/activity-feed/activity.feed.module.ts
+++ b/src/domain/activity-feed/activity.feed.module.ts
@@ -1,5 +1,4 @@
 import { AuthorizationModule } from '@core/authorization/authorization.module';
-import { CollaborationModule } from '@domain/collaboration/collaboration/collaboration.module';
 import { SpaceLookupModule } from '@domain/space/space.lookup/space.lookup.module';
 import { Module } from '@nestjs/common';
 import { ActivityModule } from '@platform/activity/activity.module';
@@ -12,7 +11,6 @@ import { ActivityFeedService } from './activity.feed.service';
   imports: [
     AuthorizationModule,
     PlatformAuthorizationPolicyModule,
-    CollaborationModule,
     SpaceLookupModule,
     ActivityModule,
     ActivityLogModule,

--- a/src/domain/activity-feed/activity.feed.service.spec.ts
+++ b/src/domain/activity-feed/activity.feed.service.spec.ts
@@ -1,10 +1,47 @@
+import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
+import { SpaceLevel } from '@common/enums/space.level';
+import { AgentInfo } from '@core/authentication.agent.info/agent.info';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { ICredentialDefinition } from '@domain/agent/credential/credential.definition.interface';
+import { Space } from '@domain/space/space/space.entity';
+import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
 import { MockWinstonProvider } from '@test/mocks';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { EntityManager } from 'typeorm';
+import { type Mocked, vi } from 'vitest';
 import { ActivityFeedService } from './activity.feed.service';
+
+function makeSpace(
+  id: string,
+  level: SpaceLevel,
+  collabId: string,
+  levelZeroSpaceID = id
+): Space {
+  return {
+    id,
+    level,
+    levelZeroSpaceID,
+    collaboration: {
+      id: collabId,
+      authorization: { id: `auth-${collabId}` },
+    },
+  } as unknown as Space;
+}
+
+function makeCredential(spaceId: string): ICredentialDefinition {
+  return {
+    type: AuthorizationCredential.SPACE_MEMBER,
+    resourceID: spaceId,
+  } as ICredentialDefinition;
+}
 
 describe('ActivityFeedService', () => {
   let service: ActivityFeedService;
+  let entityManager: Mocked<EntityManager>;
+  let authorizationService: Mocked<AuthorizationService>;
+  let spaceLookupService: Mocked<SpaceLookupService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -14,9 +51,231 @@ describe('ActivityFeedService', () => {
       .compile();
 
     service = module.get<ActivityFeedService>(ActivityFeedService);
+    entityManager = module.get<EntityManager>(
+      getEntityManagerToken('default')
+    ) as Mocked<EntityManager>;
+    authorizationService = module.get<AuthorizationService>(
+      AuthorizationService
+    ) as Mocked<AuthorizationService>;
+    spaceLookupService = module.get<SpaceLookupService>(
+      SpaceLookupService
+    ) as Mocked<SpaceLookupService>;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getAllAuthorizedCollaborations (via getActivityFeed)', () => {
+    it('should not query DB when no qualifying spaces', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      await service.getActivityFeed(agentInfo, { spaceIds: [] });
+
+      expect(entityManager.find).not.toHaveBeenCalled();
+    });
+
+    it('should batch-load spaces with collaborations in a single query for L2 spaces', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [makeCredential('space-1'), makeCredential('space-2')],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      const space1 = makeSpace('space-1', SpaceLevel.L2, 'collab-1');
+      const space2 = makeSpace('space-2', SpaceLevel.L2, 'collab-2');
+
+      entityManager.find.mockResolvedValueOnce([space1, space2]);
+      authorizationService.isAccessGranted.mockReturnValue(true);
+
+      await service.getActivityFeed(agentInfo, {
+        spaceIds: ['space-1', 'space-2'],
+      });
+
+      // 1 batch query for spaces (L2 has no children)
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(entityManager.find).toHaveBeenCalledWith(Space, {
+        where: { id: expect.anything() },
+        relations: { collaboration: true },
+      });
+    });
+
+    it('should batch-load L0 child spaces in a single additional query', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [makeCredential('space-l0')],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      const l0Space = makeSpace('space-l0', SpaceLevel.L0, 'collab-l0');
+      const childL1 = makeSpace(
+        'space-l1',
+        SpaceLevel.L1,
+        'collab-l1',
+        'space-l0'
+      );
+
+      entityManager.find
+        .mockResolvedValueOnce([l0Space])
+        .mockResolvedValueOnce([childL1]);
+
+      authorizationService.isAccessGranted.mockReturnValue(true);
+
+      await service.getActivityFeed(agentInfo, {
+        spaceIds: ['space-l0'],
+      });
+
+      // 2 calls: 1 for parent spaces + 1 for L0 account children
+      expect(entityManager.find).toHaveBeenCalledTimes(2);
+    });
+
+    it('should batch-load L1 subspaces in a single additional query', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [makeCredential('space-l1')],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      const l1Space = makeSpace('space-l1', SpaceLevel.L1, 'collab-l1');
+      const childL2 = makeSpace('space-l2', SpaceLevel.L2, 'collab-l2');
+
+      entityManager.find
+        .mockResolvedValueOnce([l1Space])
+        .mockResolvedValueOnce([childL2]);
+
+      authorizationService.isAccessGranted.mockReturnValue(true);
+
+      await service.getActivityFeed(agentInfo, {
+        spaceIds: ['space-l1'],
+      });
+
+      // 2 calls: 1 for parent spaces + 1 for L1 subspaces
+      expect(entityManager.find).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use isAccessGranted to filter collaborations', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [makeCredential('space-1'), makeCredential('space-2')],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      const space1 = makeSpace('space-1', SpaceLevel.L2, 'collab-1');
+      const space2 = makeSpace('space-2', SpaceLevel.L2, 'collab-2');
+
+      entityManager.find.mockResolvedValueOnce([space1, space2]);
+      authorizationService.isAccessGranted
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      await service.getActivityFeed(agentInfo, {
+        spaceIds: ['space-1', 'space-2'],
+      });
+
+      expect(authorizationService.isAccessGranted).toHaveBeenCalledTimes(2);
+      expect(authorizationService.isAccessGranted).toHaveBeenCalledWith(
+        agentInfo,
+        space1.collaboration!.authorization,
+        AuthorizationPrivilege.READ
+      );
+    });
+
+    it('should skip spaces without collaboration', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [makeCredential('space-no-collab')],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      const spaceNoCollab = {
+        id: 'space-no-collab',
+        level: SpaceLevel.L2,
+        collaboration: undefined,
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([spaceNoCollab]);
+
+      await service.getActivityFeed(agentInfo, {
+        spaceIds: ['space-no-collab'],
+      });
+
+      expect(authorizationService.isAccessGranted).not.toHaveBeenCalled();
+    });
+
+    it('should deduplicate child collaboration IDs that overlap with parent', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [makeCredential('space-l0')],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      const l0Space = makeSpace('space-l0', SpaceLevel.L0, 'collab-l0');
+      // L0 account query returns the L0 space itself + a child
+      const l0SpaceDuplicate = makeSpace(
+        'space-l0',
+        SpaceLevel.L0,
+        'collab-l0',
+        'space-l0'
+      );
+      const childL1 = makeSpace(
+        'space-l1',
+        SpaceLevel.L1,
+        'collab-l1',
+        'space-l0'
+      );
+
+      entityManager.find
+        .mockResolvedValueOnce([l0Space])
+        .mockResolvedValueOnce([l0SpaceDuplicate, childL1]);
+
+      authorizationService.isAccessGranted.mockReturnValue(true);
+
+      await service.getActivityFeed(agentInfo, {
+        spaceIds: ['space-l0'],
+      });
+
+      // l0 parent: 1 call, l0 duplicate child: skipped, l1 child: 1 call = 2 total
+      expect(authorizationService.isAccessGranted).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle mixed L0 and L1 spaces with 3 batch queries', async () => {
+      const agentInfo = Object.assign(new AgentInfo(), {
+        userID: 'user-1',
+        credentials: [makeCredential('space-l0'), makeCredential('space-l1')],
+      });
+      spaceLookupService.spacesExist.mockResolvedValue(true);
+
+      const l0Space = makeSpace('space-l0', SpaceLevel.L0, 'collab-l0');
+      const l1Space = makeSpace('space-l1', SpaceLevel.L1, 'collab-l1');
+      const l0Child = makeSpace(
+        'space-l0-child',
+        SpaceLevel.L1,
+        'collab-l0-child',
+        'space-l0'
+      );
+      const l1Child = makeSpace('space-l2', SpaceLevel.L2, 'collab-l2');
+
+      entityManager.find
+        .mockResolvedValueOnce([l0Space, l1Space]) // parent spaces
+        .mockResolvedValueOnce([l0Child]) // L0 children
+        .mockResolvedValueOnce([l1Child]); // L1 children
+
+      authorizationService.isAccessGranted.mockReturnValue(true);
+
+      await service.getActivityFeed(agentInfo, {
+        spaceIds: ['space-l0', 'space-l1'],
+      });
+
+      // 3 calls: parent spaces + L0 children + L1 children
+      expect(entityManager.find).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/src/domain/activity-feed/activity.feed.service.ts
+++ b/src/domain/activity-feed/activity.feed.service.ts
@@ -1,14 +1,15 @@
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { ActivityEventType } from '@common/enums/activity.event.type';
+import { SpaceLevel } from '@common/enums/space.level';
 import { AgentInfo } from '@core/authentication.agent.info/agent.info';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { PaginationArgs } from '@core/pagination';
 import { ActivityFeed } from '@domain/activity-feed/activity.feed.interface';
 import { ActivityFeedRoles } from '@domain/activity-feed/activity.feed.roles.enum';
-import { ICollaboration } from '@domain/collaboration/collaboration';
-import { CollaborationService } from '@domain/collaboration/collaboration/collaboration.service';
+import { Space } from '@domain/space/space/space.entity';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
 import { IActivity } from '@platform/activity';
 import { ActivityService } from '@platform/activity/activity.service';
 import { ActivityLogService } from '@services/api/activity-log';
@@ -19,6 +20,7 @@ import {
 } from '@services/api/roles/util/group.credentials.by.entity';
 import { intersection } from 'lodash';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { EntityManager, In } from 'typeorm';
 
 type ActivityFeedFilters = {
   types?: Array<ActivityEventType>;
@@ -38,11 +40,12 @@ export class ActivityFeedService {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
-    private collaborationService: CollaborationService,
     private spaceLookupService: SpaceLookupService,
     private authorizationService: AuthorizationService,
     private activityService: ActivityService,
-    private activityLogService: ActivityLogService
+    private activityLogService: ActivityLogService,
+    @InjectEntityManager('default')
+    private entityManager: EntityManager
   ) {}
 
   public async getActivityFeed(
@@ -248,63 +251,79 @@ export class ActivityFeedService {
     agentInfo: AgentInfo,
     spaceIds: string[]
   ): Promise<string[]> {
+    if (spaceIds.length === 0) {
+      return [];
+    }
+
+    // Step A: Batch-load all spaces with their collaboration (1 query instead of N)
+    const spaces = await this.entityManager.find(Space, {
+      where: { id: In(spaceIds) },
+      relations: { collaboration: true },
+    });
+
     const readableCollaborationIds: string[] = [];
-    for (const spaceId of spaceIds) {
-      // filter the collaborations by read access
-      const collaboration =
-        await this.spaceLookupService.getCollaborationOrFail(spaceId);
-      let childCollaborations: ICollaboration[] = [];
-      try {
-        this.authorizationService.grantAccessOrFail(
+
+    // Check read access on each space's collaboration (in-memory, no DB)
+    for (const space of spaces) {
+      if (!space.collaboration) {
+        continue;
+      }
+      if (
+        this.authorizationService.isAccessGranted(
           agentInfo,
-          collaboration.authorization,
-          AuthorizationPrivilege.READ,
-          `Collaboration activity query: ${agentInfo.email}`
-        );
-        readableCollaborationIds.push(collaboration.id);
-      } catch {
-        // User is not able to read collaboration - this is not uncommon
+          space.collaboration.authorization,
+          AuthorizationPrivilege.READ
+        )
+      ) {
+        readableCollaborationIds.push(space.collaboration.id);
       }
+    }
 
-      try {
-        // get all child collaborations
-        childCollaborations =
-          await this.collaborationService.getChildCollaborationsOrFail(
-            collaboration.id
-          );
-      } catch {
-        this.logger?.warn(
-          {
-            message:
-              'User is not able to read childCollaborations for collaboration',
-            userID: agentInfo.userID,
-            collaborationID: collaboration.id,
-          },
-          LogContext.ACTIVITY_FEED
-        );
+    // Step B: Batch-load child spaces based on level
+    const l0SpaceIds = spaces
+      .filter(s => s.level === SpaceLevel.L0)
+      .map(s => s.id);
+    const l1SpaceIds = spaces
+      .filter(s => s.level === SpaceLevel.L1)
+      .map(s => s.id);
+
+    // For L0 spaces: load all spaces in the account (1 query)
+    const childSpaces: Space[] = [];
+    if (l0SpaceIds.length > 0) {
+      const accountChildren = await this.entityManager.find(Space, {
+        where: { levelZeroSpaceID: In(l0SpaceIds) },
+        relations: { collaboration: true },
+      });
+      childSpaces.push(...accountChildren);
+    }
+
+    // For L1 spaces: load all L2 subspaces (1 query)
+    if (l1SpaceIds.length > 0) {
+      const subspaces = await this.entityManager.find(Space, {
+        where: { parentSpace: { id: In(l1SpaceIds) } },
+        relations: { collaboration: true },
+      });
+      childSpaces.push(...subspaces);
+    }
+
+    // Filter child collaborations by read access (in-memory)
+    for (const childSpace of childSpaces) {
+      if (!childSpace.collaboration) {
+        continue;
       }
-
-      // Filter the child collaborations by read access
-      const readableChildCollaborations = childCollaborations.filter(
-        childCollaboration => {
-          try {
-            return this.authorizationService.grantAccessOrFail(
-              agentInfo,
-              childCollaboration.authorization,
-              AuthorizationPrivilege.READ,
-              `Collaboration activity query: ${agentInfo.email} `
-            );
-          } catch {
-            return false;
-          }
-        }
-      );
-
-      const readableChildCollaborationIds = readableChildCollaborations.map(
-        childCollaboration => childCollaboration.id
-      );
-
-      readableCollaborationIds.push(...readableChildCollaborationIds);
+      // Avoid duplicates (L0 query may include the L0 space itself)
+      if (readableCollaborationIds.includes(childSpace.collaboration.id)) {
+        continue;
+      }
+      if (
+        this.authorizationService.isAccessGranted(
+          agentInfo,
+          childSpace.collaboration.authorization,
+          AuthorizationPrivilege.READ
+        )
+      ) {
+        readableCollaborationIds.push(childSpace.collaboration.id);
+      }
     }
 
     return readableCollaborationIds;

--- a/src/services/api/activity-log/activity.log.module.ts
+++ b/src/services/api/activity-log/activity.log.module.ts
@@ -9,6 +9,7 @@ import { WhiteboardModule } from '@domain/common/whiteboard/whiteboard.module';
 import { RoomModule } from '@domain/communication/room/room.module';
 import { CommunityModule } from '@domain/community/community/community.module';
 import { UserModule } from '@domain/community/user/user.module';
+import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
 import { SpaceModule } from '@domain/space/space/space.module';
 import { CalendarModule } from '@domain/timeline/calendar/calendar.module';
 import { CalendarEventModule } from '@domain/timeline/event/event.module';
@@ -30,6 +31,7 @@ import { ActivityLogService } from './activity.log.service';
     ActivityModule,
     CollaborationModule,
     UserModule,
+    UserLookupModule,
     ContributorLookupModule,
     CommunityModule,
     CalloutModule,

--- a/src/services/api/activity-log/activity.log.service.spec.ts
+++ b/src/services/api/activity-log/activity.log.service.spec.ts
@@ -1,0 +1,581 @@
+import { ActivityEventType } from '@common/enums/activity.event.type';
+import { CalloutService } from '@domain/collaboration/callout/callout.service';
+import { IUser } from '@domain/community/user/user.interface';
+import { UserService } from '@domain/community/user/user.service';
+import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
+import { Space } from '@domain/space/space/space.entity';
+import { ISpace } from '@domain/space/space/space.interface';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { IActivity } from '@platform/activity/activity.interface';
+import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
+import { ActivityService } from '@src/platform/activity/activity.service';
+import { MockWinstonProvider } from '@test/mocks';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { EntityManager } from 'typeorm';
+import { type Mocked, vi } from 'vitest';
+import { ActivityLogService } from './activity.log.service';
+import { ActivityLogInput } from './dto/activity.log.dto.collaboration.input';
+import { IActivityLogEntry } from './dto/activity.log.entry.interface';
+
+function makeUser(id: string): IUser {
+  return { id, email: `${id}@example.com` } as unknown as IUser;
+}
+
+function makeSpace(collabId: string, displayName: string): Space {
+  return {
+    id: `space-for-${collabId}`,
+    nameID: `space-${collabId}`,
+    collaboration: { id: collabId },
+    about: { profile: { displayName } },
+    community: { id: `community-${collabId}` },
+  } as unknown as Space;
+}
+
+function makeRawActivity(
+  id: string,
+  collaborationID: string,
+  triggeredBy: string,
+  type: ActivityEventType = ActivityEventType.CALLOUT_PUBLISHED
+): IActivity {
+  return {
+    id,
+    collaborationID,
+    triggeredBy,
+    resourceID: `resource-${id}`,
+    type,
+    createdDate: new Date('2024-01-01'),
+    visibility: true,
+    child: false,
+  } as unknown as IActivity;
+}
+
+describe('ActivityLogService', () => {
+  let service: ActivityLogService;
+  let entityManager: Mocked<EntityManager>;
+  let userLookupService: Mocked<UserLookupService>;
+  let userService: Mocked<UserService>;
+  let communityResolverService: Mocked<CommunityResolverService>;
+  let activityService: Mocked<ActivityService>;
+  let calloutService: Mocked<CalloutService>;
+  let logger: any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ActivityLogService, MockWinstonProvider],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get<ActivityLogService>(ActivityLogService);
+    entityManager = module.get<EntityManager>(
+      getEntityManagerToken('default')
+    ) as Mocked<EntityManager>;
+    userLookupService = module.get<UserLookupService>(
+      UserLookupService
+    ) as Mocked<UserLookupService>;
+    userService = module.get<UserService>(UserService) as Mocked<UserService>;
+    communityResolverService = module.get<CommunityResolverService>(
+      CommunityResolverService
+    ) as Mocked<CommunityResolverService>;
+    activityService = module.get<ActivityService>(
+      ActivityService
+    ) as Mocked<ActivityService>;
+    calloutService = module.get<CalloutService>(
+      CalloutService
+    ) as Mocked<CalloutService>;
+    logger = module.get(WINSTON_MODULE_NEST_PROVIDER);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('convertRawActivityToResults', () => {
+    it('should return empty array for empty input', async () => {
+      const result = await service.convertRawActivityToResults([]);
+
+      expect(result).toEqual([]);
+      expect(entityManager.find).not.toHaveBeenCalled();
+      expect(userLookupService.getUsersByUUID).not.toHaveBeenCalled();
+    });
+
+    it('should batch-load spaces and users with single queries each', async () => {
+      const user1 = makeUser('user-1');
+      const user2 = makeUser('user-2');
+      const space1 = makeSpace('collab-1', 'Space One');
+      const space2 = makeSpace('collab-2', 'Space Two');
+
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'collab-2', 'user-2'),
+        makeRawActivity('act-3', 'collab-1', 'user-1'),
+      ];
+
+      // Batch space load
+      entityManager.find.mockResolvedValueOnce([space1, space2]);
+      // Batch user load
+      userLookupService.getUsersByUUID.mockResolvedValueOnce([user1, user2]);
+
+      await service.convertRawActivityToResults(rawActivities);
+
+      // 1 batch query for spaces
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(entityManager.find).toHaveBeenCalledWith(Space, {
+        where: { collaboration: { id: expect.anything() } },
+        relations: {
+          collaboration: true,
+          about: { profile: true },
+          community: true,
+        },
+      });
+
+      // 1 batch query for users
+      expect(userLookupService.getUsersByUUID).toHaveBeenCalledTimes(1);
+      // Should deduplicate user IDs
+      expect(userLookupService.getUsersByUUID).toHaveBeenCalledWith(
+        expect.arrayContaining(['user-1', 'user-2'])
+      );
+
+      // Should NOT call individual user/space lookups
+      expect(userService.getUserOrFail).not.toHaveBeenCalled();
+      expect(
+        communityResolverService.getSpaceForCollaborationOrFail
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should deduplicate collaboration IDs and user IDs', async () => {
+      const user1 = makeUser('user-1');
+      const space1 = makeSpace('collab-1', 'Space One');
+
+      // Three activities with the same collaboration and user
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'collab-1', 'user-1'),
+        makeRawActivity('act-3', 'collab-1', 'user-1'),
+      ];
+
+      entityManager.find.mockResolvedValueOnce([space1]);
+      userLookupService.getUsersByUUID.mockResolvedValueOnce([user1]);
+
+      await service.convertRawActivityToResults(rawActivities);
+
+      // Still just 1 query each, not 3
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(userLookupService.getUsersByUUID).toHaveBeenCalledTimes(1);
+      expect(userLookupService.getUsersByUUID).toHaveBeenCalledWith(['user-1']);
+    });
+
+    it('should skip MEMBER_JOINED activities without parentID', async () => {
+      const user1 = makeUser('user-1');
+      const space1 = makeSpace('collab-1', 'Space One');
+
+      const rawActivities = [
+        {
+          ...makeRawActivity(
+            'act-1',
+            'collab-1',
+            'user-1',
+            ActivityEventType.MEMBER_JOINED
+          ),
+          parentID: undefined,
+        },
+      ];
+
+      entityManager.find.mockResolvedValueOnce([space1]);
+      userLookupService.getUsersByUUID.mockResolvedValueOnce([user1]);
+
+      const result = await service.convertRawActivityToResults(
+        rawActivities as IActivity[]
+      );
+
+      // Should return undefined for the MEMBER_JOINED activity without parentID
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeUndefined();
+    });
+  });
+
+  describe('convertRawActivityToResult', () => {
+    it('should use pre-loaded maps when provided', async () => {
+      const user = makeUser('user-1');
+      const space = makeSpace('collab-1', 'Space One');
+
+      const spaceMap = new Map<string, ISpace>([
+        ['collab-1', space as unknown as ISpace],
+      ]);
+      const userMap = new Map<string, IUser>([['user-1', user]]);
+
+      const rawActivity = makeRawActivity('act-1', 'collab-1', 'user-1');
+
+      await service.convertRawActivityToResult(rawActivity, spaceMap, userMap);
+
+      // Should NOT call individual lookups when maps are provided
+      expect(userService.getUserOrFail).not.toHaveBeenCalled();
+      expect(
+        communityResolverService.getSpaceForCollaborationOrFail
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to individual queries when maps are not provided', async () => {
+      const user = makeUser('user-1');
+      const space = makeSpace('collab-1', 'Space One');
+
+      userService.getUserOrFail.mockResolvedValueOnce(user);
+      communityResolverService.getSpaceForCollaborationOrFail.mockResolvedValueOnce(
+        space as unknown as ISpace
+      );
+
+      const rawActivity = makeRawActivity('act-1', 'collab-1', 'user-1');
+
+      await service.convertRawActivityToResult(rawActivity);
+
+      // Should use individual lookups as fallback
+      expect(userService.getUserOrFail).toHaveBeenCalledWith('user-1');
+      expect(
+        communityResolverService.getSpaceForCollaborationOrFail
+      ).toHaveBeenCalledWith('collab-1', expect.anything());
+    });
+
+    it('should fall back to individual query when user not found in map', async () => {
+      const user = makeUser('user-1');
+      const space = makeSpace('collab-1', 'Space One');
+
+      const spaceMap = new Map<string, ISpace>([
+        ['collab-1', space as unknown as ISpace],
+      ]);
+      // Empty user map — user not pre-loaded
+      const userMap = new Map<string, IUser>();
+
+      userService.getUserOrFail.mockResolvedValueOnce(user);
+
+      const rawActivity = makeRawActivity('act-1', 'collab-1', 'user-1');
+
+      await service.convertRawActivityToResult(rawActivity, spaceMap, userMap);
+
+      // User should be loaded individually since not in map
+      expect(userService.getUserOrFail).toHaveBeenCalledWith('user-1');
+      // Space should come from map
+      expect(
+        communityResolverService.getSpaceForCollaborationOrFail
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to individual query when space not found in map', async () => {
+      const user = makeUser('user-1');
+      const space = makeSpace('collab-1', 'Space One');
+
+      // Empty space map — space not pre-loaded
+      const spaceMap = new Map<string, ISpace>();
+      const userMap = new Map<string, IUser>([['user-1', user]]);
+
+      communityResolverService.getSpaceForCollaborationOrFail.mockResolvedValueOnce(
+        space as unknown as ISpace
+      );
+
+      const rawActivity = makeRawActivity('act-1', 'collab-1', 'user-1');
+
+      await service.convertRawActivityToResult(rawActivity, spaceMap, userMap);
+
+      // Space should be loaded individually since not in map
+      expect(
+        communityResolverService.getSpaceForCollaborationOrFail
+      ).toHaveBeenCalledWith('collab-1', expect.anything());
+      // User should come from map
+      expect(userService.getUserOrFail).not.toHaveBeenCalled();
+    });
+
+    it('should extract parentDisplayName from the pre-loaded space', async () => {
+      const user = makeUser('user-1');
+      const space = makeSpace('collab-1', 'My Space Name');
+
+      const spaceMap = new Map<string, ISpace>([
+        ['collab-1', space as unknown as ISpace],
+      ]);
+      const userMap = new Map<string, IUser>([['user-1', user]]);
+
+      const rawActivity = makeRawActivity('act-1', 'collab-1', 'user-1');
+
+      const result = await service.convertRawActivityToResult(
+        rawActivity,
+        spaceMap,
+        userMap
+      );
+
+      // parentDisplayName should come from space.about.profile.displayName
+      expect(result?.parentDisplayName).toBe('My Space Name');
+    });
+  });
+
+  describe('activityLog', () => {
+    it('should fetch activities from activityService and convert them', async () => {
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'collab-1', 'user-2'),
+      ];
+      activityService.getActivityForCollaborations.mockResolvedValueOnce(
+        rawActivities
+      );
+
+      const mockResult = { id: 'result-1' } as unknown as IActivityLogEntry;
+      const convertSpy = vi
+        .spyOn(service, 'convertRawActivityToResult')
+        .mockResolvedValue(mockResult);
+
+      const queryData = {
+        collaborationID: 'collab-1',
+      } as ActivityLogInput;
+      const results = await service.activityLog(queryData);
+
+      expect(activityService.getActivityForCollaborations).toHaveBeenCalledWith(
+        ['collab-1'],
+        { types: undefined }
+      );
+      expect(convertSpy).toHaveBeenCalledTimes(2);
+      expect(results).toHaveLength(2);
+    });
+
+    it('should mark child collaboration activities with child: true', async () => {
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'child-collab', 'user-2'),
+      ];
+      activityService.getActivityForCollaborations.mockResolvedValueOnce(
+        rawActivities
+      );
+
+      const convertSpy = vi
+        .spyOn(service, 'convertRawActivityToResult')
+        .mockResolvedValue({ id: 'r' } as unknown as IActivityLogEntry);
+
+      const queryData = {
+        collaborationID: 'collab-1',
+      } as ActivityLogInput;
+      await service.activityLog(queryData, ['child-collab']);
+
+      // Parent collaboration activity — child should remain falsy
+      const firstCall = convertSpy.mock.calls[0][0];
+      expect(firstCall.child).toBeFalsy();
+
+      // Child collaboration activity — should be marked child: true
+      const secondCall = convertSpy.mock.calls[1][0];
+      expect(secondCall.child).toBe(true);
+    });
+
+    it('should respect limit parameter and stop processing early', async () => {
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'collab-1', 'user-2'),
+        makeRawActivity('act-3', 'collab-1', 'user-3'),
+      ];
+      activityService.getActivityForCollaborations.mockResolvedValueOnce(
+        rawActivities
+      );
+
+      const mockResult = { id: 'result' } as unknown as IActivityLogEntry;
+      const convertSpy = vi
+        .spyOn(service, 'convertRawActivityToResult')
+        .mockResolvedValue(mockResult);
+
+      const queryData = {
+        collaborationID: 'collab-1',
+        limit: 2,
+      } as ActivityLogInput;
+      const results = await service.activityLog(queryData);
+
+      expect(results).toHaveLength(2);
+      // Should stop after reaching limit — 3rd activity never processed
+      expect(convertSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not count undefined results toward limit', async () => {
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'collab-1', 'user-2'),
+        makeRawActivity('act-3', 'collab-1', 'user-3'),
+      ];
+      activityService.getActivityForCollaborations.mockResolvedValueOnce(
+        rawActivities
+      );
+
+      const mockResult = { id: 'result' } as unknown as IActivityLogEntry;
+      const convertSpy = vi.spyOn(service, 'convertRawActivityToResult');
+      // First returns undefined, second and third return results
+      convertSpy.mockResolvedValueOnce(undefined);
+      convertSpy.mockResolvedValueOnce(mockResult);
+      convertSpy.mockResolvedValueOnce(mockResult);
+
+      const queryData = {
+        collaborationID: 'collab-1',
+        limit: 2,
+      } as ActivityLogInput;
+      const results = await service.activityLog(queryData);
+
+      // All 3 processed since undefined doesn't count toward limit
+      expect(convertSpy).toHaveBeenCalledTimes(3);
+      expect(results).toHaveLength(2);
+    });
+
+    it('should filter out undefined results when no limit is set', async () => {
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'collab-1', 'user-2'),
+        makeRawActivity('act-3', 'collab-1', 'user-3'),
+      ];
+      activityService.getActivityForCollaborations.mockResolvedValueOnce(
+        rawActivities
+      );
+
+      const mockResult = { id: 'result' } as unknown as IActivityLogEntry;
+      const convertSpy = vi.spyOn(service, 'convertRawActivityToResult');
+      convertSpy.mockResolvedValueOnce(undefined);
+      convertSpy.mockResolvedValueOnce(mockResult);
+      convertSpy.mockResolvedValueOnce(mockResult);
+
+      const queryData = {
+        collaborationID: 'collab-1',
+      } as ActivityLogInput;
+      const results = await service.activityLog(queryData);
+
+      expect(convertSpy).toHaveBeenCalledTimes(3);
+      expect(results).toHaveLength(2);
+    });
+
+    it('should pass types and child collaboration IDs to activityService', async () => {
+      activityService.getActivityForCollaborations.mockResolvedValueOnce([]);
+
+      const types = [
+        ActivityEventType.CALLOUT_PUBLISHED,
+        ActivityEventType.MEMBER_JOINED,
+      ];
+      const queryData = {
+        collaborationID: 'collab-1',
+        types,
+      } as ActivityLogInput;
+      await service.activityLog(queryData, ['child-1', 'child-2']);
+
+      expect(activityService.getActivityForCollaborations).toHaveBeenCalledWith(
+        ['collab-1', 'child-1', 'child-2'],
+        { types }
+      );
+    });
+  });
+
+  describe('convertRawActivityToResult - error handling', () => {
+    it('should return undefined when builder throws', async () => {
+      const user = makeUser('user-1');
+      const space = makeSpace('collab-1', 'Space One');
+
+      const spaceMap = new Map<string, ISpace>([
+        ['collab-1', space as unknown as ISpace],
+      ]);
+      const userMap = new Map<string, IUser>([['user-1', user]]);
+
+      calloutService.getCalloutOrFail.mockRejectedValueOnce(
+        new Error('DB connection lost')
+      );
+
+      const rawActivity = makeRawActivity('act-1', 'collab-1', 'user-1');
+      const result = await service.convertRawActivityToResult(
+        rawActivity,
+        spaceMap,
+        userMap
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should log a warning when an activity fails to convert', async () => {
+      const user = makeUser('user-1');
+      const space = makeSpace('collab-1', 'Space One');
+
+      const spaceMap = new Map<string, ISpace>([
+        ['collab-1', space as unknown as ISpace],
+      ]);
+      const userMap = new Map<string, IUser>([['user-1', user]]);
+
+      calloutService.getCalloutOrFail.mockRejectedValueOnce(
+        new Error('DB connection lost')
+      );
+
+      const rawActivity = makeRawActivity('act-1', 'collab-1', 'user-1');
+      await service.convertRawActivityToResult(rawActivity, spaceMap, userMap);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('act-1'),
+        expect.any(String)
+      );
+    });
+
+    it('should isolate errors: one failing activity does not affect others in batch', async () => {
+      const user1 = makeUser('user-1');
+      const space1 = makeSpace('collab-1', 'Space One');
+
+      const rawActivities = [
+        makeRawActivity('act-1', 'collab-1', 'user-1'),
+        makeRawActivity('act-2', 'collab-1', 'user-1'),
+      ];
+
+      entityManager.find.mockResolvedValueOnce([space1]);
+      userLookupService.getUsersByUUID.mockResolvedValueOnce([user1]);
+
+      // First activity fails in builder, second succeeds
+      calloutService.getCalloutOrFail
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce({ id: 'callout-1' });
+
+      const results = await service.convertRawActivityToResults(rawActivities);
+
+      expect(results).toHaveLength(2);
+      // First should be undefined (failed)
+      expect(results[0]).toBeUndefined();
+      // Second should have a result
+      expect(results[1]).toBeDefined();
+    });
+  });
+
+  describe('convertRawActivityToResults - output shape', () => {
+    it('should return entries with correct base fields', async () => {
+      const user1 = makeUser('user-1');
+      const space1 = makeSpace('collab-1', 'Space One');
+
+      const rawActivities = [makeRawActivity('act-1', 'collab-1', 'user-1')];
+
+      entityManager.find.mockResolvedValueOnce([space1]);
+      userLookupService.getUsersByUUID.mockResolvedValueOnce([user1]);
+      calloutService.getCalloutOrFail.mockResolvedValueOnce({
+        id: 'callout-1',
+      });
+
+      const results = await service.convertRawActivityToResults(rawActivities);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        id: 'act-1',
+        collaborationID: 'collab-1',
+        type: ActivityEventType.CALLOUT_PUBLISHED,
+        parentDisplayName: 'Space One',
+        triggeredBy: expect.objectContaining({ id: 'user-1' }),
+        space: expect.objectContaining({ id: 'space-for-collab-1' }),
+      });
+    });
+
+    it('should filter falsy triggeredBy from batch user load', async () => {
+      const space1 = makeSpace('collab-1', 'Space One');
+
+      const rawActivities = [makeRawActivity('act-1', 'collab-1', '')];
+
+      entityManager.find.mockResolvedValueOnce([space1]);
+      userLookupService.getUsersByUUID.mockResolvedValueOnce([]);
+
+      await service.convertRawActivityToResults(rawActivities);
+
+      // Empty triggeredBy should be filtered from batch user load
+      expect(userLookupService.getUsersByUUID).toHaveBeenCalledWith([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix N+1 query problem in `activityFeed` GraphQL query** — reduces ~121 Space SELECT statements down to ~5 by batching database queries at two layers: authorization and per-item conversion
- **Batch `getAllAuthorizedCollaborations`** in `ActivityFeedService` — replaces sequential per-space queries with 2-3 bulk `IN()` queries for spaces, child spaces (L0 accounts), and subspaces (L1→L2), using `isAccessGranted()` instead of try/catch with `grantAccessOrFail()`
- **Batch pre-load spaces and users in `convertRawActivityToResults`** — collects unique collaboration IDs and user IDs upfront, loads all spaces and users in 2 queries, then passes pre-loaded maps into per-item conversion (with fallback to individual queries for the `activityLog` code path)
- **Eliminate duplicate Space query in `UPDATE_SENT` builder** — reuses the already-loaded space from `activityLogEntryBase.space` instead of issuing a separate `entityManager.findOne(Space)` per item
- **Remove unused `EntityManager` dependency from `ActivityLogBuilderService`** and unused `CollaborationModule`/`CollaborationService` from `ActivityFeedService`

### Query count impact

| Phase | Before | After |
|---|---|---|
| Authorization (M spaces) | 2M–3M | 2–3 |
| Per-item conversion (P items) | 3P | 2 |
| Builder (`UPDATE_SENT`) | 1 per item | 0 |
| **Total (M=10, P=50)** | **~121** | **~5** |

## Test plan

- [x] `pnpm build` compiles without errors
- [x] `pnpm lint` passes (no new lint issues)
- [x] `pnpm test:ci:no:coverage` — all 435 tests pass
- [ ] Run `LatestContributions` GraphQL query against a running instance and verify Space SELECT count drops from ~121 to ~5
- [ ] Verify `activityFeed` (paginated) and `latestContributionsGrouped` (grouped) both return correct results
- [ ] Verify the `activityLog` resolver (single-collaboration path) still works correctly via fallback queries
- [ ] Test results
<img width="2443" height="140" alt="image" src="https://github.com/user-attachments/assets/0e21b304-3e1e-4e5f-8223-bd94f4c2bb44" />

EXPECTED failed tests:
- Upload document > read uploaded file
- Upload document > read uploaded file after related reference is removed
- Upload visual tests > read uploaded visual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized activity feed loading through batch operations to reduce database queries.
  * Enhanced activity log retrieval with pre-loaded data caching for improved performance.

* **Tests**
  * Expanded test coverage for activity feed and activity log services with comprehensive scenarios.

* **Refactor**
  * Simplified internal architecture and removed redundant dependencies for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->