### PR TITLE
Fix guidance privilege

### DIFF
--- a/src/platform/platform/platform.resolver.fields.ts
+++ b/src/platform/platform/platform.resolver.fields.ts
@@ -136,7 +136,7 @@ export class PlatformResolverFields {
     await this.authorizationService.grantAccessOrFail(
       actorContext,
       await this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
-      AuthorizationPrivilege.READ,
+      AuthorizationPrivilege.ACCESS_INTERACTIVE_GUIDANCE,
       `get Platform well-known Virtual Contributors: ${actorContext.actorID}`
     );
 


### PR DESCRIPTION
In order to access the well-known vcs as regular registered user, we had to change the privilege.