### PR TITLE
Add upload stream timeout, duration logging, and increase proxy timeouts for file uploads

### DIFF
--- a/.build/ory/oathkeeper/oathkeeper.yml
+++ b/.build/ory/oathkeeper/oathkeeper.yml
@@ -5,6 +5,10 @@ log:
 
 serve:
   proxy:
+    timeout:
+      read: 120s
+      write: 120s
+      idle: 120s
     cors:
       enabled: true
       allowed_origins:

--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -64,6 +64,7 @@ http:
       loadBalancer:
         servers:
           - url: 'http://oathkeeper:4455/'
+        serversTransport: oathkeeper-transport@file
 
     oathkeeper-admin:
       loadBalancer:
@@ -344,6 +345,12 @@ http:
       service: 'rabbitmq-management'
       entryPoints:
         - 'rabbitmq-management'
+
+  serversTransports:
+    oathkeeper-transport:
+      forwardingTimeouts:
+        responseHeaderTimeout: 120s
+        idleConnTimeout: 120s
 
 tcp:
   services:

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -292,6 +292,8 @@ storage:
   file:
     # 20MB
     max_file_size: ${STORAGE_MAX_FILE_SIZE}:20971520
+    # Timeout in milliseconds for reading file upload streams
+    stream_timeout_ms: ${STORAGE_STREAM_TIMEOUT_MS}:60000
   # Database configuration for usage by the Alkemio Server.
   # Uses PostgreSQL as the database backend.
   # Note: both schema / database name are used for configuration and they need to have the same value.

--- a/src/common/utils/file.util.spec.ts
+++ b/src/common/utils/file.util.spec.ts
@@ -1,10 +1,12 @@
 import { Readable } from 'stream';
 import { streamToBuffer } from './file.util';
 
+const DEFAULT_TIMEOUT_MS = 60_000;
+
 describe('streamToBuffer', () => {
   it('should convert a readable stream to a buffer', async () => {
     const stream = Readable.from([Buffer.from('hello world')]);
-    const result = await streamToBuffer(stream);
+    const result = await streamToBuffer(stream, DEFAULT_TIMEOUT_MS);
     expect(result).toBeInstanceOf(Buffer);
     expect(result.toString()).toBe('hello world');
   });
@@ -15,13 +17,13 @@ describe('streamToBuffer', () => {
       Buffer.from('chunk2'),
       Buffer.from('chunk3'),
     ]);
-    const result = await streamToBuffer(stream);
+    const result = await streamToBuffer(stream, DEFAULT_TIMEOUT_MS);
     expect(result.toString()).toBe('chunk1chunk2chunk3');
   });
 
   it('should return an empty buffer for an empty stream', async () => {
     const stream = Readable.from([]);
-    const result = await streamToBuffer(stream);
+    const result = await streamToBuffer(stream, DEFAULT_TIMEOUT_MS);
     expect(result).toBeInstanceOf(Buffer);
     expect(result.length).toBe(0);
   });
@@ -29,7 +31,7 @@ describe('streamToBuffer', () => {
   it('should handle binary data', async () => {
     const binaryData = Buffer.from([0x00, 0xff, 0x7f, 0x80, 0x01]);
     const stream = Readable.from([binaryData]);
-    const result = await streamToBuffer(stream);
+    const result = await streamToBuffer(stream, DEFAULT_TIMEOUT_MS);
     expect(result).toEqual(binaryData);
   });
 
@@ -40,13 +42,13 @@ describe('streamToBuffer', () => {
       },
     });
 
-    await expect(streamToBuffer(stream)).rejects.toThrow('stream failure');
+    await expect(streamToBuffer(stream, DEFAULT_TIMEOUT_MS)).rejects.toThrow('stream failure');
   });
 
   it('should handle a stream with a single large chunk', async () => {
     const largeData = Buffer.alloc(1024 * 1024, 'x'); // 1 MB
     const stream = Readable.from([largeData]);
-    const result = await streamToBuffer(stream);
+    const result = await streamToBuffer(stream, DEFAULT_TIMEOUT_MS);
     expect(result.length).toBe(1024 * 1024);
     expect(result.equals(largeData)).toBe(true);
   });

--- a/src/common/utils/file.util.ts
+++ b/src/common/utils/file.util.ts
@@ -1,19 +1,41 @@
 import { Readable } from 'stream';
 
-export async function streamToBuffer(stream: Readable): Promise<Buffer> {
+const DEFAULT_STREAM_TIMEOUT_MS = 60_000;
+
+export async function streamToBuffer(
+  stream: Readable,
+  timeoutMs: number = DEFAULT_STREAM_TIMEOUT_MS
+): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const data: any[] = [];
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        stream.destroy();
+        reject(new Error(`Stream read timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
 
     stream.on('data', (chunk: any) => {
       data.push(chunk);
     });
 
     stream.on('end', () => {
-      resolve(Buffer.concat(data));
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve(Buffer.concat(data));
+      }
     });
 
     stream.on('error', (err: any) => {
-      reject(err);
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      }
     });
   });
 }

--- a/src/common/utils/file.util.ts
+++ b/src/common/utils/file.util.ts
@@ -1,10 +1,8 @@
 import { Readable } from 'stream';
 
-const DEFAULT_STREAM_TIMEOUT_MS = 60_000;
-
 export async function streamToBuffer(
   stream: Readable,
-  timeoutMs: number = DEFAULT_STREAM_TIMEOUT_MS
+  timeoutMs: number
 ): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const data: any[] = [];

--- a/src/domain/common/visual/visual.service.ts
+++ b/src/domain/common/visual/visual.service.ts
@@ -15,6 +15,7 @@ import { DocumentService } from '@domain/storage/document/document.service';
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Readable } from 'stream';
@@ -41,7 +42,8 @@ export class VisualService {
     @InjectRepository(Visual)
     private visualRepository: Repository<Visual>,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService
+    private readonly logger: LoggerService,
+    private configService: ConfigService
   ) {}
 
   public createVisual(
@@ -113,7 +115,11 @@ export class VisualService {
 
     const startTime = Date.now();
     try {
-      const buffer = await streamToBuffer(readStream);
+      const streamTimeoutMs = this.configService.get<number>(
+        'storage.file.stream_timeout_ms',
+        { infer: true }
+      )!;
+      const buffer = await streamToBuffer(readStream, streamTimeoutMs);
       this.logger.verbose?.(
         {
           message: 'Stream buffered',

--- a/src/domain/common/visual/visual.service.ts
+++ b/src/domain/common/visual/visual.service.ts
@@ -14,8 +14,9 @@ import { IDocument } from '@domain/storage/document/document.interface';
 import { DocumentService } from '@domain/storage/document/document.service';
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Readable } from 'stream';
 import { FindOneOptions, Repository } from 'typeorm';
 import { AuthorizationPolicyService } from '../authorization-policy/authorization.policy.service';
@@ -38,7 +39,9 @@ export class VisualService {
     private imageConversionService: ImageConversionService,
     private imageCompressionService: ImageCompressionService,
     @InjectRepository(Visual)
-    private visualRepository: Repository<Visual>
+    private visualRepository: Repository<Visual>,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
   ) {}
 
   public createVisual(
@@ -108,8 +111,18 @@ export class VisualService {
         LogContext.DOCUMENT
       );
 
+    const startTime = Date.now();
     try {
       const buffer = await streamToBuffer(readStream);
+      this.logger.verbose?.(
+        {
+          message: 'Stream buffered',
+          fileName,
+          durationMs: Date.now() - startTime,
+          sizeBytes: buffer.length,
+        },
+        LogContext.STORAGE_BUCKET
+      );
 
       // Stage 1: HEIC/HEIF → JPEG conversion
       const conversionResult =
@@ -156,6 +169,15 @@ export class VisualService {
           ID: documentForVisual.id,
         });
       }
+      this.logger.verbose?.(
+        {
+          message: 'Visual upload completed',
+          fileName,
+          visualId: visual.id,
+          durationMs: Date.now() - startTime,
+        },
+        LogContext.STORAGE_BUCKET
+      );
       return newDocument;
     } catch (error: any) {
       if (error instanceof StorageUploadFailedException) {

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -21,6 +21,7 @@ import { Profile } from '@domain/common/profile/profile.entity';
 import { ImageCompressionService } from '@domain/common/visual/image.compression.service';
 import { ImageConversionService } from '@domain/common/visual/image.conversion.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AvatarCreatorService } from '@services/external/avatar-creator/avatar.creator.service';
 import { UrlGeneratorService } from '@services/infrastructure/url-generator/url.generator.service';
@@ -55,7 +56,8 @@ export class StorageBucketService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
     @InjectRepository(Profile)
-    private profileRepository: Repository<Profile>
+    private profileRepository: Repository<Profile>,
+    private configService: ConfigService
   ) {}
 
   public createStorageBucket(
@@ -152,7 +154,11 @@ export class StorageBucketService {
     temporaryDocument = false
   ): Promise<IDocument> {
     try {
-      const buffer = await streamToBuffer(readStream);
+      const streamTimeoutMs = this.configService.get<number>(
+        'storage.file.stream_timeout_ms',
+        { infer: true }
+      )!;
+      const buffer = await streamToBuffer(readStream, streamTimeoutMs);
 
       // Process image: HEIC conversion + optimization
       const conversionResult =

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -115,6 +115,7 @@ export type AlkemioConfig = {
     enabled: boolean;
     file: {
       max_file_size: number;
+      stream_timeout_ms: number;
     };
     database: {
       host: string;


### PR DESCRIPTION

  - Added a 60-second timeout to streamToBuffer() to clean up hung connections instead of waiting indefinitely
  - Added verbose logging for upload duration (stream buffering time + total processing time) to aid debugging bulk upload issues
  - Increased Oathkeeper proxy timeouts from Go defaults (~8s) to 120s — the ~8s default was the root cause of 499 errors on slow connections
  - Increased Traefik forwarding timeouts to Oathkeeper to 120s to match

  Root cause

  The 499 "Request disconnected during file upload stream parsing" errors were caused by Oathkeeper's default Go HTTP timeout (~8 seconds). On slow
  networks, file uploads that took longer than ~8s were terminated by the proxy before the server could finish reading the stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Configured timeout settings (120 seconds) for proxy and HTTP routing layers to improve service resilience.

* **Monitoring & Diagnostics**
  * Enhanced logging capabilities for file operations and uploads with performance metrics.
  * Implemented timeout handling for stream processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->