### PR TITLE
Adds GraphQL and non-interactive login skills

### DIFF
--- a/.claude/commands/gql.md
+++ b/.claude/commands/gql.md
@@ -1,0 +1,74 @@
+---
+description: Execute a GraphQL query or mutation against the Alkemio API using the pipeline session token
+arguments:
+  - name: query
+    description: "The GraphQL query or mutation to execute (e.g., 'query { me { user { id } } }')"
+    required: true
+---
+
+Execute a GraphQL request against the Alkemio server's non-interactive API endpoint.
+
+## Prerequisites
+
+A valid session token must exist at `.claude/pipeline/.session-token`. If not, run `/non-interactive-login` first.
+
+## Execution steps
+
+IMPORTANT: The query must be written to a file to avoid shell escaping issues with GraphQL syntax (`!`, `$`, `{`, etc.).
+
+1. **Write the query** to `/tmp/.gql-query` using the **Write** tool (exactly as provided, no escaping)
+2. **If variables are needed**, write the variables JSON to `/tmp/.gql-variables` using the **Write** tool
+3. **Run the script**:
+
+```bash
+# Without variables:
+.scripts/gql-request.sh
+
+# With variables:
+.scripts/gql-request.sh /tmp/.gql-variables
+```
+
+4. Parse and present the JSON response to the user in a readable format
+
+## Examples
+
+### Simple query — current user
+```graphql
+query { me { user { id nameID profile { displayName } } } }
+```
+
+### Query with variables — space by ID
+```graphql
+query SpaceById($id: UUID!) {
+  lookup {
+    space(ID: $id) {
+      id
+      nameID
+      profile { displayName }
+    }
+  }
+}
+```
+Variables: `{"id": "some-uuid-here"}`
+
+### Mutation — update profile
+```graphql
+mutation UpdateProfile($input: UpdateProfileDirectInput!) {
+  updateProfile(profileData: $input) {
+    id
+    displayName
+  }
+}
+```
+Variables: `{"input": {"profileID": "some-uuid", "displayName": "New Name"}}`
+
+### Introspection — list all query fields
+```graphql
+query { __schema { queryType { fields { name description } } } }
+```
+
+## Troubleshooting
+
+- **"No session token found"** → Run `/non-interactive-login` first
+- **"401 Unauthorized"** → Token may be expired, re-run `/non-interactive-login`
+- **GraphQL errors** → Check query syntax; use introspection to discover the schema

--- a/.claude/commands/gql.md
+++ b/.claude/commands/gql.md
@@ -44,11 +44,10 @@ query SpaceById($id: UUID!) {
     space(ID: $id) {
       id
       nameID
-      profile { displayName }
+      about { profile { displayName } }
     }
   }
 }
-```
 Variables: `{"id": "some-uuid-here"}`
 
 ### Mutation — update profile

--- a/.claude/commands/non-interactive-login.md
+++ b/.claude/commands/non-interactive-login.md
@@ -1,0 +1,14 @@
+---
+description: Acquire a Kratos session token for the pipeline service account (reads credentials from .claude/pipeline/.env)
+---
+
+Run the non-interactive login script to authenticate the pipeline service account against Kratos and store a session token. The script reads `PIPELINE_USER` and `PIPELINE_PASSWORD` from `.claude/pipeline/.env` and writes the token to `.claude/pipeline/.session-token`.
+
+```bash
+.scripts/non-interactive-login.sh
+```
+
+Report the result to the user. If it fails, show the error and suggest checking:
+- That services are running (`pnpm run start:services`)
+- That `.claude/pipeline/.env` has valid `PIPELINE_USER` and `PIPELINE_PASSWORD`
+- That the user is registered (suggest `/register-user` if not)

--- a/.claude/commands/register-user.md
+++ b/.claude/commands/register-user.md
@@ -15,10 +15,17 @@ arguments:
     required: false
 ---
 
-Run the registration script. Parse the arguments from `$ARGUMENTS` (email, password, firstName, lastName in that order) and execute:
+Parse the arguments from `$ARGUMENTS` (email, password, firstName, lastName in that order).
+
+IMPORTANT: The password must be written to a file to avoid shell escaping issues with special characters like `!`, `\`, etc. Follow these steps exactly:
+
+1. Use the **Write** tool to write the password (exactly as provided, no escaping) to `/tmp/.register-password`
+2. Then run the script via Bash (password is NOT a CLI argument):
 
 ```bash
-.scripts/register-user.sh <email> <password> [firstName] [lastName]
+.scripts/register-user.sh <email> [firstName] [lastName]
 ```
+
+The script reads and deletes the password file automatically.
 
 Report the script output to the user. If it fails, show the error.

--- a/.claude/skills/gql.md
+++ b/.claude/skills/gql.md
@@ -1,0 +1,246 @@
+# GraphQL Requests
+
+When asked to execute GraphQL queries or mutations against the Alkemio API, or when you need to interact with the API as part of a task, follow this guide.
+
+## Overview
+
+The GQL pipeline uses a stored Kratos session token to authenticate requests against the non-interactive GraphQL endpoint. Queries and variables are passed via temp files to avoid shell escaping issues.
+
+**Scripts involved:**
+- `.scripts/gql-request.sh` — standalone GQL executor
+- `.scripts/lib/graphql.sh` — shared `gql_request` function (for use in other scripts)
+- `.scripts/lib/kratos.sh` — shared Kratos auth helpers
+
+## Prerequisites
+
+### 1. Session Token
+
+A valid session token must exist at `.claude/pipeline/.session-token`.
+
+```bash
+# Check if token exists
+test -f .claude/pipeline/.session-token && echo "OK" || echo "Missing - run /non-interactive-login"
+```
+
+If missing or expired, acquire one first:
+```bash
+.scripts/non-interactive-login.sh
+```
+
+### 2. Pipeline Config
+
+Ensure `.claude/pipeline/.env` has the required variables:
+- `PIPELINE_USER` — email of the service account
+- `PIPELINE_PASSWORD` — password for the service account
+- `GRAPHQL_NON_INTERACTIVE_ENDPOINT` — API endpoint (defaults to `http://localhost:3000/api/private/non-interactive/graphql`)
+
+### 3. Running Services
+
+The Alkemio server must be running:
+```bash
+pnpm run start:services  # infrastructure
+pnpm start:dev           # server
+```
+
+## Executing Queries
+
+IMPORTANT: Always write queries and variables via the **Write** tool to avoid shell escaping issues with GraphQL syntax (`!`, `$`, `{`, etc.). Never pass them as Bash command arguments.
+
+### Step-by-step
+
+1. **Write the query** to `/tmp/.gql-query` using the Write tool
+2. **If variables are needed**, write the JSON to `/tmp/.gql-variables` using the Write tool
+3. **Run the script**:
+
+```bash
+# Without variables
+.scripts/gql-request.sh
+
+# With variables
+.scripts/gql-request.sh /tmp/.gql-variables
+```
+
+The script auto-deletes the temp files after reading them.
+
+### Using the lib in other scripts
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/kratos.sh"
+source "$SCRIPT_DIR/lib/graphql.sh"
+
+# SESSION_TOKEN must be set (e.g., via kratos_login or read from token file)
+SESSION_TOKEN=$(cat .claude/pipeline/.session-token)
+
+# Query only
+response=$(gql_request 'query { me { user { id } } }')
+
+# Query with variables
+response=$(gql_request \
+  'query($id: UUID!) { lookup { space(ID: $id) { id nameID } } }' \
+  '{"id": "some-uuid"}')
+```
+
+## Schema Reference
+
+The full GraphQL schema is at `schema.graphql` in the repository root. **Always consult it before writing queries** to verify field names, types, and nesting:
+
+```bash
+# Read the schema (or use the Read tool directly on schema.graphql)
+```
+
+Key things to know:
+- `Space` has `about` (not `profile` directly) — use `space { about { profile { displayName } } }`
+- `User` has `profile` directly — use `user { profile { displayName } }`
+- Non-null fields are marked with `!` in the schema
+- Use `lookup` / `lookupByName` for direct entity access (see **Entity Lookup** section below)
+- Pagination uses `limit` / `offset` on collection queries
+
+When unsure about a type's fields, either read the schema file or use introspection:
+```graphql
+query { __type(name: "TypeName") { fields { name type { name kind ofType { name } } } } }
+```
+
+## Entity Lookup (lookup & lookupByName)
+
+The API provides two direct-access entry points under `query { lookup { ... } }` and `query { lookupByName { ... } }`. **Always prefer these over listing + filtering** — they save roundtrips and return exactly one entity.
+
+### `lookup` — fetch by UUID
+
+Use when you have an entity's UUID. Returns the full entity object.
+
+```graphql
+query { lookup { <entity>(ID: $id) { ...fields } } }
+```
+
+**Available entities** (all take `ID: UUID!`):
+
+| Entity | Return Type | Entity | Return Type |
+|--------|-------------|--------|-------------|
+| `space` | `Space` | `user` | `User` |
+| `organization` | `Organization` | `virtualContributor` | `VirtualContributor` |
+| `account` | `Account` | `community` | `Community` |
+| `collaboration` | `Collaboration` | `callout` | `Callout` |
+| `calloutsSet` | `CalloutsSet` | `contribution` | `CalloutContribution` |
+| `post` | `Post` | `whiteboard` | `Whiteboard` |
+| `profile` | `Profile` | `roleSet` | `RoleSet` |
+| `room` | `Room` | `template` | `Template` |
+| `templatesSet` | `TemplatesSet` | `templatesManager` | `TemplatesManager` |
+| `innovationHub` | `InnovationHub` | `innovationPack` | `InnovationPack` |
+| `innovationFlow` | `InnovationFlow` | `knowledgeBase` | `KnowledgeBase` |
+| `about` | `SpaceAbout` | `document` | `Document` |
+| `invitation` | `Invitation` | `application` | `Application` |
+| `calendar` | `Calendar` | `calendarEvent` | `CalendarEvent` |
+| `conversation` | `Conversation` | `memo` | `Memo` |
+| `storageBucket` | `StorageBucket` | `storageAggregator` | `StorageAggregator` |
+| `license` | `License` | `communityGuidelines` | `CommunityGuidelines` |
+
+Special lookups:
+- `authorizationPolicy(ID: UUID!)` → `Authorization`
+- `authorizationPrivilegesForUser(authorizationPolicyID: UUID!, userID: UUID!)` → `[AuthorizationPrivilege!]`
+- `myPrivileges` → `LookupMyPrivilegesQueryResults` (sub-lookups for privilege checks)
+
+### `lookupByName` — resolve by NameID
+
+Use when you have a human-readable `nameID` (slug) instead of a UUID. **Most return a UUID string**, except `space` which returns the full `Space` object.
+
+```graphql
+query { lookupByName { <entity>(NAMEID: $nameId) } }
+```
+
+**Available entities** (all take `NAMEID: NameID!`):
+
+| Entity | Return Type | Notes |
+|--------|-------------|-------|
+| `space` | `Space` | Returns full Space object |
+| `user` | `String` | Returns UUID |
+| `organization` | `String` | Returns UUID |
+| `virtualContributor` | `String` | Returns UUID |
+| `innovationHub` | `String` | Returns UUID |
+| `innovationPack` | `String` | Returns UUID |
+| `template` | `String` | Also requires `templatesSetID: UUID!` |
+
+### Recommended flow
+
+1. **You have a UUID** → use `lookup` directly:
+   ```graphql
+   query { lookup { space(ID: "uuid-here") { id nameID about { profile { displayName } } } } }
+   ```
+
+2. **You have a nameID (slug)** → use `lookupByName`:
+   - For **spaces**: returns the full object directly:
+     ```graphql
+     query { lookupByName { space(NAMEID: "building-alkemio-org") { id nameID about { profile { displayName } } } } }
+     ```
+   - For **other entities**: returns a UUID, then use `lookup` for details:
+     ```graphql
+     # Step 1: resolve nameID → UUID
+     query { lookupByName { organization(NAMEID: "alkemio") } }
+     # Step 2: use UUID to fetch full object
+     query { lookup { organization(ID: "returned-uuid") { id profile { displayName } } } }
+     ```
+
+3. **You have neither** → list and filter (last resort):
+   ```graphql
+   query { spaces { id nameID about { profile { displayName } } } }
+   ```
+
+## Common Queries
+
+### Current user
+```graphql
+query { me { user { id nameID profile { displayName } } } }
+```
+
+### List spaces
+```graphql
+query { spaces { id nameID about { profile { displayName tagline } } } }
+```
+
+### Space by ID
+```graphql
+query SpaceById($id: UUID!) {
+  lookup {
+    space(ID: $id) {
+      id
+      nameID
+      about { profile { displayName tagline } }
+      community { id }
+      collaboration { id }
+    }
+  }
+}
+```
+
+### Space by nameID
+```graphql
+query SpaceByName($nameId: NameID!) {
+  lookupByName {
+    space(NAMEID: $nameId) {
+      id
+      nameID
+      about { profile { displayName tagline } }
+    }
+  }
+}
+```
+
+### Schema introspection (queries)
+```graphql
+query { __schema { queryType { fields { name description } } } }
+```
+
+### Schema introspection (mutations)
+```graphql
+query { __schema { mutationType { fields { name description } } } }
+```
+
+## Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| "No session token found" | Run `/non-interactive-login` first |
+| "401 Unauthorized" or empty response | Token expired — re-run `/non-interactive-login` |
+| "SESSION_TOKEN is not set" | Ensure the script reads the token file or `kratos_login` was called |
+| GraphQL validation errors | Check query syntax; use introspection queries to discover the schema |
+| "Kratos not reachable" | Run `pnpm run start:services` |

--- a/.scripts/lib/graphql.sh
+++ b/.scripts/lib/graphql.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Shared GraphQL helpers for pipeline scripts.
+# Source this file; do NOT execute it directly.
+#
+# Requires: curl, jq
+# Provides: gql_request
+# Expects:  SESSION_TOKEN (set by kratos_login or read from token file)
+#           GQL_ENDPOINT  (defaults to http://localhost:3000/api/private/non-interactive/graphql)
+
+GQL_ENDPOINT="${GRAPHQL_NON_INTERACTIVE_ENDPOINT:-http://localhost:3000/api/private/non-interactive/graphql}"
+
+# Execute a GraphQL request and return the full JSON response.
+# Fails with error details if the response contains errors and no data.
+#
+# Usage:
+#   gql_request '<query>'                          # query only
+#   gql_request '<query>' '<variables_json>'       # query + variables
+#
+# Requires SESSION_TOKEN to be set.
+#
+# Example:
+#   gql_request 'query { me { user { id } } }'
+#   gql_request 'mutation($input: CreateSpaceInput!) { createSpace(spaceData: $input) { id } }' \
+#               '{"input":{"nameID":"test"}}'
+gql_request() {
+  local query="$1"
+  local variables="${2:-}"
+
+  [ -n "${SESSION_TOKEN:-}" ] || { echo "ERROR: SESSION_TOKEN is not set" >&2; return 1; }
+
+  local payload
+  if [ -n "$variables" ]; then
+    payload=$(jq -nc --arg q "$query" --argjson v "$variables" '{query:$q, variables:$v}')
+  else
+    payload=$(jq -nc --arg q "$query" '{query:$q}')
+  fi
+
+  local response
+  response=$(curl -s -X POST "$GQL_ENDPOINT" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: Bearer $SESSION_TOKEN" \
+    -d "$payload")
+
+  # Print the response (caller extracts what they need)
+  echo "$response"
+
+  # Return non-zero if there are errors and no data
+  local has_data has_errors
+  has_data=$(echo "$response" | jq -r '.data // empty')
+  has_errors=$(echo "$response" | jq -r '.errors // empty')
+  if [ -z "$has_data" ] && [ -n "$has_errors" ]; then
+    echo "GraphQL error: $(echo "$response" | jq -c '.errors')" >&2
+    return 1
+  fi
+}

--- a/.scripts/lib/kratos.sh
+++ b/.scripts/lib/kratos.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Shared Kratos helpers for authentication scripts.
+# Source this file; do NOT execute it directly.
+#
+# Requires: curl, jq
+# Provides: fail, kratos_health_check, kratos_login, kratos_verify_session
+# Expects:  KRATOS_PUBLIC_URL (defaults to http://localhost:3000/ory/kratos/public)
+
+KRATOS_PUBLIC_URL="${KRATOS_PUBLIC_URL:-http://localhost:3000/ory/kratos/public}"
+
+fail() { echo "ERROR: $1" >&2; exit 1; }
+
+# Check that Kratos is reachable.
+kratos_health_check() {
+  curl -sf "$KRATOS_PUBLIC_URL/health/alive" >/dev/null 2>&1 \
+    || fail "Kratos not reachable at $KRATOS_PUBLIC_URL. Run: pnpm run start:services"
+}
+
+# Log in to Kratos and set SESSION_TOKEN + IDENTITY_ID.
+# Usage: kratos_login <email> <password>
+kratos_login() {
+  local email="$1" password="$2"
+
+  local flow_response flow_id login_response
+
+  flow_response=$(curl -s -X GET \
+    -H "Accept: application/json" \
+    "$KRATOS_PUBLIC_URL/self-service/login/api")
+
+  flow_id=$(echo "$flow_response" | jq -r '.id')
+  [ "$flow_id" != "null" ] && [ -n "$flow_id" ] \
+    || fail "Could not create login flow"
+
+  login_response=$(curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d "$(jq -n \
+      --arg id "$email" \
+      --arg pw "$password" \
+      '{method:"password", identifier:$id, password:$pw}')" \
+    "$KRATOS_PUBLIC_URL/self-service/login?flow=$flow_id")
+
+  SESSION_TOKEN=$(echo "$login_response" | jq -r '.session_token // empty')
+  [ -n "$SESSION_TOKEN" ] \
+    || fail "Login failed: $(echo "$login_response" | jq -c '.ui.messages // .error // .')"
+
+  IDENTITY_ID=$(echo "$login_response" | jq -r '.session.identity.id // empty')
+}
+
+# Verify that SESSION_TOKEN is valid via the whoami endpoint.
+kratos_verify_session() {
+  [ -n "${SESSION_TOKEN:-}" ] || fail "SESSION_TOKEN is not set"
+
+  local whoami
+  whoami=$(curl -sf \
+    -H "Accept: application/json" \
+    -H "Authorization: Bearer $SESSION_TOKEN" \
+    "$KRATOS_PUBLIC_URL/sessions/whoami" 2>/dev/null || echo "")
+
+  if [ -z "$whoami" ] || echo "$whoami" | jq -e '.error' >/dev/null 2>&1; then
+    fail "Session token verification failed"
+  fi
+}


### PR DESCRIPTION
### Describe the background of your pull request

This pull request introduces new commands (`gql` and `non-interactive-login`) and a GraphQL skill to enhance the bot's ability to interact with the Alkemio API in a non-interactive pipeline environment. It addresses the need for automated GraphQL queries and mutations using a service account. It also fixes a bug in the `register-user` command, ensuring proper password handling.

### Additional context

The changes include:

- Introduction of `.claude/commands/gql.md` and `.claude/skills/gql.md` for GraphQL query execution, including documentation and examples.
- Addition of `.claude/commands/non-interactive-login.md` to handle Kratos session token acquisition for the pipeline service account.
- Modification of `.claude/commands/register-user.md` and `.scripts/register-user.sh` to securely handle passwords via a temporary file, addressing shell escaping issues.
- Creation of shared library scripts `.scripts/lib/graphql.sh` and `.scripts/lib/kratos.sh` for GraphQL requests and Kratos authentication, respectively.

### Governance 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for GraphQL usage, non-interactive login, and updated user registration instructions with examples and troubleshooting.

* **Chores**
  * Improved authentication and GraphQL tooling for pipelines and scripts.
  * Refactored registration flow to use file-based password input and stronger pre-flight checks for more reliable, secure account creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->