### PR TITLE
Query my memberships

### DIFF
--- a/src/core/dataloader/creators/loader.creators/community/community.roleset.loader.creator.spec.ts
+++ b/src/core/dataloader/creators/loader.creators/community/community.roleset.loader.creator.spec.ts
@@ -1,0 +1,159 @@
+import { IRoleSet } from '@domain/access/role-set/role.set.interface';
+import { Community } from '@domain/community/community/community.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+import { type Mocked, vi } from 'vitest';
+import { CommunityRoleSetLoaderCreator } from './community.roleset.loader.creator';
+
+function makeCommunity(communityId: string, roleSetId: string): Community {
+  return {
+    id: communityId,
+    roleSet: {
+      id: roleSetId,
+      roles: [{ id: 'role-1', name: 'member' }],
+    },
+  } as unknown as Community;
+}
+
+describe('CommunityRoleSetLoaderCreator', () => {
+  let creator: CommunityRoleSetLoaderCreator;
+  let entityManager: Mocked<EntityManager>;
+
+  beforeEach(async () => {
+    const mockEntityManager = {
+      find: vi.fn(),
+      findOne: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommunityRoleSetLoaderCreator,
+        {
+          provide: getEntityManagerToken(),
+          useValue: mockEntityManager,
+        },
+      ],
+    }).compile();
+
+    creator = module.get(CommunityRoleSetLoaderCreator);
+    entityManager = module.get(
+      getEntityManagerToken()
+    ) as Mocked<EntityManager>;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(creator).toBeDefined();
+  });
+
+  it('should create a DataLoader', () => {
+    const loader = creator.create({ parentClassRef: Community } as any);
+    expect(loader).toBeDefined();
+    expect(typeof loader.load).toBe('function');
+  });
+
+  describe('batch loading', () => {
+    it('should batch multiple loads into a single query', async () => {
+      const community1 = makeCommunity('comm-1', 'rs-1');
+      const community2 = makeCommunity('comm-2', 'rs-2');
+
+      entityManager.find.mockResolvedValueOnce([community1, community2]);
+
+      const loader = creator.create({ parentClassRef: Community } as any);
+
+      const [result1, result2] = await Promise.all([
+        loader.load('comm-1'),
+        loader.load('comm-2'),
+      ]);
+
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(entityManager.find).toHaveBeenCalledWith(
+        Community,
+        expect.objectContaining({
+          where: { id: expect.anything() },
+          relations: { roleSet: { roles: true } },
+        })
+      );
+
+      expect((result1 as IRoleSet).id).toBe('rs-1');
+      expect((result2 as IRoleSet).id).toBe('rs-2');
+    });
+
+    it('should return results in input key order', async () => {
+      const community1 = makeCommunity('comm-1', 'rs-1');
+      const community2 = makeCommunity('comm-2', 'rs-2');
+      const community3 = makeCommunity('comm-3', 'rs-3');
+
+      // DB returns in different order
+      entityManager.find.mockResolvedValueOnce([
+        community3,
+        community1,
+        community2,
+      ]);
+
+      const loader = creator.create({ parentClassRef: Community } as any);
+
+      const [result1, result2, result3] = await Promise.all([
+        loader.load('comm-2'),
+        loader.load('comm-1'),
+        loader.load('comm-3'),
+      ]);
+
+      expect((result1 as IRoleSet).id).toBe('rs-2');
+      expect((result2 as IRoleSet).id).toBe('rs-1');
+      expect((result3 as IRoleSet).id).toBe('rs-3');
+    });
+
+    it('should use DataLoader caching for repeated keys', async () => {
+      const community1 = makeCommunity('comm-1', 'rs-1');
+
+      entityManager.find.mockResolvedValueOnce([community1]);
+
+      const loader = creator.create({ parentClassRef: Community } as any);
+
+      const result1 = await loader.load('comm-1');
+      const result2 = await loader.load('comm-1');
+
+      expect(entityManager.find).toHaveBeenCalledTimes(1);
+      expect(result1).toBe(result2);
+    });
+
+    it('should pre-load roles on the returned roleSet', async () => {
+      const community = makeCommunity('comm-1', 'rs-1');
+
+      entityManager.find.mockResolvedValueOnce([community]);
+
+      const loader = creator.create({ parentClassRef: Community } as any);
+
+      const result = (await loader.load('comm-1')) as IRoleSet;
+
+      expect(result.roles).toBeDefined();
+      expect(result.roles).toHaveLength(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should propagate database errors to all pending loads', async () => {
+      entityManager.find.mockRejectedValueOnce(
+        new Error('DB connection failed')
+      );
+
+      const loader = creator.create({ parentClassRef: Community } as any);
+
+      const [result1, result2] = await Promise.allSettled([
+        loader.load('comm-1'),
+        loader.load('comm-2'),
+      ]);
+
+      expect(result1.status).toBe('rejected');
+      expect(result2.status).toBe('rejected');
+      expect((result1 as PromiseRejectedResult).reason.message).toBe(
+        'DB connection failed'
+      );
+    });
+  });
+});

--- a/src/core/dataloader/creators/loader.creators/community/community.roleset.loader.creator.ts
+++ b/src/core/dataloader/creators/loader.creators/community/community.roleset.loader.creator.ts
@@ -1,0 +1,24 @@
+import { IRoleSet } from '@domain/access/role-set/role.set.interface';
+import { Community } from '@domain/community/community/community.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
+import { createTypedRelationDataLoader } from '../../../utils';
+import { DataLoaderCreator, DataLoaderCreatorOptions } from '../../base';
+
+@Injectable()
+export class CommunityRoleSetLoaderCreator
+  implements DataLoaderCreator<IRoleSet>
+{
+  constructor(@InjectEntityManager() private manager: EntityManager) {}
+
+  create(options: DataLoaderCreatorOptions<IRoleSet>) {
+    return createTypedRelationDataLoader(
+      this.manager,
+      Community,
+      { roleSet: { roles: true } },
+      this.constructor.name,
+      options
+    );
+  }
+}

--- a/src/core/dataloader/creators/loader.creators/index.ts
+++ b/src/core/dataloader/creators/loader.creators/index.ts
@@ -11,11 +11,11 @@ export * from './authorization.loader.creator';
 export * from './callout-framing/callout.framing.whiteboard.loader';
 
 export * from './classification.tagsets.loader.creator';
-
 export * from './collaboration/collaboration.callouts.set.loader.creator';
 export * from './collaboration/collaboration.timeline.loader.creator';
 export * from './collaboration/contributor.by.agent.id.loader.creator';
 export * from './collaboration/knowledge.base.callouts.set.loader.creator';
+export * from './community/community.roleset.loader.creator';
 export * from './conversation/conversation.memberships.loader.creator';
 export * from './in-app-notification/callout.loader.creator';
 export * from './in-app-notification/contributor.loader.creator';

--- a/src/domain/access/application/application.service.ts
+++ b/src/domain/access/application/application.service.ts
@@ -191,6 +191,11 @@ export class ApplicationService {
     return this.applicationLifecycleService.isFinalState(application.lifecycle);
   }
 
+  /** Synchronous check when the entity (with eager lifecycle) is already loaded. */
+  isApplicationFinalized(application: IApplication): boolean {
+    return this.applicationLifecycleService.isFinalState(application.lifecycle);
+  }
+
   async getQuestionsSorted(application: IApplication): Promise<IQuestion[]> {
     const questions = application.questions;
     if (!questions) {

--- a/src/domain/access/invitation/invitation.service.ts
+++ b/src/domain/access/invitation/invitation.service.ts
@@ -248,11 +248,18 @@ export class InvitationService {
 
   async canInvitationBeAccepted(invitationID: string): Promise<boolean> {
     const invitation = await this.getInvitationOrFail(invitationID);
-    const lifecycle = invitation.lifecycle;
+    return this.canAcceptInvitation(invitation);
+  }
 
-    const canAccept = this.invitationLifecycleService
-      .getNextEvents(lifecycle)
+  /** Synchronous check when the entity (with eager lifecycle) is already loaded. */
+  isInvitationFinalized(invitation: IInvitation): boolean {
+    return this.invitationLifecycleService.isFinalState(invitation.lifecycle);
+  }
+
+  /** Synchronous check when the entity (with eager lifecycle) is already loaded. */
+  canAcceptInvitation(invitation: IInvitation): boolean {
+    return this.invitationLifecycleService
+      .getNextEvents(invitation.lifecycle)
       .includes('ACCEPT');
-    return canAccept;
   }
 }

--- a/src/domain/access/role-set/role.set.data.loader.membership.status.spec.ts
+++ b/src/domain/access/role-set/role.set.data.loader.membership.status.spec.ts
@@ -68,9 +68,9 @@ function createMocks() {
   };
 
   const invitationService: Mocked<
-    Pick<InvitationService, 'canInvitationBeAccepted'>
+    Pick<InvitationService, 'canAcceptInvitation'>
   > = {
-    canInvitationBeAccepted: vi.fn().mockResolvedValue(false),
+    canAcceptInvitation: vi.fn().mockReturnValue(false),
   };
 
   const roleSetRepository: Mocked<Pick<Repository<RoleSet>, 'find'>> = {
@@ -384,7 +384,7 @@ describe('RoleSetMembershipStatusDataLoader', () => {
       mocks.roleSetService.findOpenInvitation.mockResolvedValue({
         id: 'inv-1',
       } as any);
-      mocks.invitationService.canInvitationBeAccepted.mockResolvedValue(true);
+      mocks.invitationService.canAcceptInvitation.mockReturnValue(true);
 
       const loader = createLoader(mocks);
       const result = await loader.loader.load(
@@ -399,7 +399,7 @@ describe('RoleSetMembershipStatusDataLoader', () => {
       mocks.roleSetService.findOpenInvitation.mockResolvedValue({
         id: 'inv-1',
       } as any);
-      mocks.invitationService.canInvitationBeAccepted.mockResolvedValue(false);
+      mocks.invitationService.canAcceptInvitation.mockReturnValue(false);
 
       const loader = createLoader(mocks);
       const result = await loader.loader.load(
@@ -429,16 +429,15 @@ describe('RoleSetMembershipStatusDataLoader', () => {
       mocks.roleSetService.findOpenInvitation.mockResolvedValue({
         id: 'inv-1',
       } as any);
-      mocks.invitationService.canInvitationBeAccepted.mockResolvedValue(true);
+      mocks.invitationService.canAcceptInvitation.mockReturnValue(true);
 
       const loader = createLoader(mocks);
       const result = await loader.loader.load(
         makeKey('agent-1', 'user-1', roleSet)
       );
 
+      // Application and invitation are fetched in parallel, but application takes precedence
       expect(result).toBe(CommunityMembershipStatus.APPLICATION_PENDING);
-      // Should NOT even check invitations
-      expect(mocks.roleSetService.findOpenInvitation).not.toHaveBeenCalled();
     });
   });
 

--- a/src/domain/access/role-set/role.set.data.loader.membership.status.spec.ts
+++ b/src/domain/access/role-set/role.set.data.loader.membership.status.spec.ts
@@ -1,0 +1,538 @@
+import { CommunityMembershipStatus } from '@common/enums/community.membership.status';
+import { RoleName } from '@common/enums/role.name';
+import { AgentService } from '@domain/agent/agent/agent.service';
+import { ICredential } from '@domain/agent/credential/credential.interface';
+import { Repository } from 'typeorm';
+import { type Mocked, vi, describe, it, expect, beforeEach } from 'vitest';
+import { InvitationService } from '../invitation/invitation.service';
+import { RoleSet } from './role.set.entity';
+import { IRoleSet } from './role.set.interface';
+import { RoleSetMembershipStatusDataLoader } from './role.set.data.loader.membership.status';
+import { RoleSetService } from './role.set.service';
+import { RoleSetCacheService } from './role.set.service.cache';
+import { AgentRoleKey } from './types';
+
+/* ───────── helpers ───────── */
+
+function makeCredential(type: string, resourceID: string): ICredential {
+  return { type, resourceID } as unknown as ICredential;
+}
+
+function makeRoleSet(
+  id: string,
+  roles?: Array<{ name: RoleName; credential: { type: string; resourceID: string } }>
+): IRoleSet {
+  return {
+    id,
+    roles: roles?.map((r, i) => ({
+      id: `role-${i}`,
+      name: r.name,
+      credential: r.credential,
+    })),
+  } as unknown as IRoleSet;
+}
+
+function makeKey(
+  agentID: string,
+  userID: string,
+  roleSet: IRoleSet
+): AgentRoleKey {
+  return {
+    agentInfo: { agentID, userID } as any,
+    roleSet,
+  };
+}
+
+/* ───────── mocks ───────── */
+
+function createMocks() {
+  const agentService: Mocked<Pick<AgentService, 'getAgentCredentialsBatch'>> = {
+    getAgentCredentialsBatch: vi.fn().mockResolvedValue(new Map()),
+  };
+
+  const roleSetCacheService: Mocked<
+    Pick<
+      RoleSetCacheService,
+      'getMembershipStatusBatchFromCache' | 'setMembershipStatusCache'
+    >
+  > = {
+    getMembershipStatusBatchFromCache: vi.fn().mockResolvedValue([]),
+    setMembershipStatusCache: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const roleSetService: Mocked<
+    Pick<RoleSetService, 'findOpenApplication' | 'findOpenInvitation'>
+  > = {
+    findOpenApplication: vi.fn().mockResolvedValue(undefined),
+    findOpenInvitation: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const invitationService: Mocked<
+    Pick<InvitationService, 'canInvitationBeAccepted'>
+  > = {
+    canInvitationBeAccepted: vi.fn().mockResolvedValue(false),
+  };
+
+  const roleSetRepository: Mocked<Pick<Repository<RoleSet>, 'find'>> = {
+    find: vi.fn().mockResolvedValue([]),
+  };
+
+  return {
+    agentService,
+    roleSetCacheService,
+    roleSetService,
+    invitationService,
+    roleSetRepository,
+  };
+}
+
+function createLoader(mocks: ReturnType<typeof createMocks>) {
+  return new RoleSetMembershipStatusDataLoader(
+    mocks.agentService as unknown as AgentService,
+    mocks.roleSetCacheService as unknown as RoleSetCacheService,
+    mocks.roleSetService as unknown as RoleSetService,
+    mocks.invitationService as unknown as InvitationService,
+    mocks.roleSetRepository as unknown as Repository<RoleSet>
+  );
+}
+
+/* ═══════════════════════════════════════════════
+   RoleSetMembershipStatusDataLoader
+   ═══════════════════════════════════════════════ */
+
+describe('RoleSetMembershipStatusDataLoader', () => {
+  let mocks: ReturnType<typeof createMocks>;
+
+  beforeEach(() => {
+    mocks = createMocks();
+  });
+
+  /* ─── Empty agentID ─── */
+
+  describe('empty agentID handling', () => {
+    it('should return NOT_MEMBER immediately for empty agentID', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        { name: RoleName.MEMBER, credential: { type: 'space-member', resourceID: 'space-1' } },
+      ]);
+      const key = makeKey('', 'user-1', roleSet);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+      // Should not check cache for empty agent
+      expect(
+        mocks.roleSetCacheService.getMembershipStatusBatchFromCache
+      ).toHaveBeenCalledWith([]);
+    });
+  });
+
+  /* ─── Cache hits ─── */
+
+  describe('cache hits', () => {
+    it('should return cached membership status without computing', async () => {
+      const roleSet = makeRoleSet('rs-1');
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map()
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [CommunityMembershipStatus.MEMBER]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.MEMBER);
+      // Should not try to set cache or check applications
+      expect(
+        mocks.roleSetCacheService.setMembershipStatusCache
+      ).not.toHaveBeenCalled();
+      expect(mocks.roleSetService.findOpenApplication).not.toHaveBeenCalled();
+    });
+  });
+
+  /* ─── In-memory membership check ─── */
+
+  describe('isMemberInMemory', () => {
+    it('should detect member via credential match', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      const cred = makeCredential('space-member', 'space-1');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.MEMBER);
+      expect(
+        mocks.roleSetCacheService.setMembershipStatusCache
+      ).toHaveBeenCalledWith(
+        'agent-1',
+        'rs-1',
+        CommunityMembershipStatus.MEMBER
+      );
+    });
+
+    it('should not match when credential type differs', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      const cred = makeCredential('org-member', 'space-1');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+
+    it('should not match when resourceID differs', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      const cred = makeCredential('space-member', 'space-OTHER');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+
+    it('should match any resourceID when credDef resourceID is falsy', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: '' },
+        },
+      ]);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      const cred = makeCredential('space-member', 'any-resource');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.MEMBER);
+    });
+
+    it('should return NOT_MEMBER when roleSet has no roles', async () => {
+      const roleSet = makeRoleSet('rs-1', []);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      const cred = makeCredential('space-member', 'space-1');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+
+    it('should return NOT_MEMBER when roleSet has no MEMBER role', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.LEAD,
+          credential: { type: 'space-lead', resourceID: 'space-1' },
+        },
+      ]);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      const cred = makeCredential('space-lead', 'space-1');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      // Even though the agent has the LEAD credential, the isMemberInMemory
+      // check only looks for the MEMBER role
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+
+    it('should return NOT_MEMBER when agent has no credentials', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      // Agent exists but has no credentials
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', []]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+
+    it('should return NOT_MEMBER when agent is not in credentials map', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      // Agent not in the map at all
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map()
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+  });
+
+  /* ─── Non-member status resolution ─── */
+
+  describe('resolveNonMemberStatus', () => {
+    let roleSet: IRoleSet;
+
+    beforeEach(() => {
+      roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      // Agent has NO matching credentials → triggers non-member path
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', []]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined]
+      );
+    });
+
+    it('should return APPLICATION_PENDING when open application exists', async () => {
+      mocks.roleSetService.findOpenApplication.mockResolvedValue({
+        id: 'app-1',
+      } as any);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toBe(CommunityMembershipStatus.APPLICATION_PENDING);
+    });
+
+    it('should return INVITATION_PENDING when open invitation exists and can be accepted', async () => {
+      mocks.roleSetService.findOpenApplication.mockResolvedValue(undefined);
+      mocks.roleSetService.findOpenInvitation.mockResolvedValue({
+        id: 'inv-1',
+      } as any);
+      mocks.invitationService.canInvitationBeAccepted.mockResolvedValue(true);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toBe(CommunityMembershipStatus.INVITATION_PENDING);
+    });
+
+    it('should return NOT_MEMBER when invitation exists but cannot be accepted', async () => {
+      mocks.roleSetService.findOpenApplication.mockResolvedValue(undefined);
+      mocks.roleSetService.findOpenInvitation.mockResolvedValue({
+        id: 'inv-1',
+      } as any);
+      mocks.invitationService.canInvitationBeAccepted.mockResolvedValue(false);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+
+    it('should return NOT_MEMBER when no application or invitation exists', async () => {
+      mocks.roleSetService.findOpenApplication.mockResolvedValue(undefined);
+      mocks.roleSetService.findOpenInvitation.mockResolvedValue(undefined);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+
+    it('should prioritize application over invitation', async () => {
+      // Both exist, but application takes precedence
+      mocks.roleSetService.findOpenApplication.mockResolvedValue({
+        id: 'app-1',
+      } as any);
+      mocks.roleSetService.findOpenInvitation.mockResolvedValue({
+        id: 'inv-1',
+      } as any);
+      mocks.invitationService.canInvitationBeAccepted.mockResolvedValue(true);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toBe(CommunityMembershipStatus.APPLICATION_PENDING);
+      // Should NOT even check invitations
+      expect(mocks.roleSetService.findOpenInvitation).not.toHaveBeenCalled();
+    });
+  });
+
+  /* ─── Batching behavior ─── */
+
+  describe('batching', () => {
+    it('should process multiple keys in a single batch', async () => {
+      const rs1 = makeRoleSet('rs-1', [
+        { name: RoleName.MEMBER, credential: { type: 'space-member', resourceID: 'space-1' } },
+      ]);
+      const rs2 = makeRoleSet('rs-2', [
+        { name: RoleName.MEMBER, credential: { type: 'space-member', resourceID: 'space-2' } },
+      ]);
+
+      const cred1 = makeCredential('space-member', 'space-1');
+      const cred2 = makeCredential('space-member', 'space-2');
+
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred1, cred2]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined, undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const [result1, result2] = await Promise.all([
+        loader.loader.load(makeKey('agent-1', 'user-1', rs1)),
+        loader.loader.load(makeKey('agent-1', 'user-1', rs2)),
+      ]);
+
+      expect(result1).toBe(CommunityMembershipStatus.MEMBER);
+      expect(result2).toBe(CommunityMembershipStatus.MEMBER);
+      // Credentials loaded only once
+      expect(
+        mocks.agentService.getAgentCredentialsBatch
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should mix cached and uncached results in the same batch', async () => {
+      const rs1 = makeRoleSet('rs-1', [
+        { name: RoleName.MEMBER, credential: { type: 'space-member', resourceID: 'space-1' } },
+      ]);
+      const rs2 = makeRoleSet('rs-2', [
+        { name: RoleName.MEMBER, credential: { type: 'space-member', resourceID: 'space-2' } },
+      ]);
+
+      const cred = makeCredential('space-member', 'space-2');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred]]])
+      );
+      // First key is cached, second is not
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [CommunityMembershipStatus.NOT_MEMBER, undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const [result1, result2] = await Promise.all([
+        loader.loader.load(makeKey('agent-1', 'user-1', rs1)),
+        loader.loader.load(makeKey('agent-1', 'user-1', rs2)),
+      ]);
+
+      expect(result1).toBe(CommunityMembershipStatus.NOT_MEMBER); // from cache
+      expect(result2).toBe(CommunityMembershipStatus.MEMBER); // computed
+    });
+  });
+
+  /* ─── Cache key function ─── */
+
+  describe('DataLoader cache key', () => {
+    it('should differentiate keys by agentID + roleSetID', async () => {
+      const rs1 = makeRoleSet('rs-1', [
+        { name: RoleName.MEMBER, credential: { type: 'space-member', resourceID: 'space-1' } },
+      ]);
+      const rs2 = makeRoleSet('rs-2', [
+        { name: RoleName.MEMBER, credential: { type: 'space-member', resourceID: 'space-2' } },
+      ]);
+
+      const cred1 = makeCredential('space-member', 'space-1');
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', [cred1]]])
+      );
+      mocks.roleSetCacheService.getMembershipStatusBatchFromCache.mockResolvedValue(
+        [undefined, undefined]
+      );
+
+      const loader = createLoader(mocks);
+      const [result1, result2] = await Promise.all([
+        loader.loader.load(makeKey('agent-1', 'user-1', rs1)),
+        loader.loader.load(makeKey('agent-1', 'user-1', rs2)),
+      ]);
+
+      // Same agent, different roleSets → different results
+      expect(result1).toBe(CommunityMembershipStatus.MEMBER);
+      expect(result2).toBe(CommunityMembershipStatus.NOT_MEMBER);
+    });
+  });
+});

--- a/src/domain/access/role-set/role.set.data.loader.membership.status.ts
+++ b/src/domain/access/role-set/role.set.data.loader.membership.status.ts
@@ -1,7 +1,20 @@
 import { CommunityMembershipStatus } from '@common/enums/community.membership.status';
+import { RoleName } from '@common/enums/role.name';
+import { AgentService } from '@domain/agent/agent/agent.service';
+import { ICredential } from '@domain/agent/credential/credential.interface';
 import { Injectable, Scope } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import DataLoader from 'dataloader';
+import { Repository } from 'typeorm';
+import { InvitationService } from '../invitation/invitation.service';
+import {
+  ensureRolesLoaded,
+  loadAgentCredentials,
+} from './role.set.data.loader.utils';
+import { RoleSet } from './role.set.entity';
+import { IRoleSet } from './role.set.interface';
 import { RoleSetService } from './role.set.service';
+import { RoleSetCacheService } from './role.set.service.cache';
 import { AgentRoleKey } from './types';
 
 @Injectable({ scope: Scope.REQUEST })
@@ -12,28 +25,133 @@ export class RoleSetMembershipStatusDataLoader {
     string
   >;
 
-  constructor(private readonly roleSetService: RoleSetService) {
+  constructor(
+    private readonly agentService: AgentService,
+    private readonly roleSetCacheService: RoleSetCacheService,
+    private readonly roleSetService: RoleSetService,
+    private readonly invitationService: InvitationService,
+    @InjectRepository(RoleSet)
+    private readonly roleSetRepository: Repository<RoleSet>
+  ) {
     this.loader = new DataLoader<
       AgentRoleKey,
       CommunityMembershipStatus,
       string
-    >(
-      async (keys: readonly AgentRoleKey[]) => {
-        // Batch each key concurrently using getRolesForAgentInfo.
-        return Promise.all(
-          keys.map(({ agentInfo, roleSet }) =>
-            this.roleSetService.getMembershipStatusByAgentInfo(
-              agentInfo,
-              roleSet
-            )
-          )
-        );
-      },
-      {
-        // Assuming agentInfo and roleSet have an id property
-        cacheKeyFn: (key: AgentRoleKey) =>
-          `${key.agentInfo.agentID}-${key.roleSet.id}`,
-      }
+    >(async (keys: readonly AgentRoleKey[]) => this.batchLoad(keys), {
+      cacheKeyFn: (key: AgentRoleKey) =>
+        `${key.agentInfo.agentID}-${key.roleSet.id}`,
+    });
+  }
+
+  private async batchLoad(
+    keys: readonly AgentRoleKey[]
+  ): Promise<CommunityMembershipStatus[]> {
+    const results: CommunityMembershipStatus[] = new Array(keys.length);
+
+    // 1. Load agent credentials ONCE for the unique agent(s) in this batch.
+    const credentialsByAgent = await loadAgentCredentials(
+      keys,
+      this.agentService
     );
+
+    // 2. Check Redis cache; collect indices that still need computation.
+    const uncachedIndices: number[] = [];
+    for (let i = 0; i < keys.length; i++) {
+      const { agentInfo, roleSet } = keys[i];
+      if (!agentInfo.agentID) {
+        results[i] = CommunityMembershipStatus.NOT_MEMBER;
+        continue;
+      }
+
+      const cached =
+        await this.roleSetCacheService.getMembershipStatusFromCache(
+          agentInfo.agentID,
+          roleSet.id
+        );
+      if (cached) {
+        results[i] = cached;
+      } else {
+        uncachedIndices.push(i);
+      }
+    }
+
+    // 3. Batch-load roles for any roleSets that don't have them pre-loaded.
+    await ensureRolesLoaded(
+      uncachedIndices.map(i => keys[i].roleSet),
+      this.roleSetRepository
+    );
+
+    // 4. In-memory membership check + fallback for non-members.
+    for (const i of uncachedIndices) {
+      const { agentInfo, roleSet } = keys[i];
+      const credentials = credentialsByAgent.get(agentInfo.agentID);
+
+      // Check member credential in memory
+      if (credentials && this.isMemberInMemory(roleSet, credentials)) {
+        results[i] = CommunityMembershipStatus.MEMBER;
+        await this.roleSetCacheService.setMembershipStatusCache(
+          agentInfo.agentID,
+          roleSet.id,
+          CommunityMembershipStatus.MEMBER
+        );
+        continue;
+      }
+
+      // For non-members: check application & invitation (already cached individually)
+      const status = await this.resolveNonMemberStatus(agentInfo, roleSet);
+      results[i] = status;
+      await this.roleSetCacheService.setMembershipStatusCache(
+        agentInfo.agentID,
+        roleSet.id,
+        status
+      );
+    }
+
+    return results;
+  }
+
+  /** Pure in-memory check: does the agent hold the MEMBER role? */
+  private isMemberInMemory(
+    roleSet: IRoleSet,
+    credentials: ICredential[]
+  ): boolean {
+    const memberRole = (roleSet.roles ?? []).find(
+      r => r.name === RoleName.MEMBER
+    );
+    if (!memberRole) return false;
+
+    const credDef = memberRole.credential;
+    return credentials.some(
+      c =>
+        c.type === credDef.type &&
+        (!credDef.resourceID || c.resourceID === credDef.resourceID)
+    );
+  }
+
+  /** For non-members, check pending applications and invitations. */
+  private async resolveNonMemberStatus(
+    agentInfo: { userID: string },
+    roleSet: IRoleSet
+  ): Promise<CommunityMembershipStatus> {
+    const openApplication = await this.roleSetService.findOpenApplication(
+      agentInfo.userID,
+      roleSet.id
+    );
+    if (openApplication) {
+      return CommunityMembershipStatus.APPLICATION_PENDING;
+    }
+
+    const openInvitation = await this.roleSetService.findOpenInvitation(
+      agentInfo.userID,
+      roleSet.id
+    );
+    if (
+      openInvitation &&
+      (await this.invitationService.canInvitationBeAccepted(openInvitation.id))
+    ) {
+      return CommunityMembershipStatus.INVITATION_PENDING;
+    }
+
+    return CommunityMembershipStatus.NOT_MEMBER;
   }
 }

--- a/src/domain/access/role-set/role.set.data.loader.utils.spec.ts
+++ b/src/domain/access/role-set/role.set.data.loader.utils.spec.ts
@@ -1,0 +1,223 @@
+import { AgentService } from '@domain/agent/agent/agent.service';
+import { ICredential } from '@domain/agent/credential/credential.interface';
+import { type Mocked, vi, describe, it, expect, beforeEach } from 'vitest';
+import { Repository, In } from 'typeorm';
+import { RoleSet } from './role.set.entity';
+import { IRoleSet } from './role.set.interface';
+import { AgentRoleKey } from './types';
+import { loadAgentCredentials, ensureRolesLoaded } from './role.set.data.loader.utils';
+
+/* ───────── helpers ───────── */
+
+function makeAgentRoleKey(
+  agentID: string,
+  userID: string,
+  roleSetId: string,
+  roles?: any[]
+): AgentRoleKey {
+  return {
+    agentInfo: { agentID, userID } as any,
+    roleSet: { id: roleSetId, roles } as unknown as IRoleSet,
+  };
+}
+
+function makeCredential(type: string, resourceID: string): ICredential {
+  return { type, resourceID } as unknown as ICredential;
+}
+
+/* ═══════════════════════════════════════════════
+   loadAgentCredentials
+   ═══════════════════════════════════════════════ */
+
+describe('loadAgentCredentials', () => {
+  let agentService: Mocked<Pick<AgentService, 'getAgentCredentialsBatch'>>;
+
+  beforeEach(() => {
+    agentService = {
+      getAgentCredentialsBatch: vi.fn().mockResolvedValue(new Map()),
+    };
+  });
+
+  it('should deduplicate agent IDs across keys', async () => {
+    const keys: AgentRoleKey[] = [
+      makeAgentRoleKey('agent-1', 'user-1', 'rs-1'),
+      makeAgentRoleKey('agent-1', 'user-1', 'rs-2'),
+      makeAgentRoleKey('agent-1', 'user-1', 'rs-3'),
+    ];
+
+    await loadAgentCredentials(keys, agentService as unknown as AgentService);
+
+    expect(agentService.getAgentCredentialsBatch).toHaveBeenCalledTimes(1);
+    expect(agentService.getAgentCredentialsBatch).toHaveBeenCalledWith([
+      'agent-1',
+    ]);
+  });
+
+  it('should pass multiple unique agent IDs', async () => {
+    const keys: AgentRoleKey[] = [
+      makeAgentRoleKey('agent-1', 'user-1', 'rs-1'),
+      makeAgentRoleKey('agent-2', 'user-2', 'rs-2'),
+      makeAgentRoleKey('agent-1', 'user-1', 'rs-3'),
+    ];
+
+    await loadAgentCredentials(keys, agentService as unknown as AgentService);
+
+    const passedIds =
+      agentService.getAgentCredentialsBatch.mock.calls[0][0];
+    expect(passedIds).toHaveLength(2);
+    expect(passedIds).toContain('agent-1');
+    expect(passedIds).toContain('agent-2');
+  });
+
+  it('should filter out empty agent IDs', async () => {
+    const keys: AgentRoleKey[] = [
+      makeAgentRoleKey('', 'user-1', 'rs-1'),
+      makeAgentRoleKey('agent-2', 'user-2', 'rs-2'),
+      makeAgentRoleKey('', 'user-3', 'rs-3'),
+    ];
+
+    await loadAgentCredentials(keys, agentService as unknown as AgentService);
+
+    expect(agentService.getAgentCredentialsBatch).toHaveBeenCalledWith([
+      'agent-2',
+    ]);
+  });
+
+  it('should return empty map when all agent IDs are empty', async () => {
+    const keys: AgentRoleKey[] = [
+      makeAgentRoleKey('', 'user-1', 'rs-1'),
+      makeAgentRoleKey('', 'user-2', 'rs-2'),
+    ];
+
+    // When no valid IDs, getAgentCredentialsBatch([]) returns empty map
+    agentService.getAgentCredentialsBatch.mockResolvedValue(new Map());
+
+    const result = await loadAgentCredentials(
+      keys,
+      agentService as unknown as AgentService
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should return the map from agentService', async () => {
+    const cred = makeCredential('space-member', 'space-123');
+    const expected = new Map([['agent-1', [cred]]]);
+    agentService.getAgentCredentialsBatch.mockResolvedValue(expected);
+
+    const keys: AgentRoleKey[] = [
+      makeAgentRoleKey('agent-1', 'user-1', 'rs-1'),
+    ];
+
+    const result = await loadAgentCredentials(
+      keys,
+      agentService as unknown as AgentService
+    );
+
+    expect(result).toBe(expected);
+    expect(result.get('agent-1')).toEqual([cred]);
+  });
+});
+
+/* ═══════════════════════════════════════════════
+   ensureRolesLoaded
+   ═══════════════════════════════════════════════ */
+
+describe('ensureRolesLoaded', () => {
+  let roleSetRepository: Mocked<Pick<Repository<RoleSet>, 'find'>>;
+
+  beforeEach(() => {
+    roleSetRepository = {
+      find: vi.fn().mockResolvedValue([]),
+    };
+  });
+
+  it('should skip DB query when all roleSets already have roles', async () => {
+    const roleSets: IRoleSet[] = [
+      { id: 'rs-1', roles: [{ id: 'role-1', name: 'member' }] } as any,
+      { id: 'rs-2', roles: [{ id: 'role-2', name: 'lead' }] } as any,
+    ];
+
+    await ensureRolesLoaded(
+      roleSets,
+      roleSetRepository as unknown as Repository<RoleSet>
+    );
+
+    expect(roleSetRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('should fetch roles for roleSets with undefined roles', async () => {
+    const rs1: IRoleSet = { id: 'rs-1', roles: undefined } as any;
+    const rs2: IRoleSet = {
+      id: 'rs-2',
+      roles: [{ id: 'role-2', name: 'lead' }],
+    } as any;
+
+    const loadedRoles = [{ id: 'role-1', name: 'member' }];
+    roleSetRepository.find.mockResolvedValue([
+      { id: 'rs-1', roles: loadedRoles } as any,
+    ]);
+
+    await ensureRolesLoaded(
+      [rs1, rs2],
+      roleSetRepository as unknown as Repository<RoleSet>
+    );
+
+    expect(roleSetRepository.find).toHaveBeenCalledTimes(1);
+    expect(roleSetRepository.find).toHaveBeenCalledWith({
+      where: { id: In(['rs-1']) },
+      relations: { roles: true },
+    });
+    // Mutates in place
+    expect(rs1.roles).toEqual(loadedRoles);
+    // Already-loaded roleSet untouched
+    expect(rs2.roles).toHaveLength(1);
+  });
+
+  it('should deduplicate roleSet IDs for the query', async () => {
+    const rs1: IRoleSet = { id: 'rs-1', roles: undefined } as any;
+    const rs2: IRoleSet = { id: 'rs-1', roles: undefined } as any; // same ID, different ref
+
+    const loadedRoles = [{ id: 'role-1', name: 'member' }];
+    roleSetRepository.find.mockResolvedValue([
+      { id: 'rs-1', roles: loadedRoles } as any,
+    ]);
+
+    await ensureRolesLoaded(
+      [rs1, rs2],
+      roleSetRepository as unknown as Repository<RoleSet>
+    );
+
+    // Should only query with unique IDs
+    expect(roleSetRepository.find).toHaveBeenCalledWith({
+      where: { id: In(['rs-1']) },
+      relations: { roles: true },
+    });
+    // Both references should be hydrated
+    expect(rs1.roles).toEqual(loadedRoles);
+    expect(rs2.roles).toEqual(loadedRoles);
+  });
+
+  it('should handle empty input array', async () => {
+    await ensureRolesLoaded(
+      [],
+      roleSetRepository as unknown as Repository<RoleSet>
+    );
+
+    expect(roleSetRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('should handle roleSet not found in DB (sets undefined)', async () => {
+    const rs1: IRoleSet = { id: 'rs-missing', roles: undefined } as any;
+
+    roleSetRepository.find.mockResolvedValue([]);
+
+    await ensureRolesLoaded(
+      [rs1],
+      roleSetRepository as unknown as Repository<RoleSet>
+    );
+
+    // rolesById.get('rs-missing') returns undefined
+    expect(rs1.roles).toBeUndefined();
+  });
+});

--- a/src/domain/access/role-set/role.set.data.loader.utils.ts
+++ b/src/domain/access/role-set/role.set.data.loader.utils.ts
@@ -1,0 +1,45 @@
+import { AgentService } from '@domain/agent/agent/agent.service';
+import { ICredential } from '@domain/agent/credential/credential.interface';
+import { In, Repository } from 'typeorm';
+import { RoleSet } from './role.set.entity';
+import { IRoleSet } from './role.set.interface';
+import { AgentRoleKey } from './types';
+
+/** Load credentials once per unique agentID across all keys. */
+export async function loadAgentCredentials(
+  keys: readonly AgentRoleKey[],
+  agentService: AgentService
+): Promise<Map<string, ICredential[]>> {
+  const map = new Map<string, ICredential[]>();
+  const uniqueAgentIDs = [
+    ...new Set(keys.map(k => k.agentInfo.agentID).filter(id => id.length > 0)),
+  ];
+  for (const agentID of uniqueAgentIDs) {
+    const { credentials } = await agentService.getAgentCredentials(agentID);
+    map.set(agentID, credentials);
+  }
+  return map;
+}
+
+/**
+ * For any roleSet in the list whose `.roles` are not loaded,
+ * batch-fetch them in a single DB query and attach to the objects.
+ */
+export async function ensureRolesLoaded(
+  roleSets: IRoleSet[],
+  roleSetRepository: Repository<RoleSet>
+): Promise<void> {
+  const needsLoad = roleSets.filter(rs => !rs.roles);
+  if (needsLoad.length === 0) return;
+
+  const uniqueIds = [...new Set(needsLoad.map(rs => rs.id))];
+  const loaded = await roleSetRepository.find({
+    where: { id: In(uniqueIds) },
+    relations: { roles: true },
+  });
+  const rolesById = new Map(loaded.map(rs => [rs.id, rs.roles]));
+
+  for (const rs of needsLoad) {
+    rs.roles = rolesById.get(rs.id);
+  }
+}

--- a/src/domain/access/role-set/role.set.data.loader.utils.ts
+++ b/src/domain/access/role-set/role.set.data.loader.utils.ts
@@ -5,20 +5,15 @@ import { RoleSet } from './role.set.entity';
 import { IRoleSet } from './role.set.interface';
 import { AgentRoleKey } from './types';
 
-/** Load credentials once per unique agentID across all keys. */
+/** Load credentials once per unique agentID across all keys using batch mget. */
 export async function loadAgentCredentials(
   keys: readonly AgentRoleKey[],
   agentService: AgentService
 ): Promise<Map<string, ICredential[]>> {
-  const map = new Map<string, ICredential[]>();
   const uniqueAgentIDs = [
     ...new Set(keys.map(k => k.agentInfo.agentID).filter(id => id.length > 0)),
   ];
-  for (const agentID of uniqueAgentIDs) {
-    const { credentials } = await agentService.getAgentCredentials(agentID);
-    map.set(agentID, credentials);
-  }
-  return map;
+  return agentService.getAgentCredentialsBatch(uniqueAgentIDs);
 }
 
 /**

--- a/src/domain/access/role-set/role.set.data.loaders.agent.roles.spec.ts
+++ b/src/domain/access/role-set/role.set.data.loaders.agent.roles.spec.ts
@@ -1,0 +1,419 @@
+import { RoleName } from '@common/enums/role.name';
+import { AgentService } from '@domain/agent/agent/agent.service';
+import { ICredential } from '@domain/agent/credential/credential.interface';
+import { Repository } from 'typeorm';
+import { type Mocked, vi, describe, it, expect, beforeEach } from 'vitest';
+import { RoleSet } from './role.set.entity';
+import { IRoleSet } from './role.set.interface';
+import { RoleSetAgentRolesDataLoader } from './role.set.data.loaders.agent.roles';
+import { RoleSetCacheService } from './role.set.service.cache';
+import { AgentRoleKey } from './types';
+
+/* ───────── helpers ───────── */
+
+function makeCredential(type: string, resourceID: string): ICredential {
+  return { type, resourceID } as unknown as ICredential;
+}
+
+function makeRoleSet(
+  id: string,
+  roles?: Array<{
+    name: RoleName;
+    credential: { type: string; resourceID: string };
+  }>
+): IRoleSet {
+  return {
+    id,
+    roles: roles?.map((r, i) => ({
+      id: `role-${i}`,
+      name: r.name,
+      credential: r.credential,
+    })),
+  } as unknown as IRoleSet;
+}
+
+function makeKey(
+  agentID: string,
+  userID: string,
+  roleSet: IRoleSet
+): AgentRoleKey {
+  return {
+    agentInfo: { agentID, userID } as any,
+    roleSet,
+  };
+}
+
+/* ───────── mocks ───────── */
+
+function createMocks() {
+  const agentService: Mocked<
+    Pick<AgentService, 'getAgentCredentialsBatch'>
+  > = {
+    getAgentCredentialsBatch: vi.fn().mockResolvedValue(new Map()),
+  };
+
+  const roleSetCacheService: Mocked<
+    Pick<
+      RoleSetCacheService,
+      'getAgentRolesBatchFromCache' | 'setAgentRolesCache'
+    >
+  > = {
+    getAgentRolesBatchFromCache: vi.fn().mockResolvedValue([]),
+    setAgentRolesCache: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const roleSetRepository: Mocked<Pick<Repository<RoleSet>, 'find'>> = {
+    find: vi.fn().mockResolvedValue([]),
+  };
+
+  return { agentService, roleSetCacheService, roleSetRepository };
+}
+
+function createLoader(mocks: ReturnType<typeof createMocks>) {
+  return new RoleSetAgentRolesDataLoader(
+    mocks.agentService as unknown as AgentService,
+    mocks.roleSetCacheService as unknown as RoleSetCacheService,
+    mocks.roleSetRepository as unknown as Repository<RoleSet>
+  );
+}
+
+/* ═══════════════════════════════════════════════
+   RoleSetAgentRolesDataLoader
+   ═══════════════════════════════════════════════ */
+
+describe('RoleSetAgentRolesDataLoader', () => {
+  let mocks: ReturnType<typeof createMocks>;
+
+  beforeEach(() => {
+    mocks = createMocks();
+  });
+
+  /* ─── Empty agentID ─── */
+
+  describe('empty agentID handling', () => {
+    it('should return empty roles array for empty agentID', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(makeKey('', 'user-1', roleSet));
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  /* ─── Cache hits ─── */
+
+  describe('cache hits', () => {
+    it('should return cached roles without computing', async () => {
+      const roleSet = makeRoleSet('rs-1');
+      const key = makeKey('agent-1', 'user-1', roleSet);
+
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        [RoleName.MEMBER, RoleName.LEAD],
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(key);
+
+      expect(result).toEqual([RoleName.MEMBER, RoleName.LEAD]);
+      expect(
+        mocks.roleSetCacheService.setAgentRolesCache
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  /* ─── matchRolesInMemory ─── */
+
+  describe('in-memory role matching', () => {
+    it('should match multiple roles the agent holds', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+        {
+          name: RoleName.LEAD,
+          credential: { type: 'space-lead', resourceID: 'space-1' },
+        },
+        {
+          name: RoleName.ADMIN,
+          credential: { type: 'space-admin', resourceID: 'space-1' },
+        },
+      ]);
+
+      const creds = [
+        makeCredential('space-member', 'space-1'),
+        makeCredential('space-lead', 'space-1'),
+        // No admin credential
+      ];
+
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toEqual([RoleName.MEMBER, RoleName.LEAD]);
+      expect(result).not.toContain(RoleName.ADMIN);
+    });
+
+    it('should return empty array when no credentials match any role', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+
+      const creds = [makeCredential('org-member', 'org-1')];
+
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when agent has no credentials', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', []]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when roleSet has no role definitions', async () => {
+      const roleSet = makeRoleSet('rs-1', []);
+
+      const creds = [makeCredential('space-member', 'space-1')];
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when credentials map has no entry for agent', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+
+      // Agent not in the credentials map
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map()
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toEqual([]);
+      // Should NOT cache when there's no credentials entry
+      expect(
+        mocks.roleSetCacheService.setAgentRolesCache
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should match when credDef resourceID is empty (wildcard)', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'global-role', resourceID: '' },
+        },
+      ]);
+
+      const creds = [makeCredential('global-role', 'any-resource-123')];
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toEqual([RoleName.MEMBER]);
+    });
+
+    it('should NOT match when credential resourceID is empty but credDef requires specific one', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+
+      // Credential has empty resourceID, but role requires 'space-1'
+      const creds = [makeCredential('space-member', '')];
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const result = await loader.loader.load(
+        makeKey('agent-1', 'user-1', roleSet)
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  /* ─── Caching behavior ─── */
+
+  describe('caching', () => {
+    it('should cache computed roles', async () => {
+      const roleSet = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+
+      const creds = [makeCredential('space-member', 'space-1')];
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      await loader.loader.load(makeKey('agent-1', 'user-1', roleSet));
+
+      expect(
+        mocks.roleSetCacheService.setAgentRolesCache
+      ).toHaveBeenCalledWith('agent-1', 'rs-1', [RoleName.MEMBER]);
+    });
+  });
+
+  /* ─── Batching behavior ─── */
+
+  describe('batching', () => {
+    it('should batch multiple loads and deduplicate agent credential fetches', async () => {
+      const rs1 = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      const rs2 = makeRoleSet('rs-2', [
+        {
+          name: RoleName.LEAD,
+          credential: { type: 'space-lead', resourceID: 'space-2' },
+        },
+      ]);
+
+      const creds = [
+        makeCredential('space-member', 'space-1'),
+        makeCredential('space-lead', 'space-2'),
+      ];
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const [roles1, roles2] = await Promise.all([
+        loader.loader.load(makeKey('agent-1', 'user-1', rs1)),
+        loader.loader.load(makeKey('agent-1', 'user-1', rs2)),
+      ]);
+
+      expect(roles1).toEqual([RoleName.MEMBER]);
+      expect(roles2).toEqual([RoleName.LEAD]);
+      expect(
+        mocks.agentService.getAgentCredentialsBatch
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle mixed empty and valid agentIDs in one batch', async () => {
+      const rs1 = makeRoleSet('rs-1', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-1' },
+        },
+      ]);
+      const rs2 = makeRoleSet('rs-2', [
+        {
+          name: RoleName.MEMBER,
+          credential: { type: 'space-member', resourceID: 'space-2' },
+        },
+      ]);
+
+      const creds = [makeCredential('space-member', 'space-1')];
+      mocks.agentService.getAgentCredentialsBatch.mockResolvedValue(
+        new Map([['agent-1', creds]])
+      );
+      // Only one entry for agent-1; the empty agent doesn't go through cache
+      mocks.roleSetCacheService.getAgentRolesBatchFromCache.mockResolvedValue([
+        undefined,
+      ]);
+
+      const loader = createLoader(mocks);
+      const [roles1, roles2] = await Promise.all([
+        loader.loader.load(makeKey('', 'user-anon', rs1)), // empty agentID
+        loader.loader.load(makeKey('agent-1', 'user-1', rs2)),
+      ]);
+
+      expect(roles1).toEqual([]); // empty agent → empty roles
+      expect(roles2).toEqual([]); // agent-1 has space-1 cred, not space-2
+    });
+  });
+});

--- a/src/domain/access/role-set/role.set.data.loaders.agent.roles.ts
+++ b/src/domain/access/role-set/role.set.data.loaders.agent.roles.ts
@@ -119,6 +119,10 @@ export class RoleSetAgentRolesDataLoader {
     const agentRoles: RoleName[] = [];
     for (const roleDef of roleDefinitions) {
       const credDef = roleDef.credential;
+      if (!credDef) {
+        continue;
+      }
+
       const hasRole = credentials.some(
         c =>
           c.type === credDef.type &&

--- a/src/domain/access/role-set/role.set.data.loaders.agent.roles.ts
+++ b/src/domain/access/role-set/role.set.data.loaders.agent.roles.ts
@@ -106,7 +106,9 @@ export class RoleSetAgentRolesDataLoader {
     }
 
     // 5. Fire-and-forget: cache writes don't affect the response.
-    void Promise.all(cacheWrites);
+    void Promise.all(cacheWrites).catch(() => {
+    // swallowed – RoleSetCacheService already logs failures
+    });
 
     return results;
   }

--- a/src/domain/access/role-set/role.set.data.loaders.agent.roles.ts
+++ b/src/domain/access/role-set/role.set.data.loaders.agent.roles.ts
@@ -1,28 +1,119 @@
 import { RoleName } from '@common/enums/role.name';
+import { AgentService } from '@domain/agent/agent/agent.service';
+import { ICredential } from '@domain/agent/credential/credential.interface';
 import { Injectable, Scope } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import DataLoader from 'dataloader';
-import { RoleSetService } from './role.set.service';
+import { Repository } from 'typeorm';
+import { IRole } from '../role/role.interface';
+import {
+  ensureRolesLoaded,
+  loadAgentCredentials,
+} from './role.set.data.loader.utils';
+import { RoleSet } from './role.set.entity';
+import { RoleSetCacheService } from './role.set.service.cache';
 import { AgentRoleKey } from './types';
 
 @Injectable({ scope: Scope.REQUEST })
 export class RoleSetAgentRolesDataLoader {
   public readonly loader: DataLoader<AgentRoleKey, RoleName[], string>;
 
-  constructor(private readonly roleSetService: RoleSetService) {
+  constructor(
+    private readonly agentService: AgentService,
+    private readonly roleSetCacheService: RoleSetCacheService,
+    @InjectRepository(RoleSet)
+    private readonly roleSetRepository: Repository<RoleSet>
+  ) {
     this.loader = new DataLoader<AgentRoleKey, RoleName[], string>(
-      async (keys: readonly AgentRoleKey[]) => {
-        // Batch each key concurrently using getRolesForAgentInfo.
-        return Promise.all(
-          keys.map(({ agentInfo, roleSet }) =>
-            this.roleSetService.getRolesForAgentInfo(agentInfo, roleSet)
-          )
-        );
-      },
+      async (keys: readonly AgentRoleKey[]) => this.batchLoad(keys),
       {
-        // Use a composite key string to avoid duplicate lookups in a single request.
         cacheKeyFn: (key: AgentRoleKey) =>
           `${key.agentInfo.agentID}-${key.roleSet.id}`,
       }
     );
+  }
+
+  private async batchLoad(
+    keys: readonly AgentRoleKey[]
+  ): Promise<RoleName[][]> {
+    const results: RoleName[][] = new Array(keys.length);
+
+    // 1. Load agent credentials ONCE for the unique agent(s) in this batch.
+    //    In the MyMemberships flow all keys share the same agentID.
+    const credentialsByAgent = await loadAgentCredentials(
+      keys,
+      this.agentService
+    );
+
+    // 2. Check Redis cache; collect indices that still need computation.
+    const uncachedIndices: number[] = [];
+    for (let i = 0; i < keys.length; i++) {
+      const { agentInfo, roleSet } = keys[i];
+      if (!agentInfo.agentID) {
+        results[i] = [];
+        continue;
+      }
+
+      const cached = await this.roleSetCacheService.getAgentRolesFromCache(
+        agentInfo.agentID,
+        roleSet.id
+      );
+      if (cached) {
+        results[i] = cached;
+      } else {
+        uncachedIndices.push(i);
+      }
+    }
+
+    // 3. Batch-load roles for any roleSets that don't have them pre-loaded.
+    await ensureRolesLoaded(
+      uncachedIndices.map(i => keys[i].roleSet),
+      this.roleSetRepository
+    );
+
+    // 4. In-memory credential matching for uncached keys.
+    for (const i of uncachedIndices) {
+      const { agentInfo, roleSet } = keys[i];
+      const credentials = credentialsByAgent.get(agentInfo.agentID);
+      if (!credentials) {
+        results[i] = [];
+        continue;
+      }
+
+      const agentRoles = this.matchRolesInMemory(
+        roleSet.roles ?? [],
+        credentials
+      );
+      results[i] = agentRoles;
+
+      // 5. Cache the result.
+      await this.roleSetCacheService.setAgentRolesCache(
+        agentInfo.agentID,
+        roleSet.id,
+        agentRoles
+      );
+    }
+
+    return results;
+  }
+
+  /** Pure in-memory check: which roles does the agent hold? */
+  private matchRolesInMemory(
+    roleDefinitions: IRole[],
+    credentials: ICredential[]
+  ): RoleName[] {
+    const agentRoles: RoleName[] = [];
+    for (const roleDef of roleDefinitions) {
+      const credDef = roleDef.credential;
+      const hasRole = credentials.some(
+        c =>
+          c.type === credDef.type &&
+          (!credDef.resourceID || c.resourceID === credDef.resourceID)
+      );
+      if (hasRole) {
+        agentRoles.push(roleDef.name);
+      }
+    }
+    return agentRoles;
   }
 }

--- a/src/domain/access/role-set/role.set.module.ts
+++ b/src/domain/access/role-set/role.set.module.ts
@@ -82,6 +82,12 @@ import { RoleSetServiceLifecycleInvitation } from './role.set.service.lifecycle.
     RoleSetAgentRolesDataLoader,
     RoleSetMembershipStatusDataLoader,
   ],
-  exports: [RoleSetService, RoleSetAuthorizationService, RoleSetLicenseService],
+  exports: [
+    RoleSetService,
+    RoleSetAuthorizationService,
+    RoleSetLicenseService,
+    RoleSetAgentRolesDataLoader,
+    RoleSetMembershipStatusDataLoader,
+  ],
 })
 export class RoleSetModule {}

--- a/src/domain/access/role-set/role.set.service.cache.spec.ts
+++ b/src/domain/access/role-set/role.set.service.cache.spec.ts
@@ -4,6 +4,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Cache } from 'cache-manager';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { type Mocked, vi, describe, it, expect, beforeEach } from 'vitest';
 import { RoleSetCacheService } from './role.set.service.cache';
 
@@ -43,6 +44,7 @@ describe('RoleSetCacheService', () => {
       providers: [
         RoleSetCacheService,
         { provide: CACHE_MANAGER, useValue: cacheManager },
+        { provide: WINSTON_MODULE_NEST_PROVIDER, useValue: { warn: vi.fn() } },
         { provide: ConfigService, useValue: createMockConfigService() },
       ],
     }).compile();

--- a/src/domain/access/role-set/role.set.service.cache.spec.ts
+++ b/src/domain/access/role-set/role.set.service.cache.spec.ts
@@ -1,0 +1,289 @@
+import { CommunityMembershipStatus } from '@common/enums/community.membership.status';
+import { RoleName } from '@common/enums/role.name';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Cache } from 'cache-manager';
+import { type Mocked, vi, describe, it, expect, beforeEach } from 'vitest';
+import { RoleSetCacheService } from './role.set.service.cache';
+
+/* ───────── helpers ───────── */
+
+function createMockCacheManager(supportMget: boolean): Mocked<Cache> {
+  const store: any = {};
+  if (supportMget) {
+    store.mget = vi.fn();
+  }
+  return {
+    get: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn().mockImplementation((_key, value) => Promise.resolve(value)),
+    del: vi.fn().mockResolvedValue(undefined),
+    store,
+  } as unknown as Mocked<Cache>;
+}
+
+function createMockConfigService(): Partial<ConfigService> {
+  return {
+    get: vi.fn().mockReturnValue(300), // 300s TTL
+  } as any;
+}
+
+/* ═══════════════════════════════════════════════
+   RoleSetCacheService
+   ═══════════════════════════════════════════════ */
+
+describe('RoleSetCacheService', () => {
+  let service: RoleSetCacheService;
+  let cacheManager: Mocked<Cache>;
+
+  async function createService(supportMget = true) {
+    cacheManager = createMockCacheManager(supportMget);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoleSetCacheService,
+        { provide: CACHE_MANAGER, useValue: cacheManager },
+        { provide: ConfigService, useValue: createMockConfigService() },
+      ],
+    }).compile();
+
+    service = module.get(RoleSetCacheService);
+  }
+
+  beforeEach(async () => {
+    await createService(true);
+  });
+
+  /* ─── Key generation (tested via set/get round-trip) ─── */
+
+  describe('cache key generation', () => {
+    it('should generate distinct keys for membership status', async () => {
+      await service.setMembershipStatusCache(
+        'agent-1',
+        'rs-1',
+        CommunityMembershipStatus.MEMBER
+      );
+
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'membershipStatus:agent-1:rs-1',
+        CommunityMembershipStatus.MEMBER,
+        { ttl: 300 }
+      );
+    });
+
+    it('should generate distinct keys for agent roles', async () => {
+      await service.setAgentRolesCache('agent-1', 'rs-1', [RoleName.MEMBER]);
+
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'agentRoles:agent-1:rs-1',
+        [RoleName.MEMBER],
+        { ttl: 300 }
+      );
+    });
+
+    it('should generate distinct keys for isMember', async () => {
+      await service.setAgentIsMemberCache('agent-1', 'rs-1', true);
+
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'isMember:agent-1:rs-1',
+        true,
+        { ttl: 300 }
+      );
+    });
+  });
+
+  /* ─── Batch retrieval with mget ─── */
+
+  describe('batch cache retrieval (mget available)', () => {
+    it('should use mget for agent roles batch', async () => {
+      const entries = [
+        { agentId: 'a1', roleSetId: 'rs-1' },
+        { agentId: 'a2', roleSetId: 'rs-2' },
+      ];
+
+      cacheManager.store.mget!.mockResolvedValue([
+        [RoleName.MEMBER],
+        undefined,
+      ]);
+
+      const results = await service.getAgentRolesBatchFromCache(entries);
+
+      expect(cacheManager.store.mget).toHaveBeenCalledWith(
+        'agentRoles:a1:rs-1',
+        'agentRoles:a2:rs-2'
+      );
+      expect(results).toEqual([[RoleName.MEMBER], undefined]);
+    });
+
+    it('should use mget for membership status batch', async () => {
+      const entries = [
+        { agentId: 'a1', roleSetId: 'rs-1' },
+        { agentId: 'a2', roleSetId: 'rs-2' },
+      ];
+
+      cacheManager.store.mget!.mockResolvedValue([
+        CommunityMembershipStatus.MEMBER,
+        CommunityMembershipStatus.NOT_MEMBER,
+      ]);
+
+      const results =
+        await service.getMembershipStatusBatchFromCache(entries);
+
+      expect(results).toEqual([
+        CommunityMembershipStatus.MEMBER,
+        CommunityMembershipStatus.NOT_MEMBER,
+      ]);
+    });
+
+    it('should return empty array for empty entries', async () => {
+      const results = await service.getAgentRolesBatchFromCache([]);
+
+      expect(cacheManager.store.mget).not.toHaveBeenCalled();
+      expect(results).toEqual([]);
+    });
+  });
+
+  /* ─── Batch retrieval without mget (fallback) ─── */
+
+  describe('batch cache retrieval (mget NOT available)', () => {
+    beforeEach(async () => {
+      await createService(false);
+    });
+
+    it('should fall back to sequential gets', async () => {
+      const entries = [
+        { agentId: 'a1', roleSetId: 'rs-1' },
+        { agentId: 'a2', roleSetId: 'rs-2' },
+      ];
+
+      cacheManager.get
+        .mockResolvedValueOnce([RoleName.LEAD] as any)
+        .mockResolvedValueOnce(undefined as any);
+
+      const results = await service.getAgentRolesBatchFromCache(entries);
+
+      expect(cacheManager.get).toHaveBeenCalledTimes(2);
+      expect(cacheManager.get).toHaveBeenCalledWith('agentRoles:a1:rs-1');
+      expect(cacheManager.get).toHaveBeenCalledWith('agentRoles:a2:rs-2');
+      expect(results).toEqual([[RoleName.LEAD], undefined]);
+    });
+  });
+
+  /* ─── appendAgentRoleCache ─── */
+
+  describe('appendAgentRoleCache', () => {
+    it('should return undefined when no cached roles exist', async () => {
+      cacheManager.get.mockResolvedValue(undefined as any);
+
+      const result = await service.appendAgentRoleCache(
+        'agent-1',
+        'rs-1',
+        RoleName.LEAD
+      );
+
+      expect(result).toBeUndefined();
+      // Should not attempt to set
+      expect(cacheManager.set).not.toHaveBeenCalled();
+    });
+
+    it('should append a new role to existing cached roles', async () => {
+      cacheManager.get.mockResolvedValue([RoleName.MEMBER] as any);
+
+      const result = await service.appendAgentRoleCache(
+        'agent-1',
+        'rs-1',
+        RoleName.LEAD
+      );
+
+      expect(result).toEqual([RoleName.MEMBER, RoleName.LEAD]);
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        'agentRoles:agent-1:rs-1',
+        [RoleName.MEMBER, RoleName.LEAD],
+        { ttl: 300 }
+      );
+    });
+
+    it('should not duplicate an already-existing role', async () => {
+      cacheManager.get.mockResolvedValue([RoleName.MEMBER, RoleName.LEAD] as any);
+
+      const result = await service.appendAgentRoleCache(
+        'agent-1',
+        'rs-1',
+        RoleName.MEMBER
+      );
+
+      expect(result).toEqual([RoleName.MEMBER, RoleName.LEAD]);
+      // Should not call set since no change needed
+      expect(cacheManager.set).not.toHaveBeenCalled();
+    });
+  });
+
+  /* ─── cleanAgentMembershipCache ─── */
+
+  describe('cleanAgentMembershipCache', () => {
+    it('should delete all three related cache keys', async () => {
+      await service.cleanAgentMembershipCache('agent-1', 'rs-1');
+
+      expect(cacheManager.del).toHaveBeenCalledTimes(3);
+      expect(cacheManager.del).toHaveBeenCalledWith(
+        'membershipStatus:agent-1:rs-1'
+      );
+      expect(cacheManager.del).toHaveBeenCalledWith(
+        'agentRoles:agent-1:rs-1'
+      );
+      expect(cacheManager.del).toHaveBeenCalledWith(
+        'isMember:agent-1:rs-1'
+      );
+    });
+  });
+
+  /* ─── Individual get/set/delete methods ─── */
+
+  describe('individual cache operations', () => {
+    it('should get membership status from cache', async () => {
+      cacheManager.get.mockResolvedValue(CommunityMembershipStatus.MEMBER as any);
+
+      const result = await service.getMembershipStatusFromCache(
+        'agent-1',
+        'rs-1'
+      );
+
+      expect(cacheManager.get).toHaveBeenCalledWith(
+        'membershipStatus:agent-1:rs-1'
+      );
+      expect(result).toBe(CommunityMembershipStatus.MEMBER);
+    });
+
+    it('should return undefined for cache miss', async () => {
+      cacheManager.get.mockResolvedValue(undefined as any);
+
+      const result = await service.getAgentRolesFromCache('agent-1', 'rs-1');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should delete membership status from cache', async () => {
+      await service.deleteMembershipStatusCache('agent-1', 'rs-1');
+
+      expect(cacheManager.del).toHaveBeenCalledWith(
+        'membershipStatus:agent-1:rs-1'
+      );
+    });
+
+    it('should delete open invitation from cache', async () => {
+      await service.deleteOpenInvitationFromCache('user-1', 'rs-1');
+
+      expect(cacheManager.del).toHaveBeenCalledWith(
+        'openInvitation:user-1:rs-1'
+      );
+    });
+
+    it('should delete open application from cache', async () => {
+      await service.deleteOpenApplicationFromCache('user-1', 'rs-1');
+
+      expect(cacheManager.del).toHaveBeenCalledWith(
+        'openApplication:user-1:rs-1'
+      );
+    });
+  });
+});

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -361,7 +361,7 @@ export class RoleSetService {
     const agentRoles = rolesThatAgentHas.filter(
       (role): role is RoleName => role !== undefined
     );
-    await this.roleSetCacheService.setAgentRolesCache(
+    void this.roleSetCacheService.setAgentRolesCache(
       agent.id,
       roleSet.id,
       agentRoles
@@ -386,12 +386,9 @@ export class RoleSetService {
       roleSetID
     );
     for (const application of applications) {
-      // skip any finalized applications; only want to return pending applications
-      const isFinalized = await this.applicationService.isFinalizedApplication(
-        application.id
-      );
-      if (isFinalized) continue;
-      await this.roleSetCacheService.setOpenApplicationCache(
+      // Lifecycle is eager-loaded; check in-memory without re-fetching from DB
+      if (this.applicationService.isApplicationFinalized(application)) continue;
+      void this.roleSetCacheService.setOpenApplicationCache(
         userID,
         roleSetID,
         application
@@ -420,7 +417,7 @@ export class RoleSetService {
     const agent = await this.agentService.getAgentOrFail(agentInfo.agentID);
     const isMember = await this.isMember(agent, roleSet);
     if (isMember) {
-      await this.roleSetCacheService.setMembershipStatusCache(
+      void this.roleSetCacheService.setMembershipStatusCache(
         agent.id,
         roleSet.id,
         CommunityMembershipStatus.MEMBER
@@ -434,7 +431,7 @@ export class RoleSetService {
       roleSet.id
     );
     if (openApplication) {
-      await this.roleSetCacheService.setMembershipStatusCache(
+      void this.roleSetCacheService.setMembershipStatusCache(
         agent.id,
         roleSet.id,
         CommunityMembershipStatus.APPLICATION_PENDING
@@ -450,7 +447,7 @@ export class RoleSetService {
       openInvitation &&
       (await this.invitationService.canInvitationBeAccepted(openInvitation.id))
     ) {
-      await this.roleSetCacheService.setMembershipStatusCache(
+      void this.roleSetCacheService.setMembershipStatusCache(
         agent.id,
         roleSet.id,
         CommunityMembershipStatus.INVITATION_PENDING
@@ -458,7 +455,7 @@ export class RoleSetService {
       return CommunityMembershipStatus.INVITATION_PENDING;
     }
 
-    await this.roleSetCacheService.setMembershipStatusCache(
+    void this.roleSetCacheService.setMembershipStatusCache(
       agent.id,
       roleSet.id,
       CommunityMembershipStatus.NOT_MEMBER
@@ -484,14 +481,9 @@ export class RoleSetService {
       roleSetID
     );
     for (const invitation of invitations) {
-      // skip any finalized invitations; only return pending invitations
-      const isFinalized = await this.invitationService.isFinalizedInvitation(
-        invitation.id
-      );
-      if (isFinalized) {
-        continue;
-      }
-      await this.roleSetCacheService.setOpenInvitationCache(
+      // Lifecycle is eager-loaded; check in-memory without re-fetching from DB
+      if (this.invitationService.isInvitationFinalized(invitation)) continue;
+      void this.roleSetCacheService.setOpenInvitationCache(
         contributorID,
         roleSetID,
         invitation
@@ -1598,7 +1590,7 @@ export class RoleSetService {
         resourceID: membershipCredential.resourceID,
       }
     );
-    await this.roleSetCacheService.setAgentIsMemberCache(
+    void this.roleSetCacheService.setAgentIsMemberCache(
       agent.id,
       roleSet.id,
       validCredential

--- a/src/domain/agent/agent/agent.service.get.credentials.batch.spec.ts
+++ b/src/domain/agent/agent/agent.service.get.credentials.batch.spec.ts
@@ -1,0 +1,224 @@
+import { Agent, IAgent } from '@domain/agent/agent';
+import { ICredential } from '@domain/agent/credential/credential.interface';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Cache } from 'cache-manager';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+import { type Mocked, vi, describe, it, expect, beforeEach } from 'vitest';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AgentService } from './agent.service';
+
+/* ───────── helpers ───────── */
+
+function makeAgent(id: string, credentials: ICredential[]): IAgent {
+  return { id, credentials } as unknown as IAgent;
+}
+
+function makeCredential(type: string, resourceID: string): ICredential {
+  return { type, resourceID } as unknown as ICredential;
+}
+
+/**
+ * Custom cache manager mock that exposes mget on the store,
+ * unlike the default MockCacheManager which has store as vi.fn().
+ */
+function createCacheManagerWithMget() {
+  return {
+    get: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn().mockImplementation((_key: string, value: any) =>
+      Promise.resolve(value)
+    ),
+    del: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn().mockResolvedValue(undefined),
+    wrap: vi.fn(),
+    store: {
+      mget: vi.fn().mockResolvedValue([]),
+    },
+  };
+}
+
+/* ═══════════════════════════════════════════════
+   AgentService.getAgentCredentialsBatch
+   ═══════════════════════════════════════════════ */
+
+describe('AgentService.getAgentCredentialsBatch', () => {
+  let service: AgentService;
+  let cacheManager: ReturnType<typeof createCacheManagerWithMget>;
+  let agentRepository: Mocked<Repository<Agent>>;
+
+  beforeEach(async () => {
+    cacheManager = createCacheManagerWithMget();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AgentService,
+        { provide: CACHE_MANAGER, useValue: cacheManager },
+        {
+          provide: ConfigService,
+          useValue: { get: vi.fn().mockReturnValue(300) },
+        },
+        repositoryProviderMockFactory(Agent),
+        MockWinstonProvider,
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get(AgentService);
+    agentRepository = module.get(
+      getRepositoryToken(Agent)
+    ) as Mocked<Repository<Agent>>;
+  });
+
+  it('should return empty map for empty input', async () => {
+    const result = await service.getAgentCredentialsBatch([]);
+
+    expect(result.size).toBe(0);
+    expect(cacheManager.store.mget).not.toHaveBeenCalled();
+    expect(agentRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('should return from cache when all agents are cached', async () => {
+    const cred1 = makeCredential('space-member', 'space-1');
+    const cred2 = makeCredential('org-member', 'org-1');
+    const agent1 = makeAgent('agent-1', [cred1]);
+    const agent2 = makeAgent('agent-2', [cred2]);
+
+    cacheManager.store.mget.mockResolvedValue([agent1, agent2]);
+
+    const result = await service.getAgentCredentialsBatch([
+      'agent-1',
+      'agent-2',
+    ]);
+
+    expect(result.size).toBe(2);
+    expect(result.get('agent-1')).toEqual([cred1]);
+    expect(result.get('agent-2')).toEqual([cred2]);
+    // No DB query needed
+    expect(agentRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('should query DB for cache misses only', async () => {
+    const cred1 = makeCredential('space-member', 'space-1');
+    const cred2 = makeCredential('org-member', 'org-1');
+    const agent1 = makeAgent('agent-1', [cred1]);
+    const agent2 = makeAgent('agent-2', [cred2]);
+
+    // agent-1 is cached, agent-2 is not
+    cacheManager.store.mget.mockResolvedValue([agent1, undefined]);
+    agentRepository.find.mockResolvedValue([agent2 as unknown as Agent]);
+
+    const result = await service.getAgentCredentialsBatch([
+      'agent-1',
+      'agent-2',
+    ]);
+
+    expect(result.size).toBe(2);
+    expect(result.get('agent-1')).toEqual([cred1]);
+    expect(result.get('agent-2')).toEqual([cred2]);
+    // DB queried only for agent-2
+    expect(agentRepository.find).toHaveBeenCalledTimes(1);
+    expect(agentRepository.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: expect.anything() },
+        relations: { credentials: true },
+      })
+    );
+  });
+
+  it('should warm cache for agents loaded from DB', async () => {
+    const cred = makeCredential('space-member', 'space-1');
+    const agent = makeAgent('agent-1', [cred]);
+
+    cacheManager.store.mget.mockResolvedValue([undefined]);
+    agentRepository.find.mockResolvedValue([agent as unknown as Agent]);
+
+    await service.getAgentCredentialsBatch(['agent-1']);
+
+    // Should set agent in cache
+    expect(cacheManager.set).toHaveBeenCalledWith(
+      '@agent:id:agent-1',
+      agent,
+      expect.objectContaining({ ttl: expect.any(Number) })
+    );
+  });
+
+  it('should return empty credentials array for agents not found in DB', async () => {
+    cacheManager.store.mget.mockResolvedValue([undefined]);
+    agentRepository.find.mockResolvedValue([]); // Agent not in DB
+
+    const result = await service.getAgentCredentialsBatch(['agent-missing']);
+
+    expect(result.size).toBe(1);
+    expect(result.get('agent-missing')).toEqual([]);
+  });
+
+  it('should handle agent cached without credentials (treated as miss)', async () => {
+    // Agent in cache but without credentials property
+    const agentNoCreds = { id: 'agent-1' } as unknown as IAgent;
+    cacheManager.store.mget.mockResolvedValue([agentNoCreds]);
+
+    const cred = makeCredential('space-member', 'space-1');
+    const fullAgent = makeAgent('agent-1', [cred]);
+    agentRepository.find.mockResolvedValue([fullAgent as unknown as Agent]);
+
+    const result = await service.getAgentCredentialsBatch(['agent-1']);
+
+    expect(result.get('agent-1')).toEqual([cred]);
+    // Should fall back to DB since cached agent had no credentials
+    expect(agentRepository.find).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fall back to sequential gets when mget is not available', async () => {
+    // Remove mget from store to simulate stores that don't support it
+    (cacheManager as any).store = {};
+
+    const cred = makeCredential('space-member', 'space-1');
+    const agent = makeAgent('agent-1', [cred]);
+
+    cacheManager.get.mockResolvedValue(agent as any);
+
+    const result = await service.getAgentCredentialsBatch(['agent-1']);
+
+    expect(result.get('agent-1')).toEqual([cred]);
+    expect(cacheManager.get).toHaveBeenCalledWith('@agent:id:agent-1');
+    expect(agentRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('should handle multiple cache misses in a single DB batch', async () => {
+    const cred1 = makeCredential('space-member', 'space-1');
+    const cred2 = makeCredential('org-member', 'org-1');
+    const cred3 = makeCredential('space-lead', 'space-1');
+    const agent1 = makeAgent('agent-1', [cred1]);
+    const agent2 = makeAgent('agent-2', [cred2]);
+    const agent3 = makeAgent('agent-3', [cred3]);
+
+    cacheManager.store.mget.mockResolvedValue([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    agentRepository.find.mockResolvedValue([
+      agent1,
+      agent2,
+      agent3,
+    ] as unknown as Agent[]);
+
+    const result = await service.getAgentCredentialsBatch([
+      'agent-1',
+      'agent-2',
+      'agent-3',
+    ]);
+
+    expect(result.size).toBe(3);
+    expect(result.get('agent-1')).toEqual([cred1]);
+    expect(result.get('agent-2')).toEqual([cred2]);
+    expect(result.get('agent-3')).toEqual([cred3]);
+    // Single DB call for all misses
+    expect(agentRepository.find).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domain/agent/agent/agent.service.ts
+++ b/src/domain/agent/agent/agent.service.ts
@@ -16,7 +16,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { AlkemioConfig } from '@src/types';
 import { Cache } from 'cache-manager';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, Repository } from 'typeorm';
+import { FindOneOptions, In, Repository } from 'typeorm';
 import { AgentInfoCacheService } from '../../../core/authentication.agent.info/agent.info.cache.service';
 import { CredentialService } from '../credential/credential.service';
 import { GrantCredentialToAgentInput } from './dto/agent.dto.credential.grant';
@@ -142,6 +142,60 @@ export class AgentService {
       }
     }
     return { agent: agent, credentials: agent.credentials };
+  }
+
+  /**
+   * Batch-load credentials for multiple agents using a single Redis mget + batched DB fallback.
+   * Returns a Map from agentID to its credentials array.
+   */
+  async getAgentCredentialsBatch(
+    agentIDs: string[]
+  ): Promise<Map<string, ICredential[]>> {
+    const result = new Map<string, ICredential[]>();
+    if (agentIDs.length === 0) return result;
+
+    // 1. Build cache keys and attempt mget
+    const cacheKeys = agentIDs.map(id => this.getAgentCacheKey(id));
+    const mget = this.cacheManager.store.mget;
+    const cached: (IAgent | undefined)[] = mget
+      ? await mget<IAgent>(...cacheKeys)
+      : await Promise.all(cacheKeys.map(k => this.cacheManager.get<IAgent>(k)));
+
+    // 2. Separate hits from misses
+    const missedIDs: string[] = [];
+    for (let i = 0; i < agentIDs.length; i++) {
+      const agent = cached[i];
+      if (agent?.credentials) {
+        result.set(agentIDs[i], agent.credentials);
+      } else {
+        missedIDs.push(agentIDs[i]);
+      }
+    }
+
+    if (missedIDs.length === 0) return result;
+
+    // 3. Batch DB load for cache misses
+    const agents = await this.agentRepository.find({
+      where: { id: In(missedIDs) },
+      relations: { credentials: true },
+    });
+
+    // 4. Populate result + warm cache
+    for (const agent of agents) {
+      if (agent.credentials) {
+        result.set(agent.id, agent.credentials);
+      }
+      await this.setAgentCache(agent);
+    }
+
+    // 5. For any IDs that weren't in DB either, set empty
+    for (const id of missedIDs) {
+      if (!result.has(id)) {
+        result.set(id, []);
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/src/domain/community/community/community.resolver.fields.ts
+++ b/src/domain/community/community/community.resolver.fields.ts
@@ -1,5 +1,8 @@
 import { AuthorizationPrivilege } from '@common/enums';
 import { GraphqlGuard } from '@core/authorization';
+import { CommunityRoleSetLoaderCreator } from '@core/dataloader/creators/loader.creators';
+import { Loader } from '@core/dataloader/decorators';
+import { ILoader } from '@core/dataloader/loader.interface';
 import { IRoleSet } from '@domain/access/role-set';
 import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { ICommunication } from '@domain/communication/communication/communication.interface';
@@ -55,7 +58,11 @@ export class CommunityResolverFields {
     nullable: false,
     description: 'The RoleSet for this Community.',
   })
-  async roleSet(@Parent() community: Community): Promise<IRoleSet> {
-    return this.communityService.getRoleSet(community);
+  async roleSet(
+    @Parent() community: Community,
+    @Loader(CommunityRoleSetLoaderCreator, { parentClassRef: Community })
+    loader: ILoader<IRoleSet>
+  ): Promise<IRoleSet> {
+    return loader.load(community.id);
   }
 }

--- a/src/domain/space/space.about.membership/space.about.membership.module.ts
+++ b/src/domain/space/space.about.membership/space.about.membership.module.ts
@@ -1,5 +1,4 @@
 import { AuthorizationModule } from '@core/authorization/authorization.module';
-import { RoleSetMembershipStatusDataLoader } from '@domain/access/role-set/role.set.data.loader.membership.status';
 import { RoleSetModule } from '@domain/access/role-set/role.set.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { CommunityModule } from '@domain/community/community/community.module';
@@ -14,11 +13,7 @@ import { SpaceAboutMembershipService } from './space.about.membership.service';
     AuthorizationPolicyModule,
     AuthorizationModule,
   ],
-  providers: [
-    SpaceAboutMembershipResolverFields,
-    SpaceAboutMembershipService,
-    RoleSetMembershipStatusDataLoader,
-  ],
+  providers: [SpaceAboutMembershipResolverFields, SpaceAboutMembershipService],
   exports: [SpaceAboutMembershipService],
 })
 export class SpaceAboutMembershipModule {}

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -508,9 +508,7 @@ export class SpaceService {
       relations: {
         parentSpace: true,
         collaboration: true,
-        about: {
-          profile: true,
-        },
+        about: true,
       },
     });
 

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -508,7 +508,9 @@ export class SpaceService {
       relations: {
         parentSpace: true,
         collaboration: true,
-        about: true,
+        about: {
+          profile: true,
+        },
       },
     });
 


### PR DESCRIPTION
## Results TL;DR
Key takeaways: The biggest improvement is in the first few requests — the initial/cold calls went from 14.7–26.4s down to 3.8–4.6s. Once warmed up, both are comparable at ~3.7s. Excluding some spikes, the steady-state performance is essentially the same.
The database hits have also been reduced.

 ## Summary                                                                                                                      
                                                                                                                               
  - Refactor RoleSetAgentRolesDataLoader and RoleSetMembershipStatusDataLoader from per-key concurrent processing to true batch
   processing with deduplication, Redis mget, and in-memory credential matching
  - Add AgentService.getAgentCredentialsBatch() for batch agent credential loading (Redis mget + batched DB fallback)
  - Harden RoleSetCacheService with error handling and logging so cache failures degrade gracefully instead of propagating
  exceptions
  - Replace await with void on fire-and-forget cache writes across RoleSetService, eliminating unnecessary blocking on
  non-critical cache updates
  - Introduce synchronous isApplicationFinalized() and isInvitationFinalized()/canAcceptInvitation() methods that operate on
  eager-loaded lifecycle data, removing redundant DB fetches
  - Add CommunityRoleSetLoaderCreator DataLoader for batched Community-to-RoleSet resolution in the community.roleSet field
  resolver
  - Add ~2,600 lines of unit tests across all new and modified components

## Test plan

  - Run pnpm test:ci to verify all new unit tests pass (8 new spec files)
  - Query myMemberships / community.roleSet in GraphQL playground to confirm correct membership status and roles are returned
  - Verify cache fallback behavior: stop Redis, confirm membership queries still resolve (with degraded performance, no errors)
  - Validate batch deduplication: query memberships across multiple spaces in a single request, confirm agent credentials are
  fetched only once per unique agent (check logs or add verbose tracing)
  - Confirm fire-and-forget cache writes don't block GraphQL response times
  - API Integration tests
<img width="2476" height="223" alt="image" src="https://github.com/user-attachments/assets/d33208ea-2677-4733-ade7-3404a10e493c" />

3 EXPECTED failing
- Upload document > read uploaded file
- Upload document > read uploaded file after related reference is removed
- Upload visual tests > read uploaded visual

  🤖 Generated with https://claude.com/claude-code

  ---
##  Insight

  Key architectural patterns in this PR:

  1. DataLoader batch coalescing - The core optimization replaces the previous pattern of Promise.all(keys.map(k =>
  fetchOneAtATime(k))) with a multi-phase pipeline: deduplicate agent IDs → batch mget from Redis → batch DB fallback for
  misses → in-memory credential matching. This reduces N+1 queries to constant DB calls per batch.
  2. Cache resilience via degradation - Wrapping every cacheGet/cacheSet/cacheMget in try/catch with warning logs means a Redis
   outage doesn't take down the membership system. The service degrades to direct DB queries instead of throwing 500s.
  3. void vs await for cache writes - Changing await this.cacheService.set(...) to void this.cacheService.set(...) is a
  deliberate trade-off: cache writes are fire-and-forget because they're an optimization, not correctness-critical. This shaves
   latency from every mutation path that touches membership state.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DataLoader-backed roleSet resolution for communities for faster, batched role retrieval.
  * Synchronous helpers to check finalized state for applications and invitations.

* **Refactor**
  * Expanded batching and caching across role-set and agent credential flows to reduce DB calls and improve responsiveness.
  * Cache operations made more resilient and non-blocking (fire-and-forget) to lower latency.

* **Tests**
  * Extensive new tests covering loaders, utilities, cache behavior, and membership resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->