### PR TITLE
Remove redundant joins leading to errors on querying subspaces

### DIFF
--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -613,11 +613,6 @@ export class SpaceService {
     const qb = this.spaceRepository.createQueryBuilder('space');
 
     qb.leftJoinAndSelect('space.subspaces', 'subspace');
-    qb.leftJoin('space.actor', 'actor_for_auth');
-    qb.leftJoinAndSelect(
-      'actor_for_auth.authorization',
-      'authorization_policy'
-    );
     qb.leftJoinAndSelect('subspace.subspaces', 'subspaces');
     qb.where({
       level: SpaceLevel.L0,


### PR DESCRIPTION
Fix applied: Removed the stale space.actor and actor_for_auth.authorization joins from getSpacesWithSortOrderDefault in src/domain/space/space/space.service.ts:616-620. These were leftover from the CTI   
  migration — Space now extends Actor directly so there's no actor relation, and the sorting logic never used authorization data anyway.