### PR TITLE
update matrix version

### DIFF
--- a/quickstart-services-ai-debug.yml
+++ b/quickstart-services-ai-debug.yml
@@ -354,7 +354,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.12
+    image: alkemio/matrix-adapter-go:v0.8.14
     depends_on:
       - rabbitmq
     environment:

--- a/quickstart-services-ai.yml
+++ b/quickstart-services-ai.yml
@@ -405,7 +405,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.12
+    image: alkemio/matrix-adapter-go:v0.8.14
     depends_on:
       - rabbitmq
     environment:

--- a/quickstart-services-kratos-debug.yml
+++ b/quickstart-services-kratos-debug.yml
@@ -418,7 +418,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.12
+    image: alkemio/matrix-adapter-go:v0.8.14
     depends_on:
       - rabbitmq
     environment:

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -413,7 +413,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.12
+    image: alkemio/matrix-adapter-go:v0.8.14
     depends_on:
       - rabbitmq
     environment:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated matrix-adapter service container image to v0.8.14 (from v0.8.12) across all Docker Compose configuration files, including standard, AI-enabled, and debug deployment variants, to maintain consistent service versions across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->