### PR TITLE
fix: add null checks for user context in subscription and exception handler

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -266,7 +266,7 @@ import { AdminSearchIngestModule } from './platform-admin/services/search/admin.
             'graphql-ws': {
               onNext: (ctx, message, args, result) => {
                 const context = args.contextValue as IGraphQLContext;
-                const expiry = context.req.user.expiry;
+                const expiry = context.req?.user?.expiry;
                 // if the session has expired, close the socket
                 if (expiry && expiry < Date.now()) {
                   (ctx as WebsocketContext).extra.socket.close(

--- a/src/core/error-handling/graphql.exception.filter.ts
+++ b/src/core/error-handling/graphql.exception.filter.ts
@@ -15,7 +15,7 @@ export class GraphqlExceptionFilter implements GqlExceptionFilter {
     const httpArguments = host.switchToHttp();
     const ctx = httpArguments.getNext<IGraphQLContext>();
     const userID =
-      exception.details?.userId ?? ctx.req.user.actorID ?? 'unknown';
+      exception.details?.userId ?? ctx?.req?.user?.actorID ?? 'unknown';
     exception.details = {
       ...exception.details,
       userId: userID,


### PR DESCRIPTION
## Summary
- Add optional chaining for `context.req?.user?.expiry` in the `graphql-ws` `onNext` handler (`app.module.ts`)
- Add optional chaining for `ctx?.req?.user?.actorID` in the GraphQL exception filter (`graphql.exception.filter.ts`)

Prevents `TypeError: Cannot read properties of undefined (reading 'expiry')` when `req.user` is not populated during WebSocket subscriptions — e.g., after DB connection drops or stale auth contexts. This error causes the `UserConversationsUnreadCount` subscription to go pending, hanging the application on refresh.

### Root cause chain

The production logs show a sequence of failures:

1. **DB connection drops** (`connect ECONNREFUSED` / `Connection terminated unexpectedly`) during whiteboard-integration auth checks (`AgentInfoService.buildAgentInfoForUser`)
2. When the DB is temporarily unreachable, user authentication context (`req.user`) may not be populated on the request
3. The `graphql-ws` `onNext` handler runs on every subscription message and accesses `context.req.user.expiry` **without null checks**
4. This throws `TypeError: Cannot read properties of undefined (reading 'expiry')`, crashing the subscription handler
5. The crashed handler prevents subscription results from being delivered, causing `UserConversationsUnreadCount` and other subscriptions to go **pending**
6. Subsequent requests also hang because the WebSocket connection is in a broken state
7. The user experiences the app not loading fully after refresh, requiring a wait before the application becomes usable again

The same unsafe access pattern exists in `graphql.exception.filter.ts` (`ctx.req.user.actorID`), which could crash the error handler itself during exception processing.

Closes alkem-io/client-web#9287

## Test plan
- [ ] Verify subscriptions (e.g. `UserConversationsUnreadCount`) continue working after browser refresh
- [ ] Verify no pending requests accumulate on repeated refreshes
- [ ] Verify error handling still captures user ID when available
- [ ] Verify subscription expiry check still closes sockets for expired sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced defensive programming practices in GraphQL error handling modules to improve code stability and reduce potential runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->