### PR TITLE
Updates core service image versions

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -258,8 +258,7 @@ services:
     restart: unless-stopped
 
   whiteboard-collaboration:
-    image: alkemio/whiteboard-collaboration-service:v0.8.0
-    platform: linux/amd64
+    image: alkemio/whiteboard-collaboration-service:v0.10.1
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -275,8 +274,7 @@ services:
       - "4002:4002"
 
   file-service:
-    image: alkemio/file-service:v0.2.0
-    platform: linux/amd64
+    image: alkemio/file-service:v0.2.1
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -454,8 +454,7 @@ services:
   whiteboard-collaboration:
     container_name: alkemio_dev_whiteboard_collaboration
     hostname: whiteboard-collaboration
-    image: alkemio/whiteboard-collaboration-service:v0.8.0
-    platform: linux/amd64
+    image: alkemio/whiteboard-collaboration-service:v0.10.1
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -475,8 +474,7 @@ services:
   file-service:
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service:v0.2.0
-    platform: linux/amd64
+    image: alkemio/file-service:v0.2.1
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -472,8 +472,7 @@ services:
   whiteboard-collaboration:
     container_name: alkemio_dev_whiteboard_collaboration
     hostname: whiteboard-collaboration
-    image: alkemio/whiteboard-collaboration-service:v0.8.0
-    platform: linux/amd64
+    image: alkemio/whiteboard-collaboration-service:v0.10.1
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -493,8 +492,7 @@ services:
   file-service:
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service:v0.2.0
-    platform: linux/amd64
+    image: alkemio/file-service:v0.2.1
     depends_on:
       rabbitmq:
         condition: service_healthy


### PR DESCRIPTION
### Describe the background of your pull request

This pull request updates the Docker image versions for the `whiteboard-collaboration` and `file-service` components across all local development and quickstart Docker Compose configurations. It specifically upgrades the `whiteboard-collaboration-service` to `v0.10.1` (from `v0.8.0`) and the `file-service` to `v0.2.1` (from `v0.2.0`). This ensures the development and quickstart environments utilize the latest specified versions of these core services.

### Additional context

This change is part of routine maintenance to keep service dependencies up to date, as indicated by the `chore/package-versions` branch. The explicit `platform: linux/amd64` specification was also removed for these services during this update, streamlining the configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated whiteboard collaboration service to v0.10.1
  * Updated file service to v0.2.1
  * Simplified service configurations across development and production environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->