### PR TITLE
chore: bump file-service-go to v0.0.8

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -498,7 +498,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.7
+    image: alkemio/file-service-go:v0.0.8
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Bump `alkemio/file-service-go` image tag in `quickstart-services.yml` from `v0.0.7` → `v0.0.8`.

## Test plan

- [ ] Recompose dev stack and confirm file-service container starts on v0.0.8
- [ ] Smoke: upload / read / delete a document succeeds end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates

* **Chores**
  * Updated file-service component to the latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->