### PR TITLE
fix: CTI-safe updates for Space and Account entities

### DIFF
--- a/src/common/decorators/innovation.hub.decoration.spec.ts
+++ b/src/common/decorators/innovation.hub.decoration.spec.ts
@@ -9,7 +9,6 @@ import { InnovationHub } from './innovation.hub.decoration';
 // createParamDecorator returns a factory: calling InnovationHub() returns a ParameterDecorator.
 function getParamDecoratorFactory(decoratorFactory: any) {
   class TestClass {
-    // biome-ignore lint/suspicious/noExplicitAny: test helper
     testMethod(@decoratorFactory() _param: any) {}
   }
 

--- a/src/domain/space/account/account.service.ts
+++ b/src/domain/space/account/account.service.ts
@@ -260,11 +260,16 @@ export class AccountService {
     return account;
   }
 
-  public updateExternalSubscriptionId(
+  public async updateExternalSubscriptionId(
     accountID: string,
     externalSubscriptionID: string
-  ) {
-    return this.accountRepository.update(accountID, { externalSubscriptionID });
+  ): Promise<void> {
+    await this.accountRepository
+      .createQueryBuilder()
+      .update()
+      .set({ externalSubscriptionID })
+      .where({ id: accountID })
+      .execute();
   }
 
   async getAccountOrFail(

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -925,12 +925,12 @@ export class SpaceService {
     levelZeroSpaceID: string,
     visibility: SpaceVisibility
   ) {
-    await this.spaceRepository.update(
-      {
-        levelZeroSpaceID: levelZeroSpaceID,
-      },
-      { visibility }
-    );
+    await this.spaceRepository
+      .createQueryBuilder()
+      .update()
+      .set({ visibility })
+      .where({ levelZeroSpaceID })
+      .execute();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace `Repository.update()` with `QueryBuilder.update()` on Space and Account (CTI child entities) to avoid TypeORM's "update() is not supported for CTI child entities" error
- Remove unused biome suppression comments

Fixes alkem-io/client-web#9427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed lint suppression from test helper.

* **Refactor**
  * Optimized internal update operations for account subscriptions and space visibility using async patterns and improved query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->