### PR TITLE
feat: update socket.io URL format and add Oathkeeper middleware

### DIFF
--- a/.build/ory/oathkeeper/access-rules.yml
+++ b/.build/ory/oathkeeper/access-rules.yml
@@ -86,7 +86,7 @@
     preserve_host: true
     url: 'http://whiteboard-collaboration:4002'
   match:
-    url: 'http://localhost:3000/socket.io/<**>'
+    url: 'http://localhost:3000/socket.io<**>'
     methods:
       - GET
   authenticators:

--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -145,6 +145,12 @@ http:
           - /hydra/admin
         forceSlash: false
 
+    oathkeeper-auth-socket-io:
+      forwardAuth:
+        address: 'http://oathkeeper:4456/decisions'
+        authResponseHeaders:
+          - Authorization
+
   routers:
     oidc-public:
       rule: 'PathPrefix(`/oidc`)'
@@ -231,9 +237,10 @@ http:
 
     whiteboard-collaboration:
       rule: 'PathPrefix(`/api/private/ws`)'
-      service: 'oathkeeper-proxy'
+      service: 'whiteboard-collaboration'
       middlewares:
         - strip-api-private-prefix-socket-io
+        - oathkeeper-auth-socket-io
       entryPoints:
         - 'web'
 


### PR DESCRIPTION
Not something misconfigured. It's a collision between two opinionated behaviors:           
  - Oathkeeper v26.2.0: "trailing slashes are unclean, strip them"                                    
  - Socket.io: "my path ends with a slash, always"                                                      
                                                                                                        
  The ForwardAuth approach sidesteps it cleanly.  

---

 1. Request hits Traefik with cookies                                                                  
  2. ForwardAuth middleware sends a side request to Oathkeeper's decision API (port 4456)
  3. Oathkeeper authenticates cookie, creates JWT, returns it in Authorization header                   
  4. Traefik copies that Authorization header onto the original request (path still /socket.io/ —       
  untouched)                                                                                            
  5. Traefik proxies to whiteboard service with both the JWT and the original path                      
                                                                                                        
  The middleware doesn't proxy — it just enriches the request with the JWT. Traefik does the proxying. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Socket.IO request path matching in access rules.
  * Updated authentication middleware and routing configuration for real-time collaboration features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->