### PR TITLE
Added urls to allow list to try and download OIDC provided avatars

### DIFF
--- a/src/domain/common/profile/profile.service.spec.ts
+++ b/src/domain/common/profile/profile.service.spec.ts
@@ -1042,24 +1042,17 @@ describe('ProfileService', () => {
       expect(warnSpy).toHaveBeenCalled();
     });
 
-    // NOTE: the committed change puts DEFAULT_AVATAR_SERVICE_URL (a full URL,
-    // 'https://eu.ui-avatars.com/api/') into a Set that is matched against
-    // URL.hostname — so the platform's own fallback avatar service is never
-    // accepted. This test pins that (buggy) behavior so a fix flips it to pass
-    // via the positive branch.
-    it('FIXME: currently rejects our own DEFAULT_AVATAR_SERVICE_URL hostname (bug: full URL stored in hostname allowlist)', async () => {
+    it('allows our own DEFAULT_AVATAR_SERVICE_URL hostname', async () => {
       const uri = `${DEFAULT_AVATAR_SERVICE_URL}?name=Foo&size=64`;
       expect(uri.startsWith('https://eu.ui-avatars.com/')).toBe(true);
 
       await addAvatarWithUri(uri);
-      assertReuploadInternalUrlRequired(true);
+      assertReuploadInternalUrlRequired(false);
     });
 
-    // Same class of bug: 'ui-avatars.com' is in the allowlist but URL.hostname
-    // returns the full 'eu.ui-avatars.com', and Set.has is strict equality.
-    it('FIXME: currently rejects eu.ui-avatars.com despite ui-avatars.com being in the allowlist (no suffix match)', async () => {
+    it('allows eu.ui-avatars.com avatar URL', async () => {
       await addAvatarWithUri('https://eu.ui-avatars.com/api/?name=Foo');
-      assertReuploadInternalUrlRequired(true);
+      assertReuploadInternalUrlRequired(false);
     });
   });
 

--- a/src/domain/common/profile/profile.service.spec.ts
+++ b/src/domain/common/profile/profile.service.spec.ts
@@ -18,6 +18,7 @@ import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.a
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { DEFAULT_AVATAR_SERVICE_URL } from '@services/external/avatar-creator/avatar.creator.service';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
@@ -880,6 +881,185 @@ describe('ProfileService', () => {
       expect(visualService.createVisualBannerWide).toHaveBeenCalled();
       expect(visualService.createVisualMediaGalleryImage).toHaveBeenCalled();
       expect(visualService.createVisualMediaGalleryVideo).toHaveBeenCalled();
+    });
+  });
+
+  describe('addVisualsOnProfile - trusted external avatar host allowlist', () => {
+    const trustedHosts = [
+      'media.licdn.com',
+      'media.licdn-ei.com',
+      'avatars.githubusercontent.com',
+      'graph.microsoft.com',
+    ];
+
+    const buildProfile = (): Profile =>
+      ({
+        id: 'p-1',
+        visuals: [],
+        storageBucket: { id: 'sb-1' },
+      }) as unknown as Profile;
+
+    const addAvatarWithUri = async (uri: string) => {
+      vi.mocked(visualService.createVisualAvatar).mockReturnValue({
+        id: 'av-1',
+        name: VisualType.AVATAR,
+        uri: '',
+      } as any);
+      vi.mocked(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).mockResolvedValue(uri);
+
+      await service.addVisualsOnProfile(
+        buildProfile(),
+        [{ name: VisualType.AVATAR, uri }],
+        [VisualType.AVATAR]
+      );
+    };
+
+    const assertReuploadInternalUrlRequired = (expected: boolean) => {
+      expect(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).toHaveBeenCalledWith(expect.any(String), expect.anything(), expected);
+    };
+
+    it.each(
+      trustedHosts
+    )('allows external AVATAR URL from trusted host %s (internalUrlRequired=false)', async host => {
+      await addAvatarWithUri(`https://${host}/path/img.png`);
+      assertReuploadInternalUrlRequired(false);
+    });
+
+    it('matches trusted host case-insensitively', async () => {
+      await addAvatarWithUri('https://MEDIA.LICDN.COM/path/img.png');
+      assertReuploadInternalUrlRequired(false);
+    });
+
+    it('rejects external AVATAR URL from non-allowlisted host', async () => {
+      await addAvatarWithUri('https://evil.example.com/img.png');
+      assertReuploadInternalUrlRequired(true);
+    });
+
+    it('rejects non-https URL even for allowlisted host', async () => {
+      await addAvatarWithUri('http://media.licdn.com/img.png');
+      assertReuploadInternalUrlRequired(true);
+    });
+
+    it('rejects malformed URL', async () => {
+      await addAvatarWithUri('not-a-url');
+      assertReuploadInternalUrlRequired(true);
+    });
+
+    it('rejects empty-string uri by not invoking reupload at all', async () => {
+      vi.mocked(visualService.createVisualAvatar).mockReturnValue({
+        id: 'av-1',
+        name: VisualType.AVATAR,
+        uri: '',
+      } as any);
+
+      await service.addVisualsOnProfile(
+        buildProfile(),
+        [{ name: VisualType.AVATAR, uri: '' }],
+        [VisualType.AVATAR]
+      );
+
+      expect(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).not.toHaveBeenCalled();
+    });
+
+    it('rejects external URL for non-AVATAR visual type even when host is trusted', async () => {
+      vi.mocked(visualService.createVisualBanner).mockReturnValue({
+        id: 'bv-1',
+        name: VisualType.BANNER,
+        uri: '',
+      } as any);
+      vi.mocked(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).mockResolvedValue('https://media.licdn.com/img.png');
+
+      await service.addVisualsOnProfile(
+        buildProfile(),
+        [
+          {
+            name: VisualType.BANNER,
+            uri: 'https://media.licdn.com/img.png',
+          },
+        ],
+        [VisualType.BANNER]
+      );
+
+      assertReuploadInternalUrlRequired(true);
+    });
+
+    it('persists returned URL onto the visual when reupload resolves a value', async () => {
+      vi.mocked(visualService.createVisualAvatar).mockReturnValue({
+        id: 'av-1',
+        name: VisualType.AVATAR,
+        uri: '',
+      } as any);
+      vi.mocked(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).mockResolvedValue('https://media.licdn.com/final.png');
+
+      const profile = buildProfile();
+      const result = await service.addVisualsOnProfile(
+        profile,
+        [
+          {
+            name: VisualType.AVATAR,
+            uri: 'https://media.licdn.com/raw.png',
+          },
+        ],
+        [VisualType.AVATAR]
+      );
+
+      expect(result.visuals![0].uri).toBe('https://media.licdn.com/final.png');
+    });
+
+    it('logs a warning when reupload returns undefined', async () => {
+      vi.mocked(visualService.createVisualAvatar).mockReturnValue({
+        id: 'av-1',
+        name: VisualType.AVATAR,
+        uri: '',
+      } as any);
+      vi.mocked(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).mockResolvedValue(undefined);
+
+      const warnSpy = vi.spyOn((service as any).logger, 'warn');
+
+      await service.addVisualsOnProfile(
+        buildProfile(),
+        [
+          {
+            name: VisualType.AVATAR,
+            uri: 'https://evil.example.com/img.png',
+          },
+        ],
+        [VisualType.AVATAR]
+      );
+
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    // NOTE: the committed change puts DEFAULT_AVATAR_SERVICE_URL (a full URL,
+    // 'https://eu.ui-avatars.com/api/') into a Set that is matched against
+    // URL.hostname — so the platform's own fallback avatar service is never
+    // accepted. This test pins that (buggy) behavior so a fix flips it to pass
+    // via the positive branch.
+    it('FIXME: currently rejects our own DEFAULT_AVATAR_SERVICE_URL hostname (bug: full URL stored in hostname allowlist)', async () => {
+      const uri = `${DEFAULT_AVATAR_SERVICE_URL}?name=Foo&size=64`;
+      expect(uri.startsWith('https://eu.ui-avatars.com/')).toBe(true);
+
+      await addAvatarWithUri(uri);
+      assertReuploadInternalUrlRequired(true);
+    });
+
+    // Same class of bug: 'ui-avatars.com' is in the allowlist but URL.hostname
+    // returns the full 'eu.ui-avatars.com', and Set.has is strict equality.
+    it('FIXME: currently rejects eu.ui-avatars.com despite ui-avatars.com being in the allowlist (no suffix match)', async () => {
+      await addAvatarWithUri('https://eu.ui-avatars.com/api/?name=Foo');
+      assertReuploadInternalUrlRequired(true);
     });
   });
 

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -500,7 +500,7 @@ export class ProfileService {
   }
 
   private static readonly TRUSTED_EXTERNAL_AVATAR_HOSTS = new Set<string>([
-    DEFAULT_AVATAR_SERVICE_URL,
+    new URL(DEFAULT_AVATAR_SERVICE_URL).hostname.toLowerCase(),
     'ui-avatars.com',
     'media.licdn.com',
     'media.licdn-ei.com',

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -217,6 +217,21 @@ export class ProfileService {
     return await this.profileRepository.save(profile);
   }
 
+  private isTrustedExternalAvatarHost(candidate: string): boolean {
+    let parsed: URL;
+    try {
+      parsed = new URL(candidate);
+    } catch {
+      return false;
+    }
+    if (parsed.protocol !== 'https:') {
+      return false;
+    }
+    return ProfileService.TRUSTED_EXTERNAL_AVATAR_HOSTS.has(
+      parsed.hostname.toLowerCase()
+    );
+  }
+
   public async addVisualsOnProfile(
     profile: IProfile,
     visualsData: CreateVisualOnProfileInput[] | undefined,
@@ -261,10 +276,14 @@ export class ProfileService {
       }
       const providedVisual = visualsData?.find(v => v.name === visualType);
       if (providedVisual && providedVisual.uri.length > 0) {
-        // Only allow external URL if we are creating an Avatar and if it comes from https://eu.ui-avatars.com
+        // External AVATAR URLs are allowed only from a small allowlist of trusted
+        // hosts (our own fallback service and supported OIDC provider CDNs); the
+        // subsequent ensureAvatarIsStoredInLocalStorageBucket step downloads and
+        // re-hosts the image locally. Keeping the allowlist narrow limits SSRF
+        // exposure in user-controlled profile inputs.
         const allowExternalUrl =
           visualType === VisualType.AVATAR &&
-          providedVisual.uri.startsWith(DEFAULT_AVATAR_SERVICE_URL);
+          this.isTrustedExternalAvatarHost(providedVisual.uri);
 
         const url =
           await this.profileDocumentsService.reuploadFileOnStorageBucket(
@@ -479,4 +498,13 @@ export class ProfileService {
     }
     return result;
   }
+
+  private static readonly TRUSTED_EXTERNAL_AVATAR_HOSTS = new Set<string>([
+    DEFAULT_AVATAR_SERVICE_URL,
+    'ui-avatars.com',
+    'media.licdn.com',
+    'media.licdn-ei.com',
+    'avatars.githubusercontent.com',
+    'graph.microsoft.com',
+  ]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a curated allowlist of trusted external avatar hosts (HTTPS-only, case-insensitive host matching) so approved external avatar URLs are accepted; other hosts, non-HTTPS, malformed or empty URLs require reupload. Resolved reupload URLs are persisted and a warning is logged if resolution fails.

* **Tests**
  * Expanded coverage for avatar allowlist behavior, non-avatar visual handling, empty/malformed URLs, case-insensitive hosts, and known avatar service URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->