### PR TITLE
Fix Oathkeeper calendar rule ID naming convention

### DIFF
--- a/.build/ory/oathkeeper/access-rules.yml
+++ b/.build/ory/oathkeeper/access-rules.yml
@@ -65,7 +65,7 @@
   mutators:
     - handler: id_token
 
-- id: 'alkemio:api:private:rest:calendar'
+- id: 'alkemio:api:rest:calendar:private'
   upstream:
     preserve_host: true
     url: 'http://host.docker.internal:4000'


### PR DESCRIPTION
## Summary
- Rename Oathkeeper access rule ID from `alkemio:api:private:rest:calendar` to `alkemio:api:rest:calendar:private`
- Aligns with the established REST rule naming pattern used in the dev-orchestration overlays (e.g. `alkemio:api:rest:storage:private`)

## Related
- Companion fix in dev-orchestration: https://github.com/alkem-io/dev-orchestration/pull/24

## Test plan
- [ ] Verify local Oathkeeper still routes calendar ICS requests correctly with the renamed rule ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal access rule configuration identifier for system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->