### PR TITLE
Fix push notification redirect URLs and differentiate poll messages

### DIFF
--- a/src/common/enums/url.path.element.space.ts
+++ b/src/common/enums/url.path.element.space.ts
@@ -4,4 +4,5 @@ export enum UrlPathElementSpace {
   COMMUNITY = 'community',
   KNOWLEDGE_BASE = 'knowledge-base',
   SETTINGS = 'settings',
+  UPDATES = 'updates',
 }

--- a/src/common/utils/file.util.spec.ts
+++ b/src/common/utils/file.util.spec.ts
@@ -42,7 +42,9 @@ describe('streamToBuffer', () => {
       },
     });
 
-    await expect(streamToBuffer(stream, DEFAULT_TIMEOUT_MS)).rejects.toThrow('stream failure');
+    await expect(streamToBuffer(stream, DEFAULT_TIMEOUT_MS)).rejects.toThrow(
+      'stream failure'
+    );
   });
 
   it('should handle a stream with a single large chunk', async () => {

--- a/src/services/adapters/notification-adapter/notification.platform.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.platform.adapter.ts
@@ -180,7 +180,9 @@ export class NotificationPlatformAdapter {
         {
           title: `New discussion: ${discussionName}`,
           body: `${actorName} started a new forum discussion`,
-          url: await this.urlGeneratorService.getForumDiscussionUrlPath(eventData.discussion.id),
+          url: await this.urlGeneratorService.getForumDiscussionUrlPath(
+            eventData.discussion.id
+          ),
         }
       );
     }
@@ -273,7 +275,9 @@ export class NotificationPlatformAdapter {
         {
           title: `Comment on ${discussionName}`,
           body: `${actorName} commented on a discussion`,
-          url: await this.urlGeneratorService.getForumDiscussionUrlPath(eventData.discussion.id),
+          url: await this.urlGeneratorService.getForumDiscussionUrlPath(
+            eventData.discussion.id
+          ),
         }
       );
     }
@@ -354,7 +358,9 @@ export class NotificationPlatformAdapter {
         {
           title: `New space: ${spaceName}`,
           body: `${actorName} created a new space`,
-          url: await this.urlGeneratorService.getSpaceUrlPathByID(eventData.space.id),
+          url: await this.urlGeneratorService.getSpaceUrlPathByID(
+            eventData.space.id
+          ),
         }
       );
     }

--- a/src/services/adapters/notification-adapter/notification.space.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.space.adapter.ts
@@ -3,13 +3,13 @@ import { LogContext } from '@common/enums/logging.context';
 import { NotificationEvent } from '@common/enums/notification.event';
 import { NotificationEventCategory } from '@common/enums/notification.event.category';
 import { NotificationEventPayload } from '@common/enums/notification.event.payload';
+import { UrlPathElementSpace } from '@common/enums/url.path.element.space';
 import { EntityNotFoundException } from '@common/exceptions/entity.not.found.exception';
 import { CalloutLookupService } from '@domain/collaboration/callout/callout.lookup/callout.lookup.service';
 import { IUser } from '@domain/community/user/user.interface';
 import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
-import { UrlGeneratorService } from '@services/infrastructure/url-generator/url.generator.service';
 import { InAppNotificationPayloadSpaceCollaborationCallout } from '@platform/in-app-notification-payload/dto/space/notification.in.app.payload.space.collaboration.callout';
 import { InAppNotificationPayloadSpaceCollaborationCalloutComment } from '@platform/in-app-notification-payload/dto/space/notification.in.app.payload.space.collaboration.callout.comment';
 import { InAppNotificationPayloadSpaceCollaborationCalloutPostComment } from '@platform/in-app-notification-payload/dto/space/notification.in.app.payload.space.collaboration.callout.post.comment';
@@ -21,6 +21,7 @@ import { InAppNotificationPayloadSpaceCommunityCalendarEvent } from '@platform/i
 import { InAppNotificationPayloadSpaceCommunityCalendarEventComment } from '@platform/in-app-notification-payload/dto/space/notification.in.app.payload.space.community.calendar.event.comment';
 import { NotificationRecipientResult } from '@services/api/notification-recipients/dto/notification.recipients.dto.result';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
+import { UrlGeneratorService } from '@services/infrastructure/url-generator/url.generator.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { InAppNotificationPayloadSpaceCommunicationUpdate } from '../../../platform/in-app-notification-payload/dto/space/notification.in.app.payload.space.communication.update';
 import { NotificationExternalAdapter } from '../notification-external-adapter/notification.external.adapter';
@@ -149,7 +150,9 @@ export class NotificationSpaceAdapter {
       const calloutName =
         eventData.callout.framing?.profile?.displayName ?? 'A callout';
       const spaceName = space.about?.profile?.displayName ?? 'your space';
-      const calloutUrl = await this.urlGeneratorService.getCalloutUrlPath(eventData.callout.id);
+      const calloutUrl = await this.urlGeneratorService.getCalloutUrlPath(
+        eventData.callout.id
+      );
       await this.notificationPushAdapter.sendPushNotifications(
         pushRecipientsFiltered,
         event,
@@ -243,7 +246,9 @@ export class NotificationSpaceAdapter {
         {
           title: 'New calendar event',
           body: `${actorName} created a calendar event in ${spaceName}`,
-          url: await this.urlGeneratorService.getSpaceUrlPathByID(space.id),
+          url: await this.urlGeneratorService.getCalendarEventUrlPath(
+            eventData.calendarEvent.id
+          ),
         }
       );
     }
@@ -335,7 +340,9 @@ export class NotificationSpaceAdapter {
         {
           title: 'New comment on calendar event',
           body: `${actorName} commented on your calendar event`,
-          url: await this.urlGeneratorService.getSpaceUrlPathByID(space.id),
+          url: await this.urlGeneratorService.getCalendarEventUrlPath(
+            eventData.calendarEvent.id
+          ),
         }
       );
     }
@@ -439,7 +446,9 @@ export class NotificationSpaceAdapter {
         {
           title: `New contribution in ${calloutName}`,
           body: `${actorName} added a contribution in ${spaceName}`,
-          url: await this.urlGeneratorService.getCalloutUrlPath(eventData.callout.id),
+          url: await this.urlGeneratorService.getCalloutUrlPath(
+            eventData.callout.id
+          ),
         }
       );
     }
@@ -525,15 +534,16 @@ export class NotificationSpaceAdapter {
       const adminActorName = await this.getTriggeredByDisplayName(
         eventData.triggeredBy
       );
-      const adminSpaceName =
-        space.about?.profile?.displayName ?? 'your space';
+      const adminSpaceName = space.about?.profile?.displayName ?? 'your space';
       await this.notificationPushAdapter.sendPushNotifications(
         adminPushRecipientsFiltered,
         adminEvent,
         {
           title: `New contribution in ${adminCalloutName}`,
           body: `${adminActorName} added a contribution in ${adminSpaceName}`,
-          url: await this.urlGeneratorService.getCalloutUrlPath(eventData.callout.id),
+          url: await this.urlGeneratorService.getCalloutUrlPath(
+            eventData.callout.id
+          ),
         }
       );
     }
@@ -634,7 +644,9 @@ export class NotificationSpaceAdapter {
         {
           title: 'Comment on your post',
           body: `${actorName} commented on your post`,
-          url: await this.urlGeneratorService.getCalloutUrlPath(eventData.callout.id),
+          url: await this.urlGeneratorService.getCalloutUrlPath(
+            eventData.callout.id
+          ),
         }
       );
     }
@@ -726,7 +738,9 @@ export class NotificationSpaceAdapter {
         {
           title: `Comment in ${calloutName}`,
           body: `${actorName} commented in ${spaceName}`,
-          url: await this.urlGeneratorService.getCalloutUrlPath(eventData.callout.id),
+          url: await this.urlGeneratorService.getCalloutUrlPath(
+            eventData.callout.id
+          ),
         }
       );
     }
@@ -795,9 +809,7 @@ export class NotificationSpaceAdapter {
       recipient => recipient.id !== eventData.actorID
     );
     if (adminPushRecipientsFiltered.length > 0) {
-      const actorName = await this.getTriggeredByDisplayName(
-        eventData.actorID
-      );
+      const actorName = await this.getTriggeredByDisplayName(eventData.actorID);
       const spaceName = space.about?.profile?.displayName ?? 'your space';
       await this.notificationPushAdapter.sendPushNotifications(
         adminPushRecipientsFiltered,
@@ -805,7 +817,9 @@ export class NotificationSpaceAdapter {
         {
           title: `New member in ${spaceName}`,
           body: `${actorName} joined your space`,
-          url: await this.urlGeneratorService.createSpaceAdminCommunityURL(space.id),
+          url: await this.urlGeneratorService.createSpaceAdminCommunityURL(
+            space.id
+          ),
         }
       );
     }
@@ -940,7 +954,9 @@ export class NotificationSpaceAdapter {
         {
           title: `New application for ${spaceName}`,
           body: 'A new application has been submitted',
-          url: await this.urlGeneratorService.createSpaceAdminCommunityURL(space.id),
+          url: await this.urlGeneratorService.createSpaceAdminCommunityURL(
+            space.id
+          ),
         }
       );
     }
@@ -1046,7 +1062,10 @@ export class NotificationSpaceAdapter {
         {
           title: `Message in ${spaceName}`,
           body: `${actorName} sent a message`,
-          url: await this.urlGeneratorService.getSpaceUrlPathByID(space.id),
+          url: await this.urlGeneratorService.getSpaceUrlPathByID(
+            space.id,
+            UrlPathElementSpace.UPDATES
+          ),
         }
       );
     }
@@ -1132,7 +1151,10 @@ export class NotificationSpaceAdapter {
         {
           title: `Update in ${spaceName}`,
           body: `New update posted in ${spaceName}`,
-          url: await this.urlGeneratorService.getSpaceUrlPathByID(space.id),
+          url: await this.urlGeneratorService.getSpaceUrlPathByID(
+            space.id,
+            UrlPathElementSpace.UPDATES
+          ),
         }
       );
     }
@@ -1288,18 +1310,56 @@ export class NotificationSpaceAdapter {
       r => r.id !== dto.triggeredBy
     );
     if (pushRecipientsFiltered.length > 0) {
-      const pollTitle =
-        callout.framing?.poll?.title ?? 'a poll';
+      const pollTitle = callout.framing?.poll?.title || 'a poll';
       const spaceName = space.about?.profile?.displayName ?? 'your space';
+      const { title, body } = this.getPollPushMessage(
+        event,
+        pollTitle,
+        spaceName
+      );
       await this.notificationPushAdapter.sendPushNotifications(
         pushRecipientsFiltered,
         event,
         {
-          title: `Poll activity: ${pollTitle}`,
-          body: `New activity on a poll in ${spaceName}`,
+          title,
+          body,
           url: await this.urlGeneratorService.getCalloutUrlPath(dto.calloutID),
         }
       );
+    }
+  }
+
+  private getPollPushMessage(
+    event: NotificationEvent,
+    pollTitle: string,
+    spaceName: string
+  ): { title: string; body: string } {
+    switch (event) {
+      case NotificationEvent.SPACE_COLLABORATION_POLL_VOTE_CAST_ON_OWN_POLL:
+        return {
+          title: `New vote on your poll`,
+          body: `Someone voted on "${pollTitle}" in ${spaceName}`,
+        };
+      case NotificationEvent.SPACE_COLLABORATION_POLL_VOTE_CAST_ON_POLL_I_VOTED_ON:
+        return {
+          title: `New vote on a poll you voted on`,
+          body: `Someone else voted on "${pollTitle}" in ${spaceName}`,
+        };
+      case NotificationEvent.SPACE_COLLABORATION_POLL_MODIFIED_ON_POLL_I_VOTED_ON:
+        return {
+          title: `Poll updated`,
+          body: `"${pollTitle}" in ${spaceName} has been modified`,
+        };
+      case NotificationEvent.SPACE_COLLABORATION_POLL_VOTE_AFFECTED_BY_OPTION_CHANGE:
+        return {
+          title: `Your vote was affected`,
+          body: `An option change in "${pollTitle}" in ${spaceName} affected your vote`,
+        };
+      default:
+        return {
+          title: `Poll activity: ${pollTitle}`,
+          body: `New activity on a poll in ${spaceName}`,
+        };
     }
   }
 

--- a/src/services/adapters/notification-adapter/notification.user.adapter.ts
+++ b/src/services/adapters/notification-adapter/notification.user.adapter.ts
@@ -306,7 +306,7 @@ export class NotificationUserAdapter {
         {
           title: 'You were mentioned',
           body: `${actorName} mentioned you`,
-          url: '/',
+          url: await this.urlGeneratorService.getRoomUrlPath(eventData.roomID),
         }
       );
     }
@@ -450,7 +450,9 @@ export class NotificationUserAdapter {
           {
             title: 'Reply to your comment',
             body: `${actorName} replied to your comment`,
-            url: '/',
+            url: await this.urlGeneratorService.getRoomUrlPath(
+              eventData.roomId
+            ),
           }
         );
       }
@@ -521,7 +523,9 @@ export class NotificationUserAdapter {
         {
           title: 'Application declined',
           body: 'Your application was declined',
-          url: await this.urlGeneratorService.getSpaceUrlPathByID(eventData.spaceID),
+          url: await this.urlGeneratorService.getSpaceUrlPathByID(
+            eventData.spaceID
+          ),
         }
       );
     }

--- a/src/services/adapters/notification-push-adapter/push.delivery.service.spec.ts
+++ b/src/services/adapters/notification-push-adapter/push.delivery.service.spec.ts
@@ -1,9 +1,9 @@
 import { PushSubscriptionService } from '@domain/push-subscription/push.subscription.service';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import webpush from 'web-push';
 import { PushDeliveryService } from './push.delivery.service';
 import { PushNotificationMessage } from './push.notification.message';
-import webpush from 'web-push';
 
 const mockLogger = {
   verbose: vi.fn(),

--- a/src/services/infrastructure/url-generator/url.generator.service.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.ts
@@ -12,6 +12,7 @@ import { Callout } from '@domain/collaboration/callout/callout.entity';
 import { CalloutContribution } from '@domain/collaboration/callout-contribution/callout.contribution.entity';
 import { CalloutFraming } from '@domain/collaboration/callout-framing/callout.framing.entity';
 import { Collaboration } from '@domain/collaboration/collaboration/collaboration.entity';
+import { Post } from '@domain/collaboration/post/post.entity';
 import { Memo } from '@domain/common/memo/memo.entity';
 import { IProfile } from '@domain/common/profile/profile.interface';
 import { Whiteboard } from '@domain/common/whiteboard/whiteboard.entity';
@@ -1235,6 +1236,32 @@ export class UrlGeneratorService {
     );
     const spaceUrl = `${l1SpaceUrlPath}/${UrlPathElement.OPPORTUNITIES}/${l2SpaceNameID}`;
     return this.appendSpacePathToUrl(spaceUrl, spacePath);
+  }
+
+  public async getRoomUrlPath(roomID: string): Promise<string> {
+    // Check if the room belongs to a callout
+    const callout = await this.entityManager.findOne(Callout, {
+      where: { comments: { id: roomID } },
+      select: { id: true },
+    });
+    if (callout) {
+      return this.getCalloutUrlPath(callout.id);
+    }
+
+    // Check if the room belongs to a post
+    const post = await this.entityManager.findOne(Post, {
+      where: { comments: { id: roomID } },
+      select: { id: true },
+    });
+    if (post) {
+      return this.getPostUrlPath(post.id);
+    }
+
+    this.logger.verbose?.(
+      `Unable to resolve URL for room: ${roomID}, falling back to '/'`,
+      LogContext.URL_GENERATOR
+    );
+    return '/';
   }
 
   private appendSpacePathToUrl(


### PR DESCRIPTION
## Summary
- Fixed push notification URLs for calendar events (created & comment) to navigate to the specific event instead of the space dashboard
- Fixed mention and comment reply push notifications to resolve room → callout/post URL instead of redirecting to `/`
- Fixed leads message and communication update push notifications to include `/updates` path
- Differentiated poll notification push messages per event type (vote on own poll, vote on shared poll, poll modified, vote affected)
- Added `getRoomUrlPath` to `UrlGeneratorService` for resolving room → parent entity URL
- Added `UPDATES` enum value to `UrlPathElementSpace`

Cherry-picked from fix/pwa-redirect (PR #5957)
Closes alkem-io/client-web#9474

## Test plan
- [x] Trigger a calendar event creation → push notification should link to the calendar event page
- [x] Comment on a calendar event → push notification should link to the calendar event
- [x] Mention a user in a callout/post → push notification should link to the callout/post
- [x] Reply to a comment → push notification should link to the callout/post
- [x] Send a leads message → push notification should link to `/<space>/updates`
- [x] Post a communication update → push notification should link to `/<space>/updates`
- [x] Vote on polls → push notification messages should be specific to each vote event type
- [ ] Verify fallback: if room cannot be resolved, notification still works (falls back to `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)