### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -3055,7 +3055,7 @@ type InAppNotificationPayloadUserMessageDirect implements InAppNotificationPaylo
 }
 
 type InAppNotificationPayloadVirtualContributor implements InAppNotificationPayload {
-  contributor: VirtualContributor!
+  actor: VirtualContributor!
   """The Space related to the notification"""
   space: Space!
   """The payload type."""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 257084 bytes
Snapshot md5: 4c2ae0503cf51953ce2d7f5370cdbd1e

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated the schema for virtual contributor notifications. The `contributor` field in notification payloads has been renamed to `actor`. Any integrations currently using the `contributor` field will need to be updated to reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->