### PR TITLE
Fix - can't change space visibility

### DIFF
--- a/src/domain/space/account/account.service.spec.ts
+++ b/src/domain/space/account/account.service.spec.ts
@@ -415,19 +415,27 @@ describe('AccountService', () => {
   });
 
   describe('updateExternalSubscriptionId', () => {
-    it('should call repository update with correct arguments', async () => {
+    it('should call query builder update with correct arguments', async () => {
       // Arrange
-      const updateSpy = vi
-        .spyOn(accountRepository, 'update')
-        .mockResolvedValue({ affected: 1 } as any);
+      const executeMock = vi.fn().mockResolvedValue({ affected: 1 });
+      const whereMock = vi.fn().mockReturnValue({ execute: executeMock });
+      const setMock = vi.fn().mockReturnValue({ where: whereMock });
+      const updateMock = vi.fn().mockReturnValue({ set: setMock });
+      vi.spyOn(accountRepository, 'createQueryBuilder').mockReturnValue({
+        update: updateMock,
+      } as any);
 
       // Act
       await service.updateExternalSubscriptionId('account-1', 'ext-sub-new');
 
       // Assert
-      expect(updateSpy).toHaveBeenCalledWith('account-1', {
+      expect(setMock).toHaveBeenCalledWith({
         externalSubscriptionID: 'ext-sub-new',
       });
+      expect(whereMock).toHaveBeenCalledWith('id = :accountID', {
+        accountID: 'account-1',
+      });
+      expect(executeMock).toHaveBeenCalled();
     });
   });
 

--- a/src/domain/space/account/account.service.ts
+++ b/src/domain/space/account/account.service.ts
@@ -264,7 +264,14 @@ export class AccountService {
     accountID: string,
     externalSubscriptionID: string
   ) {
-    return this.accountRepository.update(accountID, { externalSubscriptionID });
+    // Cannot use repository.update() on CTI child entities;
+    // use query builder to target the account table directly.
+    return this.accountRepository
+      .createQueryBuilder()
+      .update()
+      .set({ externalSubscriptionID })
+      .where('id = :accountID', { accountID })
+      .execute();
   }
 
   async getAccountOrFail(

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -925,12 +925,14 @@ export class SpaceService {
     levelZeroSpaceID: string,
     visibility: SpaceVisibility
   ) {
-    await this.spaceRepository.update(
-      {
-        levelZeroSpaceID: levelZeroSpaceID,
-      },
-      { visibility }
-    );
+    // Cannot use repository.update() on CTI child entities;
+    // use query builder to target the space table directly.
+    await this.spaceRepository
+      .createQueryBuilder()
+      .update()
+      .set({ visibility })
+      .where('levelZeroSpaceID = :levelZeroSpaceID', { levelZeroSpaceID })
+      .execute();
   }
 
   /**


### PR DESCRIPTION
Root cause: Space and Account entities use CTI (Class Table Inheritance) via @ChildEntity extending Actor. TypeORM's repository.update() doesn't support CTI child entities — it tries to update the parent table instead of the child table.                                                       
                                                                                                                                                     
  Fix: Replaced repository.update() with repository.createQueryBuilder().update() which correctly targets the child table:                           
                                                                                                                                                     
  1. src/domain/space/space/space.service.ts:928 — updateSpaceVisibilityAllSubspaces() now uses query builder to bulk-update visibility on all subspaces                                                                                                                                          
  2. src/domain/space/account/account.service.ts:267 — updateExternalSubscriptionId() also fixed (same latent bug)                                   
  3. Updated test in account.service.spec.ts to match the new query builder pattern                                                                  
                                                                                                                            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.139.0

* **Tests**
  * Updated test case verification for account service update operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->