### PR TITLE
[Calendar] Fix the UTC issues and missing URLs in email notification

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -310,7 +310,7 @@ services:
       - "4004:4004"
 
   notification:
-    image: alkemio/notifications:v0.28.1
+    image: alkemio/notifications:v0.32.0
     platform: linux/amd64
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -366,7 +366,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_notifications
     hostname: notifications
-    image: alkemio/notifications:v0.28.1
+    image: alkemio/notifications:v0.32.0
     platform: linux/amd64
     depends_on:
       rabbitmq:

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -380,7 +380,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_notifications
     hostname: notifications
-    image: alkemio/notifications:v0.28.1
+    image: alkemio/notifications:v0.32.0
     environment:
       - RABBITMQ_HOST
       - RABBITMQ_USER

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -375,7 +375,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_notifications
     hostname: notifications
-    image: alkemio/notifications:v0.28.1
+    image: alkemio/notifications:v0.32.0
     platform: linux/amd64
     depends_on:
       rabbitmq:

--- a/src/domain/timeline/event/calendar.event.calendar-links.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.ts
@@ -107,6 +107,7 @@ export const generateICS = (
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
     'PRODID:-//Alkemio//Calendar Event//EN',
+    'X-WR-TIMEZONE:Europe/Amsterdam',
     'BEGIN:VEVENT',
     `UID:${event.id}@alkem.io`,
     `DTSTAMP:${formatDateForCalendar(new Date().toISOString())}`,

--- a/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
+++ b/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
@@ -48,8 +48,12 @@ import { IUser } from '@domain/community/user/user.interface';
 import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
 import { ISpace } from '@domain/space/space/space.interface';
 import {
+  CalendarEventCalendarData,
   calculateCalendarEventEndDate,
+  formatLocation,
+  generateCalendarUrls,
   toIsoString,
+  validateCalendarDateRange,
 } from '@domain/timeline/event/calendar.event.calendar-links';
 import { ICalendarEvent } from '@domain/timeline/event/event.interface';
 import { Inject, Injectable } from '@nestjs/common';
@@ -544,7 +548,32 @@ export class NotificationExternalAdapter {
     const calendarEventUrl =
       await this.urlGeneratorService.getCalendarEventUrlPath(calendarEvent.id);
 
-    // Add calendar event details - will be properly typed once notifications-lib is updated
+    const startDateIso = toIsoString(calendarEvent.startDate, 'startDate');
+    const endDateIso = toIsoString(
+      calculateCalendarEventEndDate(calendarEvent).toISOString(),
+      'endDate'
+    );
+    validateCalendarDateRange(startDateIso, endDateIso, calendarEvent.id);
+
+    const description = calendarEvent.profile?.description ?? undefined;
+    const location = formatLocation(calendarEvent.profile?.location);
+
+    const calendarEventData: CalendarEventCalendarData = {
+      id: calendarEvent.id,
+      title: calendarEvent.profile.displayName,
+      url: calendarEventUrl,
+      startDate: startDateIso,
+      endDate: endDateIso,
+      wholeDay: calendarEvent.wholeDay,
+      description,
+      location,
+    };
+
+    const icsRestUrl = this.urlGeneratorService.getCalendarEventIcsRestUrl(
+      calendarEvent.id
+    );
+    const calendarUrls = generateCalendarUrls(calendarEventData, icsRestUrl);
+
     return {
       ...spacePayload,
       calendarEvent: {
@@ -553,13 +582,14 @@ export class NotificationExternalAdapter {
         type: calendarEvent.type,
         createdBy: createdByUser,
         url: calendarEventUrl,
-        startDate: calendarEvent.startDate.toISOString(),
-        endDate: '',
+        startDate: startDateIso,
+        endDate: endDateIso,
         wholeDay: calendarEvent.wholeDay,
-        description: calendarEvent.profile?.description ?? undefined,
-        googleCalendarUrl: '',
-        outlookCalendarUrl: '',
-        icsDownloadUrl: '',
+        description,
+        location,
+        googleCalendarUrl: calendarUrls.googleCalendarUrl,
+        outlookCalendarUrl: calendarUrls.outlookCalendarUrl,
+        icsDownloadUrl: calendarUrls.icsDownloadUrl,
       },
     };
   }


### PR DESCRIPTION
- fixing UTC - show CET as most of our clients are in NL
- properly set all props expected by the notification service (regression)
- updating the notification service in the QuickStart services

Connected to: https://github.com/alkem-io/notifications/pull/469

Fixing: 
BUG: Buttons from email template for downloading calendar event are not clickable #9466
BUG: ICS file shows times in UTC #9465
BUG: Email template from calendar events gives "invalid date" for end date #9463
BUG: Calendar event time displayed in email notification is in UTC #9464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated notification service to v0.32.0 across all deployment configurations.

* **New Features**
  * Enhanced calendar event handling with improved timezone support and better calendar URL generation for Google Calendar, Outlook, and ICS download formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->