### PR TITLE
Bump matrix-adapter-go to v0.8.6 and fix lint errors

### DIFF
--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -354,7 +354,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.5
+    image: alkemio/matrix-adapter-go:v0.8.6
     depends_on:
       - rabbitmq
     environment:

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -405,7 +405,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.5
+    image: alkemio/matrix-adapter-go:v0.8.6
     depends_on:
       - rabbitmq
     environment:

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -418,7 +418,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.5
+    image: alkemio/matrix-adapter-go:v0.8.6
     depends_on:
       - rabbitmq
     environment:

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -413,7 +413,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.5
+    image: alkemio/matrix-adapter-go:v0.8.6
     depends_on:
       - rabbitmq
     environment:

--- a/src/common/decorators/current-actor.decorator.spec.ts
+++ b/src/common/decorators/current-actor.decorator.spec.ts
@@ -8,7 +8,6 @@ import { CurrentActor } from './current-actor.decorator';
 // createParamDecorator returns a factory: calling CurrentActor() returns a ParameterDecorator.
 function getParamDecoratorFactory(decoratorFactory: any) {
   class TestClass {
-    // biome-ignore lint/suspicious/noExplicitAny: test helper
     testMethod(@decoratorFactory() _param: any) {}
   }
 

--- a/src/common/decorators/innovation.hub.decoration.spec.ts
+++ b/src/common/decorators/innovation.hub.decoration.spec.ts
@@ -9,7 +9,6 @@ import { InnovationHub } from './innovation.hub.decoration';
 // createParamDecorator returns a factory: calling InnovationHub() returns a ParameterDecorator.
 function getParamDecoratorFactory(decoratorFactory: any) {
   class TestClass {
-    // biome-ignore lint/suspicious/noExplicitAny: test helper
     testMethod(@decoratorFactory() _param: any) {}
   }
 

--- a/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.authorization.ts
@@ -1,6 +1,5 @@
 import { LogContext } from '@common/enums/logging.context';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
-import { IPoll } from '@domain/collaboration/poll/poll.interface';
 import { PollAuthorizationService } from '@domain/collaboration/poll/poll.service.authorization';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';

--- a/src/domain/collaboration/callout/callout.lookup/callout.lookup.service.ts
+++ b/src/domain/collaboration/callout/callout.lookup/callout.lookup.service.ts
@@ -1,7 +1,7 @@
 import { LogContext } from '@common/enums';
 import { EntityNotFoundException } from '@common/exceptions';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
-import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { InjectEntityManager } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { EntityManager, FindOneOptions } from 'typeorm';
 import { Callout } from '../callout.entity';

--- a/src/domain/collaboration/poll-vote/poll.vote.service.spec.ts
+++ b/src/domain/collaboration/poll-vote/poll.vote.service.spec.ts
@@ -124,6 +124,7 @@ describe('PollVoteService', () => {
           maxResponses: 0,
           resultsVisibility: PollResultsVisibility.VISIBLE,
           resultsDetail: PollResultsDetail.FULL,
+          allowContributorsAddOptions: false,
         },
       });
       await expect(
@@ -138,6 +139,7 @@ describe('PollVoteService', () => {
           maxResponses: 2,
           resultsVisibility: PollResultsVisibility.VISIBLE,
           resultsDetail: PollResultsDetail.FULL,
+          allowContributorsAddOptions: false,
         },
       });
       await expect(
@@ -152,6 +154,7 @@ describe('PollVoteService', () => {
           maxResponses: 1,
           resultsVisibility: PollResultsVisibility.VISIBLE,
           resultsDetail: PollResultsDetail.FULL,
+          allowContributorsAddOptions: false,
         },
       });
       await expect(

--- a/src/domain/communication/conversation/conversation.service.spec.ts
+++ b/src/domain/communication/conversation/conversation.service.spec.ts
@@ -6,6 +6,7 @@ import {
   ValidationException,
 } from '@common/exceptions';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { IRoom } from '@domain/communication/room/room.interface';
 import { RoomService } from '@domain/communication/room/room.service';
 import { RoomAuthorizationService } from '@domain/communication/room/room.service.authorization';
 import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
@@ -438,7 +439,7 @@ describe('ConversationService', () => {
       });
       roomService.deleteRoom.mockImplementation(async () => {
         callOrder.push('deleteRoom');
-        return {};
+        return {} as IRoom;
       });
 
       await service.resetConversation(

--- a/src/domain/space/space/space.service.platform.roles.access.spec.ts
+++ b/src/domain/space/space/space.service.platform.roles.access.spec.ts
@@ -1,4 +1,5 @@
 import { AuthorizationPrivilege } from '@common/enums';
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
 import { CommunityMembershipPolicy } from '@common/enums/community.membership.policy';
 import { RoleName } from '@common/enums/role.name';
 import { SpaceLevel } from '@common/enums/space.level';
@@ -38,6 +39,9 @@ describe('SpacePlatformRolesAccessService', () => {
       allowGuestContributions: false,
     },
     sortMode: SpaceSortMode.ALPHABETICAL,
+    layout: {
+      calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+    },
   };
 
   const createSpace = (overrides: Partial<ISpace> = {}): ISpace =>

--- a/src/domain/storage/document/document.entity.ts
+++ b/src/domain/storage/document/document.entity.ts
@@ -6,7 +6,14 @@ import {
 import { MimeFileType } from '@common/enums/mime.file.type';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { Tagset } from '@domain/common/tagset';
-import { Column, Entity, Index, JoinColumn, ManyToOne, OneToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+} from 'typeorm';
 import { StorageBucket } from '../storage-bucket/storage.bucket.entity';
 import { IDocument } from './document.interface';
 

--- a/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
+++ b/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
@@ -41,7 +41,6 @@ import { IActor } from '@domain/actor/actor/actor.interface';
 import { getActorType } from '@domain/actor/actor/actor.service';
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { ICallout } from '@domain/collaboration/callout/callout.interface';
-import { IPoll } from '@domain/collaboration/poll/poll.interface';
 import { IMessage } from '@domain/communication/message/message.interface';
 import { MessageDetails } from '@domain/communication/message.details/message.details.interface';
 import { IRoom } from '@domain/communication/room/room.interface';

--- a/src/services/subscriptions/subscription-service/subscription.publish.service.spec.ts
+++ b/src/services/subscriptions/subscription-service/subscription.publish.service.spec.ts
@@ -264,6 +264,7 @@ describe('SubscriptionPublishService', () => {
             minResponses: 1,
             resultsDetail: PollResultsDetail.FULL,
             resultsVisibility: PollResultsVisibility.VISIBLE,
+            allowContributorsAddOptions: false,
           },
           createdDate: new Date(),
           updatedDate: new Date(),


### PR DESCRIPTION
## Summary
- Bump `alkemio/matrix-adapter-go` image from `v0.8.5` to `v0.8.6` in all 4 quickstart-services YAML files
- Fix pre-existing lint errors (missing properties in test mocks, unused imports, formatting)

## Test plan
- [x] `pnpm lint` passes clean
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated matrix-adapter service to v0.8.6 across all deployment configurations.
  * Removed unused imports and obsolete lint suppression comments.
  * Improved code formatting and import structure organization.

* **Tests**
  * Enhanced test fixtures with expanded configuration parameters for improved coverage and reliability.
  * Updated mock implementations with explicit type assertions for better type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->