### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -3900,6 +3900,8 @@ enum MimeType {
   DOC
   DOCX
   GIF
+  HEIC
+  HEIF
   JPEG
   JPG
   ODP


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 257089 bytes
Snapshot md5: 5d78dbdc1b718eff1077520989f0b90c

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HEIC and HEIF image formats, enabling users to upload and work with these modern image file types in documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->