### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -545,6 +545,8 @@ type Actor {
   authorization: Authorization
   """The date at which the entity was created."""
   createdDate: DateTime!
+  """The credentials held by this Actor."""
+  credentials: [Credential!]
   """The ID of the entity"""
   id: UUID!
   """A name identifier of the entity, unique within a given scope."""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 257090 bytes
Snapshot md5: 64b40b34b76e79b7cef1466509294c7e

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Credentials field is now available on Actor, Organization, and Space entities, allowing you to access associated credentials for these resources through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->