### PR TITLE
Add skipDedup opt-out to file-service create flow

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -499,7 +499,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.10
+    image: alkemio/file-service-go:v0.0.13
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -205,7 +205,8 @@ export class StorageBucketService {
     filename: string,
     mimeType: string,
     userID?: string,
-    temporaryLocation = false
+    temporaryLocation = false,
+    skipDedup = false
   ): Promise<IDocument> {
     const storage = await this.getStorageBucketOrFail(storageBucketId, {
       relations: {},
@@ -245,6 +246,7 @@ export class StorageBucketService {
         temporaryLocation,
         allowedMimeTypes: storage.allowedMimeTypes.join(','),
         maxFileSize: storage.maxFileSize,
+        skipDedup: skipDedup || undefined,
       });
 
       // Load the document with relations needed for auth. On a dedup reuse

--- a/src/services/adapters/file-service-adapter/dto/create.document.metadata.ts
+++ b/src/services/adapters/file-service-adapter/dto/create.document.metadata.ts
@@ -17,4 +17,13 @@ export interface CreateDocumentMetadata {
   temporaryLocation?: boolean;
   allowedMimeTypes?: string;
   maxFileSize?: number;
+  /**
+   * Bypass file-service-go's per-bucket content-hash dedup and force a fresh
+   * row even if an identical-content row already exists in the same bucket.
+   * Used by placeholder-then-edit flows (e.g. Collabora documents) where two
+   * logical documents must NOT share a backing row even though their initial
+   * content (often `Buffer.alloc(0)`) is identical. Default false preserves
+   * dedup for genuine content uploads.
+   */
+  skipDedup?: boolean;
 }

--- a/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
@@ -98,6 +98,59 @@ describe('FileServiceAdapter', () => {
       expect(callArgs.url).toBe('http://file-service:4003/internal/file');
     });
 
+    it('sends skipDedup=true as a multipart form field when set', async () => {
+      const responseData = {
+        id: 'doc-skip',
+        externalID: 'ext-skip',
+        mimeType: 'image/png',
+        size: 0,
+        reused: false,
+      };
+
+      (httpService.request as Mock).mockReturnValue(
+        of(axiosResponse(responseData, 201))
+      );
+
+      await adapter.createDocument(Buffer.alloc(0), {
+        displayName: 'placeholder.docx',
+        storageBucketId: 'bucket-1',
+        authorizationId: 'auth-1',
+        tagsetId: 'tagset-1',
+        skipDedup: true,
+      });
+
+      // FormData carries the field as a serialized stream; assert via the
+      // serialized buffer rather than introspection.
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      const serialized = callArgs.data.getBuffer().toString('utf8');
+      expect(serialized).toContain('name="skipDedup"');
+      expect(serialized).toMatch(/name="skipDedup"\r\n\r\ntrue/);
+    });
+
+    it('omits skipDedup when not set (preserves dedup default)', async () => {
+      const responseData = {
+        id: 'doc-default',
+        externalID: 'ext-default',
+        mimeType: 'image/png',
+        size: 4,
+        reused: false,
+      };
+
+      (httpService.request as Mock).mockReturnValue(
+        of(axiosResponse(responseData, 201))
+      );
+
+      await adapter.createDocument(Buffer.from('data'), {
+        displayName: 'avatar.png',
+        storageBucketId: 'bucket-1',
+        authorizationId: 'auth-1',
+      });
+
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      const serialized = callArgs.data.getBuffer().toString('utf8');
+      expect(serialized).not.toContain('name="skipDedup"');
+    });
+
     it('should throw FileServiceAdapterException on 4xx error', async () => {
       const axiosError = new AxiosError('Bad Request', '400', undefined, null, {
         status: 400,

--- a/src/services/adapters/file-service-adapter/file.service.adapter.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.ts
@@ -96,6 +96,9 @@ export class FileServiceAdapter extends HttpClientBase {
     if (metadata.maxFileSize !== undefined) {
       form.append('maxFileSize', String(metadata.maxFileSize));
     }
+    if (metadata.skipDedup) {
+      form.append('skipDedup', 'true');
+    }
 
     return this.sendRequest<CreateDocumentResult>(
       'createDocument',


### PR DESCRIPTION
## Summary

- Wires file-service-go v0.0.13's new `skipDedup` form field through the adapter and `StorageBucketService.uploadFileAsDocumentFromBuffer`
- Adds optional `skipDedup?: boolean` to `CreateDocumentMetadata` and a 7th `skipDedup = false` parameter to the upload service method
- Bumps `quickstart-services.yml` to `alkemio/file-service-go:v0.0.13`

## Why

v0.0.10 introduced per-bucket content-hash dedup on `POST /internal/file`. That's correct for genuine content uploads (image attachments, document references) but breaks placeholder-then-edit flows where the upload only establishes identity and the actual content arrives later via a side channel.

Concrete trigger: the Collabora integration on branch `086-collabora-integration` calls `uploadFileAsDocumentFromBuffer(..., Buffer.alloc(0), ...)` to create the backing `Document`; Collabora Online writes the real content via WOPI `PutFile` afterward. With v0.0.10 dedup on, two empty-buffer creates in the same storage bucket coalesce to a single backing row, and Collabora editor sessions on the two logical documents corrupt each other.

The remediation is a contract-level opt-out, not a workaround (see [file-service-go PR #14](https://github.com/alkem-io/file-service-go/pull/14)). file-service-go v0.0.13 ships the flag; this PR plumbs it through to the server.

## Behavior

- Default unchanged. `skipDedup` is opt-in; existing callers (avatars, references, attachments) continue to dedupe.
- When set, the adapter sends `skipDedup=true` as a multipart form field. file-service-go bypasses its dedup lookup and always inserts a fresh row, returning `reused: false`.
- Existing dedup-reuse compensation logic (`if (result.reused) { release pre-created auth/tagset }`) remains correct — the branch is simply unreachable when `skipDedup=true`.
- 409 from file-service-go (only reachable if/when we add a `unique(externalID, storageBucketID)` index, which we deliberately did not in PR #6000) maps to existing `OPERATION_NOT_ALLOWED` via `mapHttpStatusToAlkemioStatus` — no change needed.

## Follow-ups (out of scope here)

- The `086-collabora-integration` branch will pass `skipDedup: true` at its call site once this lands and develop is merged in. That callsite change stays in the collabora PR.

## Test plan

- [x] `pnpm exec vitest run src/services/adapters/file-service-adapter/file.service.adapter.spec.ts src/domain/storage/storage-bucket/storage.bucket.service.spec.ts` — 53 tests pass, including 2 new ones (skipDedup=true serializes the form field; omitted preserves default)
- [x] `pnpm exec biome check` — clean on touched files
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional deduplication bypass capability for document uploads. Users can now create independent document copies even when identical file content already exists within the storage bucket system.

* **Tests**
  * Added comprehensive test coverage for the new deduplication bypass feature, including validation of flag transmission to the underlying file service.

* **Chores**
  * Updated file service container image version to the latest available release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->