### PR TITLE
Adds database restoration skill

### DIFF
--- a/.claude/commands/restore-dbs.md
+++ b/.claude/commands/restore-dbs.md
@@ -1,0 +1,61 @@
+---
+description: Restore databases (alkemio, synapse, optionally kratos) from latest backup set
+arguments:
+  - name: environment
+    description: Environment to restore from (prod/dev/acc/sandbox)
+    required: true
+  - name: restart_services
+    description: Whether to restart services after restore (true/false, default true)
+    required: false
+  - name: non_interactive
+    description: Run without prompts (true/false, default true)
+    required: false
+  - name: restore_kratos
+    description: Whether to also restore kratos database (true/false, default false)
+    required: false
+---
+
+## Prerequisites
+
+Before running, ensure `.scripts/backups/.env` exists with AWS and PostgreSQL credentials:
+
+```bash
+# Check if .env exists
+cat .scripts/backups/.env
+```
+
+If missing, copy from sample and fill in credentials:
+```bash
+cp .scripts/backups/.env.sample .scripts/backups/.env
+```
+
+Required variables:
+- `AWS_ACCESS_KEY_ID` - Scaleway S3 access key
+- `AWS_SECRET_ACCESS_KEY` - Scaleway S3 secret key
+- `POSTGRES_USER` - PostgreSQL user (typically "synapse")
+- `POSTGRES_PASSWORD` - PostgreSQL password
+- `POSTGRES_ALKEMIO_DB`, `POSTGRES_KRATOS_DB`, `POSTGRES_SYNAPSE_DB` - Database names
+
+## Execution
+
+1. First verify credentials exist:
+```bash
+test -f .scripts/backups/.env && echo "Credentials file exists" || echo "ERROR: Missing .scripts/backups/.env - copy from .env.sample and configure"
+```
+
+2. If credentials exist, run the restore script. Parse arguments from `$ARGUMENTS` (environment, restart_services, non_interactive, restore_kratos):
+```bash
+cd .scripts/backups && bash restore_latest_backup_set.sh <environment> [restart_services] [non_interactive] [restore_kratos]
+```
+
+**Default behavior:**
+- Restores `alkemio` and `synapse` databases
+- Kratos is NOT restored by default (pass `true` as 4th argument to include it)
+- Services are restarted after restore
+
+**Examples:**
+- `/restore-dbs prod` - Restore prod databases (no kratos), restart services
+- `/restore-dbs dev false` - Restore dev databases, don't restart services
+- `/restore-dbs acc true true true` - Restore acc databases INCLUDING kratos
+
+Report the script output to the user. If credentials are missing, guide the user to set them up.

--- a/.claude/skills/restore-dbs.md
+++ b/.claude/skills/restore-dbs.md
@@ -1,0 +1,125 @@
+# Database Restoration
+
+When asked to restore databases or work with backup data from environments (prod, dev, acc, sandbox), follow this guide.
+
+## Overview
+
+The restore system downloads PostgreSQL backups from Scaleway S3 and restores them to the local Docker PostgreSQL container (`alkemio_dev_postgres`).
+
+**Databases available:**
+- `alkemio` - Main application database
+- `synapse` - Matrix/Synapse communication database
+- `kratos` - Ory Kratos identity database (optional, usually not restored)
+
+## Prerequisites
+
+### 1. Credentials File
+
+Ensure `.scripts/backups/.env` exists:
+
+```bash
+# Check if credentials exist
+test -f .scripts/backups/.env && echo "OK" || echo "Missing - needs setup"
+```
+
+If missing, create from sample:
+```bash
+cp .scripts/backups/.env.sample .scripts/backups/.env
+```
+
+Required variables:
+- `AWS_ACCESS_KEY_ID` - Scaleway S3 access key
+- `AWS_SECRET_ACCESS_KEY` - Scaleway S3 secret key
+- `POSTGRES_USER` - PostgreSQL user (typically "synapse")
+- `POSTGRES_PASSWORD` - PostgreSQL password
+- `POSTGRES_ALKEMIO_DB` - Alkemio database name
+- `POSTGRES_KRATOS_DB` - Kratos database name
+- `POSTGRES_SYNAPSE_DB` - Synapse database name
+
+### 2. Docker Services
+
+The PostgreSQL container must be running:
+```bash
+docker ps | grep alkemio_dev_postgres
+```
+
+If not running:
+```bash
+pnpm run start:services
+```
+
+## Restoration Commands
+
+### Restore Full Set (Recommended)
+
+Restores alkemio + synapse (kratos optional):
+
+```bash
+cd .scripts/backups && bash restore_latest_backup_set.sh <environment> [restart_services] [non_interactive] [restore_kratos]
+```
+
+**Arguments:**
+| Arg | Values | Default | Description |
+|-----|--------|---------|-------------|
+| environment | prod/dev/acc/sandbox | prod | Source environment |
+| restart_services | true/false | true | Restart services after |
+| non_interactive | true/false | true | Skip confirmation prompts |
+| restore_kratos | true/false | false | Include kratos database |
+
+**Examples:**
+```bash
+# Restore prod, restart services
+bash restore_latest_backup_set.sh prod
+
+# Restore dev, no restart
+bash restore_latest_backup_set.sh dev false
+
+# Restore acc with kratos
+bash restore_latest_backup_set.sh acc true true true
+```
+
+### Restore Single Database
+
+For restoring just one database:
+
+```bash
+cd .scripts/backups && bash restore_latest_backup.sh <database> <environment> [non_interactive]
+```
+
+**Examples:**
+```bash
+bash restore_latest_backup.sh alkemio prod true
+bash restore_latest_backup.sh synapse dev true
+bash restore_latest_backup.sh kratos acc true
+```
+
+## Environment Mapping
+
+| Environment | S3 Bucket | Region | Matrix Server |
+|-------------|-----------|--------|---------------|
+| prod | alkemio-s3-backups-prod-paris | fr-par | matrix.alkem.io |
+| dev | alkemio-s3-backups-dev | nl-ams | matrix-dev.alkem.io |
+| acc | alkemio-s3-backups-dev | nl-ams | matrix-acc.alkem.io |
+| sandbox | alkemio-s3-backups-dev | nl-ams | matrix-sandbox.alkem.io |
+
+## Troubleshooting
+
+### AWS CLI Issues
+The script auto-installs AWS CLI v2 if missing. If authentication fails:
+```bash
+aws configure list  # Check current config
+cat ~/.aws/credentials  # Verify credentials
+```
+
+### Database Connection Errors
+Ensure container is running and healthy:
+```bash
+docker exec alkemio_dev_postgres pg_isready -U synapse
+```
+
+### Backup Not Found
+List available backups:
+```bash
+source .scripts/backups/.env
+aws s3 ls s3://alkemio-s3-backups-prod-paris/storage/postgres/backups/alkemio/
+```

--- a/.scripts/backups/restore_latest_backup_set.sh
+++ b/.scripts/backups/restore_latest_backup_set.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-# Usage: ./restore_latest_backup_set.sh <environment> [restart_services] [non_interactive]
+# Usage: ./restore_latest_backup_set.sh <environment> [restart_services] [non_interactive] [restore_kratos]
 # Arguments:
 #   environment      - Environment to restore (acc/dev/sandbox/prod). Default: prod
 #   restart_services - Whether to restart services after restore (true/false). Default: true
 #   non_interactive  - Run without prompts (true/false). Default: true
+#   restore_kratos   - Whether to restore kratos database (true/false). Default: false
 # Examples:
-#   ./restore_latest_backup_set.sh acc false true   # Restore acc, no restart, non-interactive
-#   ./restore_latest_backup_set.sh dev true false   # Restore dev, restart, interactive mode
+#   ./restore_latest_backup_set.sh acc false true        # Restore acc, no restart, non-interactive, no kratos
+#   ./restore_latest_backup_set.sh dev true false        # Restore dev, restart, interactive mode, no kratos
+#   ./restore_latest_backup_set.sh prod true true true   # Restore prod with kratos database
 
 # Determine the platform (macOS vs. Linux vs. others)
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
@@ -55,6 +57,9 @@ RESTART_SERVICES=${2:-true}
 
 # Optional parameter for non-interactive mode (default is true)
 NON_INTERACTIVE=${3:-true}
+
+# Optional parameter to restore kratos database (default is false)
+RESTORE_KRATOS=${4:-false}
 
 # The path to the .env.docker file is the second argument.
 ENV_FILE_PATH=../../.env.docker
@@ -108,8 +113,13 @@ SCRIPT_PATH='restore_latest_backup.sh'
 # Call the existing script for alkemio (pass NON_INTERACTIVE mode)
 bash $SCRIPT_PATH alkemio $ENV $NON_INTERACTIVE
 
-# Call the existing script for kratos (pass NON_INTERACTIVE mode)
-bash $SCRIPT_PATH kratos $ENV $NON_INTERACTIVE
+# Conditionally restore kratos database based on the RESTORE_KRATOS flag
+if [[ "$RESTORE_KRATOS" == "true" ]]; then
+    echo "Restoring kratos database..."
+    bash $SCRIPT_PATH kratos $ENV $NON_INTERACTIVE
+else
+    echo "Skipping kratos database restore (use 4th argument 'true' to enable)."
+fi
 
 # Call the existing script for synapse (pass NON_INTERACTIVE mode)
 bash $SCRIPT_PATH synapse $ENV $NON_INTERACTIVE


### PR DESCRIPTION
### Describe the background of your pull request

Adds a new skill to restore databases from backups. This includes instructions and scripts for restoring PostgreSQL databases (alkemio, synapse, and kratos) from Scaleway S3 backups to a local Docker container. It also introduces a `restore_kratos` option to include the kratos database in the restoration process.

### Additional context

The database restoration skill aims to streamline the process of restoring databases from various environments (prod, dev, acc, sandbox) for development and testing purposes.

### Governance

- [x] Documentation is added




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for database restoration workflows and procedures.

* **Chores**
  * Enhanced database restoration script with optional restoration controls and conditional service restart capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->