### PR TITLE
Guidance chat fixes

### DIFF
--- a/src/migrations/1773800000001-FixWellKnownVCMappingsFormat.ts
+++ b/src/migrations/1773800000001-FixWellKnownVCMappingsFormat.ts
@@ -1,0 +1,82 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Converts the platform.wellKnownVirtualContributors column from legacy formats to
+ * the canonical array format expected by the new service code.
+ *
+ * History of the bug:
+ *  1. The seed migration stored { "mappings": [] } (the IPlatformWellKnownVirtualContributors shape).
+ *  2. The old setMapping() service cast the stored JSON to a flat Record and mutated it
+ *     in-place, producing a hybrid object: { "mappings": [], "CHAT_GUIDANCE": "uuid", ... }.
+ *  3. The new service code reads stored.mappings (the array), which is empty in the hybrid
+ *     format, so getVirtualContributorID() still returns undefined — breaking guidance
+ *     conversation creation completely.
+ *
+ * This migration converts:
+ *   flat:   { "CHAT_GUIDANCE": "uuid" }
+ *   hybrid: { "mappings": [], "CHAT_GUIDANCE": "uuid" }
+ * to the canonical format:
+ *   { "mappings": [{ "wellKnown": "CHAT_GUIDANCE", "virtualContributorID": "uuid" }] }
+ *
+ * Rows already in canonical format (no UUID-valued top-level keys other than "mappings")
+ * are not touched.
+ */
+export class FixWellKnownVCMappingsFormat1773800000001
+  implements MigrationInterface
+{
+  name = 'FixWellKnownVCMappingsFormat1773800000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Only update rows that have at least one top-level key (other than "mappings")
+    // whose value looks like a UUID — i.e., rows still in the old flat/hybrid format.
+    const result = await queryRunner.query(`
+      UPDATE platform
+      SET "wellKnownVirtualContributors" = jsonb_build_object(
+        'mappings',
+        COALESCE(
+          (
+            SELECT jsonb_agg(
+              jsonb_build_object('wellKnown', k, 'virtualContributorID', v)
+            )
+            FROM (
+              SELECT key AS k, value AS v
+              FROM jsonb_each_text("wellKnownVirtualContributors")
+              WHERE key != 'mappings'
+                AND value ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+            ) t
+          ),
+          '[]'::jsonb
+        )
+      )
+      WHERE EXISTS (
+        SELECT 1
+        FROM jsonb_each_text("wellKnownVirtualContributors")
+        WHERE key != 'mappings'
+          AND value ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      )
+    `);
+
+    console.log(
+      `[Migration] FixWellKnownVCMappingsFormat: converted ${result[1] ?? 0} platform rows to canonical array format`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Best-effort revert: convert canonical array format back to flat { key: uuid } format.
+    // Note: the original hybrid { "mappings": [], ... } state is not fully restorable.
+    // Rows whose 'mappings' array is empty are left as-is (no entries to convert back).
+    await queryRunner.query(`
+      UPDATE platform
+      SET "wellKnownVirtualContributors" = COALESCE(
+        (
+          SELECT jsonb_object_agg(m->>'wellKnown', m->>'virtualContributorID')
+          FROM jsonb_array_elements("wellKnownVirtualContributors"->'mappings') AS m
+        ),
+        '{}'::jsonb
+      )
+      WHERE jsonb_typeof("wellKnownVirtualContributors"->'mappings') = 'array'
+    `);
+
+    console.log('[Migration] FixWellKnownVCMappingsFormat: reverted to flat format');
+  }
+}

--- a/src/migrations/1773800000002-FixGuidanceVCMemberships.ts
+++ b/src/migrations/1773800000002-FixGuidanceVCMemberships.ts
@@ -1,0 +1,109 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Fixes stale virtual contributor actor IDs in DIRECT conversation memberships.
+ *
+ * Problem:
+ *   When the well-known guidance VC is recreated (new VC entity under the same Account),
+ *   the platform mapping is updated to the new VC's ID (X) but existing DIRECT conversations
+ *   still reference the old VC's actor ID (Y) in conversation_membership.
+ *
+ *   As a result, findConversationBetweenActors(userActorId, X) never finds the old
+ *   conversation (which has Y as a member), so a duplicate conversation is created on
+ *   every guidance session start.
+ *
+ * Fix:
+ *   For each well-known VC mapping, find DIRECT conversations where a different VC from
+ *   the same Account is listed as a member (stale reference), and update that membership
+ *   to use the current well-known VC's actor ID.
+ *
+ *   Rows are only updated when the current VC is NOT already a member of the conversation
+ *   (to avoid primary-key violations on the (conversationId, actorId) composite PK).
+ *
+ * Depends on: 1773800000001-FixWellKnownVCMappingsFormat (must run first so the
+ *             mappings are in canonical array format).
+ */
+export class FixGuidanceVCMemberships1773800000002 implements MigrationInterface {
+  name = 'FixGuidanceVCMemberships1773800000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Read current well-known VC mappings (canonical array format after format migration).
+    const platforms = await queryRunner.query(
+      `SELECT "wellKnownVirtualContributors"->'mappings' AS mappings FROM platform LIMIT 1`
+    );
+
+    const mappings: Array<{ wellKnown: string; virtualContributorID: string }> =
+      platforms?.[0]?.mappings ?? [];
+
+    if (mappings.length === 0) {
+      console.log(
+        '[Migration] FixGuidanceVCMemberships: no well-known VC mappings found, skipping'
+      );
+      return;
+    }
+
+    for (const mapping of mappings) {
+      const { wellKnown, virtualContributorID: currentVcId } = mapping;
+
+      // Resolve the account that owns the current well-known VC.
+      const vcRows = await queryRunner.query(
+        `SELECT "accountId" FROM virtual_contributor WHERE id = $1`,
+        [currentVcId]
+      );
+
+      if (!vcRows?.[0]?.accountId) {
+        console.log(
+          `[Migration] FixGuidanceVCMemberships: well-known VC ${wellKnown} (id: ${currentVcId}) has no account — skipping`
+        );
+        continue;
+      }
+
+      const accountId: string = vcRows[0].accountId;
+
+      // Update conversation_membership rows in DIRECT conversations where:
+      //  - The VC member belongs to the same Account as the current well-known VC
+      //  - But its actor ID differs from the current well-known VC's actor ID (stale ref)
+      //  - The current well-known VC is NOT already a member (avoids PK violation)
+      //
+      // CTE identifies stale rows without referencing the UPDATE target inside a JOIN ON
+      // (PostgreSQL forbids that and raises "invalid reference to FROM-clause entry").
+      const updateResult = await queryRunner.query(
+        `
+        WITH stale AS (
+          SELECT cm."conversationId", cm."actorId" AS stale_actor_id
+          FROM conversation_membership cm
+          JOIN conversation c ON c.id = cm."conversationId"
+          JOIN room r ON r.id = c."roomId"
+          JOIN virtual_contributor stale_vc ON stale_vc.id = cm."actorId"
+          WHERE r.type = 'conversation_direct'
+            AND cm."actorId" != $1
+            AND stale_vc."accountId" = $2
+            AND NOT EXISTS (
+              SELECT 1 FROM conversation_membership cm2
+              WHERE cm2."conversationId" = cm."conversationId"
+                AND cm2."actorId" = $1
+            )
+        )
+        UPDATE conversation_membership
+        SET "actorId" = $1
+        FROM stale
+        WHERE conversation_membership."conversationId" = stale."conversationId"
+          AND conversation_membership."actorId" = stale.stale_actor_id
+        `,
+        [currentVcId, accountId]
+      );
+
+      console.log(
+        `[Migration] FixGuidanceVCMemberships: updated ${updateResult[1] ?? 0} stale memberships for well-known VC ${wellKnown} (account: ${accountId})`
+      );
+    }
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Cannot automatically revert — the original stale actor IDs are not recorded.
+    // Manual rollback is required if this migration needs to be undone.
+    console.log(
+      '[Migration] FixGuidanceVCMemberships: down() is a no-op — manual rollback required'
+    );
+  }
+}

--- a/src/migrations/1773800000002-FixGuidanceVCMemberships.ts
+++ b/src/migrations/1773800000002-FixGuidanceVCMemberships.ts
@@ -1,33 +1,44 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 /**
- * Fixes stale virtual contributor actor IDs in DIRECT conversation memberships.
+ * Reconciles the platform.wellKnownVirtualContributors mapping with the actual VC actors
+ * already present in DIRECT conversation memberships.
  *
  * Problem:
- *   When the well-known guidance VC is recreated (new VC entity under the same Account),
- *   the platform mapping is updated to the new VC's ID (X) but existing DIRECT conversations
- *   still reference the old VC's actor ID (Y) in conversation_membership.
+ *   When the well-known guidance VC is recreated, the platform mapping is updated to the
+ *   new VC's ID (X) but:
+ *   - Matrix/Synapse already has room memberships using the OLD actor's identity (Y)
+ *   - Existing conversation_membership rows still reference Y
  *
- *   As a result, findConversationBetweenActors(userActorId, X) never finds the old
- *   conversation (which has Y as a member), so a duplicate conversation is created on
- *   every guidance session start.
+ *   Updating conversation_membership.actorId to X would break Matrix-side operations
+ *   (message attribution, room membership) because Synapse uses room-level identities
+ *   that are hard to migrate.
  *
- * Fix:
- *   For each well-known VC mapping, find DIRECT conversations where a different VC from
- *   the same Account is listed as a member (stale reference), and update that membership
- *   to use the current well-known VC's actor ID.
+ * Fix (opposite direction vs. first draft):
+ *   Preserve conversation_membership.actorId.
+ *   Instead, update platform.wellKnownVirtualContributors so the mapping points BACK to
+ *   the VC actor that is already present in the existing conversations (Y), ensuring:
+ *   - findConversationBetweenActors(userActorId, Y) finds the existing conversation
+ *   - createConversationWithWellKnownVC creates new conversations with Y (consistent with Synapse)
  *
- *   Rows are only updated when the current VC is NOT already a member of the conversation
- *   (to avoid primary-key violations on the (conversationId, actorId) composite PK).
+ * Safety:
+ *   Only updates the mapping when there is EXACTLY ONE distinct VC actor (from the same
+ *   Account as the currently-mapped VC) across all existing DIRECT conversations.
+ *   Multiple distinct stale actors → ambiguous → log warning, skip.
+ *   No existing stale actors → no mismatch → skip.
  *
- * Depends on: 1773800000001-FixWellKnownVCMappingsFormat (must run first so the
- *             mappings are in canonical array format).
+ * Testability:
+ *   After running: SELECT "wellKnownVirtualContributors" FROM platform;
+ *   The virtualContributorID in each mapping should match the actorId used in existing
+ *   DIRECT conversation memberships for that well-known VC's account.
+ *
+ * Depends on: 1773800000001-FixWellKnownVCMappingsFormat (must run first).
  */
 export class FixGuidanceVCMemberships1773800000002 implements MigrationInterface {
   name = 'FixGuidanceVCMemberships1773800000002';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Read current well-known VC mappings (canonical array format after format migration).
+    // Read current canonical mappings (format migration must have run already).
     const platforms = await queryRunner.query(
       `SELECT "wellKnownVirtualContributors"->'mappings' AS mappings FROM platform LIMIT 1`
     );
@@ -45,7 +56,7 @@ export class FixGuidanceVCMemberships1773800000002 implements MigrationInterface
     for (const mapping of mappings) {
       const { wellKnown, virtualContributorID: currentVcId } = mapping;
 
-      // Resolve the account that owns the current well-known VC.
+      // Find the account that owns the currently-mapped VC.
       const vcRows = await queryRunner.query(
         `SELECT "accountId" FROM virtual_contributor WHERE id = $1`,
         [currentVcId]
@@ -60,48 +71,75 @@ export class FixGuidanceVCMemberships1773800000002 implements MigrationInterface
 
       const accountId: string = vcRows[0].accountId;
 
-      // Update conversation_membership rows in DIRECT conversations where:
-      //  - The VC member belongs to the same Account as the current well-known VC
-      //  - But its actor ID differs from the current well-known VC's actor ID (stale ref)
-      //  - The current well-known VC is NOT already a member (avoids PK violation)
-      //
-      // CTE identifies stale rows without referencing the UPDATE target inside a JOIN ON
-      // (PostgreSQL forbids that and raises "invalid reference to FROM-clause entry").
-      const updateResult = await queryRunner.query(
+      // Find all DISTINCT VC actor IDs (from the same account, NOT the current mapping)
+      // that appear in existing DIRECT conversation memberships.
+      const staleActors = await queryRunner.query(
         `
-        WITH stale AS (
-          SELECT cm."conversationId", cm."actorId" AS stale_actor_id
-          FROM conversation_membership cm
-          JOIN conversation c ON c.id = cm."conversationId"
-          JOIN room r ON r.id = c."roomId"
-          JOIN virtual_contributor stale_vc ON stale_vc.id = cm."actorId"
-          WHERE r.type = 'conversation_direct'
-            AND cm."actorId" != $1
-            AND stale_vc."accountId" = $2
-            AND NOT EXISTS (
-              SELECT 1 FROM conversation_membership cm2
-              WHERE cm2."conversationId" = cm."conversationId"
-                AND cm2."actorId" = $1
-            )
-        )
-        UPDATE conversation_membership
-        SET "actorId" = $1
-        FROM stale
-        WHERE conversation_membership."conversationId" = stale."conversationId"
-          AND conversation_membership."actorId" = stale.stale_actor_id
+        SELECT DISTINCT cm."actorId"
+        FROM conversation_membership cm
+        JOIN conversation c ON c.id = cm."conversationId"
+        JOIN room r ON r.id = c."roomId"
+        JOIN virtual_contributor vc ON vc.id = cm."actorId"
+        WHERE r.type = 'conversation_direct'
+          AND cm."actorId" != $1
+          AND vc."accountId" = $2
         `,
         [currentVcId, accountId]
       );
 
+      if (staleActors.length === 0) {
+        console.log(
+          `[Migration] FixGuidanceVCMemberships: no stale memberships found for ${wellKnown} — mapping is already consistent`
+        );
+        continue;
+      }
+
+      if (staleActors.length > 1) {
+        const ids = staleActors.map((r: { actorId: string }) => r.actorId).join(', ');
+        console.warn(
+          `[Migration] FixGuidanceVCMemberships: ambiguous — ${staleActors.length} distinct stale VC actors found for ${wellKnown} (${ids}) — skipping to avoid incorrect update`
+        );
+        continue;
+      }
+
+      // Exactly one stale VC actor — safe to update the mapping to point to it.
+      const correctVcId: string = staleActors[0].actorId;
+
+      // Update the single matching entry inside the JSONB mappings array.
+      await queryRunner.query(
+        `
+        UPDATE platform
+        SET "wellKnownVirtualContributors" = jsonb_set(
+          "wellKnownVirtualContributors",
+          '{mappings}',
+          (
+            SELECT jsonb_agg(
+              CASE
+                WHEN m->>'wellKnown' = $1
+                THEN jsonb_build_object(
+                  'wellKnown', m->>'wellKnown',
+                  'virtualContributorID', $2::text
+                )
+                ELSE m
+              END
+            )
+            FROM jsonb_array_elements("wellKnownVirtualContributors"->'mappings') AS m
+          )
+        )
+        `,
+        [wellKnown, correctVcId]
+      );
+
       console.log(
-        `[Migration] FixGuidanceVCMemberships: updated ${updateResult[1] ?? 0} stale memberships for well-known VC ${wellKnown} (account: ${accountId})`
+        `[Migration] FixGuidanceVCMemberships: updated mapping for ${wellKnown} from ${currentVcId} → ${correctVcId} (account: ${accountId})`
       );
     }
   }
 
-  public async down(_queryRunner: QueryRunner): Promise<void> {
-    // Cannot automatically revert — the original stale actor IDs are not recorded.
-    // Manual rollback is required if this migration needs to be undone.
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Cannot automatically revert — the previous virtualContributorID values are not
+    // recorded in this migration. To rollback, re-run setPlatformWellKnownVirtualContributor
+    // with the correct VC IDs, or restore from a database backup.
     console.log(
       '[Migration] FixGuidanceVCMemberships: down() is a no-op — manual rollback required'
     );

--- a/src/platform/platform.well.known.virtual.contributors/platform.well.known.virtual.contributors.service.spec.ts
+++ b/src/platform/platform.well.known.virtual.contributors/platform.well.known.virtual.contributors.service.spec.ts
@@ -33,15 +33,34 @@ describe('PlatformWellKnownVirtualContributorsService', () => {
 
   describe('getMappings', () => {
     it('should return the wellKnownVirtualContributors when platform exists', async () => {
-      const mappings = {
-        [VirtualContributorWellKnown.CHAT_GUIDANCE]: 'vc-1',
-      };
-      const platform = { wellKnownVirtualContributors: mappings } as any;
+      const platform = {
+        wellKnownVirtualContributors: {
+          mappings: [
+            {
+              wellKnown: VirtualContributorWellKnown.CHAT_GUIDANCE,
+              virtualContributorID: 'vc-1',
+            },
+          ],
+        },
+      } as any;
       platformRepository.findOne!.mockResolvedValue(platform);
 
       const result = await service.getMappings();
 
-      expect(result).toEqual(mappings);
+      expect(result).toEqual({
+        [VirtualContributorWellKnown.CHAT_GUIDANCE]: 'vc-1',
+      });
+    });
+
+    it('should return empty object when mappings array is empty', async () => {
+      const platform = {
+        wellKnownVirtualContributors: { mappings: [] },
+      } as any;
+      platformRepository.findOne!.mockResolvedValue(platform);
+
+      const result = await service.getMappings();
+
+      expect(result).toEqual({});
     });
 
     it('should return empty object when wellKnownVirtualContributors is falsy', async () => {
@@ -64,7 +83,9 @@ describe('PlatformWellKnownVirtualContributorsService', () => {
 
   describe('setMapping', () => {
     it('should set a new mapping and save the platform', async () => {
-      const platform = { wellKnownVirtualContributors: {} } as any;
+      const platform = {
+        wellKnownVirtualContributors: { mappings: [] },
+      } as any;
       platformRepository.findOne!.mockResolvedValue(platform);
       platformRepository.save!.mockResolvedValue(platform);
 
@@ -74,13 +95,29 @@ describe('PlatformWellKnownVirtualContributorsService', () => {
       );
 
       expect(result[VirtualContributorWellKnown.CHAT_GUIDANCE]).toBe('vc-new');
-      expect(platformRepository.save).toHaveBeenCalledWith(platform);
+      expect(platformRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          wellKnownVirtualContributors: {
+            mappings: [
+              {
+                wellKnown: VirtualContributorWellKnown.CHAT_GUIDANCE,
+                virtualContributorID: 'vc-new',
+              },
+            ],
+          },
+        })
+      );
     });
 
     it('should overwrite an existing mapping', async () => {
       const platform = {
         wellKnownVirtualContributors: {
-          [VirtualContributorWellKnown.CHAT_GUIDANCE]: 'vc-old',
+          mappings: [
+            {
+              wellKnown: VirtualContributorWellKnown.CHAT_GUIDANCE,
+              virtualContributorID: 'vc-old',
+            },
+          ],
         },
       } as any;
       platformRepository.findOne!.mockResolvedValue(platform);
@@ -122,7 +159,12 @@ describe('PlatformWellKnownVirtualContributorsService', () => {
     it('should return the VC ID for the given well-known type', async () => {
       const platform = {
         wellKnownVirtualContributors: {
-          [VirtualContributorWellKnown.CHAT_GUIDANCE]: 'vc-1',
+          mappings: [
+            {
+              wellKnown: VirtualContributorWellKnown.CHAT_GUIDANCE,
+              virtualContributorID: 'vc-1',
+            },
+          ],
         },
       } as any;
       platformRepository.findOne!.mockResolvedValue(platform);
@@ -135,7 +177,9 @@ describe('PlatformWellKnownVirtualContributorsService', () => {
     });
 
     it('should return undefined when the well-known type is not mapped', async () => {
-      const platform = { wellKnownVirtualContributors: {} } as any;
+      const platform = {
+        wellKnownVirtualContributors: { mappings: [] },
+      } as any;
       platformRepository.findOne!.mockResolvedValue(platform);
 
       const result = await service.getVirtualContributorID(

--- a/src/platform/platform.well.known.virtual.contributors/platform.well.known.virtual.contributors.service.ts
+++ b/src/platform/platform.well.known.virtual.contributors/platform.well.known.virtual.contributors.service.ts
@@ -6,7 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Platform } from '@platform/platform/platform.entity';
 import { Repository } from 'typeorm';
 
-// Internal storage type - Record for JSON storage
+// Internal convenience type - flat record for key-based lookups
 type WellKnownVCMappingsRecord = Record<
   VirtualContributorWellKnown,
   string | undefined
@@ -31,7 +31,13 @@ export class PlatformWellKnownVirtualContributorsService {
       );
     }
 
-    return (platform.wellKnownVirtualContributors as any) || {};
+    const record: Partial<WellKnownVCMappingsRecord> = {};
+    for (const mapping of platform.wellKnownVirtualContributors?.mappings ??
+      []) {
+      record[mapping.wellKnown as VirtualContributorWellKnown] =
+        mapping.virtualContributorID;
+    }
+    return record as WellKnownVCMappingsRecord;
   }
 
   async setMapping(
@@ -49,18 +55,26 @@ export class PlatformWellKnownVirtualContributorsService {
       );
     }
 
-    // Initialize if needed
-    const mappings = ((platform.wellKnownVirtualContributors as any) ||
-      {}) as WellKnownVCMappingsRecord;
+    const existingMappings = [
+      ...(platform.wellKnownVirtualContributors?.mappings ?? []),
+    ];
+    const index = existingMappings.findIndex(m => m.wellKnown === wellKnown);
+    if (index >= 0) {
+      existingMappings[index] = { wellKnown, virtualContributorID };
+    } else {
+      existingMappings.push({ wellKnown, virtualContributorID });
+    }
 
-    // Set the mapping
-    mappings[wellKnown] = virtualContributorID;
-
-    platform.wellKnownVirtualContributors = mappings as any;
+    platform.wellKnownVirtualContributors = { mappings: existingMappings };
 
     await this.platformRepository.save(platform);
 
-    return mappings;
+    const record: Partial<WellKnownVCMappingsRecord> = {};
+    for (const mapping of existingMappings) {
+      record[mapping.wellKnown as VirtualContributorWellKnown] =
+        mapping.virtualContributorID;
+    }
+    return record as WellKnownVCMappingsRecord;
   }
 
   async getVirtualContributorID(

--- a/src/platform/platform/platform.resolver.fields.spec.ts
+++ b/src/platform/platform/platform.resolver.fields.spec.ts
@@ -168,8 +168,10 @@ describe('PlatformResolverFields', () => {
       const platform = {
         id: 'p1',
         wellKnownVirtualContributors: {
-          GUIDANCE: 'vc-1',
-          IMPACT: 'vc-2',
+          mappings: [
+            { wellKnown: 'GUIDANCE', virtualContributorID: 'vc-1' },
+            { wellKnown: 'IMPACT', virtualContributorID: 'vc-2' },
+          ],
         },
       } as any;
       const actorContext = { actorID: 'user-1' } as any;
@@ -192,10 +194,10 @@ describe('PlatformResolverFields', () => {
       });
     });
 
-    it('should handle empty wellKnownVirtualContributors', async () => {
+    it('should handle empty wellKnownVirtualContributors mappings', async () => {
       const platform = {
         id: 'p1',
-        wellKnownVirtualContributors: {},
+        wellKnownVirtualContributors: { mappings: [] },
       } as any;
       const actorContext = { actorID: 'user-1' } as any;
       authorizationService.grantAccessOrFail.mockResolvedValue(

--- a/src/platform/platform/platform.resolver.fields.ts
+++ b/src/platform/platform/platform.resolver.fields.ts
@@ -1,6 +1,5 @@
 import { CurrentActor } from '@common/decorators';
 import { AuthorizationPrivilege } from '@common/enums';
-import { VirtualContributorWellKnown } from '@common/enums/virtual.contributor.well.known';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { IRoleSet } from '@domain/access/role-set/role.set.interface';
@@ -17,7 +16,6 @@ import { ILicensingFramework } from '@platform/licensing/credential-based/licens
 import { IMetadata } from '@platform/metadata/metadata.interface';
 import { MetadataService } from '@platform/metadata/metadata.service';
 import { IPlatformWellKnownVirtualContributors } from '@platform/platform.well.known.virtual.contributors';
-import { PlatformWellKnownVirtualContributorMapping } from '@platform/platform.well.known.virtual.contributors/dto/platform.well.known.virtual.contributor.dto.mapping';
 import { ReleaseDiscussionOutput } from './dto/release.discussion.dto';
 import { IPlatform } from './platform.interface';
 import { PlatformService } from './platform.service';
@@ -142,16 +140,7 @@ export class PlatformResolverFields {
       `get Platform well-known Virtual Contributors: ${actorContext.actorID}`
     );
 
-    // Convert from JSON storage format to DTO array format
-    const mappingsRecord = platform.wellKnownVirtualContributors as any;
-    const mappingsArray: PlatformWellKnownVirtualContributorMapping[] =
-      Object.entries(mappingsRecord || {}).map(
-        ([wellKnown, virtualContributorID]) => ({
-          wellKnown: wellKnown as VirtualContributorWellKnown,
-          virtualContributorID: virtualContributorID as string,
-        })
-      );
-
-    return { mappings: mappingsArray };
+    const stored = platform.wellKnownVirtualContributors;
+    return { mappings: stored?.mappings ?? [] };
   }
 }


### PR DESCRIPTION
## Problem
Two related bugs were causing the guidance chat feature to break.

Bug 1 — GraphQL enum error when querying wellKnown fieldProblem
Bug 2 — Stale actor IDs in guidance conversation memberships


## Risk
- Low — schema is unchanged; no new GraphQL types or fields.
- Migration 1 is idempotent: only rows with UUID-valued non-[mappings] keys are updated.
- Migration 2 contains a NOT EXISTS guard to prevent PK violations; no rows are deleted.
- Both migrations have [down()] implementations.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed virtual contributor mapping data format to ensure consistency and proper association with conversations.
  * Reconciled existing virtual contributor memberships with updated mapping structures to maintain data integrity.

* **Tests**
  * Updated test fixtures to reflect the new virtual contributor mapping structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->