### PR TITLE
feat: Space page resolvers optimized

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(npx biome check*)",
       "Bash(npx biome*)",
       "Bash(npx vitest*)",
-      "Bash(.scripts/register-user.sh:*)"
+      "Bash(.scripts/register-user.sh:*)",
+      "Bash(git stash:*)"
     ]
   }
 }

--- a/src/core/dataloader/creators/loader.creators/callout/callout.activity.loader.creator.spec.ts
+++ b/src/core/dataloader/creators/loader.creators/callout/callout.activity.loader.creator.spec.ts
@@ -1,0 +1,226 @@
+import { CalloutContribution } from '@domain/collaboration/callout-contribution/callout.contribution.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { type Mocked, vi } from 'vitest';
+import { EntityManager } from 'typeorm';
+import { CalloutActivityLoaderCreator } from './callout.activity.loader.creator';
+
+/**
+ * Helper to build the mock query builder chain used by
+ * `manager.getRepository(CalloutContribution).createQueryBuilder(...)`.
+ * Returns the terminal mock so we can set what `getRawMany` resolves to.
+ */
+function mockQueryBuilder(
+  entityManager: Mocked<EntityManager>,
+  rawResult: { calloutId: string; count: string }[]
+) {
+  const qb = {
+    select: vi.fn().mockReturnThis(),
+    addSelect: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
+    getRawMany: vi.fn().mockResolvedValue(rawResult),
+  };
+  const repo = { createQueryBuilder: vi.fn().mockReturnValue(qb) };
+  entityManager.getRepository.mockReturnValue(repo as any);
+  return qb;
+}
+
+describe('CalloutActivityLoaderCreator', () => {
+  let creator: CalloutActivityLoaderCreator;
+  let entityManager: Mocked<EntityManager>;
+
+  beforeEach(async () => {
+    const mockEntityManager = {
+      find: vi.fn(),
+      getRepository: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalloutActivityLoaderCreator,
+        {
+          provide: getEntityManagerToken(),
+          useValue: mockEntityManager,
+        },
+      ],
+    }).compile();
+
+    creator = module.get(CalloutActivityLoaderCreator);
+    entityManager = module.get(
+      getEntityManagerToken()
+    ) as Mocked<EntityManager>;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(creator).toBeDefined();
+  });
+
+  it('should create a DataLoader', () => {
+    const loader = creator.create();
+    expect(loader).toBeDefined();
+    expect(typeof loader.load).toBe('function');
+  });
+
+  describe('batch loading', () => {
+    it('should batch multiple loads into a single grouped COUNT query', async () => {
+      mockQueryBuilder(entityManager, [
+        { calloutId: 'callout-1', count: '5' },
+        { calloutId: 'callout-2', count: '12' },
+      ]);
+
+      const loader = creator.create();
+
+      const [count1, count2] = await Promise.all([
+        loader.load('callout-1'),
+        loader.load('callout-2'),
+      ]);
+
+      expect(entityManager.getRepository).toHaveBeenCalledWith(
+        CalloutContribution
+      );
+      expect(count1).toBe(5);
+      expect(count2).toBe(12);
+    });
+
+    it('should return 0 for callouts with no contributions', async () => {
+      // DB only returns a row for callout-1; callout-2 has no contributions
+      mockQueryBuilder(entityManager, [
+        { calloutId: 'callout-1', count: '3' },
+      ]);
+
+      const loader = creator.create();
+
+      const [count1, count2] = await Promise.all([
+        loader.load('callout-1'),
+        loader.load('callout-2'),
+      ]);
+
+      expect(count1).toBe(3);
+      expect(count2).toBe(0);
+    });
+
+    it('should return results in input order regardless of DB return order', async () => {
+      // DB returns in reverse order
+      mockQueryBuilder(entityManager, [
+        { calloutId: 'callout-3', count: '30' },
+        { calloutId: 'callout-1', count: '10' },
+        { calloutId: 'callout-2', count: '20' },
+      ]);
+
+      const loader = creator.create();
+
+      const [c1, c2, c3] = await Promise.all([
+        loader.load('callout-1'),
+        loader.load('callout-2'),
+        loader.load('callout-3'),
+      ]);
+
+      expect(c1).toBe(10);
+      expect(c2).toBe(20);
+      expect(c3).toBe(30);
+    });
+
+    it('should parse count strings from DB as integers', async () => {
+      mockQueryBuilder(entityManager, [
+        { calloutId: 'callout-1', count: '999' },
+      ]);
+
+      const loader = creator.create();
+      const count = await loader.load('callout-1');
+
+      expect(count).toBe(999);
+      expect(typeof count).toBe('number');
+    });
+  });
+
+  describe('caching', () => {
+    it('should use DataLoader caching for repeated keys', async () => {
+      mockQueryBuilder(entityManager, [
+        { calloutId: 'callout-1', count: '7' },
+      ]);
+
+      const loader = creator.create();
+
+      const result1 = await loader.load('callout-1');
+      const result2 = await loader.load('callout-1');
+
+      expect(entityManager.getRepository).toHaveBeenCalledTimes(1);
+      expect(result1).toBe(result2);
+    });
+
+    it('should cache zero counts and not re-query', async () => {
+      mockQueryBuilder(entityManager, []);
+
+      const loader = creator.create();
+
+      const result1 = await loader.load('callout-missing');
+      expect(result1).toBe(0);
+
+      const result2 = await loader.load('callout-missing');
+      expect(result2).toBe(0);
+
+      expect(entityManager.getRepository).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should propagate database errors to all pending loads', async () => {
+      const qb = {
+        select: vi.fn().mockReturnThis(),
+        addSelect: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        groupBy: vi.fn().mockReturnThis(),
+        getRawMany: vi
+          .fn()
+          .mockRejectedValue(new Error('DB connection failed')),
+      };
+      const repo = { createQueryBuilder: vi.fn().mockReturnValue(qb) };
+      entityManager.getRepository.mockReturnValue(repo as any);
+
+      const loader = creator.create();
+
+      const [result1, result2] = await Promise.allSettled([
+        loader.load('callout-1'),
+        loader.load('callout-2'),
+      ]);
+
+      expect(result1.status).toBe('rejected');
+      expect(result2.status).toBe('rejected');
+      expect((result1 as PromiseRejectedResult).reason.message).toBe(
+        'DB connection failed'
+      );
+    });
+
+    it('should handle a single callout load', async () => {
+      mockQueryBuilder(entityManager, [
+        { calloutId: 'solo', count: '42' },
+      ]);
+
+      const loader = creator.create();
+      const count = await loader.load('solo');
+
+      expect(count).toBe(42);
+    });
+
+    it('should handle all callouts having zero contributions', async () => {
+      mockQueryBuilder(entityManager, []);
+
+      const loader = creator.create();
+
+      const [c1, c2, c3] = await Promise.all([
+        loader.load('callout-1'),
+        loader.load('callout-2'),
+        loader.load('callout-3'),
+      ]);
+
+      expect(c1).toBe(0);
+      expect(c2).toBe(0);
+      expect(c3).toBe(0);
+    });
+  });
+});

--- a/src/core/dataloader/creators/loader.creators/callout/callout.activity.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/callout/callout.activity.loader.creator.ts
@@ -11,9 +11,9 @@ import { EntityManager, In } from 'typeorm';
  * For N contribution-type callouts, this performs a single grouped COUNT
  * query instead of N individual COUNT queries.
  *
- * Returns -1 for callout IDs not found in the results, signaling the
- * resolver to fall back to the original per-callout method (e.g. for
- * comment-type callouts that require RPC).
+ * Returns 0 for callout IDs with no contributions. The resolver is
+ * responsible for routing comment-type callouts to the RPC path
+ * before reaching this loader.
  */
 @Injectable()
 export class CalloutActivityLoaderCreator

--- a/src/core/dataloader/creators/loader.creators/callout/callout.activity.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/callout/callout.activity.loader.creator.ts
@@ -1,0 +1,58 @@
+import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import { ILoader } from '@core/dataloader/loader.interface';
+import { CalloutContribution } from '@domain/collaboration/callout-contribution/callout.contribution.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import DataLoader from 'dataloader';
+import { EntityManager, In } from 'typeorm';
+
+/**
+ * DataLoader creator that batches callout contribution counts.
+ * For N contribution-type callouts, this performs a single grouped COUNT
+ * query instead of N individual COUNT queries.
+ *
+ * Returns -1 for callout IDs not found in the results, signaling the
+ * resolver to fall back to the original per-callout method (e.g. for
+ * comment-type callouts that require RPC).
+ */
+@Injectable()
+export class CalloutActivityLoaderCreator
+  implements DataLoaderCreator<number>
+{
+  constructor(@InjectEntityManager() private manager: EntityManager) {}
+
+  public create(): ILoader<number> {
+    return new DataLoader<string, number>(
+      async calloutIds => this.batchLoad(calloutIds),
+      { cache: true, name: 'CalloutActivityLoader' }
+    );
+  }
+
+  private async batchLoad(
+    calloutIds: readonly string[]
+  ): Promise<number[]> {
+    if (calloutIds.length === 0) {
+      return [];
+    }
+
+    // Single grouped COUNT query for all callout IDs
+    const results = await this.manager
+      .getRepository(CalloutContribution)
+      .createQueryBuilder('contribution')
+      .select('contribution.calloutId', 'calloutId')
+      .addSelect('COUNT(*)', 'count')
+      .where('contribution.calloutId IN (:...calloutIds)', {
+        calloutIds: [...calloutIds],
+      })
+      .groupBy('contribution.calloutId')
+      .getRawMany<{ calloutId: string; count: string }>();
+
+    const countsMap = new Map<string, number>();
+    for (const row of results) {
+      countsMap.set(row.calloutId, parseInt(row.count, 10));
+    }
+
+    // Return in input order; 0 for callouts with no contributions
+    return calloutIds.map(id => countsMap.get(id) ?? 0);
+  }
+}

--- a/src/core/dataloader/creators/loader.creators/index.ts
+++ b/src/core/dataloader/creators/loader.creators/index.ts
@@ -8,6 +8,7 @@ export * from './agent.loader.creator';
 
 export * from './authorization.loader.creator';
 
+export * from './callout/callout.activity.loader.creator';
 export * from './callout-framing/callout.framing.whiteboard.loader';
 
 export * from './classification.tagsets.loader.creator';
@@ -33,6 +34,9 @@ export * from './space/space.about.loader.creator';
 export * from './space/space.by.space.about.id.loader.creator';
 export * from './space/space.collaboration.loader.creator';
 export * from './space/space.community.loader.creator';
+export * from './space/space.community.with.roleset.loader.creator';
+export * from './space/space.metrics.loader.creator';
+export * from './space/space.provider.loader.creator';
 export * from './user/user.settings.loader.creator';
 export * from './user.loader.creator';
 export * from './visual.loader.creator';

--- a/src/core/dataloader/creators/loader.creators/space/space.community.with.roleset.loader.creator.spec.ts
+++ b/src/core/dataloader/creators/loader.creators/space/space.community.with.roleset.loader.creator.spec.ts
@@ -1,0 +1,202 @@
+import { Space } from '@domain/space/space/space.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { type Mocked, vi } from 'vitest';
+import { EntityManager } from 'typeorm';
+import { SpaceCommunityWithRoleSetLoaderCreator } from './space.community.with.roleset.loader.creator';
+
+function makeSpaceWithCommunity(
+  spaceId: string,
+  aboutId: string,
+  communityId: string
+): Space {
+  return {
+    id: spaceId,
+    about: { id: aboutId },
+    community: {
+      id: communityId,
+      roleSet: { id: `roleset-${communityId}`, roles: [] },
+    },
+  } as unknown as Space;
+}
+
+describe('SpaceCommunityWithRoleSetLoaderCreator', () => {
+  let creator: SpaceCommunityWithRoleSetLoaderCreator;
+  let entityManager: Mocked<EntityManager>;
+
+  beforeEach(async () => {
+    const mockEntityManager = {
+      find: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SpaceCommunityWithRoleSetLoaderCreator,
+        {
+          provide: getEntityManagerToken(),
+          useValue: mockEntityManager,
+        },
+      ],
+    }).compile();
+
+    creator = module.get(SpaceCommunityWithRoleSetLoaderCreator);
+    entityManager = module.get(
+      getEntityManagerToken()
+    ) as Mocked<EntityManager>;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(creator).toBeDefined();
+  });
+
+  it('should create a DataLoader', () => {
+    const loader = creator.create();
+    expect(loader).toBeDefined();
+    expect(typeof loader.load).toBe('function');
+  });
+
+  describe('batch loading', () => {
+    it('should batch multiple loads into a single query', async () => {
+      const space1 = makeSpaceWithCommunity('s-1', 'about-1', 'comm-1');
+      const space2 = makeSpaceWithCommunity('s-2', 'about-2', 'comm-2');
+
+      entityManager.find.mockResolvedValueOnce([space1, space2]);
+
+      const loader = creator.create();
+
+      const [result1, result2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(entityManager.find).toHaveBeenCalledWith(Space, {
+        where: { about: { id: expect.anything() } },
+        relations: {
+          about: true,
+          community: { roleSet: { roles: true } },
+        },
+      });
+
+      expect(result1).not.toBeNull();
+      expect(result1!.id).toBe('comm-1');
+      expect(result2).not.toBeNull();
+      expect(result2!.id).toBe('comm-2');
+    });
+
+    it('should return null for SpaceAbout IDs not found', async () => {
+      const space1 = makeSpaceWithCommunity('s-1', 'about-1', 'comm-1');
+      entityManager.find.mockResolvedValueOnce([space1]);
+
+      const loader = creator.create();
+
+      const [result1, result2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-nonexistent'),
+      ]);
+
+      expect(result1!.id).toBe('comm-1');
+      expect(result2).toBeNull();
+    });
+
+    it('should return results in input order regardless of DB return order', async () => {
+      const space1 = makeSpaceWithCommunity('s-1', 'about-1', 'comm-1');
+      const space2 = makeSpaceWithCommunity('s-2', 'about-2', 'comm-2');
+      const space3 = makeSpaceWithCommunity('s-3', 'about-3', 'comm-3');
+
+      // DB returns in reverse order
+      entityManager.find.mockResolvedValueOnce([space3, space1, space2]);
+
+      const loader = creator.create();
+
+      const [r1, r2, r3] = await Promise.all([
+        loader.load('about-2'),
+        loader.load('about-1'),
+        loader.load('about-3'),
+      ]);
+
+      expect(r1!.id).toBe('comm-2');
+      expect(r2!.id).toBe('comm-1');
+      expect(r3!.id).toBe('comm-3');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should skip spaces where about is undefined', async () => {
+      const orphan = { id: 'orphan', about: undefined } as unknown as Space;
+      const valid = makeSpaceWithCommunity('s-1', 'about-1', 'comm-1');
+
+      entityManager.find.mockResolvedValueOnce([orphan, valid]);
+
+      const loader = creator.create();
+
+      const [result1, result2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-orphan'),
+      ]);
+
+      expect(result1!.id).toBe('comm-1');
+      expect(result2).toBeNull();
+    });
+
+    it('should skip spaces where community is undefined', async () => {
+      const noCommunity = {
+        id: 's-1',
+        about: { id: 'about-1' },
+        community: undefined,
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([noCommunity]);
+
+      const loader = creator.create();
+      const result = await loader.load('about-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate database errors to all pending loads', async () => {
+      entityManager.find.mockRejectedValueOnce(new Error('DB timeout'));
+
+      const loader = creator.create();
+
+      const [r1, r2] = await Promise.allSettled([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      expect(r1.status).toBe('rejected');
+      expect(r2.status).toBe('rejected');
+    });
+
+    it('should use DataLoader caching for repeated keys', async () => {
+      const space = makeSpaceWithCommunity('s-1', 'about-1', 'comm-1');
+      entityManager.find.mockResolvedValueOnce([space]);
+
+      const loader = creator.create();
+
+      const result1 = await loader.load('about-1');
+      const result2 = await loader.load('about-1');
+
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(result1).toBe(result2);
+    });
+
+    it('should cache null results and not re-query for same key', async () => {
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+
+      const result1 = await loader.load('about-missing');
+      expect(result1).toBeNull();
+
+      const result2 = await loader.load('about-missing');
+      expect(result2).toBeNull();
+
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/core/dataloader/creators/loader.creators/space/space.community.with.roleset.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/space/space.community.with.roleset.loader.creator.ts
@@ -1,0 +1,52 @@
+import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import { ILoader } from '@core/dataloader/loader.interface';
+import { ICommunity } from '@domain/community/community';
+import { Space } from '@domain/space/space/space.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import DataLoader from 'dataloader';
+import { EntityManager, In } from 'typeorm';
+
+/**
+ * DataLoader creator for batching community+roleSet lookups by SpaceAbout ID.
+ * Prevents duplicate queries when both `membership` and `metrics` resolvers
+ * need the same community+roleSet data.
+ */
+@Injectable()
+export class SpaceCommunityWithRoleSetLoaderCreator
+  implements DataLoaderCreator<ICommunity | null>
+{
+  constructor(@InjectEntityManager() private manager: EntityManager) {}
+
+  public create(): ILoader<ICommunity | null> {
+    return new DataLoader<string, ICommunity | null>(
+      async spaceAboutIds =>
+        this.batchLoadBySpaceAboutIds(spaceAboutIds),
+      { cache: true, name: 'SpaceCommunityWithRoleSetLoader' }
+    );
+  }
+
+  private async batchLoadBySpaceAboutIds(
+    spaceAboutIds: readonly string[]
+  ): Promise<(ICommunity | null)[]> {
+    if (spaceAboutIds.length === 0) {
+      return [];
+    }
+
+    const spaces = await this.manager.find(Space, {
+      where: { about: { id: In([...spaceAboutIds]) } },
+      relations: { about: true, community: { roleSet: { roles: true } } },
+    });
+
+    // Map by about.id for O(1) lookup
+    const byAboutId = new Map<string, ICommunity>();
+    for (const space of spaces) {
+      if (space.about && space.community) {
+        byAboutId.set(space.about.id, space.community);
+      }
+    }
+
+    // Return in input order; null for SpaceAbout IDs not found
+    return spaceAboutIds.map(id => byAboutId.get(id) ?? null);
+  }
+}

--- a/src/core/dataloader/creators/loader.creators/space/space.metrics.loader.creator.spec.ts
+++ b/src/core/dataloader/creators/loader.creators/space/space.metrics.loader.creator.spec.ts
@@ -1,0 +1,326 @@
+import { RoleName } from '@common/enums/role.name';
+import { Credential } from '@domain/agent/credential/credential.entity';
+import { Space } from '@domain/space/space/space.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { type Mocked, vi } from 'vitest';
+import { EntityManager } from 'typeorm';
+import { SpaceMetricsLoaderCreator } from './space.metrics.loader.creator';
+
+/**
+ * Helper to build a Space with the nested community → roleSet → roles chain
+ * that the loader traverses.
+ */
+function makeSpaceWithMemberRole(
+  spaceId: string,
+  aboutId: string,
+  resourceID: string
+): Space {
+  return {
+    id: spaceId,
+    about: { id: aboutId },
+    community: {
+      roleSet: {
+        roles: [
+          {
+            name: RoleName.MEMBER,
+            credential: { resourceID },
+          },
+          {
+            name: RoleName.LEAD,
+            credential: { resourceID: `lead-${resourceID}` },
+          },
+        ],
+      },
+    },
+  } as unknown as Space;
+}
+
+/**
+ * Sets up the mock for the Credential query builder chain.
+ */
+function mockCredentialQueryBuilder(
+  entityManager: Mocked<EntityManager>,
+  rawResult: { resourceID: string; count: string }[]
+) {
+  const qb = {
+    select: vi.fn().mockReturnThis(),
+    addSelect: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
+    getRawMany: vi.fn().mockResolvedValue(rawResult),
+  };
+  const repo = { createQueryBuilder: vi.fn().mockReturnValue(qb) };
+  entityManager.getRepository.mockReturnValue(repo as any);
+  return qb;
+}
+
+describe('SpaceMetricsLoaderCreator', () => {
+  let creator: SpaceMetricsLoaderCreator;
+  let entityManager: Mocked<EntityManager>;
+
+  beforeEach(async () => {
+    const mockEntityManager = {
+      find: vi.fn(),
+      getRepository: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SpaceMetricsLoaderCreator,
+        {
+          provide: getEntityManagerToken(),
+          useValue: mockEntityManager,
+        },
+      ],
+    }).compile();
+
+    creator = module.get(SpaceMetricsLoaderCreator);
+    entityManager = module.get(
+      getEntityManagerToken()
+    ) as Mocked<EntityManager>;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(creator).toBeDefined();
+  });
+
+  it('should create a DataLoader', () => {
+    const loader = creator.create();
+    expect(loader).toBeDefined();
+    expect(typeof loader.load).toBe('function');
+  });
+
+  describe('batch loading', () => {
+    it('should resolve member metrics for multiple spaces', async () => {
+      const space1 = makeSpaceWithMemberRole('s-1', 'about-1', 'res-1');
+      const space2 = makeSpaceWithMemberRole('s-2', 'about-2', 'res-2');
+
+      entityManager.find.mockResolvedValueOnce([space1, space2]);
+      mockCredentialQueryBuilder(entityManager, [
+        { resourceID: 'res-1', count: '25' },
+        { resourceID: 'res-2', count: '50' },
+      ]);
+
+      const loader = creator.create();
+
+      const [metrics1, metrics2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      // Each result should be an array with one NVP: { name: 'members', value: '<count>' }
+      expect(metrics1).toHaveLength(1);
+      expect(metrics1[0].name).toBe('members');
+      expect(metrics1[0].value).toBe('25');
+
+      expect(metrics2).toHaveLength(1);
+      expect(metrics2[0].name).toBe('members');
+      expect(metrics2[0].value).toBe('50');
+    });
+
+    it('should batch the Space find into a single call', async () => {
+      const space = makeSpaceWithMemberRole('s-1', 'about-1', 'res-1');
+      entityManager.find.mockResolvedValueOnce([space]);
+      mockCredentialQueryBuilder(entityManager, [
+        { resourceID: 'res-1', count: '10' },
+      ]);
+
+      const loader = creator.create();
+      await loader.load('about-1');
+
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(entityManager.find).toHaveBeenCalledWith(Space, {
+        where: { about: { id: expect.anything() } },
+        relations: {
+          about: true,
+          community: { roleSet: { roles: true } },
+        },
+      });
+    });
+
+    it('should return 0 members when credential count query returns no rows', async () => {
+      const space = makeSpaceWithMemberRole('s-1', 'about-1', 'res-1');
+      entityManager.find.mockResolvedValueOnce([space]);
+      mockCredentialQueryBuilder(entityManager, []);
+
+      const loader = creator.create();
+      const metrics = await loader.load('about-1');
+
+      expect(metrics).toHaveLength(1);
+      expect(metrics[0].name).toBe('members');
+      expect(metrics[0].value).toBe('0');
+    });
+
+    it('should return empty array for spaceAbout IDs not found', async () => {
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+      const metrics = await loader.load('about-nonexistent');
+
+      expect(metrics).toEqual([]);
+    });
+
+    it('should return results in input order regardless of DB return order', async () => {
+      const space1 = makeSpaceWithMemberRole('s-1', 'about-1', 'res-1');
+      const space2 = makeSpaceWithMemberRole('s-2', 'about-2', 'res-2');
+
+      // DB returns in reverse order
+      entityManager.find.mockResolvedValueOnce([space2, space1]);
+      mockCredentialQueryBuilder(entityManager, [
+        { resourceID: 'res-2', count: '200' },
+        { resourceID: 'res-1', count: '100' },
+      ]);
+
+      const loader = creator.create();
+
+      const [m1, m2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      expect(m1[0].value).toBe('100');
+      expect(m2[0].value).toBe('200');
+    });
+
+    it('should assign deterministic IDs to NVP objects', async () => {
+      const space = makeSpaceWithMemberRole('s-1', 'about-1', 'res-1');
+      entityManager.find.mockResolvedValueOnce([space]);
+      mockCredentialQueryBuilder(entityManager, [
+        { resourceID: 'res-1', count: '5' },
+      ]);
+
+      const loader = creator.create();
+      const metrics = await loader.load('about-1');
+
+      expect(metrics[0].id).toBe('members-about-1');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should skip spaces without community or roleSet', async () => {
+      const noCommunity = {
+        id: 's-1',
+        about: { id: 'about-1' },
+        community: undefined,
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([noCommunity]);
+
+      const loader = creator.create();
+      const metrics = await loader.load('about-1');
+
+      // No credential query should be made since no member roles found
+      expect(entityManager.getRepository).not.toHaveBeenCalled();
+      expect(metrics).toEqual([]);
+    });
+
+    it('should skip spaces where member role has no credential', async () => {
+      const noCredential = {
+        id: 's-1',
+        about: { id: 'about-1' },
+        community: {
+          roleSet: {
+            roles: [
+              { name: RoleName.MEMBER, credential: undefined },
+            ],
+          },
+        },
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([noCredential]);
+
+      const loader = creator.create();
+      const metrics = await loader.load('about-1');
+
+      expect(entityManager.getRepository).not.toHaveBeenCalled();
+      expect(metrics).toEqual([]);
+    });
+
+    it('should skip spaces with no MEMBER role at all', async () => {
+      const noMemberRole = {
+        id: 's-1',
+        about: { id: 'about-1' },
+        community: {
+          roleSet: {
+            roles: [
+              {
+                name: RoleName.LEAD,
+                credential: { resourceID: 'lead-res' },
+              },
+            ],
+          },
+        },
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([noMemberRole]);
+
+      const loader = creator.create();
+      const metrics = await loader.load('about-1');
+
+      expect(entityManager.getRepository).not.toHaveBeenCalled();
+      expect(metrics).toEqual([]);
+    });
+
+    it('should deduplicate resourceIDs when subspaces share credentials', async () => {
+      // Two spaces sharing the same resourceID (e.g. subspaces under same L0)
+      const space1 = makeSpaceWithMemberRole('s-1', 'about-1', 'shared-res');
+      const space2 = makeSpaceWithMemberRole('s-2', 'about-2', 'shared-res');
+
+      entityManager.find.mockResolvedValueOnce([space1, space2]);
+
+      const qb = mockCredentialQueryBuilder(entityManager, [
+        { resourceID: 'shared-res', count: '77' },
+      ]);
+
+      const loader = creator.create();
+
+      const [m1, m2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      // Both should get the same count
+      expect(m1[0].value).toBe('77');
+      expect(m2[0].value).toBe('77');
+
+      // The WHERE clause should use deduplicated resourceIDs
+      const whereCall = qb.where.mock.calls[0];
+      expect(whereCall[1].resourceIDs).toEqual(['shared-res']);
+    });
+
+    it('should propagate database errors to all pending loads', async () => {
+      entityManager.find.mockRejectedValueOnce(new Error('connection lost'));
+
+      const loader = creator.create();
+
+      const [r1, r2] = await Promise.allSettled([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      expect(r1.status).toBe('rejected');
+      expect(r2.status).toBe('rejected');
+    });
+
+    it('should use DataLoader caching for repeated keys', async () => {
+      const space = makeSpaceWithMemberRole('s-1', 'about-1', 'res-1');
+      entityManager.find.mockResolvedValueOnce([space]);
+      mockCredentialQueryBuilder(entityManager, [
+        { resourceID: 'res-1', count: '10' },
+      ]);
+
+      const loader = creator.create();
+
+      const result1 = await loader.load('about-1');
+      const result2 = await loader.load('about-1');
+
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(result1).toBe(result2);
+    });
+  });
+});

--- a/src/core/dataloader/creators/loader.creators/space/space.metrics.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/space/space.metrics.loader.creator.ts
@@ -1,0 +1,105 @@
+import { RoleName } from '@common/enums/role.name';
+import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import { ILoader } from '@core/dataloader/loader.interface';
+import { Credential } from '@domain/agent/credential/credential.entity';
+import { NVP } from '@domain/common/nvp/nvp.entity';
+import { INVP } from '@domain/common/nvp/nvp.interface';
+import { Space } from '@domain/space/space/space.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import DataLoader from 'dataloader';
+import { EntityManager, In } from 'typeorm';
+
+/**
+ * DataLoader creator that resolves space metrics (member count) in batch.
+ * Given N spaceAbout IDs, this performs 3 queries total:
+ *   1. Load spaces with community → roleSet → roles
+ *   2. Batch-count credentials by resourceID (single grouped COUNT)
+ * Instead of 2N queries (N role lookups + N credential counts).
+ */
+@Injectable()
+export class SpaceMetricsLoaderCreator
+  implements DataLoaderCreator<INVP[]>
+{
+  constructor(@InjectEntityManager() private manager: EntityManager) {}
+
+  public create(): ILoader<INVP[]> {
+    return new DataLoader<string, INVP[]>(
+      async spaceAboutIds => this.batchLoad(spaceAboutIds),
+      { cache: true, name: 'SpaceMetricsLoader' }
+    );
+  }
+
+  private async batchLoad(
+    spaceAboutIds: readonly string[]
+  ): Promise<INVP[][]> {
+    if (spaceAboutIds.length === 0) {
+      return [];
+    }
+
+    // Step 1: Load spaces with community → roleSet → roles
+    const spaces = await this.manager.find(Space, {
+      where: { about: { id: In([...spaceAboutIds]) } },
+      relations: {
+        about: true,
+        community: { roleSet: { roles: true } },
+      },
+    });
+
+    // Build map: spaceAboutId → { roleSet, memberCredentialResourceID }
+    const spaceDataByAboutId = new Map<
+      string,
+      { resourceID: string }
+    >();
+
+    const resourceIDs: string[] = [];
+
+    for (const space of spaces) {
+      if (!space.about || !space.community?.roleSet?.roles) continue;
+
+      const memberRole = space.community.roleSet.roles.find(
+        r => r.name === RoleName.MEMBER
+      );
+      if (!memberRole?.credential?.resourceID) continue;
+
+      const resourceID = memberRole.credential.resourceID;
+      spaceDataByAboutId.set(space.about.id, { resourceID });
+      resourceIDs.push(resourceID);
+    }
+
+    // Step 2: Batch count credentials
+    const countsByResourceID = new Map<string, number>();
+
+    if (resourceIDs.length > 0) {
+      // Deduplicate resourceIDs (subspaces under same L0 might share)
+      const uniqueResourceIDs = [...new Set(resourceIDs)];
+
+      const results = await this.manager
+        .getRepository(Credential)
+        .createQueryBuilder('credential')
+        .select('credential.resourceID', 'resourceID')
+        .addSelect('COUNT(*)', 'count')
+        .where('credential.resourceID IN (:...resourceIDs)', {
+          resourceIDs: uniqueResourceIDs,
+        })
+        .groupBy('credential.resourceID')
+        .getRawMany<{ resourceID: string; count: string }>();
+
+      for (const row of results) {
+        countsByResourceID.set(row.resourceID, parseInt(row.count, 10));
+      }
+    }
+
+    // Step 3: Build metrics for each spaceAboutId
+    return spaceAboutIds.map(aboutId => {
+      const spaceData = spaceDataByAboutId.get(aboutId);
+      if (!spaceData) return [];
+
+      const membersCount = countsByResourceID.get(spaceData.resourceID) ?? 0;
+      const membersTopic = new NVP('members', membersCount.toString());
+      membersTopic.id = `members-${aboutId}`;
+
+      return [membersTopic];
+    });
+  }
+}

--- a/src/core/dataloader/creators/loader.creators/space/space.provider.loader.creator.spec.ts
+++ b/src/core/dataloader/creators/loader.creators/space/space.provider.loader.creator.spec.ts
@@ -1,0 +1,309 @@
+import { Space } from '@domain/space/space/space.entity';
+import { User } from '@domain/community/user/user.entity';
+import { Organization } from '@domain/community/organization/organization.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { type Mocked, vi } from 'vitest';
+import { EntityManager, In } from 'typeorm';
+import { SpaceProviderLoaderCreator } from './space.provider.loader.creator';
+
+/** Builds a space stub with about and levelZeroSpaceID. */
+function makeSpace(
+  spaceId: string,
+  aboutId: string,
+  levelZeroSpaceID: string
+): Space {
+  return {
+    id: spaceId,
+    about: { id: aboutId },
+    levelZeroSpaceID,
+  } as unknown as Space;
+}
+
+/** Builds an L0 space stub with account relation. */
+function makeL0Space(spaceId: string, accountId: string): Space {
+  return {
+    id: spaceId,
+    account: { id: accountId },
+  } as unknown as Space;
+}
+
+describe('SpaceProviderLoaderCreator', () => {
+  let creator: SpaceProviderLoaderCreator;
+  let entityManager: Mocked<EntityManager>;
+
+  beforeEach(async () => {
+    const mockEntityManager = {
+      find: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SpaceProviderLoaderCreator,
+        {
+          provide: getEntityManagerToken(),
+          useValue: mockEntityManager,
+        },
+      ],
+    }).compile();
+
+    creator = module.get(SpaceProviderLoaderCreator);
+    entityManager = module.get(
+      getEntityManagerToken()
+    ) as Mocked<EntityManager>;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(creator).toBeDefined();
+  });
+
+  it('should create a DataLoader', () => {
+    const loader = creator.create();
+    expect(loader).toBeDefined();
+    expect(typeof loader.load).toBe('function');
+  });
+
+  describe('batch loading', () => {
+    it('should resolve provider (user) via full chain: aboutId → space → l0Space → account → user', async () => {
+      const space = makeSpace('s-1', 'about-1', 'l0-1');
+      const l0Space = makeL0Space('l0-1', 'acc-1');
+      const user = {
+        id: 'user-1',
+        accountID: 'acc-1',
+        nameID: 'provider-user',
+      } as unknown as User;
+
+      // Call 1: load spaces by about.id
+      entityManager.find.mockResolvedValueOnce([space]);
+      // Call 2: load L0 spaces with account
+      entityManager.find.mockResolvedValueOnce([l0Space]);
+      // Call 3+4: load users and orgs in parallel (Promise.all)
+      entityManager.find.mockResolvedValueOnce([user]); // users
+      entityManager.find.mockResolvedValueOnce([]); // orgs
+
+      const loader = creator.create();
+      const result = await loader.load('about-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('user-1');
+    });
+
+    it('should resolve provider (organization) when no user found', async () => {
+      const space = makeSpace('s-1', 'about-1', 'l0-1');
+      const l0Space = makeL0Space('l0-1', 'acc-1');
+      const org = {
+        id: 'org-1',
+        accountID: 'acc-1',
+        nameID: 'provider-org',
+      } as unknown as Organization;
+
+      entityManager.find.mockResolvedValueOnce([space]);
+      entityManager.find.mockResolvedValueOnce([l0Space]);
+      entityManager.find.mockResolvedValueOnce([]); // users
+      entityManager.find.mockResolvedValueOnce([org]); // orgs
+
+      const loader = creator.create();
+      const result = await loader.load('about-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('org-1');
+    });
+
+    it('should give user precedence over organization when both exist for same account', async () => {
+      const space = makeSpace('s-1', 'about-1', 'l0-1');
+      const l0Space = makeL0Space('l0-1', 'acc-1');
+      const user = { id: 'user-1', accountID: 'acc-1' } as unknown as User;
+      const org = { id: 'org-1', accountID: 'acc-1' } as unknown as Organization;
+
+      entityManager.find.mockResolvedValueOnce([space]);
+      entityManager.find.mockResolvedValueOnce([l0Space]);
+      entityManager.find.mockResolvedValueOnce([user]);
+      entityManager.find.mockResolvedValueOnce([org]);
+
+      const loader = creator.create();
+      const result = await loader.load('about-1');
+
+      // User should take precedence (set after org in the map)
+      expect(result!.id).toBe('user-1');
+    });
+
+    it('should batch multiple spaces and deduplicate L0 lookups', async () => {
+      // Two subspaces under the same L0
+      const space1 = makeSpace('s-1', 'about-1', 'l0-shared');
+      const space2 = makeSpace('s-2', 'about-2', 'l0-shared');
+      const l0Space = makeL0Space('l0-shared', 'acc-1');
+      const user = { id: 'user-1', accountID: 'acc-1' } as unknown as User;
+
+      entityManager.find.mockResolvedValueOnce([space1, space2]);
+      entityManager.find.mockResolvedValueOnce([l0Space]);
+      entityManager.find.mockResolvedValueOnce([user]);
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+
+      const [r1, r2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      // Both subspaces should resolve to the same provider
+      expect(r1!.id).toBe('user-1');
+      expect(r2!.id).toBe('user-1');
+
+      // L0 space query should only list the deduplicated ID
+      const l0FindCall = entityManager.find.mock.calls[1];
+      expect(l0FindCall[0]).toBe(Space);
+    });
+
+    it('should return results in input order', async () => {
+      const space1 = makeSpace('s-1', 'about-1', 'l0-1');
+      const space2 = makeSpace('s-2', 'about-2', 'l0-2');
+      const l0Space1 = makeL0Space('l0-1', 'acc-1');
+      const l0Space2 = makeL0Space('l0-2', 'acc-2');
+      const user1 = { id: 'u-1', accountID: 'acc-1' } as unknown as User;
+      const user2 = { id: 'u-2', accountID: 'acc-2' } as unknown as User;
+
+      // Return spaces in reverse order
+      entityManager.find.mockResolvedValueOnce([space2, space1]);
+      entityManager.find.mockResolvedValueOnce([l0Space2, l0Space1]);
+      entityManager.find.mockResolvedValueOnce([user2, user1]);
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+
+      const [r1, r2] = await Promise.all([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      // Results should match input order
+      expect(r1!.id).toBe('u-1');
+      expect(r2!.id).toBe('u-2');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return null for spaceAbout IDs not found', async () => {
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+      const result = await loader.load('about-nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when L0 space has no account', async () => {
+      const space = makeSpace('s-1', 'about-1', 'l0-1');
+      const l0SpaceNoAccount = {
+        id: 'l0-1',
+        account: undefined,
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([space]);
+      entityManager.find.mockResolvedValueOnce([l0SpaceNoAccount]);
+
+      const loader = creator.create();
+      const result = await loader.load('about-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no user or org matches the account', async () => {
+      const space = makeSpace('s-1', 'about-1', 'l0-1');
+      const l0Space = makeL0Space('l0-1', 'acc-1');
+
+      entityManager.find.mockResolvedValueOnce([space]);
+      entityManager.find.mockResolvedValueOnce([l0Space]);
+      entityManager.find.mockResolvedValueOnce([]); // no users
+      entityManager.find.mockResolvedValueOnce([]); // no orgs
+
+      const loader = creator.create();
+      const result = await loader.load('about-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('should skip user/org lookup when no accounts are found', async () => {
+      const space = makeSpace('s-1', 'about-1', 'l0-1');
+      const l0SpaceNoAccount = {
+        id: 'l0-1',
+        account: undefined,
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([space]);
+      entityManager.find.mockResolvedValueOnce([l0SpaceNoAccount]);
+
+      const loader = creator.create();
+      await loader.load('about-1');
+
+      // Only 2 find calls: spaces and L0 spaces.
+      // User/Org queries should be skipped (accountIdArray is empty).
+      expect(entityManager.find).toHaveBeenCalledTimes(2);
+    });
+
+    it('should skip L0 lookup when no spaces found for about IDs', async () => {
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+      await loader.load('about-nonexistent');
+
+      // Only 1 find call: initial space lookup returns empty → no L0 lookup
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate database errors to all pending loads', async () => {
+      entityManager.find.mockRejectedValueOnce(
+        new Error('DB connection failed')
+      );
+
+      const loader = creator.create();
+
+      const [r1, r2] = await Promise.allSettled([
+        loader.load('about-1'),
+        loader.load('about-2'),
+      ]);
+
+      expect(r1.status).toBe('rejected');
+      expect(r2.status).toBe('rejected');
+    });
+
+    it('should use DataLoader caching for repeated keys', async () => {
+      const space = makeSpace('s-1', 'about-1', 'l0-1');
+      const l0Space = makeL0Space('l0-1', 'acc-1');
+      const user = { id: 'u-1', accountID: 'acc-1' } as unknown as User;
+
+      entityManager.find.mockResolvedValueOnce([space]);
+      entityManager.find.mockResolvedValueOnce([l0Space]);
+      entityManager.find.mockResolvedValueOnce([user]);
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+
+      const result1 = await loader.load('about-1');
+      const result2 = await loader.load('about-1');
+
+      expect(entityManager.find).toHaveBeenCalledTimes(4); // only from first load
+      expect(result1).toBe(result2);
+    });
+
+    it('should handle space with undefined about property', async () => {
+      const orphan = {
+        id: 'orphan',
+        about: undefined,
+        levelZeroSpaceID: 'l0-1',
+      } as unknown as Space;
+
+      entityManager.find.mockResolvedValueOnce([orphan]);
+      entityManager.find.mockResolvedValueOnce([]);
+
+      const loader = creator.create();
+      const result = await loader.load('about-orphan');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/core/dataloader/creators/loader.creators/space/space.provider.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/space/space.provider.loader.creator.ts
@@ -1,0 +1,115 @@
+import { DataLoaderCreator } from '@core/dataloader/creators/base';
+import { ILoader } from '@core/dataloader/loader.interface';
+import { IContributor } from '@domain/community/contributor/contributor.interface';
+import { Organization } from '@domain/community/organization/organization.entity';
+import { User } from '@domain/community/user/user.entity';
+import { Space } from '@domain/space/space/space.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import DataLoader from 'dataloader';
+import { EntityManager, In } from 'typeorm';
+
+/**
+ * DataLoader creator that resolves the full provider (host) chain for spaces
+ * in batch. Given N spaceAbout IDs, this performs at most 4 queries total:
+ *   1. Load spaces by about.id
+ *   2. Load L0 spaces with account relation (deduplicated)
+ *   3. Load Users by accountID  (parallel with #4)
+ *   4. Load Organizations by accountID (parallel with #3)
+ */
+@Injectable()
+export class SpaceProviderLoaderCreator
+  implements DataLoaderCreator<IContributor | null>
+{
+  constructor(@InjectEntityManager() private manager: EntityManager) {}
+
+  public create(): ILoader<IContributor | null> {
+    return new DataLoader<string, IContributor | null>(
+      async spaceAboutIds => this.batchLoad(spaceAboutIds),
+      { cache: true, name: 'SpaceProviderLoader' }
+    );
+  }
+
+  private async batchLoad(
+    spaceAboutIds: readonly string[]
+  ): Promise<(IContributor | null)[]> {
+    if (spaceAboutIds.length === 0) {
+      return [];
+    }
+
+    // Step 1: Load all spaces by about.id
+    const spaces = await this.manager.find(Space, {
+      where: { about: { id: In([...spaceAboutIds]) } },
+      relations: { about: true },
+    });
+
+    const spaceByAboutId = new Map<string, Space>();
+    for (const space of spaces) {
+      if (space.about) {
+        spaceByAboutId.set(space.about.id, space);
+      }
+    }
+
+    // Step 2: Collect unique L0 space IDs that need account loading
+    const l0SpaceIds = new Set<string>();
+    for (const space of spaces) {
+      l0SpaceIds.add(space.levelZeroSpaceID);
+    }
+
+    // Batch load L0 spaces with account relation
+    const l0Spaces =
+      l0SpaceIds.size > 0
+        ? await this.manager.find(Space, {
+            where: { id: In([...l0SpaceIds]) },
+            relations: { account: true },
+          })
+        : [];
+
+    const l0SpaceById = new Map<string, Space>();
+    for (const l0Space of l0Spaces) {
+      l0SpaceById.set(l0Space.id, l0Space);
+    }
+
+    // Step 3: Collect unique account IDs for host lookup
+    const accountIds = new Set<string>();
+    for (const l0Space of l0Spaces) {
+      if (l0Space.account) {
+        accountIds.add(l0Space.account.id);
+      }
+    }
+
+    // Batch load users and organizations in parallel
+    const accountIdArray = [...accountIds];
+    const [users, organizations] =
+      accountIdArray.length > 0
+        ? await Promise.all([
+            this.manager.find(User, {
+              where: { accountID: In(accountIdArray) },
+            }),
+            this.manager.find(Organization, {
+              where: { accountID: In(accountIdArray) },
+            }),
+          ])
+        : [[], []];
+
+    // Build accountID → contributor map (user takes precedence)
+    const hostByAccountId = new Map<string, IContributor>();
+    for (const org of organizations) {
+      hostByAccountId.set(org.accountID, org);
+    }
+    for (const user of users) {
+      hostByAccountId.set(user.accountID, user);
+    }
+
+    // Resolve: spaceAboutId → space → l0Space → account → host
+    return spaceAboutIds.map(aboutId => {
+      const space = spaceByAboutId.get(aboutId);
+      if (!space) return null;
+
+      const l0Space = l0SpaceById.get(space.levelZeroSpaceID);
+      if (!l0Space?.account) return null;
+
+      return hostByAccountId.get(l0Space.account.id) ?? null;
+    });
+  }
+}

--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -1,13 +1,25 @@
+import { RoleName } from '@common/enums/role.name';
+import { AgentService } from '@domain/agent/agent/agent.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+import { type Mocked } from 'vitest';
 import { RoleSet } from './role.set.entity';
+import { IRoleSet } from './role.set.interface';
 import { RoleSetService } from './role.set.service';
+
+function makeRoleSet(
+  id: string,
+  roles?: { name: RoleName; credential: { type: string; resourceID: string } }[]
+): IRoleSet {
+  return { id, roles } as unknown as IRoleSet;
+}
 
 describe('RoleSetService', () => {
   let service: RoleSetService;
+  let agentService: Mocked<AgentService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,9 +34,125 @@ describe('RoleSetService', () => {
       .compile();
 
     service = module.get<RoleSetService>(RoleSetService);
+    agentService = module.get<AgentService>(
+      AgentService
+    ) as Mocked<AgentService>;
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getMembersCountBatch', () => {
+    it('should return empty Map for empty input', async () => {
+      const result = await service.getMembersCountBatch([]);
+      expect(result).toEqual(new Map());
+      expect(
+        agentService.countAgentsWithMatchingCredentialsBatch
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should skip roleSets with roles undefined', async () => {
+      const roleSet = makeRoleSet('rs-1', undefined);
+      const result = await service.getMembersCountBatch([roleSet]);
+      expect(result).toEqual(new Map());
+      expect(
+        agentService.countAgentsWithMatchingCredentialsBatch
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should skip roleSets with no MEMBER role', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.LEAD,
+          credential: { type: 'space-lead', resourceID: 'res-1' },
+        },
+      ]);
+      const result = await service.getMembersCountBatch([roleSet]);
+      expect(result).toEqual(new Map());
+      expect(
+        agentService.countAgentsWithMatchingCredentialsBatch
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should return empty Map when all roleSets are skipped', async () => {
+      const rs1 = makeRoleSet('rs-1', undefined);
+      const rs2 = makeRoleSet('rs-2', [
+        {
+          name: RoleName.LEAD,
+          credential: { type: 'lead', resourceID: 'res-2' },
+        },
+      ]);
+      const result = await service.getMembersCountBatch([rs1, rs2]);
+      expect(result).toEqual(new Map());
+    });
+
+    it('should batch count two valid roleSets and map by roleSet.id', async () => {
+      const rs1 = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'res-A' },
+        },
+      ]);
+      const rs2 = makeRoleSet('rs-2', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'res-B' },
+        },
+      ]);
+
+      agentService.countAgentsWithMatchingCredentialsBatch.mockResolvedValue(
+        new Map([
+          ['res-A', 5],
+          ['res-B', 12],
+        ])
+      );
+
+      const result = await service.getMembersCountBatch([rs1, rs2]);
+
+      expect(
+        agentService.countAgentsWithMatchingCredentialsBatch
+      ).toHaveBeenCalledOnce();
+      expect(result.get('rs-1')).toBe(5);
+      expect(result.get('rs-2')).toBe(12);
+    });
+
+    it('should default to 0 when resourceID has no match in batch result', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'res-missing' },
+        },
+      ]);
+
+      agentService.countAgentsWithMatchingCredentialsBatch.mockResolvedValue(
+        new Map()
+      );
+
+      const result = await service.getMembersCountBatch([roleSet]);
+      expect(result.get('rs-1')).toBe(0);
+    });
+
+    it('should include only valid roleSets when mixed with skipped ones', async () => {
+      const validRs = makeRoleSet('rs-valid', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'res-V' },
+        },
+      ]);
+      const skippedRs = makeRoleSet('rs-skipped', undefined);
+
+      agentService.countAgentsWithMatchingCredentialsBatch.mockResolvedValue(
+        new Map([['res-V', 7]])
+      );
+
+      const result = await service.getMembersCountBatch([validRs, skippedRs]);
+
+      expect(result.get('rs-valid')).toBe(7);
+      expect(result.has('rs-skipped')).toBe(false);
+      expect(
+        agentService.countAgentsWithMatchingCredentialsBatch
+      ).toHaveBeenCalledWith([{ type: 'space-member', resourceID: 'res-V' }]);
+    });
   });
 });

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1914,6 +1914,66 @@ export class RoleSetService {
     return credentialMatches;
   }
 
+  /**
+   * Batch-counts members for multiple roleSets in a single DB query.
+   * Returns a Map from roleSet.id to member count.
+   * Requires roleSet.roles to be pre-loaded.
+   */
+  async getMembersCountBatch(
+    roleSets: IRoleSet[]
+  ): Promise<Map<string, number>> {
+    if (roleSets.length === 0) {
+      return new Map();
+    }
+
+    // Build credential criteria for each roleSet
+    const criteriaList: { roleSetId: string; type: string; resourceID: string }[] = [];
+    for (const roleSet of roleSets) {
+      const credential = this.getCredentialForRoleSync(roleSet, RoleName.MEMBER);
+      if (credential) {
+        criteriaList.push({
+          roleSetId: roleSet.id,
+          type: credential.type,
+          resourceID: credential.resourceID,
+        });
+      }
+    }
+
+    if (criteriaList.length === 0) {
+      return new Map();
+    }
+
+    // Batch count credentials
+    const countsByResourceID =
+      await this.agentService.countAgentsWithMatchingCredentialsBatch(
+        criteriaList.map(c => ({ type: c.type, resourceID: c.resourceID }))
+      );
+
+    // Map back to roleSet.id
+    const result = new Map<string, number>();
+    for (const criteria of criteriaList) {
+      result.set(
+        criteria.roleSetId,
+        countsByResourceID.get(criteria.resourceID) ?? 0
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Synchronous version of getCredentialForRole that works when roles are pre-loaded.
+   * Returns null if roles are not loaded.
+   */
+  private getCredentialForRoleSync(
+    roleSet: IRoleSet,
+    roleName: RoleName
+  ): ICredentialDefinition | null {
+    if (!roleSet.roles) return null;
+    const role = roleSet.roles.find(rd => rd.name === roleName);
+    if (!role) return null;
+    return role.credential;
+  }
+
   async getImplicitRoles(
     agentInfo: AgentInfo,
     roleSet: IRoleSet

--- a/src/domain/agent/agent/agent.service.ts
+++ b/src/domain/agent/agent/agent.service.ts
@@ -238,4 +238,12 @@ export class AgentService {
       credentialCriteria
     );
   }
+
+  async countAgentsWithMatchingCredentialsBatch(
+    criteriaList: CredentialsSearchInput[]
+  ): Promise<Map<string, number>> {
+    return await this.credentialService.countMatchingCredentialsBatch(
+      criteriaList
+    );
+  }
 }

--- a/src/domain/agent/credential/credential.service.spec.ts
+++ b/src/domain/agent/credential/credential.service.spec.ts
@@ -1,0 +1,200 @@
+import { Credential } from '@domain/agent/credential/credential.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { vi } from 'vitest';
+import { CredentialService } from './credential.service';
+
+/**
+ * Helper to create a mock query builder chain for the credential repository.
+ * Returns the mock qb so individual tests can override specific method behaviors.
+ */
+function createMockQueryBuilder(
+  rawResult: { resourceID: string; count: string }[] = []
+) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    addSelect: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    andWhere: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
+    getRawMany: vi.fn().mockResolvedValue(rawResult),
+    leftJoinAndSelect: vi.fn().mockReturnThis(),
+    getMany: vi.fn().mockResolvedValue([]),
+    getCount: vi.fn().mockResolvedValue(0),
+  };
+}
+
+describe('CredentialService', () => {
+  let service: CredentialService;
+  let mockRepository: any;
+
+  beforeEach(async () => {
+    mockRepository = {
+      findOneBy: vi.fn(),
+      save: vi.fn(),
+      remove: vi.fn(),
+      createQueryBuilder: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CredentialService,
+        {
+          provide: getRepositoryToken(Credential),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CredentialService>(CredentialService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('countMatchingCredentialsBatch', () => {
+    it('should return an empty map for empty criteria list', async () => {
+      const result = await service.countMatchingCredentialsBatch([]);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+      expect(mockRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should return an empty map when all criteria have undefined resourceID', async () => {
+      const result = await service.countMatchingCredentialsBatch([
+        { type: 'space-member' },
+        { type: 'space-member', resourceID: undefined },
+      ]);
+
+      expect(result.size).toBe(0);
+      expect(mockRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should batch count credentials in a single grouped query', async () => {
+      const qb = createMockQueryBuilder([
+        { resourceID: 'res-1', count: '10' },
+        { resourceID: 'res-2', count: '20' },
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.countMatchingCredentialsBatch([
+        { type: 'space-member', resourceID: 'res-1' },
+        { type: 'space-member', resourceID: 'res-2' },
+      ]);
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith(
+        'credential'
+      );
+      expect(result.get('res-1')).toBe(10);
+      expect(result.get('res-2')).toBe(20);
+    });
+
+    it('should use the type from the first criteria item', async () => {
+      const qb = createMockQueryBuilder([]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.countMatchingCredentialsBatch([
+        { type: 'space-member', resourceID: 'res-1' },
+        { type: 'space-member', resourceID: 'res-2' },
+      ]);
+
+      expect(qb.where).toHaveBeenCalledWith('credential.type = :type', {
+        type: 'space-member',
+      });
+    });
+
+    it('should pass all resourceIDs in the IN clause', async () => {
+      const qb = createMockQueryBuilder([]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.countMatchingCredentialsBatch([
+        { type: 'space-member', resourceID: 'res-a' },
+        { type: 'space-member', resourceID: 'res-b' },
+        { type: 'space-member', resourceID: 'res-c' },
+      ]);
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'credential.resourceID IN (:...resourceIDs)',
+        { resourceIDs: ['res-a', 'res-b', 'res-c'] }
+      );
+    });
+
+    it('should parse count strings from DB as integers', async () => {
+      const qb = createMockQueryBuilder([
+        { resourceID: 'res-1', count: '9999' },
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.countMatchingCredentialsBatch([
+        { type: 'space-member', resourceID: 'res-1' },
+      ]);
+
+      const count = result.get('res-1');
+      expect(count).toBe(9999);
+      expect(typeof count).toBe('number');
+    });
+
+    it('should not include resourceIDs for criteria without resourceID', async () => {
+      const qb = createMockQueryBuilder([
+        { resourceID: 'res-1', count: '5' },
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.countMatchingCredentialsBatch([
+        { type: 'space-member', resourceID: 'res-1' },
+        { type: 'space-member' }, // no resourceID
+      ]);
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'credential.resourceID IN (:...resourceIDs)',
+        { resourceIDs: ['res-1'] }
+      );
+      expect(result.get('res-1')).toBe(5);
+    });
+
+    it('should return 0 for resourceIDs with no matching credentials', async () => {
+      const qb = createMockQueryBuilder([
+        { resourceID: 'res-1', count: '3' },
+        // res-2 has no results
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.countMatchingCredentialsBatch([
+        { type: 'space-member', resourceID: 'res-1' },
+        { type: 'space-member', resourceID: 'res-2' },
+      ]);
+
+      expect(result.get('res-1')).toBe(3);
+      expect(result.has('res-2')).toBe(false); // not in map → caller uses ?? 0
+    });
+
+    it('should propagate database errors', async () => {
+      const qb = createMockQueryBuilder();
+      qb.getRawMany.mockRejectedValue(new Error('query timeout'));
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.countMatchingCredentialsBatch([
+          { type: 'space-member', resourceID: 'res-1' },
+        ])
+      ).rejects.toThrow('query timeout');
+    });
+
+    it('should filter out empty string resourceIDs', async () => {
+      const result = await service.countMatchingCredentialsBatch([
+        { type: 'space-member', resourceID: '' },
+      ]);
+
+      // Empty string is falsy → filtered out → returns empty map
+      expect(result.size).toBe(0);
+      expect(mockRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/domain/agent/credential/credential.service.ts
+++ b/src/domain/agent/credential/credential.service.ts
@@ -95,4 +95,42 @@ export class CredentialService {
       })
       .getCount();
   }
+
+  /**
+   * Batch-counts matching credentials for multiple (type, resourceID) pairs
+   * in a single grouped query. Returns a Map keyed by resourceID.
+   */
+  async countMatchingCredentialsBatch(
+    criteriaList: CredentialsSearchInput[]
+  ): Promise<Map<string, number>> {
+    if (criteriaList.length === 0) {
+      return new Map();
+    }
+
+    const resourceIDs = criteriaList
+      .map(c => c.resourceID)
+      .filter((id): id is string => !!id);
+
+    if (resourceIDs.length === 0) {
+      return new Map();
+    }
+
+    // All criteria should share the same type for member counts
+    const type = criteriaList[0].type;
+
+    const results = await this.credentialRepository
+      .createQueryBuilder('credential')
+      .select('credential.resourceID', 'resourceID')
+      .addSelect('COUNT(*)', 'count')
+      .where('credential.type = :type', { type })
+      .andWhere('credential.resourceID IN (:...resourceIDs)', { resourceIDs })
+      .groupBy('credential.resourceID')
+      .getRawMany<{ resourceID: string; count: string }>();
+
+    const countsMap = new Map<string, number>();
+    for (const row of results) {
+      countsMap.set(row.resourceID, parseInt(row.count, 10));
+    }
+    return countsMap;
+  }
 }

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.spec.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.spec.ts
@@ -1,0 +1,172 @@
+import { CalloutContribution } from '@domain/collaboration/callout-contribution/callout.contribution.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { vi } from 'vitest';
+import { CalloutContributionService } from './callout.contribution.service';
+
+function createMockQueryBuilder(
+  rawResult: { calloutId: string; count: string }[] = []
+) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    addSelect: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    groupBy: vi.fn().mockReturnThis(),
+    getRawMany: vi.fn().mockResolvedValue(rawResult),
+  };
+}
+
+describe('CalloutContributionService', () => {
+  let service: CalloutContributionService;
+  let mockRepository: any;
+
+  beforeEach(async () => {
+    mockRepository = {
+      findOne: vi.fn(),
+      find: vi.fn(),
+      save: vi.fn(),
+      remove: vi.fn(),
+      count: vi.fn(),
+      createQueryBuilder: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalloutContributionService,
+        {
+          provide: getRepositoryToken(CalloutContribution),
+          useValue: mockRepository,
+        },
+        MockWinstonProvider,
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get<CalloutContributionService>(
+      CalloutContributionService
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getContributionsCountBatch', () => {
+    it('should return an empty map for empty calloutIds', async () => {
+      const result = await service.getContributionsCountBatch([]);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+      expect(mockRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should batch count contributions in a single grouped query', async () => {
+      const qb = createMockQueryBuilder([
+        { calloutId: 'callout-1', count: '5' },
+        { calloutId: 'callout-2', count: '12' },
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getContributionsCountBatch([
+        'callout-1',
+        'callout-2',
+      ]);
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith(
+        'contribution'
+      );
+      expect(result.get('callout-1')).toBe(5);
+      expect(result.get('callout-2')).toBe(12);
+    });
+
+    it('should pass callout IDs in the IN clause', async () => {
+      const qb = createMockQueryBuilder([]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getContributionsCountBatch([
+        'callout-a',
+        'callout-b',
+        'callout-c',
+      ]);
+
+      expect(qb.where).toHaveBeenCalledWith(
+        'contribution.calloutId IN (:...calloutIds)',
+        { calloutIds: ['callout-a', 'callout-b', 'callout-c'] }
+      );
+    });
+
+    it('should return 0 for callouts with no contributions (not in map)', async () => {
+      const qb = createMockQueryBuilder([
+        { calloutId: 'callout-1', count: '3' },
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getContributionsCountBatch([
+        'callout-1',
+        'callout-2',
+      ]);
+
+      expect(result.get('callout-1')).toBe(3);
+      expect(result.has('callout-2')).toBe(false); // caller uses ?? 0
+    });
+
+    it('should parse count strings as integers', async () => {
+      const qb = createMockQueryBuilder([
+        { calloutId: 'callout-1', count: '4567' },
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getContributionsCountBatch(['callout-1']);
+      const count = result.get('callout-1');
+
+      expect(count).toBe(4567);
+      expect(typeof count).toBe('number');
+    });
+
+    it('should handle a single callout ID', async () => {
+      const qb = createMockQueryBuilder([
+        { calloutId: 'only-one', count: '1' },
+      ]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getContributionsCountBatch(['only-one']);
+
+      expect(result.get('only-one')).toBe(1);
+    });
+
+    it('should propagate database errors', async () => {
+      const qb = createMockQueryBuilder();
+      qb.getRawMany.mockRejectedValue(new Error('DB error'));
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.getContributionsCountBatch(['callout-1'])
+      ).rejects.toThrow('DB error');
+    });
+
+    it('should handle large batch of callout IDs', async () => {
+      const calloutIds = Array.from({ length: 100 }, (_, i) => `callout-${i}`);
+      const rawResult = calloutIds.map(id => ({
+        calloutId: id,
+        count: '1',
+      }));
+      const qb = createMockQueryBuilder(rawResult);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getContributionsCountBatch(calloutIds);
+
+      expect(result.size).toBe(100);
+      for (const id of calloutIds) {
+        expect(result.get(id)).toBe(1);
+      }
+    });
+  });
+});

--- a/src/domain/collaboration/callout/callout.resolver.fields.spec.ts
+++ b/src/domain/collaboration/callout/callout.resolver.fields.spec.ts
@@ -1,0 +1,91 @@
+import { ILoader } from '@core/dataloader/loader.interface';
+import { ICallout } from '@domain/collaboration/callout/callout.interface';
+import { CalloutService } from '@domain/collaboration/callout/callout.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { type Mocked, vi } from 'vitest';
+import { CalloutResolverFields } from './callout.resolver.fields';
+
+function makeCallout(
+  id: string,
+  allowedTypes: string[],
+  activity?: number
+): ICallout {
+  return {
+    id,
+    activity,
+    settings: { contribution: { allowedTypes } },
+  } as unknown as ICallout;
+}
+
+describe('CalloutResolverFields', () => {
+  let resolver: CalloutResolverFields;
+  let calloutService: Mocked<CalloutService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CalloutResolverFields, MockWinstonProvider],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    resolver = module.get<CalloutResolverFields>(CalloutResolverFields);
+    calloutService = module.get<CalloutService>(
+      CalloutService
+    ) as Mocked<CalloutService>;
+  });
+
+  describe('activity', () => {
+    it('should return pre-computed activity without calling loader', async () => {
+      const callout = makeCallout('c-1', ['POST'], 42);
+      const loader = {
+        load: vi.fn().mockResolvedValue(10),
+      } as unknown as ILoader<number>;
+
+      const result = await resolver.activity(callout, loader);
+
+      expect(result).toBe(42);
+      expect(loader.load).not.toHaveBeenCalled();
+      expect(calloutService.getActivityCount).not.toHaveBeenCalled();
+    });
+
+    it('should use DataLoader for contribution-type callouts', async () => {
+      const callout = makeCallout('c-2', ['POST']);
+      const loader = {
+        load: vi.fn().mockResolvedValue(7),
+      } as unknown as ILoader<number>;
+
+      const result = await resolver.activity(callout, loader);
+
+      expect(result).toBe(7);
+      expect(loader.load).toHaveBeenCalledWith('c-2');
+    });
+
+    it('should fall back to service for comment-type callouts', async () => {
+      const callout = makeCallout('c-3', []);
+      const loader = {
+        load: vi.fn(),
+      } as unknown as ILoader<number>;
+      calloutService.getActivityCount.mockResolvedValue(3);
+
+      const result = await resolver.activity(callout, loader);
+
+      expect(result).toBe(3);
+      expect(loader.load).not.toHaveBeenCalled();
+      expect(calloutService.getActivityCount).toHaveBeenCalledWith(callout);
+    });
+
+    it('should prioritize pre-computed activity even for contribution-type callouts', async () => {
+      const callout = makeCallout('c-4', ['WHITEBOARD'], 99);
+      const loader = {
+        load: vi.fn().mockResolvedValue(1),
+      } as unknown as ILoader<number>;
+
+      const result = await resolver.activity(callout, loader);
+
+      expect(result).toBe(99);
+      expect(loader.load).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/domain/collaboration/callout/callout.service.spec.ts
+++ b/src/domain/collaboration/callout/callout.service.spec.ts
@@ -218,10 +218,7 @@ describe('CalloutService', () => {
       const comment1 = makeCommentCallout('c-1');
       const comment2 = makeCommentCallout('c-2');
 
-      // Track call order to verify parallelism
-      let callCount = 0;
       (roomService.getMessages as Mock).mockImplementation(async () => {
-        callCount++;
         // Simulate async delay
         await new Promise(resolve => setTimeout(resolve, 10));
         return [{ id: 'msg' }];

--- a/src/domain/collaboration/callout/callout.service.spec.ts
+++ b/src/domain/collaboration/callout/callout.service.spec.ts
@@ -1,0 +1,238 @@
+import { Callout } from '@domain/collaboration/callout/callout.entity';
+import { ICallout } from '@domain/collaboration/callout/callout.interface';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { vi, type Mock } from 'vitest';
+import { CalloutContributionService } from '../callout-contribution/callout.contribution.service';
+import { RoomService } from '@domain/communication/room/room.service';
+import { CalloutService } from './callout.service';
+
+/** Helper: creates a contribution-type callout (has allowedTypes). */
+function makeContributionCallout(id: string): ICallout {
+  return {
+    id,
+    settings: {
+      contribution: { allowedTypes: ['POST'] },
+    },
+    comments: undefined,
+  } as unknown as ICallout;
+}
+
+/** Helper: creates a comment-type callout (empty allowedTypes). */
+function makeCommentCallout(id: string, commentsRoom?: any): ICallout {
+  return {
+    id,
+    settings: {
+      contribution: { allowedTypes: [] },
+    },
+    comments: commentsRoom ?? { id: `room-${id}` },
+  } as unknown as ICallout;
+}
+
+describe('CalloutService', () => {
+  let service: CalloutService;
+  let contributionService: CalloutContributionService;
+  let roomService: RoomService;
+  let mockCalloutRepository: any;
+
+  beforeEach(async () => {
+    mockCalloutRepository = {
+      findOne: vi.fn(),
+      find: vi.fn(),
+      save: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalloutService,
+        {
+          provide: getRepositoryToken(Callout),
+          useValue: mockCalloutRepository,
+        },
+        MockWinstonProvider,
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get<CalloutService>(CalloutService);
+    contributionService = module.get<CalloutContributionService>(
+      CalloutContributionService
+    );
+    roomService = module.get<RoomService>(RoomService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getActivityCountBatch', () => {
+    it('should handle empty callout list', async () => {
+      await service.getActivityCountBatch([]);
+      // No errors, no service calls
+      expect(
+        contributionService.getContributionsCountBatch
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should batch contribution-type callouts into a single query', async () => {
+      const callout1 = makeContributionCallout('c-1');
+      const callout2 = makeContributionCallout('c-2');
+
+      (
+        contributionService.getContributionsCountBatch as Mock
+      ).mockResolvedValue(
+        new Map([
+          ['c-1', 5],
+          ['c-2', 12],
+        ])
+      );
+
+      await service.getActivityCountBatch([callout1, callout2]);
+
+      expect(
+        contributionService.getContributionsCountBatch
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        contributionService.getContributionsCountBatch
+      ).toHaveBeenCalledWith(['c-1', 'c-2']);
+
+      expect(callout1.activity).toBe(5);
+      expect(callout2.activity).toBe(12);
+    });
+
+    it('should set activity to 0 for contribution callouts with no contributions', async () => {
+      const callout = makeContributionCallout('c-1');
+
+      (
+        contributionService.getContributionsCountBatch as Mock
+      ).mockResolvedValue(new Map()); // no entries
+
+      await service.getActivityCountBatch([callout]);
+
+      expect(callout.activity).toBe(0);
+    });
+
+    it('should resolve comment-type callouts via room message count', async () => {
+      const callout = makeCommentCallout('c-comment');
+
+      (roomService.getMessages as Mock).mockResolvedValue([
+        { id: 'm1' },
+        { id: 'm2' },
+        { id: 'm3' },
+      ]);
+
+      await service.getActivityCountBatch([callout]);
+
+      expect(roomService.getMessages).toHaveBeenCalledWith(callout.comments);
+      expect(callout.activity).toBe(3);
+    });
+
+    it('should set activity to 0 for comment callouts with no comments room', async () => {
+      const callout = makeCommentCallout('c-no-room', undefined);
+      // Override to set comments = undefined (no room)
+      callout.comments = undefined as any;
+
+      await service.getActivityCountBatch([callout]);
+
+      expect(callout.activity).toBe(0);
+    });
+
+    it('should handle mixed contribution and comment callouts', async () => {
+      const contrib1 = makeContributionCallout('contrib-1');
+      const contrib2 = makeContributionCallout('contrib-2');
+      const comment1 = makeCommentCallout('comment-1');
+      const comment2 = makeCommentCallout('comment-2');
+
+      (
+        contributionService.getContributionsCountBatch as Mock
+      ).mockResolvedValue(
+        new Map([
+          ['contrib-1', 10],
+          ['contrib-2', 20],
+        ])
+      );
+
+      (roomService.getMessages as Mock)
+        .mockResolvedValueOnce([{ id: 'm1' }]) // comment-1 → 1 message
+        .mockResolvedValueOnce([{ id: 'm2' }, { id: 'm3' }]); // comment-2 → 2 messages
+
+      await service.getActivityCountBatch([
+        contrib1,
+        comment1,
+        contrib2,
+        comment2,
+      ]);
+
+      expect(contrib1.activity).toBe(10);
+      expect(contrib2.activity).toBe(20);
+      expect(comment1.activity).toBe(1);
+      expect(comment2.activity).toBe(2);
+    });
+
+    it('should not call contribution batch when all callouts are comment-type', async () => {
+      const comment = makeCommentCallout('c-1');
+      (roomService.getMessages as Mock).mockResolvedValue([]);
+
+      await service.getActivityCountBatch([comment]);
+
+      expect(
+        contributionService.getContributionsCountBatch
+      ).not.toHaveBeenCalled();
+      expect(comment.activity).toBe(0);
+    });
+
+    it('should not call room service when all callouts are contribution-type', async () => {
+      const contrib = makeContributionCallout('c-1');
+      (
+        contributionService.getContributionsCountBatch as Mock
+      ).mockResolvedValue(new Map([['c-1', 3]]));
+
+      await service.getActivityCountBatch([contrib]);
+
+      expect(roomService.getMessages).not.toHaveBeenCalled();
+      expect(contrib.activity).toBe(3);
+    });
+
+    it('should mutate callout objects in-place', async () => {
+      const callout = makeContributionCallout('c-1');
+      expect(callout.activity).toBeUndefined();
+
+      (
+        contributionService.getContributionsCountBatch as Mock
+      ).mockResolvedValue(new Map([['c-1', 7]]));
+
+      await service.getActivityCountBatch([callout]);
+
+      // The same object should now have activity set
+      expect(callout.activity).toBe(7);
+    });
+
+    it('should parallelize comment RPC calls', async () => {
+      const comment1 = makeCommentCallout('c-1');
+      const comment2 = makeCommentCallout('c-2');
+
+      // Track call order to verify parallelism
+      let callCount = 0;
+      (roomService.getMessages as Mock).mockImplementation(async () => {
+        callCount++;
+        // Simulate async delay
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return [{ id: 'msg' }];
+      });
+
+      await service.getActivityCountBatch([comment1, comment2]);
+
+      // Both should have been called
+      expect(roomService.getMessages).toHaveBeenCalledTimes(2);
+      expect(comment1.activity).toBe(1);
+      expect(comment2.activity).toBe(1);
+    });
+  });
+});

--- a/src/domain/collaboration/callouts-set/callouts.set.service.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.service.ts
@@ -563,9 +563,7 @@ export class CalloutsSetService {
 
     // (b) by activity. First get the activity for all callouts + sort by it; shuffle does not make sense.
     if (args.sortByActivity) {
-      for (const callout of availableCallouts) {
-        callout.activity = await this.calloutService.getActivityCount(callout);
-      }
+      await this.calloutService.getActivityCountBatch(availableCallouts);
       const sortedCallouts = availableCallouts.sort((a, b) =>
         a.activity < b.activity ? 1 : -1
       );

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -163,7 +163,7 @@ export class CollaborationService {
     this.innovationFlowService.validateInnovationFlowDefinition(
       innovationFlowData.states
     );
-    const allowedValues = innovationFlowData.states
+    const allowedValues = [...innovationFlowData.states]
       .sort(sortBySortOrder)
       .map(state => state.displayName);
     let defaultSelectedValue = innovationFlowData.currentStateDisplayName;

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -339,7 +339,7 @@ export class CollaborationService {
   async getInnovationFlow(collaborationID: string): Promise<IInnovationFlow> {
     const collaboration = await this.getCollaborationOrFail(collaborationID, {
       relations: {
-        innovationFlow: true,
+        innovationFlow: { states: { defaultCalloutTemplate: true } },
       },
     });
 

--- a/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.spec.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.spec.ts
@@ -1,0 +1,139 @@
+import { IInnovationFlow } from '@domain/collaboration/innovation-flow/innovation.flow.interface';
+import { IInnovationFlowState } from '@domain/collaboration/innovation-flow-state/innovation.flow.state.interface';
+import { InnovationFlowService } from '@domain/collaboration/innovation-flow/innovation.flow.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { type Mocked } from 'vitest';
+import { InnovationFlowResolverFields } from './innovation.flow.resolver.fields';
+
+function makeState(
+  id: string,
+  sortOrder: number
+): IInnovationFlowState {
+  return { id, sortOrder } as unknown as IInnovationFlowState;
+}
+
+function makeFlow(
+  id: string,
+  states?: IInnovationFlowState[],
+  currentStateID?: string
+): IInnovationFlow {
+  return { id, states, currentStateID } as unknown as IInnovationFlow;
+}
+
+describe('InnovationFlowResolverFields', () => {
+  let resolver: InnovationFlowResolverFields;
+  let innovationFlowService: Mocked<InnovationFlowService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [InnovationFlowResolverFields, MockWinstonProvider],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    resolver = module.get<InnovationFlowResolverFields>(
+      InnovationFlowResolverFields
+    );
+    innovationFlowService = module.get<InnovationFlowService>(
+      InnovationFlowService
+    ) as Mocked<InnovationFlowService>;
+  });
+
+  describe('states', () => {
+    it('should return eagerly-loaded states sorted by sortOrder', async () => {
+      const s1 = makeState('s-1', 2);
+      const s2 = makeState('s-2', 1);
+      const flow = makeFlow('flow-1', [s1, s2]);
+
+      const result = await resolver.states(flow);
+
+      expect(result).toEqual([s2, s1]);
+      expect(innovationFlowService.getStates).not.toHaveBeenCalled();
+    });
+
+    it('should delegate to service when states are undefined', async () => {
+      const flow = makeFlow('flow-1', undefined);
+      const serviceStates = [makeState('s-1', 1)];
+      innovationFlowService.getStates.mockResolvedValue(serviceStates);
+
+      const result = await resolver.states(flow);
+
+      expect(result).toEqual(serviceStates);
+      expect(innovationFlowService.getStates).toHaveBeenCalledWith('flow-1');
+    });
+
+    it('should delegate to service when states is empty array', async () => {
+      const flow = makeFlow('flow-1', []);
+      const serviceStates = [makeState('s-1', 1)];
+      innovationFlowService.getStates.mockResolvedValue(serviceStates);
+
+      const result = await resolver.states(flow);
+
+      expect(result).toEqual(serviceStates);
+      expect(innovationFlowService.getStates).toHaveBeenCalledWith('flow-1');
+    });
+  });
+
+  describe('currentState', () => {
+    it('should return null when currentStateID is not set', async () => {
+      const flow = makeFlow('flow-1', [makeState('s-1', 1)]);
+
+      const result = await resolver.currentState(flow);
+
+      expect(result).toBeNull();
+      expect(
+        innovationFlowService.getCurrentState
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should find matching state from eagerly-loaded states', async () => {
+      const s1 = makeState('s-1', 1);
+      const s2 = makeState('s-2', 2);
+      const flow = makeFlow('flow-1', [s1, s2], 's-2');
+
+      const result = await resolver.currentState(flow);
+
+      expect(result).toBe(s2);
+      expect(
+        innovationFlowService.getCurrentState
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should return null when currentStateID not found in states array', async () => {
+      const s1 = makeState('s-1', 1);
+      const flow = makeFlow('flow-1', [s1], 's-missing');
+
+      const result = await resolver.currentState(flow);
+
+      expect(result).toBeNull();
+    });
+
+    it('should delegate to service when states are not loaded', async () => {
+      const flow = makeFlow('flow-1', undefined, 's-1');
+      const expectedState = makeState('s-1', 1);
+      innovationFlowService.getCurrentState.mockResolvedValue(expectedState);
+
+      const result = await resolver.currentState(flow);
+
+      expect(result).toBe(expectedState);
+      expect(
+        innovationFlowService.getCurrentState
+      ).toHaveBeenCalledWith('s-1');
+    });
+
+    it('should delegate to service when states is empty array with currentStateID set', async () => {
+      const flow = makeFlow('flow-1', [], 's-1');
+      const expectedState = makeState('s-1', 1);
+      innovationFlowService.getCurrentState.mockResolvedValue(expectedState);
+
+      const result = await resolver.currentState(flow);
+
+      expect(result).toBe(expectedState);
+      expect(
+        innovationFlowService.getCurrentState
+      ).toHaveBeenCalledWith('s-1');
+    });
+  });
+});

--- a/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.ts
@@ -28,7 +28,7 @@ export class InnovationFlowResolverFields {
   ): Promise<IInnovationFlowState[]> {
     // If states were eagerly loaded (e.g. from getInnovationFlow), reuse them
     if (innovationFlow.states?.length) {
-      return innovationFlow.states.sort(sortBySortOrder);
+      return [...innovationFlow.states].sort(sortBySortOrder);
     }
     return await this.innovationFlowService.getStates(innovationFlow.id);
   }

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -168,7 +168,7 @@ export class InnovationFlowService {
       }
     );
 
-    const states = innovationFlow.states.sort(sortBySortOrder);
+    const states = [...innovationFlow.states].sort(sortBySortOrder);
     const currentStateID = innovationFlow.currentStateID;
 
     let updatedState = states.find(
@@ -271,7 +271,7 @@ export class InnovationFlowService {
 
     innovationFlow = await this.save(innovationFlow);
 
-    const tagsetAllowedValues = newStates
+    const tagsetAllowedValues = [...newStates]
       .sort(sortBySortOrder)
       .map(state => state.displayName);
 
@@ -640,7 +640,7 @@ export class InnovationFlowService {
     }
 
     // sort the states by sortOrder
-    return innovationFlow.states.sort(sortBySortOrder);
+    return [...innovationFlow.states].sort(sortBySortOrder);
   }
 
   public async getCurrentState(

--- a/src/domain/space/account.lookup/account.lookup.service.spec.ts
+++ b/src/domain/space/account.lookup/account.lookup.service.spec.ts
@@ -1,0 +1,99 @@
+import { User } from '@domain/community/user/user.entity';
+import { Organization } from '@domain/community/organization/organization.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { type Mocked } from 'vitest';
+import { EntityManager } from 'typeorm';
+import { IAccount } from '../account/account.interface';
+import { AccountLookupService } from './account.lookup.service';
+
+function makeAccount(id: string): IAccount {
+  return { id } as IAccount;
+}
+
+describe('AccountLookupService', () => {
+  let service: AccountLookupService;
+  let entityManager: Mocked<EntityManager>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AccountLookupService, MockWinstonProvider],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get<AccountLookupService>(AccountLookupService);
+    entityManager = module.get<EntityManager>(
+      getEntityManagerToken('default')
+    ) as Mocked<EntityManager>;
+  });
+
+  describe('getHost', () => {
+    it('should return user when user is found', async () => {
+      const account = makeAccount('acc-1');
+      const user = { id: 'user-1' } as User;
+      entityManager.findOne.mockImplementation((entity: any) => {
+        if (entity === User) return Promise.resolve(user);
+        return Promise.resolve(null);
+      });
+
+      const result = await service.getHost(account);
+
+      expect(result).toBe(user);
+    });
+
+    it('should return organization when only organization is found', async () => {
+      const account = makeAccount('acc-1');
+      const org = { id: 'org-1' } as Organization;
+      entityManager.findOne.mockImplementation((entity: any) => {
+        if (entity === Organization) return Promise.resolve(org);
+        return Promise.resolve(null);
+      });
+
+      const result = await service.getHost(account);
+
+      expect(result).toBe(org);
+    });
+
+    it('should return null when neither user nor organization is found', async () => {
+      const account = makeAccount('acc-1');
+      entityManager.findOne.mockResolvedValue(null);
+
+      const result = await service.getHost(account);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return user when both user and organization are found', async () => {
+      const account = makeAccount('acc-1');
+      const user = { id: 'user-1' } as User;
+      const org = { id: 'org-1' } as Organization;
+      entityManager.findOne.mockImplementation((entity: any) => {
+        if (entity === User) return Promise.resolve(user);
+        if (entity === Organization) return Promise.resolve(org);
+        return Promise.resolve(null);
+      });
+
+      const result = await service.getHost(account);
+
+      expect(result).toBe(user);
+    });
+
+    it('should use correct account ID for both queries', async () => {
+      const account = makeAccount('acc-42');
+      entityManager.findOne.mockResolvedValue(null);
+
+      await service.getHost(account);
+
+      expect(entityManager.findOne).toHaveBeenCalledTimes(2);
+      expect(entityManager.findOne).toHaveBeenCalledWith(User, {
+        where: { accountID: 'acc-42' },
+      });
+      expect(entityManager.findOne).toHaveBeenCalledWith(Organization, {
+        where: { accountID: 'acc-42' },
+      });
+    });
+  });
+});

--- a/src/domain/space/account.lookup/account.lookup.service.ts
+++ b/src/domain/space/account.lookup/account.lookup.service.ts
@@ -74,19 +74,18 @@ export class AccountLookupService {
   }
 
   public async getHost(account: IAccount): Promise<IContributor | null> {
-    const user = await this.entityManager.findOne(User, {
-      where: {
-        accountID: account.id,
-      },
-    });
+    const [user, organization] = await Promise.all([
+      this.entityManager.findOne(User, {
+        where: { accountID: account.id },
+      }),
+      this.entityManager.findOne(Organization, {
+        where: { accountID: account.id },
+      }),
+    ]);
+
     if (user) {
       return user;
     }
-    const organization = await this.entityManager.findOne(Organization, {
-      where: {
-        accountID: account.id,
-      },
-    });
     if (organization) {
       return organization;
     }

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -176,10 +176,16 @@ export class SpaceAboutService {
     return communityWithGuidelines.guidelines;
   }
 
-  async getMetrics(spaceAbout: ISpaceAbout): Promise<INVP[]> {
+  async getMetrics(
+    spaceAbout: ISpaceAbout,
+    preloadedCommunity?: ICommunity | null
+  ): Promise<INVP[]> {
     const metrics: INVP[] = [];
 
-    const community = await this.getCommunityWithRoleSet(spaceAbout.id);
+    const community =
+      preloadedCommunity && preloadedCommunity.roleSet
+        ? preloadedCommunity
+        : await this.getCommunityWithRoleSet(spaceAbout.id);
     const roleSet = community.roleSet;
 
     // Members

--- a/src/domain/space/space.lookup/space.lookup.service.spec.ts
+++ b/src/domain/space/space.lookup/space.lookup.service.spec.ts
@@ -1,0 +1,128 @@
+import { AccountLookupService } from '@domain/space/account.lookup/account.lookup.service';
+import { Space } from '@domain/space/space/space.entity';
+import { ISpace } from '@domain/space/space/space.interface';
+import { IContributor } from '@domain/community/contributor/contributor.interface';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+import { type Mocked } from 'vitest';
+import { Repository } from 'typeorm';
+import { SpaceLookupService } from './space.lookup.service';
+
+function makeSpace(
+  id: string,
+  levelZeroSpaceID: string,
+  account?: { id: string }
+): ISpace {
+  return { id, levelZeroSpaceID, account } as unknown as ISpace;
+}
+
+describe('SpaceLookupService', () => {
+  let service: SpaceLookupService;
+  let spaceRepository: Mocked<Repository<Space>>;
+  let accountLookupService: Mocked<AccountLookupService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SpaceLookupService,
+        repositoryProviderMockFactory(Space),
+        MockWinstonProvider,
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get<SpaceLookupService>(SpaceLookupService);
+    spaceRepository = module.get(
+      getRepositoryToken(Space)
+    ) as Mocked<Repository<Space>>;
+    accountLookupService = module.get<AccountLookupService>(
+      AccountLookupService
+    ) as Mocked<AccountLookupService>;
+  });
+
+  describe('getProviderForSpace', () => {
+    it('should skip DB query for L0 space with account already loaded', async () => {
+      const space = makeSpace('space-1', 'space-1', { id: 'acc-1' });
+      const mockHost = { id: 'user-1' } as IContributor;
+      accountLookupService.getHost.mockResolvedValue(mockHost);
+
+      const result = await service.getProviderForSpace(space);
+
+      expect(result).toBe(mockHost);
+      expect(spaceRepository.findOne).not.toHaveBeenCalled();
+      expect(accountLookupService.getHost).toHaveBeenCalledWith(space.account);
+    });
+
+    it('should load from DB for L0 space without account', async () => {
+      const space = makeSpace('space-1', 'space-1');
+      const dbSpace = makeSpace('space-1', 'space-1', { id: 'acc-1' });
+      spaceRepository.findOne.mockResolvedValue(dbSpace as unknown as Space);
+      const mockHost = { id: 'user-1' } as IContributor;
+      accountLookupService.getHost.mockResolvedValue(mockHost);
+
+      const result = await service.getProviderForSpace(space);
+
+      expect(result).toBe(mockHost);
+      expect(spaceRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'space-1' },
+        relations: { account: true },
+      });
+    });
+
+    it('should load L0 space for non-L0 space', async () => {
+      const space = makeSpace('subspace-1', 'root-space');
+      const l0Space = makeSpace('root-space', 'root-space', { id: 'acc-1' });
+      spaceRepository.findOne.mockResolvedValue(l0Space as unknown as Space);
+      const mockHost = { id: 'org-1' } as IContributor;
+      accountLookupService.getHost.mockResolvedValue(mockHost);
+
+      const result = await service.getProviderForSpace(space);
+
+      expect(result).toBe(mockHost);
+      expect(spaceRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'root-space' },
+        relations: { account: true },
+      });
+    });
+
+    it('should return null and log warning when L0 space not found in DB', async () => {
+      const space = makeSpace('space-1', 'space-1');
+      spaceRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getProviderForSpace(space);
+
+      expect(result).toBeNull();
+      expect(accountLookupService.getHost).not.toHaveBeenCalled();
+    });
+
+    it('should return null and log warning when L0 space has no account', async () => {
+      const space = makeSpace('space-1', 'space-1');
+      const dbSpace = makeSpace('space-1', 'space-1');
+      spaceRepository.findOne.mockResolvedValue(dbSpace as unknown as Space);
+
+      const result = await service.getProviderForSpace(space);
+
+      expect(result).toBeNull();
+      expect(accountLookupService.getHost).not.toHaveBeenCalled();
+    });
+
+    it('should return getHost result for full happy path', async () => {
+      const space = makeSpace('sub-1', 'l0-space');
+      const l0Space = makeSpace('l0-space', 'l0-space', { id: 'acc-42' });
+      spaceRepository.findOne.mockResolvedValue(l0Space as unknown as Space);
+      const expectedHost = { id: 'user-42' } as IContributor;
+      accountLookupService.getHost.mockResolvedValue(expectedHost);
+
+      const result = await service.getProviderForSpace(space);
+
+      expect(result).toBe(expectedHost);
+      expect(accountLookupService.getHost).toHaveBeenCalledWith(
+        l0Space.account
+      );
+    });
+  });
+});


### PR DESCRIPTION
## TL;DR
Key takeaways: Consistent improvement across the board — the new version is roughly 2x faster on average. Most requests dropped from the ~2s range down to sub-1s. The best case hit 75.2% faster (596ms vs 2.4s). Even the cold/first request improved from 4.6s to 3.5s.
DB hits must be also significant less.
                                                                                                                                                                                                   
##  Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                    
  - Batch callout activity counts: Replace per-callout COUNT(*) queries with a single GROUP BY query for contribution-type callouts, and reuse pre-computed activity values from sortByActivity in the field        
  resolver — eliminates the double N+1 problem (~35 DB spans saved for 18 callouts)
  - Deduplicate community+roleSet loading: Introduce SpaceCommunityWithRoleSetLoaderCreator DataLoader so membership and metrics resolvers share a single load instead of querying independently (~1 DB span saved)
  - Consolidate provider resolution: Add SpaceProviderLoaderCreator to batch provider lookups and reuse the space already loaded by isContentPublic (~1-2 DB spans saved)
  - Eager-load InnovationFlow states: Load states alongside the innovation flow in one query; currentState resolver finds its value from the loaded array instead of a separate DB call (~2 DB spans saved)
  - Add metrics DataLoader: SpaceMetricsLoaderCreator batches metrics computation, accepting preloaded community to avoid redundant queries

##  Test plan

  - pnpm build compiles without errors
  - pnpm test:ci:no:coverage — all existing tests pass
  - Run SpacePage query against local instance and verify reduced DB query count (target: ~33 DB spans, down from 73)
  - Verify sortByActivity: true still returns callouts in correct descending activity order
  - Verify callout activity values match before/after for a known space
  - Compare Elastic APM span counts on staging after deploy
  - Run Integration tests
    - 3 EXPECTED failed
    - Upload document > read uploaded file
    - Upload document > read uploaded file after related reference is removed
    - Upload visual tests > read uploaded visual

  🤖 Generated with https://claude.com/claude-code

  ---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batched activity/metrics/providers loading to improve aggregated counts and provider resolution.
  * New batch APIs to fetch contribution/member counts across multiple items.

* **Refactor**
  * Switched many resolvers/services to batched DataLoader-based fetching with caching and parallel queries for better performance and stability.
  * Preserved fallback paths when loader results are missing.

* **Tests**
  * Extensive unit tests covering batching, caching, ordering, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->