### PR TITLE
chore: bump file-service-go to v0.0.9

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -1,6 +1,7 @@
 volumes:
   alkemio_dev_postgres:
   alkemio_dev_synapse:
+  alkemio_dev_storage:
   tmpvolume:
   chroma-data:
   rabbitmq_data:
@@ -498,7 +499,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.8
+    image: alkemio/file-service-go:v0.0.9
     depends_on:
       postgres:
         condition: service_healthy
@@ -516,7 +517,7 @@ services:
       - LOG_LEVEL=info
     restart: always
     volumes:
-      - ${PWD}/.storage:/storage:rw
+      - alkemio_dev_storage:/storage
     networks:
       - alkemio_dev_net
     ports:


### PR DESCRIPTION
## Summary
- Bump `alkemio/file-service-go` to **v0.0.9**, which pre-creates `/storage` in its Docker image with `nonroot` ownership ([alkem-io/file-service-go#10](https://github.com/alkem-io/file-service-go/pull/10)).
- Switch the file-service storage mount from the `${PWD}/.storage` bind mount to a named Docker volume (`alkemio_dev_storage`). The named volume inherits the image's `/storage` ownership on first mount, so no host-side setup is required on any dev machine (Linux or macOS).

## Test plan
- [ ] `docker compose -f quickstart-services.yml up -d file-service` starts cleanly
- [ ] `POST /internal/file` no longer fails with `permission denied` on `/storage/.tmp-*`
- [ ] Uploaded files persist across container restarts (named volume)
- [ ] No stale root-owned `.storage` directory is created in the repo root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated file service to v0.0.9.
  * Changed storage persistence from local host binding to a dedicated Docker named volume for improved data management in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->