### PR TITLE
Handle file-service-go dedup reuse: release pre-created auth/tagset

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -499,7 +499,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.9
+    image: alkemio/file-service-go:v0.0.10
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -533,6 +533,42 @@ describe('StorageBucketService', () => {
       expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
     });
 
+    it('treats omitted reused as false (backward-compat with pre-v0.0.10 Go)', async () => {
+      // Older file-service-go versions don't emit the `reused` field. Missing
+      // must behave the same as `reused: false` — don't release pre-created
+      // auth/tagset. Pins the forward-compat contract documented on the DTO.
+      const bucket = mockStorageBucket({ id: 'bucket-legacy' });
+      const buffer = Buffer.alloc(10);
+      const freshDoc = mockDocument({ id: 'doc-legacy' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved-legacy',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({
+        id: 'tagset-saved-legacy',
+      });
+      (fileServiceAdapter.createDocument as Mock).mockResolvedValue({
+        id: 'doc-legacy',
+        externalID: 'ext-legacy',
+        mimeType: MimeTypeVisual.PNG,
+        size: 10,
+        // no `reused` field — simulates pre-v0.0.10 Go response
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(freshDoc);
+
+      await service.uploadFileAsDocumentFromBuffer(
+        'bucket-legacy',
+        buffer,
+        'file.png',
+        MimeTypeVisual.PNG,
+        'user-1'
+      );
+
+      expect(authorizationPolicyService.delete).not.toHaveBeenCalled();
+      expect(tagsetService.removeTagset).not.toHaveBeenCalled();
+    });
+
     it('keeps pre-created auth + tagset when reused is false (new document)', async () => {
       const bucket = mockStorageBucket({ id: 'bucket-fresh' });
       const buffer = Buffer.alloc(10);

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -533,42 +533,6 @@ describe('StorageBucketService', () => {
       expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
     });
 
-    it('treats omitted reused as false (backward-compat with pre-v0.0.10 Go)', async () => {
-      // Older file-service-go versions don't emit the `reused` field. Missing
-      // must behave the same as `reused: false` — don't release pre-created
-      // auth/tagset. Pins the forward-compat contract documented on the DTO.
-      const bucket = mockStorageBucket({ id: 'bucket-legacy' });
-      const buffer = Buffer.alloc(10);
-      const freshDoc = mockDocument({ id: 'doc-legacy' });
-
-      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
-      (authorizationPolicyService.save as Mock).mockResolvedValue({
-        id: 'auth-saved-legacy',
-      });
-      (tagsetService.save as Mock).mockResolvedValue({
-        id: 'tagset-saved-legacy',
-      });
-      (fileServiceAdapter.createDocument as Mock).mockResolvedValue({
-        id: 'doc-legacy',
-        externalID: 'ext-legacy',
-        mimeType: MimeTypeVisual.PNG,
-        size: 10,
-        // no `reused` field — simulates pre-v0.0.10 Go response
-      });
-      (documentService.getDocumentOrFail as Mock).mockResolvedValue(freshDoc);
-
-      await service.uploadFileAsDocumentFromBuffer(
-        'bucket-legacy',
-        buffer,
-        'file.png',
-        MimeTypeVisual.PNG,
-        'user-1'
-      );
-
-      expect(authorizationPolicyService.delete).not.toHaveBeenCalled();
-      expect(tagsetService.removeTagset).not.toHaveBeenCalled();
-    });
-
     it('keeps pre-created auth + tagset when reused is false (new document)', async () => {
       const bucket = mockStorageBucket({ id: 'bucket-fresh' });
       const buffer = Buffer.alloc(10);

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -485,6 +485,130 @@ describe('StorageBucketService', () => {
       });
       expect(tagsetService.removeTagset).toHaveBeenCalledWith('tagset-saved');
     });
+
+    it('releases pre-created auth + tagset when file-service-go returns reused:true', async () => {
+      // Go-side dedup hit the existing file row; the auth/tagset we saved
+      // before calling Go are not referenced by anyone and must be freed.
+      const bucket = mockStorageBucket({ id: 'bucket-reuse' });
+      const buffer = Buffer.alloc(10);
+      const existingDoc = mockDocument({
+        id: 'doc-existing',
+        externalID: 'ext-shared',
+      });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved-reuse',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({
+        id: 'tagset-saved-reuse',
+      });
+      (fileServiceAdapter.createDocument as Mock).mockResolvedValue({
+        id: 'doc-existing',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 10,
+        reused: true,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(
+        existingDoc
+      );
+
+      const result = await service.uploadFileAsDocumentFromBuffer(
+        'bucket-reuse',
+        buffer,
+        'file.png',
+        MimeTypeVisual.PNG,
+        'user-1'
+      );
+
+      expect(result).toBe(existingDoc);
+      expect(authorizationPolicyService.delete).toHaveBeenCalledWith({
+        id: 'auth-saved-reuse',
+      });
+      expect(tagsetService.removeTagset).toHaveBeenCalledWith(
+        'tagset-saved-reuse'
+      );
+      // Go-side delete must NOT be called: the reused doc is someone else's.
+      expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it('keeps pre-created auth + tagset when reused is false (new document)', async () => {
+      const bucket = mockStorageBucket({ id: 'bucket-fresh' });
+      const buffer = Buffer.alloc(10);
+      const freshDoc = mockDocument({ id: 'doc-fresh' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved-fresh',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({
+        id: 'tagset-saved-fresh',
+      });
+      (fileServiceAdapter.createDocument as Mock).mockResolvedValue({
+        id: 'doc-fresh',
+        externalID: 'ext-fresh',
+        mimeType: MimeTypeVisual.PNG,
+        size: 10,
+        reused: false,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(freshDoc);
+
+      await service.uploadFileAsDocumentFromBuffer(
+        'bucket-fresh',
+        buffer,
+        'file.png',
+        MimeTypeVisual.PNG,
+        'user-1'
+      );
+
+      expect(authorizationPolicyService.delete).not.toHaveBeenCalled();
+      expect(tagsetService.removeTagset).not.toHaveBeenCalled();
+    });
+
+    it('does NOT delete the Go-side document on post-upload failure if reused:true', async () => {
+      // getDocumentOrFail throws AFTER a reuse response. The catch branch
+      // must leak the pre-created auth/tagset rather than delete someone
+      // else's live document.
+      const bucket = mockStorageBucket({ id: 'bucket-reuse-reload-fail' });
+      const buffer = Buffer.alloc(10);
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved-rrf',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({
+        id: 'tagset-saved-rrf',
+      });
+      (fileServiceAdapter.createDocument as Mock).mockResolvedValue({
+        id: 'doc-existing-rrf',
+        externalID: 'ext-shared-rrf',
+        mimeType: MimeTypeVisual.PNG,
+        size: 10,
+        reused: true,
+      });
+      (documentService.getDocumentOrFail as Mock).mockRejectedValue(
+        new Error('reload failed')
+      );
+
+      await expect(
+        service.uploadFileAsDocumentFromBuffer(
+          'bucket-reuse-reload-fail',
+          buffer,
+          'file.png',
+          MimeTypeVisual.PNG,
+          'user-1'
+        )
+      ).rejects.toThrow('reload failed');
+
+      expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
+      expect(authorizationPolicyService.delete).toHaveBeenCalledWith({
+        id: 'auth-saved-rrf',
+      });
+      expect(tagsetService.removeTagset).toHaveBeenCalledWith(
+        'tagset-saved-rrf'
+      );
+    });
   });
 
   // ── uploadFileAsDocument (stream) ──────────────────────────────

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -568,8 +568,8 @@ describe('StorageBucketService', () => {
 
     it('does NOT delete the Go-side document on post-upload failure if reused:true', async () => {
       // getDocumentOrFail throws AFTER a reuse response. The catch branch
-      // must leak the pre-created auth/tagset rather than delete someone
-      // else's live document.
+      // must still clean up the pre-created auth/tagset, but must NOT
+      // delete the Go-side document — it belongs to another caller.
       const bucket = mockStorageBucket({ id: 'bucket-reuse-reload-fail' });
       const buffer = Buffer.alloc(10);
 

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -247,7 +247,8 @@ export class StorageBucketService {
         maxFileSize: storage.maxFileSize,
       });
 
-      // Load the document created by the Go service with relations needed for auth
+      // Load the document with relations needed for auth. On a dedup reuse
+      // this is an existing row; otherwise it's the freshly-inserted one.
       document = await this.documentService.getDocumentOrFail(result.id, {
         relations: {
           authorization: true,
@@ -259,8 +260,12 @@ export class StorageBucketService {
       // Rollback: delete each pre-created resource independently so one
       // failure doesn't short-circuit the others. Bind narrowed values into
       // const locals so the closures don't re-widen them.
+      //
+      // Important: only delete the Go-side document if this request created
+      // it (reused=false). On a dedup reuse, `result.id` refers to someone
+      // else's existing document — deleting it would corrupt their data.
       const createdDoc = result;
-      if (createdDoc) {
+      if (createdDoc && !createdDoc.reused) {
         await tryRollback(
           () => this.fileServiceAdapter.deleteDocument(createdDoc.id),
           `Failed to rollback Go-side document ${createdDoc.id}`,
@@ -287,6 +292,31 @@ export class StorageBucketService {
         );
       }
       throw error;
+    }
+
+    // file-service-go returned an existing row: the caller-supplied
+    // authorizationId/tagsetId were ignored (the existing row keeps its
+    // own). Release our pre-created rows here rather than leaving them
+    // as DB orphans. Same const-rebind trick as above to keep narrowing.
+    if (result.reused) {
+      const reusedAuth = savedAuth;
+      if (reusedAuth) {
+        await tryRollback(
+          () => this.authorizationPolicyService.delete(reusedAuth),
+          `Failed to release pre-created auth policy ${reusedAuth.id} on dedup reuse`,
+          this.logger,
+          LogContext.STORAGE_BUCKET
+        );
+      }
+      const reusedTagset = savedTagset;
+      if (reusedTagset) {
+        await tryRollback(
+          () => this.tagsetService.removeTagset(reusedTagset.id),
+          `Failed to release pre-created tagset ${reusedTagset.id} on dedup reuse`,
+          this.logger,
+          LogContext.STORAGE_BUCKET
+        );
+      }
     }
 
     this.logger.verbose?.(

--- a/src/services/adapters/file-service-adapter/dto/create.document.result.ts
+++ b/src/services/adapters/file-service-adapter/dto/create.document.result.ts
@@ -1,13 +1,13 @@
 /**
  * Response returned by the Go file-service-go after a successful document creation.
  *
- * `reused` is true when the Go service found an existing file row matching
- * `(externalID, storageBucketId)` and returned it as-is. On reuse the caller-
- * supplied `authorizationId` / `tagsetId` are ignored by Go — the existing row's
- * values are authoritative — so the caller must release the pre-created rows to
- * avoid leaking them.
+ * `reused` is true when the Go service found an existing file row with the
+ * same content (content-hash dedup) in the same `storageBucketId` and returned
+ * it as-is. On reuse the caller-supplied `authorizationId` / `tagsetId` are
+ * ignored by Go — the existing row's values are authoritative — so the caller
+ * must release the pre-created rows to avoid leaking them.
  *
- * Missing `reused` is treated as `false` for forward-compatibility with older
+ * Missing `reused` is treated as `false` for backward-compatibility with older
  * Go versions (pre-v0.0.10).
  */
 export interface CreateDocumentResult {

--- a/src/services/adapters/file-service-adapter/dto/create.document.result.ts
+++ b/src/services/adapters/file-service-adapter/dto/create.document.result.ts
@@ -1,9 +1,19 @@
 /**
  * Response returned by the Go file-service-go after a successful document creation.
+ *
+ * `reused` is true when the Go service found an existing file row matching
+ * `(externalID, storageBucketId)` and returned it as-is. On reuse the caller-
+ * supplied `authorizationId` / `tagsetId` are ignored by Go — the existing row's
+ * values are authoritative — so the caller must release the pre-created rows to
+ * avoid leaking them.
+ *
+ * Missing `reused` is treated as `false` for forward-compatibility with older
+ * Go versions (pre-v0.0.10).
  */
 export interface CreateDocumentResult {
   id: string;
   externalID: string;
   mimeType: string;
   size: number;
+  reused?: boolean;
 }

--- a/src/services/adapters/file-service-adapter/dto/create.document.result.ts
+++ b/src/services/adapters/file-service-adapter/dto/create.document.result.ts
@@ -6,14 +6,11 @@
  * it as-is. On reuse the caller-supplied `authorizationId` / `tagsetId` are
  * ignored by Go — the existing row's values are authoritative — so the caller
  * must release the pre-created rows to avoid leaking them.
- *
- * Missing `reused` is treated as `false` for backward-compatibility with older
- * Go versions (pre-v0.0.10).
  */
 export interface CreateDocumentResult {
   id: string;
   externalID: string;
   mimeType: string;
   size: number;
-  reused?: boolean;
+  reused: boolean;
 }


### PR DESCRIPTION
## Summary

file-service-go v0.0.10 adds row-level content dedup: `POST /internal/file` returns the existing `file` row when content + storage bucket match (`reused: true` in the body). Caller-supplied `authorizationId` / `tagsetId` are ignored on reuse — the existing row keeps its own. Without this change, the server would leak the rows it pre-creates before each Go call.

This PR wires the server adapter into the new contract.

### Fixes

- **test-suites regression "upload same file twice"** — two uploads of the same file into the same bucket now return the same document URI (sequential dedup in Go). Test passes without any change on our side beyond bumping the image.
- **Pre-created metadata leak** — when Go returns \`reused: true\`, the server now releases the just-saved \`authorization_policy\` and \`tagset\` rows.
- **Reused-document corruption risk (latent)** — the existing catch branch in \`uploadFileAsDocumentFromBuffer\` used to \`fileServiceAdapter.deleteDocument(result.id)\` on any post-Go failure. If \`result.reused\` was true and reload failed, that would delete another caller's live document. Now the Go-side delete only fires when \`!result.reused\`.

## Changes

- \`CreateDocumentResult\` DTO: add optional \`reused?: boolean\`. Missing is treated as \`false\` (forward-compat with pre-v0.0.10 Go versions).
- \`StorageBucketService.uploadFileAsDocumentFromBuffer\`:
  - After reload, if \`result.reused\` is true, \`tryRollback\`-delete the saved auth + tagset.
  - Catch branch: skip Go-side \`deleteDocument\` when \`result.reused\` is true.
- \`quickstart-services.yml\`: bump \`alkemio/file-service-go\` v0.0.9 → v0.0.10.

## Paired work

- **file-service-go PR #11**: https://github.com/alkem-io/file-service-go/pull/11 — introduces the dedup + \`reused\` signal + HTTP 201 always. Merges and publishes as v0.0.10 before this server PR.

## Not in this PR (intentional)

Unique index on \`file(externalID, storageBucketId)\` is **not** added. Pre-migration prod duplicates can't be merged safely without rewriting URL references across user content (markdown, whiteboard JSON, reference URIs, etc.). The sequential dedup path handles the common case; concurrent races remain theoretically possible but rare. We'll revisit once duplicates have drained naturally.

## Test plan

- [x] 3 new unit tests in \`storage.bucket.service.spec.ts\` covering reused=true (cleanup), reused=false (no cleanup), and reused=true + post-upload failure (catch must not delete the reused doc).
- [x] Full test suite: 6373 passed.
- [ ] Manual: on dev cluster with file-service-go v0.0.10 running, upload the same file twice and confirm identical URIs + no leaked auth/tagset rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload results now indicate when an uploaded file was reused (deduplicated).

* **Bug Fixes**
  * Prevents accidental deletion of shared/deduplicated files during rollbacks.
  * Ensures temporary authorization and tag metadata are cleaned up when uploads are reused.

* **Tests**
  * Added unit tests covering deduplication outcomes and cleanup behaviors.

* **Chores**
  * Updated file service image to v0.0.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->