### PR TITLE
fix: resolve UQ_actor_nameID_user collision blocking OIDC registration

### DIFF
--- a/src/domain/community/user/user.service.spec.ts
+++ b/src/domain/community/user/user.service.spec.ts
@@ -15,10 +15,12 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { KratosService } from '@services/infrastructure/kratos/kratos.service';
+import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+import { QueryFailedError } from 'typeorm';
 import { type Mock, vi } from 'vitest';
 import { UserLookupService } from '../user-lookup/user.lookup.service';
 import { UserSettingsService } from '../user-settings/user.settings.service';
@@ -61,6 +63,10 @@ describe('UserService', () => {
   let storageAggregatorService: { delete: Mock };
   let actorService: { deleteActorById: Mock };
   let kratosService: { deleteIdentityById: Mock };
+  let namingService: {
+    getReservedNameIDsInUsers: Mock;
+    createNameIdAvoidingReservedNameIDs: Mock;
+  };
   let repository: {
     findOne: Mock;
     save: Mock;
@@ -103,6 +109,7 @@ describe('UserService', () => {
     storageAggregatorService = module.get(StorageAggregatorService) as any;
     actorService = module.get(ActorService) as any;
     kratosService = module.get(KratosService) as any;
+    namingService = module.get(NamingService) as any;
   });
 
   it('should be defined', () => {
@@ -865,6 +872,107 @@ describe('UserService', () => {
       expect(result).toBeDefined();
       expect(repository.count).not.toHaveBeenCalled();
       expect(userLookupService.isRegisteredUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createUser nameID collision retry', () => {
+    const makeUniqueViolation = () => {
+      const err = new QueryFailedError('query', [], new Error('dup'));
+      (err as any).driverError = {
+        code: '23505',
+        constraint: 'UQ_actor_nameID_user',
+      };
+      return err;
+    };
+
+    it('regenerates nameID and retries when UQ_actor_nameID_user fires, for server-generated nameIDs', async () => {
+      namingService.getReservedNameIDsInUsers = vi
+        .fn()
+        .mockResolvedValueOnce(['evgeni-dimitrov']) // initial reservation read
+        .mockResolvedValueOnce(['evgeni-dimitrov', 'evgeni-dimitrov-1']); // after collision
+      namingService.createNameIdAvoidingReservedNameIDs = vi
+        .fn()
+        .mockReturnValueOnce('evgeni-dimitrov-1')
+        .mockReturnValueOnce('evgeni-dimitrov-2');
+      userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
+      userLookupService.isRegisteredUser.mockResolvedValue(false);
+
+      const savedUser = {
+        id: 'user-1',
+        nameID: 'evgeni-dimitrov-2',
+        profile: { id: 'profile-1' },
+        firstName: 'Evgeni',
+        lastName: 'Dimitrov',
+        email: 'ev.dimitrovv@gmail.com',
+      } as any;
+      (repository as any).manager = {
+        transaction: vi
+          .fn()
+          .mockRejectedValueOnce(makeUniqueViolation())
+          .mockResolvedValueOnce(savedUser),
+      };
+      userLookupService.getUserById.mockResolvedValue(savedUser);
+
+      await service.createUser({
+        firstName: 'Evgeni',
+        lastName: 'Dimitrov',
+        email: 'ev.dimitrovv@gmail.com',
+        profileData: { displayName: 'Evgeni Dimitrov' },
+      } as any);
+
+      expect((repository as any).manager.transaction).toHaveBeenCalledTimes(2);
+      expect(
+        namingService.createNameIdAvoidingReservedNameIDs
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry when caller supplied an explicit nameID (collision must surface)', async () => {
+      userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
+      userLookupService.isRegisteredUser.mockResolvedValue(false);
+      repository.count.mockResolvedValue(0); // isUserNameIdAvailableOrFail passes
+      const err = makeUniqueViolation();
+      (repository as any).manager = {
+        transaction: vi.fn().mockRejectedValueOnce(err),
+      };
+
+      await expect(
+        service.createUser({
+          nameID: 'explicit-name',
+          firstName: 'A',
+          lastName: 'B',
+          email: 'a@b.com',
+          profileData: { displayName: 'A B' },
+        } as any)
+      ).rejects.toBe(err);
+      expect((repository as any).manager.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows non-nameID unique violations without retry', async () => {
+      namingService.getReservedNameIDsInUsers = vi.fn().mockResolvedValue([]);
+      namingService.createNameIdAvoidingReservedNameIDs = vi
+        .fn()
+        .mockReturnValue('some-name');
+      userLookupService.getUserByAuthenticationID.mockResolvedValue(null);
+      userLookupService.isRegisteredUser.mockResolvedValue(false);
+
+      const err = new QueryFailedError('q', [], new Error('dup'));
+      (err as any).driverError = {
+        code: '23505',
+        constraint: 'UQ_user_email',
+      };
+      (repository as any).manager = {
+        transaction: vi.fn().mockRejectedValueOnce(err),
+      };
+
+      await expect(
+        service.createUser({
+          firstName: 'A',
+          lastName: 'B',
+          email: 'a@b.com',
+          profileData: { displayName: 'A B' },
+        } as any)
+      ).rejects.toBe(err);
+      expect((repository as any).manager.transaction).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -48,7 +48,7 @@ import { KratosService } from '@services/infrastructure/kratos/kratos.service';
 import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { InstrumentService } from '@src/apm/decorators';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, Repository } from 'typeorm';
+import { FindOneOptions, QueryFailedError, Repository } from 'typeorm';
 import { RoleSetRoleSelectionCredentials } from '../../access/role-set/dto/role.set.dto.role.selection.credentials';
 import { RoleSetRoleWithParentCredentials } from '../../access/role-set/dto/role.set.dto.role.with.parent.credentials';
 import { UserLookupService } from '../user-lookup/user.lookup.service';
@@ -93,8 +93,11 @@ export class UserService {
     userData: CreateUserInput,
     kratosData?: KratosSessionData
   ): Promise<IUser> {
+    // Track whether the caller supplied an explicit nameID. When they did, a
+    // unique-constraint collision must surface — we must not silently substitute
+    // a different nameID. Auto-retry only applies to server-generated nameIDs.
+    const nameIDWasGenerated = !userData.nameID;
     if (userData.nameID) {
-      // Convert nameID to lower case
       userData.nameID = userData.nameID.toLowerCase();
       await this.isUserNameIdAvailableOrFail(userData.nameID);
     } else {
@@ -102,21 +105,6 @@ export class UserService {
     }
 
     await this.validateUserProfileCreationRequest(userData);
-
-    let user: IUser = User.create({
-      ...userData,
-    });
-    // nameID is inherited from Actor (CTI), not a @Column on User,
-    // so TypeORM's create() won't copy it from the input — set it explicitly.
-    user.nameID = userData.nameID!;
-    user.authorization = new AuthorizationPolicy(AuthorizationPolicyType.USER);
-    user.settings = this.userSettingsService.createUserSettings(
-      this.getDefaultUserSettings()
-    );
-
-    if (!user.serviceProfile) {
-      user.serviceProfile = false;
-    }
 
     const profileData = await this.extendProfileDataWithReferences(
       userData.profileData
@@ -126,7 +114,6 @@ export class UserService {
 
     const authenticationID = kratosData?.authenticationID;
     if (authenticationID) {
-      // Check that authentication ID is not already in use
       const existingUser =
         await this.userLookupService.getUserByAuthenticationID(
           authenticationID
@@ -136,57 +123,101 @@ export class UserService {
           'Kratos identity already linked to another user'
         );
       }
-      user.authenticationID = authenticationID;
     }
 
     this.logger.verbose?.(
-      `Created a new user with email: ${user.email}`,
+      `Creating a new user with email: ${userData.email}`,
       LogContext.COMMUNITY
     );
 
     // Single transaction: all DB writes (StorageAggregator, Account, Actor,
-    // Settings, User) are atomic — no orphans if any step fails.
-    user = await this.userRepository.manager.transaction(async mgr => {
-      user.storageAggregator =
-        await this.storageAggregatorService.createStorageAggregator(
-          StorageAggregatorType.USER,
-          undefined,
-          mgr
-        );
-      // Do not create the guidance room here, it will be created on demand
+    // Settings, User) are atomic — no orphans if any step fails. A duplicate
+    // nameID hitting UQ_actor_nameID_user (rare race past the reservation read)
+    // rolls back cleanly and we retry with a freshly generated nameID.
+    let user: IUser | undefined;
+    const maxNameIDAttempts = 3;
+    for (let attempt = 1; attempt <= maxNameIDAttempts; attempt++) {
+      try {
+        user = await this.userRepository.manager.transaction(async mgr => {
+          // nameID is inherited from Actor (CTI), not a @Column on User,
+          // so TypeORM's create() won't copy it from the input — set it explicitly.
+          const created: IUser = User.create({ ...userData });
+          created.nameID = userData.nameID!;
+          created.authorization = new AuthorizationPolicy(
+            AuthorizationPolicyType.USER
+          );
+          created.settings = this.userSettingsService.createUserSettings(
+            this.getDefaultUserSettings()
+          );
+          if (!created.serviceProfile) {
+            created.serviceProfile = false;
+          }
+          if (authenticationID) {
+            created.authenticationID = authenticationID;
+          }
 
-      user.profile = await this.profileService.createProfile(
-        profileData,
-        ProfileType.USER,
-        user.storageAggregator
+          created.storageAggregator =
+            await this.storageAggregatorService.createStorageAggregator(
+              StorageAggregatorType.USER,
+              undefined,
+              mgr
+            );
+
+          created.profile = await this.profileService.createProfile(
+            profileData,
+            ProfileType.USER,
+            created.storageAggregator
+          );
+
+          await this.profileService.addOrUpdateTagsetOnProfile(
+            created.profile,
+            { name: TagsetReservedName.SKILLS, tags: [] }
+          );
+          await this.profileService.addOrUpdateTagsetOnProfile(
+            created.profile,
+            { name: TagsetReservedName.KEYWORDS, tags: [] }
+          );
+          await this.profileAvatarService.addAvatarVisualToProfile(
+            created.profile,
+            userData.profileData,
+            kratosData,
+            userData.firstName,
+            userData.lastName
+          );
+
+          const account = await this.accountHostService.createAccount(
+            AccountType.USER,
+            mgr
+          );
+          created.accountID = account.id;
+
+          // CTI handles multi-table saves automatically — no need to save actor separately.
+          created.settings = await mgr.save(created.settings);
+          return await mgr.save(created as User);
+        });
+        break;
+      } catch (err) {
+        if (
+          nameIDWasGenerated &&
+          attempt < maxNameIDAttempts &&
+          isUserNameIdUniqueViolation(err)
+        ) {
+          const previous = userData.nameID;
+          userData.nameID = await this.createUserNameID(userData);
+          this.logger.warn?.(
+            `createUser: nameID '${previous}' collided with UQ_actor_nameID_user; retrying with '${userData.nameID}' (attempt ${attempt + 1}/${maxNameIDAttempts})`,
+            LogContext.COMMUNITY
+          );
+          continue;
+        }
+        throw err;
+      }
+    }
+    if (!user) {
+      throw new Error(
+        'createUser: user creation completed without a result (unreachable)'
       );
-
-      await this.profileService.addOrUpdateTagsetOnProfile(user.profile, {
-        name: TagsetReservedName.SKILLS,
-        tags: [],
-      });
-      await this.profileService.addOrUpdateTagsetOnProfile(user.profile, {
-        name: TagsetReservedName.KEYWORDS,
-        tags: [],
-      });
-      await this.profileAvatarService.addAvatarVisualToProfile(
-        user.profile,
-        userData.profileData,
-        kratosData,
-        userData.firstName,
-        userData.lastName
-      );
-
-      const account = await this.accountHostService.createAccount(
-        AccountType.USER,
-        mgr
-      );
-      user.accountID = account.id;
-
-      // CTI handles multi-table saves automatically — no need to save actor separately.
-      user.settings = await mgr.save(user.settings);
-      return await mgr.save(user as User);
-    });
+    }
 
     await this.profileAvatarService.ensureAvatarIsStoredInLocalStorageBucket(
       user.profile.id,
@@ -852,10 +883,23 @@ export class UserService {
       base = userData.email.split('@')[0];
     }
     const reservedNameIDs =
-      await this.namingService.getReservedNameIDsInUsers(); // This will need to be smarter later
+      await this.namingService.getReservedNameIDsInUsers();
     return this.namingService.createNameIdAvoidingReservedNameIDs(
       base,
       reservedNameIDs
     );
   }
+}
+
+// Postgres raises unique_violation (SQLSTATE 23505) on the partial index
+// UQ_actor_nameID_user. TypeORM wraps it as QueryFailedError with the pg error
+// exposed as driverError. Match on both code and constraint to avoid reacting
+// to any other 23505 coming from the user-creation transaction.
+function isUserNameIdUniqueViolation(err: unknown): boolean {
+  if (!(err instanceof QueryFailedError)) return false;
+  const driver = (err as QueryFailedError & { driverError?: unknown })
+    .driverError as { code?: string; constraint?: string } | undefined;
+  return (
+    driver?.code === '23505' && driver?.constraint === 'UQ_actor_nameID_user'
+  );
 }

--- a/src/services/infrastructure/naming/naming.service.spec.ts
+++ b/src/services/infrastructure/naming/naming.service.spec.ts
@@ -1,3 +1,5 @@
+import { ActorType } from '@common/enums/actor.type';
+import { Actor } from '@domain/actor/actor/actor.entity';
 import { InnovationHub } from '@domain/innovation-hub/innovation.hub.entity';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getEntityManagerToken } from '@nestjs/typeorm';
@@ -196,6 +198,21 @@ describe('Naming Service', () => {
       const result = await service.getReservedNameIDsInUsers();
 
       expect(result).toEqual(['user-a', 'user-b']);
+    });
+
+    it('queries the actor table filtered by type=user so orphan actor rows are included', async () => {
+      entityManager.find.mockResolvedValue([
+        { id: '1', nameID: 'user-a' },
+        { id: '2', nameID: 'orphan-x' },
+      ]);
+
+      const result = await service.getReservedNameIDsInUsers();
+
+      expect(entityManager.find).toHaveBeenCalledWith(Actor, {
+        select: { id: true, nameID: true },
+        where: { type: ActorType.USER },
+      });
+      expect(result).toEqual(['user-a', 'orphan-x']);
     });
   });
 

--- a/src/services/infrastructure/naming/naming.service.ts
+++ b/src/services/infrastructure/naming/naming.service.ts
@@ -1,8 +1,9 @@
+import { ActorType } from '@common/enums/actor.type';
 import { RestrictedSpaceNames } from '@common/enums/restricted.space.names';
 import { SpaceLevel } from '@common/enums/space.level';
+import { Actor } from '@domain/actor/actor/actor.entity';
 import { Callout } from '@domain/collaboration/callout/callout.entity';
 import { Organization } from '@domain/community/organization';
-import { User } from '@domain/community/user/user.entity';
 import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
 import { InnovationHub } from '@domain/innovation-hub/innovation.hub.entity';
 import { Space } from '@domain/space/space/space.entity';
@@ -130,10 +131,16 @@ export class NamingService {
   }
 
   public async getReservedNameIDsInUsers(): Promise<string[]> {
-    const users = await this.entityManager.find(User, {
+    // Query the actor table with type='user' (same filter as the partial unique
+    // index UQ_actor_nameID_user) so orphan actor rows — e.g. from past users
+    // where the User row was removed but the Actor parent remained — are also
+    // treated as reserved. Reading the User entity alone misses them and leads
+    // to a deterministic duplicate-key failure on every registration retry.
+    const actors = await this.entityManager.find(Actor, {
       select: { id: true, nameID: true },
+      where: { type: ActorType.USER },
     });
-    return users.map(user => user.nameID);
+    return actors.map(actor => actor.nameID);
   }
 
   public async getReservedNameIDsInVirtualContributors(): Promise<string[]> {


### PR DESCRIPTION
## Problem

OIDC registration (LinkedIn / Microsoft) sometimes failed with `500 /webhooks/kratos/post-login — giving up after 3 attempts`. Root cause: `UserService.createUser` generated a nameID from a reservation list that only read the `User` entity, but the unique index `UQ_actor_nameID_user` lives on `actor.nameID WHERE type='user'`. An orphan `actor` row (type=user with no matching user row) was invisible to the generator, so every retry picked the same colliding slug and the CTI insert failed deterministically — 3 kratos retries, all 500, flow dies.

## Fix

- `naming.service.ts` — `getReservedNameIDsInUsers` now queries `Actor` with `type='user'`, aligning reservation reads with the actual unique index. Orphans and any concurrently-inserting rows are visible.
- `user.service.ts` — `createUser` wraps the transaction in a bounded retry (max 3) that regenerates the nameID on `UQ_actor_nameID_user` violation. Only applies when the server generated the nameID; explicit caller-supplied nameIDs still surface the collision.
- Tests added for both paths: orphan inclusion in reservation query, retry on generated nameID, no retry on explicit nameID, no retry on unrelated unique violations.

## Test plan
- [x] `pnpm test src/services/infrastructure/naming/naming.service.spec.ts src/domain/community/user/user.service.spec.ts` — 79/79 pass
- [x] `tsc --noEmit` — clean
- [ ] Smoke: register via LinkedIn on dev after rollout; verify `alkemio-server` log `Identity resolve: created user …` and no `UQ_actor_nameID_user` errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user creation reliability by implementing automatic retry logic for nameID collisions. When a system-generated nameID conflicts with existing records, the service regenerates a new nameID and retries the creation process. Explicitly provided nameIDs remain unaffected and will fail on collision as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->