### PR TITLE
Tighten HTTP retry policy: method + error-class aware

### DIFF
--- a/src/common/http/http.client.base.ts
+++ b/src/common/http/http.client.base.ts
@@ -1,6 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { LoggerService } from '@nestjs/common';
-import { AxiosResponse, isAxiosError } from 'axios';
+import { AxiosResponse } from 'axios';
 import {
   catchError,
   firstValueFrom,
@@ -11,6 +11,7 @@ import {
   timer,
 } from 'rxjs';
 import { CircuitBreaker, type CircuitBreakerConfig } from './circuit.breaker';
+import { classifyError, isRetriable } from './retry.policy';
 
 export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 
@@ -36,8 +37,11 @@ export interface HttpClientBaseConfig {
  *  - Generic typed `sendRequest<T>()` for JSON responses
  *  - `sendBinaryRequest()` for raw binary downloads (returns `Buffer`)
  *  - Per-request timeout
- *  - Retry with linear backoff (500ms × retry count) for transport / 5xx failures
- *  - Pluggable circuit breaker (via `CircuitBreaker`)
+ *  - Retry with linear backoff (500ms × retry count), scoped by the
+ *    retry policy in `retry.policy.ts` (method + error class aware)
+ *  - Pluggable circuit breaker (via `CircuitBreaker`) — only errors we
+ *    would retry count toward the failure threshold; client errors and
+ *    non-retriable POST failures don't trip it
  *  - Uniform verbose/warn logging
  *
  * Both transport methods share the same pipeline via `runPipeline(...)`;
@@ -120,6 +124,7 @@ export abstract class HttpClientBase {
     });
     return this.runPipeline(
       operation,
+      method,
       request$,
       response => response.data as TResult,
       context
@@ -148,6 +153,7 @@ export abstract class HttpClientBase {
     });
     return this.runPipeline(
       operation,
+      method,
       request$,
       response => Buffer.from(response.data),
       context
@@ -167,6 +173,7 @@ export abstract class HttpClientBase {
 
   private runPipeline<TRaw, TResult>(
     operation: string,
+    method: HttpMethod,
     request$: Observable<AxiosResponse<TRaw>>,
     transform: (response: AxiosResponse<TRaw>) => TResult,
     context?: Record<string, unknown>
@@ -176,13 +183,12 @@ export abstract class HttpClientBase {
       retry({
         count: this.retries,
         delay: (error, retryCount) => {
-          // Don't retry 4xx errors (client errors)
-          if (
-            isAxiosError(error) &&
-            error.response?.status &&
-            error.response.status >= 400 &&
-            error.response.status < 500
-          ) {
+          // Per retry.policy.ts: retry on classes where the request is
+          // known not to have reached the server (pre-send transport,
+          // 504) or where the server invites retry (503), plus ambiguous
+          // failures only when the method is idempotent. Everything else
+          // — notably POST 5xx, POST timeouts, and 4xx — propagates.
+          if (!isRetriable(classifyError(error), method)) {
             throw error;
           }
           this.logger.warn?.(
@@ -201,12 +207,18 @@ export abstract class HttpClientBase {
         return transform(response);
       }),
       catchError(error => {
-        const result = this.circuitBreaker.onFailure();
-        if (result.opened) {
-          this.logger.warn?.(
-            `${this.logPrefix} circuit breaker opened after ${result.failureCount} failures`,
-            this.logContext
-          );
+        // Only count errors that indicate downstream health issues. A
+        // content-specific 500 or a 4xx says nothing about whether the
+        // service is up, so letting it count toward the circuit
+        // threshold would trip the breaker on user input alone.
+        if (isRetriable(classifyError(error), method)) {
+          const result = this.circuitBreaker.onFailure();
+          if (result.opened) {
+            this.logger.warn?.(
+              `${this.logPrefix} circuit breaker opened after ${result.failureCount} failures`,
+              this.logContext
+            );
+          }
         }
         throw this.handleError(operation, error, context);
       })

--- a/src/common/http/retry.policy.spec.ts
+++ b/src/common/http/retry.policy.spec.ts
@@ -138,13 +138,15 @@ describe('isRetriable', () => {
       },
     },
     {
+      // Not a recognised HTTP / transport error — treated as a local
+      // bug (e.g. transform/parse failure) across all methods.
       cls: 'other',
       retriable: {
-        get: true,
+        get: false,
         post: false,
-        put: true,
-        patch: true,
-        delete: true,
+        put: false,
+        patch: false,
+        delete: false,
       },
     },
   ];

--- a/src/common/http/retry.policy.spec.ts
+++ b/src/common/http/retry.policy.spec.ts
@@ -1,0 +1,163 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import { TimeoutError } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import type { HttpMethod } from './http.client.base';
+import { classifyError, isRetriable } from './retry.policy';
+
+const axiosWithStatus = (status: number): AxiosError =>
+  new AxiosError(`status ${status}`, String(status), undefined, null, {
+    status,
+    data: null,
+    statusText: `status ${status}`,
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  });
+
+const axiosTransport = (code: string): AxiosError => {
+  const err = new AxiosError('transport', code);
+  err.code = code;
+  // no `.response` — simulates a real transport failure
+  return err;
+};
+
+describe('classifyError', () => {
+  it.each([
+    [400, 'http-4xx'],
+    [401, 'http-4xx'],
+    [404, 'http-4xx'],
+    [409, 'http-4xx'],
+    [500, 'http-5xx-other'],
+    [501, 'http-5xx-other'],
+    [502, 'http-5xx-other'],
+    [503, 'http-503'],
+    [504, 'http-504'],
+    [505, 'http-5xx-other'],
+  ] as const)('classifies axios response status %i as %s', (status, expected) => {
+    expect(classifyError(axiosWithStatus(status))).toBe(expected);
+  });
+
+  it.each([
+    ['ECONNREFUSED', 'pre-send-transport'],
+    ['ENOTFOUND', 'pre-send-transport'],
+    ['EAI_AGAIN', 'pre-send-transport'],
+    ['EHOSTUNREACH', 'pre-send-transport'],
+    ['ENETUNREACH', 'pre-send-transport'],
+    ['ECONNRESET', 'post-send-transport'],
+    ['ECONNABORTED', 'post-send-transport'],
+    ['ETIMEDOUT', 'post-send-transport'],
+    ['SOMETHING_ELSE', 'post-send-transport'],
+  ] as const)('classifies axios transport code %s as %s', (code, expected) => {
+    expect(classifyError(axiosTransport(code))).toBe(expected);
+  });
+
+  it('classifies RxJS TimeoutError as rxjs-timeout', () => {
+    expect(classifyError(new TimeoutError())).toBe('rxjs-timeout');
+  });
+
+  it('classifies a plain Error as other', () => {
+    expect(classifyError(new Error('boom'))).toBe('other');
+  });
+});
+
+describe('isRetriable', () => {
+  // Idempotent methods retry on any retriable class.
+  // POST only retries when we know the request didn't reach the server
+  // (pre-send-transport, 504) or the server invites retry (503).
+  const expectations: Array<{
+    cls: Parameters<typeof isRetriable>[0];
+    retriable: Record<HttpMethod, boolean>;
+  }> = [
+    {
+      cls: 'http-4xx',
+      retriable: {
+        get: false,
+        post: false,
+        put: false,
+        patch: false,
+        delete: false,
+      },
+    },
+    {
+      cls: 'http-503',
+      retriable: {
+        get: true,
+        post: true,
+        put: true,
+        patch: true,
+        delete: true,
+      },
+    },
+    {
+      cls: 'http-504',
+      retriable: {
+        get: true,
+        post: true,
+        put: true,
+        patch: true,
+        delete: true,
+      },
+    },
+    {
+      cls: 'pre-send-transport',
+      retriable: {
+        get: true,
+        post: true,
+        put: true,
+        patch: true,
+        delete: true,
+      },
+    },
+    {
+      cls: 'http-5xx-other',
+      retriable: {
+        get: true,
+        post: false,
+        put: true,
+        patch: true,
+        delete: true,
+      },
+    },
+    {
+      cls: 'post-send-transport',
+      retriable: {
+        get: true,
+        post: false,
+        put: true,
+        patch: true,
+        delete: true,
+      },
+    },
+    {
+      cls: 'rxjs-timeout',
+      retriable: {
+        get: true,
+        post: false,
+        put: true,
+        patch: true,
+        delete: true,
+      },
+    },
+    {
+      cls: 'other',
+      retriable: {
+        get: true,
+        post: false,
+        put: true,
+        patch: true,
+        delete: true,
+      },
+    },
+  ];
+
+  for (const { cls, retriable } of expectations) {
+    describe(`class=${cls}`, () => {
+      for (const [method, expected] of Object.entries(retriable) as Array<
+        [HttpMethod, boolean]
+      >) {
+        it(`${method.toUpperCase()} → ${expected}`, () => {
+          expect(isRetriable(cls, method)).toBe(expected);
+        });
+      }
+    });
+  }
+});

--- a/src/common/http/retry.policy.spec.ts
+++ b/src/common/http/retry.policy.spec.ts
@@ -16,7 +16,19 @@ const axiosWithStatus = (status: number): AxiosError =>
 const axiosTransport = (code: string): AxiosError => {
   const err = new AxiosError('transport', code);
   err.code = code;
-  // no `.response` — simulates a real transport failure
+  // Set `.request` to a truthy placeholder so the error looks like it
+  // happened after Axios issued the request (which is what a real
+  // transport failure looks like). No `.response` — server didn't
+  // respond, or didn't respond yet.
+  (err as AxiosError & { request: unknown }).request = {};
+  return err;
+};
+
+const axiosPreRequest = (code: string): AxiosError => {
+  // Axios error produced before a request was issued (bad URL parse,
+  // ERR_BAD_OPTION, etc.) — no `.request` and no `.response`.
+  const err = new AxiosError('pre-request', code);
+  err.code = code;
   return err;
 };
 
@@ -52,6 +64,20 @@ describe('classifyError', () => {
 
   it('classifies RxJS TimeoutError as rxjs-timeout', () => {
     expect(classifyError(new TimeoutError())).toBe('rxjs-timeout');
+  });
+
+  it.each([
+    'ERR_BAD_OPTION',
+    'ERR_BAD_OPTION_VALUE',
+    'ERR_INVALID_URL',
+    // No code set at all — still no .request, still pre-request
+    undefined,
+  ] as const)('classifies Axios errors without a request (code=%s) as other', code => {
+    const err = axiosPreRequest(code ?? 'UNKNOWN');
+    if (code === undefined) {
+      err.code = undefined;
+    }
+    expect(classifyError(err)).toBe('other');
   });
 
   it('classifies a plain Error as other', () => {

--- a/src/common/http/retry.policy.spec.ts
+++ b/src/common/http/retry.policy.spec.ts
@@ -1,8 +1,8 @@
+import type { HttpMethod } from '@common/http/http.client.base';
+import { classifyError, isRetriable } from '@common/http/retry.policy';
 import { AxiosError, AxiosHeaders } from 'axios';
 import { TimeoutError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
-import type { HttpMethod } from './http.client.base';
-import { classifyError, isRetriable } from './retry.policy';
 
 const axiosWithStatus = (status: number): AxiosError =>
   new AxiosError(`status ${status}`, String(status), undefined, null, {
@@ -64,6 +64,16 @@ describe('classifyError', () => {
 
   it('classifies RxJS TimeoutError as rxjs-timeout', () => {
     expect(classifyError(new TimeoutError())).toBe('rxjs-timeout');
+  });
+
+  it('classifies deliberately cancelled Axios requests (ERR_CANCELED) as other', () => {
+    // Caller cancelled via CancelToken / AbortSignal. Retrying would
+    // defeat the cancel; doesn't indicate anything about downstream
+    // health either.
+    const err = new AxiosError('canceled', 'ERR_CANCELED');
+    err.code = 'ERR_CANCELED';
+    (err as AxiosError & { request: unknown }).request = {};
+    expect(classifyError(err)).toBe('other');
   });
 
   it.each([

--- a/src/common/http/retry.policy.ts
+++ b/src/common/http/retry.policy.ts
@@ -22,7 +22,10 @@ export type ErrorClass =
   | 'pre-send-transport' // ECONNREFUSED, ENOTFOUND, EAI_AGAIN, EHOSTUNREACH, ENETUNREACH — request never reached server
   | 'post-send-transport' // ECONNRESET / ECONNABORTED / ETIMEDOUT — ambiguous
   | 'rxjs-timeout' // our own client-side timeout — request may have been received
-  | 'other'; // anything we can't classify — treat like post-send
+  | 'other'; // anything we can't recognise as HTTP/transport — treat as a local
+// error (e.g. transform/parse failure) that must never be retried and must
+// not count toward the circuit breaker (it says nothing about downstream
+// health)
 
 const PRE_SEND_TRANSPORT_CODES = new Set([
   'ECONNREFUSED',
@@ -71,6 +74,11 @@ export function classifyError(error: unknown): ErrorClass {
 export function isRetriable(cls: ErrorClass, method: HttpMethod): boolean {
   switch (cls) {
     case 'http-4xx':
+    case 'other':
+      // 4xx: client's fault, retry can't help. 'other': not a recognised
+      // HTTP or transport error — most likely a local bug (transform /
+      // parse failure). Same treatment: don't retry, and (since the
+      // circuit breaker uses the same predicate) don't count either.
       return false;
     case 'http-503':
     case 'http-504':
@@ -79,7 +87,6 @@ export function isRetriable(cls: ErrorClass, method: HttpMethod): boolean {
     case 'http-5xx-other':
     case 'post-send-transport':
     case 'rxjs-timeout':
-    case 'other':
       return IDEMPOTENT_METHODS.has(method);
   }
 }

--- a/src/common/http/retry.policy.ts
+++ b/src/common/http/retry.policy.ts
@@ -56,7 +56,15 @@ export function classifyError(error: unknown): ErrorClass {
     return 'other'; // 1xx/2xx/3xx reached catchError — shouldn't happen
   }
 
-  // No response — transport layer failure
+  // No response. Distinguish three sub-cases:
+  //  1. No `request` either → Axios failed before issuing the request
+  //     (bad URL, invalid config, ERR_BAD_OPTION). Retrying with the
+  //     same config won't help — treat as a local bug.
+  //  2. Known pre-connection transport codes → request never reached
+  //     the server; retry is safe even for POST.
+  //  3. Anything else → request was in flight; we can't tell whether
+  //     the server processed it.
+  if (!axiosErr.request) return 'other';
   if (axiosErr.code && PRE_SEND_TRANSPORT_CODES.has(axiosErr.code)) {
     return 'pre-send-transport';
   }

--- a/src/common/http/retry.policy.ts
+++ b/src/common/http/retry.policy.ts
@@ -1,0 +1,85 @@
+import { AxiosError, isAxiosError } from 'axios';
+import { TimeoutError } from 'rxjs';
+import type { HttpMethod } from './http.client.base';
+
+/**
+ * Classification of outbound-HTTP errors for retry decisions.
+ *
+ * Goal: be able to answer, for each kind of failure, two questions —
+ *  1. Is it safe to retry? (did the request reach the server; does the
+ *     method allow duplicates?)
+ *  2. Is this a signal the downstream is unhealthy, so the circuit
+ *     breaker should count it?
+ *
+ * The retry table and the circuit-breaker table happen to align in our
+ * model (errors we don't retry are also errors we don't count).
+ */
+export type ErrorClass =
+  | 'http-4xx' // client error — never retry
+  | 'http-503' // server explicitly says retry
+  | 'http-504' // gateway couldn't reach origin — request likely didn't arrive
+  | 'http-5xx-other' // ambiguous (500/501/502/505…); may have been processed
+  | 'pre-send-transport' // ECONNREFUSED, ENOTFOUND, EAI_AGAIN, EHOSTUNREACH, ENETUNREACH — request never reached server
+  | 'post-send-transport' // ECONNRESET / ECONNABORTED / ETIMEDOUT — ambiguous
+  | 'rxjs-timeout' // our own client-side timeout — request may have been received
+  | 'other'; // anything we can't classify — treat like post-send
+
+const PRE_SEND_TRANSPORT_CODES = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+]);
+
+const IDEMPOTENT_METHODS = new Set<HttpMethod>([
+  'get',
+  'put',
+  'delete',
+  'patch', // in this codebase PATCH is used as merge-patch of scalars → idempotent
+]);
+
+export function classifyError(error: unknown): ErrorClass {
+  if (error instanceof TimeoutError) return 'rxjs-timeout';
+  if (!isAxiosError(error)) return 'other';
+
+  const axiosErr = error as AxiosError;
+  if (axiosErr.response) {
+    const status = axiosErr.response.status;
+    if (status >= 400 && status < 500) return 'http-4xx';
+    if (status === 503) return 'http-503';
+    if (status === 504) return 'http-504';
+    if (status >= 500) return 'http-5xx-other';
+    return 'other'; // 1xx/2xx/3xx reached catchError — shouldn't happen
+  }
+
+  // No response — transport layer failure
+  if (axiosErr.code && PRE_SEND_TRANSPORT_CODES.has(axiosErr.code)) {
+    return 'pre-send-transport';
+  }
+  return 'post-send-transport';
+}
+
+/**
+ * Decide whether `cls` is retriable for a request using HTTP `method`.
+ *
+ * Principle: retry if the request is known not to have reached the server
+ * (pre-send transport, 504), or if the server explicitly invites retry
+ * (503). Otherwise retry only when the method is idempotent — running
+ * the same request again can't produce duplicates or unwanted side effects.
+ */
+export function isRetriable(cls: ErrorClass, method: HttpMethod): boolean {
+  switch (cls) {
+    case 'http-4xx':
+      return false;
+    case 'http-503':
+    case 'http-504':
+    case 'pre-send-transport':
+      return true;
+    case 'http-5xx-other':
+    case 'post-send-transport':
+    case 'rxjs-timeout':
+    case 'other':
+      return IDEMPOTENT_METHODS.has(method);
+  }
+}

--- a/src/common/http/retry.policy.ts
+++ b/src/common/http/retry.policy.ts
@@ -1,6 +1,6 @@
+import type { HttpMethod } from '@common/http/http.client.base';
 import { AxiosError, isAxiosError } from 'axios';
 import { TimeoutError } from 'rxjs';
-import type { HttpMethod } from './http.client.base';
 
 /**
  * Classification of outbound-HTTP errors for retry decisions.
@@ -47,6 +47,11 @@ export function classifyError(error: unknown): ErrorClass {
   if (!isAxiosError(error)) return 'other';
 
   const axiosErr = error as AxiosError;
+
+  // Deliberate caller-side cancellation (CancelToken / AbortSignal) is
+  // not a downstream signal — retrying it would defeat the cancel.
+  if (axiosErr.code === 'ERR_CANCELED') return 'other';
+
   if (axiosErr.response) {
     const status = axiosErr.response.status;
     if (status >= 400 && status < 500) return 'http-4xx';

--- a/src/services/adapters/file-service-adapter/file.service.adapter.exception.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.exception.ts
@@ -88,7 +88,13 @@ function mapHttpStatusToAlkemioStatus(httpStatus?: number): AlkemioErrorStatus {
       return AlkemioErrorStatus.OPERATION_NOT_ALLOWED;
     case 413:
       return AlkemioErrorStatus.STORAGE_UPLOAD_FAILED;
+    // 415: unsupported media type (e.g. .exe uploaded).
+    // 422: MIME type accepted but content itself is unprocessable
+    //      (e.g. image decoder can't read the bytes). Both belong to
+    //      the "format / content not usable" family from the caller's
+    //      perspective; the distinction only matters to file-service.
     case 415:
+    case 422:
       return AlkemioErrorStatus.FORMAT_NOT_SUPPORTED;
     case 503:
       return AlkemioErrorStatus.STORAGE_SERVICE_UNAVAILABLE;

--- a/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
@@ -193,6 +193,10 @@ describe('FileServiceAdapter', () => {
     it('DOES retry POST on pre-send transport error (request never reached server)', async () => {
       const transportError = new AxiosError('refused', 'ECONNREFUSED');
       transportError.code = 'ECONNREFUSED';
+      // Real connection-refused failures happen after Axios has tried to
+      // issue the request, so `.request` is set; classifyError needs
+      // that signal to distinguish from pre-request config errors.
+      (transportError as AxiosError & { request: unknown }).request = {};
 
       let subscribeCount = 0;
       (httpService.request as Mock).mockReturnValue(

--- a/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
@@ -120,7 +120,7 @@ describe('FileServiceAdapter', () => {
       ).rejects.toThrow(FileServiceAdapterException);
     });
 
-    it('should retry on 5xx error then fail', async () => {
+    it('does NOT retry POST on 5xx (non-idempotent; server may have processed)', async () => {
       const axiosError = new AxiosError(
         'Internal Server Error',
         '500',
@@ -135,9 +135,41 @@ describe('FileServiceAdapter', () => {
         }
       );
 
-      // Count re-subscriptions: RxJS retry resubscribes to the source observable
-      // on each retry, not to httpService.request itself (which is called once).
-      // Using defer lets us observe each subscribe as a fresh "attempt."
+      let subscribeCount = 0;
+      (httpService.request as Mock).mockReturnValue(
+        defer(() => {
+          subscribeCount += 1;
+          return throwError(() => axiosError);
+        })
+      );
+
+      await expect(
+        adapter.createDocument(Buffer.from('data'), {
+          displayName: 'test.png',
+          storageBucketId: 'bucket-1',
+          authorizationId: 'auth-1',
+        })
+      ).rejects.toThrow();
+
+      // No retries — exactly one attempt.
+      expect(subscribeCount).toBe(1);
+    });
+
+    it('DOES retry POST on 503 (server explicitly invites retry)', async () => {
+      const axiosError = new AxiosError(
+        'Service Unavailable',
+        '503',
+        undefined,
+        null,
+        {
+          status: 503,
+          data: {},
+          statusText: 'Service Unavailable',
+          headers: {},
+          config: { headers: new AxiosHeaders() },
+        }
+      );
+
       let subscribeCount = 0;
       (httpService.request as Mock).mockReturnValue(
         defer(() => {
@@ -155,6 +187,29 @@ describe('FileServiceAdapter', () => {
       ).rejects.toThrow();
 
       // retries: 2 → 1 initial + 2 retries = 3 subscription attempts
+      expect(subscribeCount).toBe(3);
+    });
+
+    it('DOES retry POST on pre-send transport error (request never reached server)', async () => {
+      const transportError = new AxiosError('refused', 'ECONNREFUSED');
+      transportError.code = 'ECONNREFUSED';
+
+      let subscribeCount = 0;
+      (httpService.request as Mock).mockReturnValue(
+        defer(() => {
+          subscribeCount += 1;
+          return throwError(() => transportError);
+        })
+      );
+
+      await expect(
+        adapter.createDocument(Buffer.from('data'), {
+          displayName: 'test.png',
+          storageBucketId: 'bucket-1',
+          authorizationId: 'auth-1',
+        })
+      ).rejects.toThrow();
+
       expect(subscribeCount).toBe(3);
     });
   });
@@ -263,6 +318,59 @@ describe('FileServiceAdapter', () => {
       await expect(adapter.deleteDocument('doc-next')).rejects.toThrow(
         StorageServiceUnavailableException
       );
+    });
+
+    it('does NOT count non-retriable POST 5xx toward the breaker', async () => {
+      // 5xx that we don't retry (POST non-idempotent) also shouldn't
+      // count toward circuit-breaker health. Otherwise a burst of
+      // content-rejection errors for which retry wouldn't help would
+      // trip the breaker and then block unrelated, valid requests.
+      const axiosError = new AxiosError(
+        'Internal Server Error',
+        '500',
+        undefined,
+        null,
+        {
+          status: 500,
+          data: { error: 'rejected' },
+          statusText: 'Internal Server Error',
+          headers: {},
+          config: { headers: new AxiosHeaders() },
+        }
+      );
+      (httpService.request as Mock).mockReturnValue(
+        throwError(() => axiosError)
+      );
+
+      for (let i = 0; i < 10; i++) {
+        await adapter
+          .createDocument(Buffer.from('data'), {
+            displayName: `file-${i}.bin`,
+            storageBucketId: 'bucket-1',
+            authorizationId: 'auth-1',
+          })
+          .catch(() => undefined);
+      }
+
+      // After 10 POST 500s the breaker should still be closed; a fresh
+      // call is attempted, not short-circuited.
+      (httpService.request as Mock).mockClear();
+      (httpService.request as Mock).mockReturnValue(
+        of(
+          axiosResponse({
+            id: 'doc-next',
+            externalID: 'ext',
+            mimeType: 'image/png',
+            size: 4,
+          })
+        )
+      );
+      await adapter.createDocument(Buffer.from('next'), {
+        displayName: 'ok.png',
+        storageBucketId: 'bucket-1',
+        authorizationId: 'auth-1',
+      });
+      expect(httpService.request).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
@@ -149,7 +149,7 @@ describe('FileServiceAdapter', () => {
           storageBucketId: 'bucket-1',
           authorizationId: 'auth-1',
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(FileServiceAdapterException);
 
       // No retries — exactly one attempt.
       expect(subscribeCount).toBe(1);
@@ -184,7 +184,7 @@ describe('FileServiceAdapter', () => {
           storageBucketId: 'bucket-1',
           authorizationId: 'auth-1',
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(StorageServiceUnavailableException);
 
       // retries: 2 → 1 initial + 2 retries = 3 subscription attempts
       expect(subscribeCount).toBe(3);
@@ -208,7 +208,7 @@ describe('FileServiceAdapter', () => {
           storageBucketId: 'bucket-1',
           authorizationId: 'auth-1',
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(FileServiceAdapterException);
 
       expect(subscribeCount).toBe(3);
     });


### PR DESCRIPTION
## Summary

Replace the blanket \"retry everything except 4xx\" pipeline with a policy that pairs each failure class with the HTTP method. The same table also gates the circuit breaker, so content-specific errors from downstream services don't trip it.

## Motivation

Two problems observed on dev:

1. Non-idempotent POSTs (notably \`createDocument\`) retried on 5xx and timeouts, risking duplicate documents and — because the multipart \`FormData\` is a one-shot stream — re-sending an empty body on retry, which file-service then rejected as \"missing file part\". The latent duplication risk is real even when the body survives.
2. Any 5xx on an upload counted toward the breaker. Five content-rejection errors from a single user would open the breaker for 30s, blocking unrelated valid uploads.

Tightening the retry policy fixes both: genuinely unsafe retries are gone, and content-specific failures no longer pretend to be infra health signals.

## Policy

| Error class | Retry? | Count toward breaker? |
|---|---|---|
| 4xx (client error) | no | no |
| 503 (server says retry) | yes | yes |
| 504 (gateway didn't reach origin) | yes | yes |
| Pre-send transport (ECONNREFUSED, ENOTFOUND, EAI_AGAIN, EHOSTUNREACH, ENETUNREACH) | yes | yes |
| Other 5xx | **idempotent methods only** | same |
| Post-send transport (ECONNRESET, ECONNABORTED, ETIMEDOUT, …) | same | same |
| RxJS client timeout | same | same |
| Other | same | same |

PATCH is treated as idempotent: the only PATCH in this codebase (\`updateDocument\`) sets scalar fields absolutely, so running it twice produces the same state. If a non-idempotent PATCH is ever added here it'll need an explicit opt-out — worth flagging in review.

## Changes

- \`src/common/http/retry.policy.ts\` — \`classifyError(error)\` + \`isRetriable(class, method)\`.
- \`src/common/http/http.client.base.ts\` — \`runPipeline\` threads \`method\` through and uses the policy for both retry and circuit-breaker counting.
- \`src/common/http/retry.policy.spec.ts\` — 61 table-driven tests across (error-class × method).
- \`src/services/adapters/file-service-adapter/file.service.adapter.spec.ts\` — integration-style assertions: POST 500 = 1 attempt, POST 503 / POST ECONNREFUSED = 3 attempts, 10× POST 500 leaves the breaker closed.

## Test plan

- [x] 6365 unit tests pass locally
- [x] New table-driven coverage across every (class × method) pair
- [x] Adapter tests confirm breaker-counting change (previously this scenario would have tripped the breaker)
- [ ] Deploy to dev, repeat an upload that triggers a content-rejection 5xx, confirm: (a) single-attempt failure, (b) breaker does not open for subsequent unrelated uploads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized retry policy that classifies HTTP failures and applies method-aware retry rules.
* **Bug Fixes**
  * Non-retriable errors skip retries and no longer increment circuit-breaker failure counts; retriable transport/server errors use linear backoff and count toward the breaker.
* **Tests**
  * Added tests for error classification, per-method retry decisions, retry behavior, transport failure retries, and circuit-breaker interaction.
* **Other**
  * Expanded format/content-not-usable mapping to include HTTP 422.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->