### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -6350,6 +6350,7 @@ enum SpaceVisibility {
   ACTIVE
   ARCHIVED
   DEMO
+  INACTIVE
 }
 
 type StorageAggregator {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 257095 bytes
Snapshot md5: e75f1690843e93356443d93f5b17b771

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added INACTIVE as a new status option for spaces. Spaces can now be configured as ACTIVE, ARCHIVED, DEMO, or INACTIVE.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->