### PR TITLE
Fix #6004 / #6005: two-phase profile materialization + copyDocument

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -92,6 +92,49 @@ NOTIFICATIONS_ENABLED=true
 
 AI_LOCAL_PATH=/home/alkemio/data
 
+# =============================================================================
+# Unified VC engine config (provider_factory)
+#
+# Drives the alkemio/virtual-contributor unified image used by the engine and
+# ingest services in overlays/ai-stack.yml. Replace the placeholders below
+# with real credentials, or copy .env.docker.scaleway.example to
+# .env.docker.scaleway and run `pnpm run start:services:ai:scaleway` for the
+# documented Scaleway/Mistral production setup.
+# =============================================================================
+
+# Main inference: Mistral API (native Mistral SDK; empty base_url → api.mistral.ai)
+MISTRAL_API_KEY=your-mistral-api-key
+MISTRAL_BASE_URL=
+MISTRAL_SMALL_MODEL_NAME=mistral-small-latest
+LLM_BASE_URL=
+
+# Summarization: Ministral 3B (smallest/fastest on Mistral API)
+SUMMARIZE_LLM_PROVIDER=mistral
+SUMMARIZE_LLM_MODEL=ministral-3b-latest
+SUMMARIZE_LLM_API_KEY=your-mistral-api-key
+SUMMARIZE_LLM_BASE_URL=
+SUMMARIZE_LLM_TIMEOUT=1800
+
+# BoK summarization: Qwen3 235B on Scaleway (OpenAI-compatible, big context)
+BOK_LLM_PROVIDER=openai
+BOK_LLM_MODEL=qwen3-235b-a22b-instruct-2507
+BOK_LLM_API_KEY=your-scaleway-secret-key
+BOK_LLM_BASE_URL=https://api.scaleway.ai/your-scaleway-project-id/v1
+BOK_LLM_TIMEOUT=1800
+
+# Embeddings: Qwen3-Embedding 8B on Scaleway
+EMBEDDINGS_API_KEY=your-scaleway-secret-key
+EMBEDDINGS_ENDPOINT=https://api.scaleway.ai/your-scaleway-project-id/v1
+EMBEDDINGS_MODEL_NAME=qwen3-embedding-8b
+
+# Retrieval score thresholds (calibrated for Qwen3-Embedding + cosine distance)
+GUIDANCE_MIN_SCORE=0.1
+EXPERT_MIN_SCORE=0.1
+
+# Vector DB distance function
+VECTOR_DB_DISTANCE_FN=cosine
+
+# Legacy Azure-format vars (kept for libra-flow until migrated to provider_factory)
 OPENAI_API_VERSION=2023-05-15
 AZURE_OPENAI_ENDPOINT=https://alkemio-gpt.openai.azure.com
 AZURE_OPENAI_API_KEY=your-openai-key

--- a/.env.docker.scaleway.example
+++ b/.env.docker.scaleway.example
@@ -1,0 +1,172 @@
+COMPOSE_PROJECT_NAME=alkemio-serverdev
+NODE_ENV=dev
+
+# Legacy MySQL configuration (deprecated)
+MYSQL_DATABASE=alkemio
+MYSQL_ROOT_PASSWORD=toor
+
+# Postgres configuration (default for all services)
+POSTGRES_USER=synapse
+POSTGRES_PASSWORD=synapse
+POSTGRES_MULTIPLE_DATABASES=alkemio,kratos,synapse,hydra
+
+# Database configuration for Alkemio server
+DATABASE_TYPE=postgres
+DATABASE_HOST=postgres
+DATABASE_PORT=5432
+DATABASE_USERNAME=synapse
+DATABASE_PASSWORD=synapse
+DATABASE_NAME=alkemio
+
+
+
+SYNAPSE_HOMESERVER_NAME=matrix.alkem.io
+SYNAPSE_SERVER_NAME=matrix.alkem.io
+SYNAPSE_SHARED_SECRET=<your-synapse-shared-secret>
+SYNAPSE_SERVER_SHARED_SECRET=<your-synapse-shared-secret>
+SYNAPSE_ENABLE_REGISTRATION=true
+SYNAPSE_NO_TLS=true
+SYNAPSE_SERVER_URL=http://synapse:8008
+SYNAPSE_PUBLIC_URL=http://localhost:8008
+SYNAPSE_ADMIN_USERNAME=matrixadmin44@alkem.io
+SYNAPSE_ADMIN_URL=http://synapse:8008
+SYNAPSE_ADMIN_TOKEN=
+SYNAPSE_DB_HOST=postgres
+SYNAPSE_DB_PORT=5432
+SYNAPSE_DB_USERNAME=synapse
+SYNAPSE_DB_PASSWORD=synapse
+SYNAPSE_DB_DATABASE=synapse
+SYNAPSE_DB_SSL=false
+
+# Ory Hydra Configuration
+HYDRA_SYSTEM_SECRET=<your-hydra-system-secret>
+# Public base URL (used for URLS_SELF_PUBLIC, URLS_SELF_ISSUER, and constructing login/consent URLs)
+HYDRA_PUBLIC_URL=http://localhost:3000
+HYDRA_ADMIN_URL=http://localhost:3000/hydra
+SYNAPSE_OIDC_CLIENT_ID=synapse-client
+SYNAPSE_OIDC_CLIENT_SECRET=<your-synapse-oidc-client-secret>
+
+# Matrix Adapter stuff, should be consistent with Synapse app registration for matrix adapter from yaml we feed to Synapse
+MATRIX_AS_TOKEN=<your-matrix-as-token>
+MATRIX_HS_TOKEN=<your-matrix-hs-token>
+# if we need specific bot user id for matrix adapter
+# MATRIX_BOT_ACTOR_ID="00000000-0000-0000-0000-000000000000"
+
+# External OIDC service configuration (development relies on insecure HTTP)
+OIDC_ALLOW_INSECURE_HTTP=true
+OIDC_HYDRA_ADMIN_URL=http://hydra:4445
+OIDC_KRATOS_ADMIN_URL=http://kratos:4434
+OIDC_KRATOS_PUBLIC_URL=http://kratos:4433
+# OIDC_KRATOS_BROWSER_URL=http://localhost:3000/ory/kratos/public
+OIDC_WEB_BASE_URL=http://localhost:3000
+OIDC_ALKEMIO_SERVER_URL=http://host.docker.internal:4000
+OIDC_ALKEMIO_IDENTITY_RESOLVE_PATH=/rest/internal/identity/resolve
+
+EMAIL_SMTP_HOST=mailslurper
+EMAIL_MULTI_PROVIDER_STRATEGY=no-fallback
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_USER=alkemio-admin
+RABBITMQ_PASSWORD=alkemio!
+RABBITMQ_PORT=5672
+
+
+RABBITMQ_INGEST_BODY_OF_KNOWLEDGE_QUEUE=virtual-contributor-ingest-body-of-knowledge
+RABBITMQ_INGEST_BODY_OF_KNOWLEDGE_RESULT_QUEUE=virtual-contributor-ingest-body-of-knowledge-result
+
+RABBITMQ_INGEST_WEBSITE_QUEUE=virtual-contributor-ingest-website
+RABBITMQ_INGEST_WEBSITE_RESULT_QUEUE=virtual-contributor-ingest-website-result
+RABBITMQ_EVENT_BUS_EXCHANGE=event-bus
+
+RABBITMQ_RESULT_ROUTING_KEY=invoke-engine-result
+RABBITMQ_RESULT_QUEUE=virtual-contributor-invoke-engine-result
+RABBITMQ_INVOKE_ENGINE_EXPERT=virtual-contributor-engine-expert
+RABBITMQ_INVOKE_ENGINE_GUIDANCE=virtual-contributor-engine-guidance
+RABBITMQ_INVOKE_ENGINE_GENERIC=virtual-contributor-engine-generic
+RABBITMQ_INVOKE_ENGINE_OPENAI_ASSISTANT=virtual-contributor-engine-openai-assistant
+
+
+ALKEMIO_SERVER_ENDPOINT=http://host.docker.internal:4000/graphql
+KRATOS_API_PUBLIC_ENDPOINT=http://kratos:4433/
+SERVICE_ACCOUNT_USERNAME=notifications@alkem.io
+SERVICE_ACCOUNT_PASSWORD=change-me-now
+NOTIFICATIONS_ENABLED=true
+
+AI_LOCAL_PATH=/home/alkemio/data
+
+# =============================================================================
+# PRODUCTION-LIKE LLM STACK — Mistral API (inference + summarization) +
+# Scaleway (BoK + embeddings, OpenAI-compatible)
+#
+# Copy this file to .env.docker.scaleway and fill in the secrets below before
+# running: pnpm run start:services:ai:scaleway
+# =============================================================================
+
+# --- Main inference: Mistral Small via Mistral API (native SDK) ---
+# Get a key at https://console.mistral.ai/api-keys
+MISTRAL_API_KEY=<your-mistral-api-key>
+MISTRAL_BASE_URL=
+MISTRAL_SMALL_MODEL_NAME=mistral-small-latest
+
+# Unified LLM config (leave base_url empty → Mistral SDK hits api.mistral.ai)
+LLM_BASE_URL=
+
+# --- Summarization: Ministral 3B (smallest/fastest on Mistral API) ---
+SUMMARIZE_LLM_PROVIDER=mistral
+SUMMARIZE_LLM_MODEL=ministral-3b-latest
+SUMMARIZE_LLM_API_KEY=<your-mistral-api-key>
+SUMMARIZE_LLM_BASE_URL=
+SUMMARIZE_LLM_TIMEOUT=1800
+
+# --- BoK: Qwen3 235B on Scaleway (OpenAI-compatible, big context) ---
+# Create an IAM key in the Scaleway console under Generative APIs.
+# Replace <project-id> with your Scaleway project UUID.
+BOK_LLM_PROVIDER=openai
+BOK_LLM_MODEL=qwen3-235b-a22b-instruct-2507
+BOK_LLM_API_KEY=<your-scaleway-secret-key>
+BOK_LLM_BASE_URL=https://api.scaleway.ai/<your-scaleway-project-id>/v1
+BOK_LLM_TIMEOUT=1800
+
+# --- Embeddings: Qwen3-Embedding 8B on Scaleway ---
+EMBEDDINGS_API_KEY=<your-scaleway-secret-key>
+EMBEDDINGS_ENDPOINT=https://api.scaleway.ai/<your-scaleway-project-id>/v1
+EMBEDDINGS_MODEL_NAME=qwen3-embedding-8b
+
+# Retrieval score thresholds (calibrated for Qwen3-Embedding + cosine distance)
+GUIDANCE_MIN_SCORE=0.1
+EXPERT_MIN_SCORE=0.1
+
+# Vector DB distance function
+VECTOR_DB_DISTANCE_FN=cosine
+
+AI_SOURCE_WEBSITE=https://www.alkemio.org
+AI_SOURCE_WEBSITE2=https://welcome.alkem.io
+
+AI_WEBSITE_REPO=github.com/alkem-io/website.git
+AI_WEBSITE_REPO2=github.com/alkem-io/welcome-site.git
+
+AI_GITHUB_USER=your-github-user
+AI_GITHUB_PAT=your-github-pat
+
+LANGCHAIN_TRACING_V2=false
+LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
+LANGCHAIN_API_KEY=your-langchain-key
+LANGCHAIN_PROJECT=guidance-engine
+
+
+VECTOR_DB_HOST=chromadb
+VECTOR_DB_PORT=8000
+VECTOR_DB_CREDENTIALS=username:password
+VECTOR_DB_CREDENTIALS=root:toor
+
+
+AUTH_ADMIN_EMAIL=admin@alkem.io
+AUTH_ADMIN_PASSWORD=password
+EMAIL_FROM=notifications@mailer.alkem.io
+EMAIL_FROM_NAME=Alkemio
+
+LOCAL_STORAGE_PATH=/storage
+
+
+# CHROMA_SERVER_AUTHN_CREDENTIALS='root:$2y$05$Zj4eHEt9RHn96JlRPPq82Olxjr4CbQTN7Wgcskfu4hHyuMtHXjpRe'
+# CHROMA_SERVER_AUTHN_PROVIDER=chromadb.auth.basic_authn.BasicAuthenticationServerProvider
+GEOAPIFY_API_KEY=your-geoapify-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ subscriptions.log
 .env
 .env.test
 .env.docker
+.env.docker.*
+!.env.docker.*.example
 
 # Synapse signing keys (security sensitive)
 /.build/synapse/signing.key

--- a/overlays/ai-stack.yml
+++ b/overlays/ai-stack.yml
@@ -1,12 +1,21 @@
 # AI stack overlay.
 #
 # Adds the vector store (ChromaDB) plus all virtual-contributor engines
-# and ingest services. Included by quickstart-services-ai.yml and
-# quickstart-services-ai-debug.yml.
+# and ingest services. Included by quickstart-services-ai.yml.
+#
+# The 6 unified engines (guidance / expert / generic / openai-assistant /
+# ingest-website / ingest-space) share the alkemio/virtual-contributor
+# image and select their behaviour via PLUGIN_TYPE. They consume
+# provider-agnostic env vars (MISTRAL_*, LLM_*, SUMMARIZE_LLM_*,
+# BOK_LLM_*, EMBEDDINGS_*) that point at any OpenAI-compatible inference
+# and embeddings endpoints — Mistral API, Scaleway, vLLM, Ollama, etc.
+#
+# libra-flow keeps its own image (separate codebase) and the legacy
+# Azure-format env vars until it is migrated to provider_factory.
 
 services:
   chromadb:
-    image: chromadb/chroma:0.6.2
+    image: chromadb/chroma:1.5.5
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_chromadb
@@ -24,136 +33,114 @@ services:
   virtual_contributor_engine_guidance:
     container_name: alkemio_dev_virtual_contributor_engine_guidance
     hostname: virtual-contributor-engine-guidance
-    image: alkemio/virtual-contributor-engine-guidance:v0.15.0
+    image: alkemio/virtual-contributor:v0.1.2
     restart: always
-    volumes:
-      - /dev/shm:/dev/shm
-      - ~/alkemio/data:${AI_LOCAL_PATH:-/home/alkemio/data}
     networks:
       - alkemio_dev_net
     depends_on:
       rabbitmq:
         condition: 'service_healthy'
     environment:
+      - PLUGIN_TYPE=guidance
       - RABBITMQ_HOST
       - RABBITMQ_USER
       - RABBITMQ_PASSWORD
+      - RABBITMQ_PORT
       - RABBITMQ_QUEUE=virtual-contributor-engine-guidance
       - RABBITMQ_EVENT_BUS_EXCHANGE
-      - RABBITMQ_RESULT_QUEUE
       - RABBITMQ_RESULT_ROUTING_KEY
-      - AZURE_MISTRAL_ENDPOINT
-      - AZURE_MISTRAL_API_KEY
-      - AZURE_MISTRAL_DEPLOYMENT_NAME
-      - AZURE_MISTRAL_API_VERSION
-      - API_ENDPOINT_PRIVATE_GRAPHQL=http://host.docker.internal:3000/api/private/non-interactive/graphql
-      - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://host.docker.internal:3000/ory/kratos/public
-      - AUTH_ADMIN_EMAIL
-      - AUTH_ADMIN_PASSWORD
-      - OPENAI_API_VERSION
-      - AI_MODEL_TEMPERATURE
+      - MISTRAL_API_KEY
+      - MISTRAL_BASE_URL
+      - MISTRAL_SMALL_MODEL_NAME
+      - LLM_BASE_URL
+      - EMBEDDINGS_API_KEY
+      - EMBEDDINGS_ENDPOINT
+      - EMBEDDINGS_MODEL_NAME
+      - GUIDANCE_MIN_SCORE
       - LOG_LEVEL=DEBUG
-      - AZURE_OPENAI_ENDPOINT=https://alkemio-gpt.openai.azure.com
-      - AZURE_OPENAI_API_KEY
-      - LLM_DEPLOYMENT_NAME=deploy-gpt-35-turbo
-      - EMBEDDINGS_DEPLOYMENT_NAME=embedding
-      - LANGCHAIN_TRACING_V2
-      - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY
-      - LANGCHAIN_PROJECT=virtual-contributor-engine-expert
       - VECTOR_DB_PORT
       - VECTOR_DB_HOST
       - VECTOR_DB_CREDENTIALS
+      - VECTOR_DB_DISTANCE_FN
 
   virtual-contributor-engine-expert:
-    extra_hosts:
-      - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_virtual_contributor_engine_expert
     hostname: virtual-contributor-engine-expert
-    image: alkemio/virtual-contributor-engine-expert:v0.18.0
+    image: alkemio/virtual-contributor:v0.1.2
     restart: always
-    volumes:
-      - /dev/shm:/dev/shm
     networks:
       - alkemio_dev_net
     depends_on:
       rabbitmq:
         condition: 'service_healthy'
     environment:
+      - PLUGIN_TYPE=expert
       - RABBITMQ_HOST
       - RABBITMQ_USER
       - RABBITMQ_PASSWORD
       - RABBITMQ_PORT
       - RABBITMQ_QUEUE=virtual-contributor-engine-expert
       - RABBITMQ_EVENT_BUS_EXCHANGE
-      - RABBITMQ_RESULT_QUEUE
       - RABBITMQ_RESULT_ROUTING_KEY
-      - AZURE_MISTRAL_ENDPOINT
-      - AZURE_MISTRAL_API_KEY
-      - AZURE_MISTRAL_DEPLOYMENT_NAME
-      - AZURE_MISTRAL_API_VERSION
-      - API_ENDPOINT_PRIVATE_GRAPHQL=http://host.docker.internal:3000/api/private/non-interactive/graphql
-      - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://host.docker.internal:3000/ory/kratos/public
-      - AUTH_ADMIN_EMAIL
-      - AUTH_ADMIN_PASSWORD
-      - OPENAI_API_VERSION
-      - AI_MODEL_TEMPERATURE
+      - MISTRAL_API_KEY
+      - MISTRAL_BASE_URL
+      - MISTRAL_SMALL_MODEL_NAME
+      - LLM_BASE_URL
+      - EMBEDDINGS_API_KEY
+      - EMBEDDINGS_ENDPOINT
+      - EMBEDDINGS_MODEL_NAME
+      - EXPERT_MIN_SCORE
       - LOG_LEVEL=DEBUG
-      - AZURE_OPENAI_ENDPOINT=https://alkemio-gpt.openai.azure.com
-      - AZURE_OPENAI_API_KEY
-      - LLM_DEPLOYMENT_NAME=deploy-gpt-35-turbo
-      - EMBEDDINGS_DEPLOYMENT_NAME=embedding
-      - LANGCHAIN_TRACING_V2
-      - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY
-      - LANGCHAIN_PROJECT=virtual-contributor-engine-expert
       - VECTOR_DB_PORT
       - VECTOR_DB_HOST
       - VECTOR_DB_CREDENTIALS
+      - VECTOR_DB_DISTANCE_FN
 
   virtual_contributor_ingest_website:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_virtual_contributor_ingest_website
     hostname: virtual-contributor-ingest-website
-    image: alkemio/virtual-contributor-ingest-website:v0.4.0
+    image: alkemio/virtual-contributor:v0.1.2
     restart: always
-    volumes:
-      - /dev/shm:/dev/shm
     networks:
       - alkemio_dev_net
     depends_on:
       rabbitmq:
         condition: 'service_healthy'
     environment:
+      - PLUGIN_TYPE=ingest-website
       - RABBITMQ_HOST
       - RABBITMQ_USER
       - RABBITMQ_PASSWORD
       - RABBITMQ_PORT
       - RABBITMQ_QUEUE=virtual-contributor-ingest-website
       - RABBITMQ_EVENT_BUS_EXCHANGE
-      - RABBITMQ_RESULT_QUEUE
-      - RABBITMQ_RESULT_ROUTING_KEY
-      - AZURE_MISTRAL_ENDPOINT
-      - AZURE_MISTRAL_API_KEY
-      - API_ENDPOINT_PRIVATE_GRAPHQL=http://host.docker.internal:3000/api/private/non-interactive/graphql
-      - AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://host.docker.internal:3000/ory/kratos/public
-      - AUTH_ADMIN_EMAIL
-      - AUTH_ADMIN_PASSWORD
-      - OPENAI_API_VERSION
-      - AI_MODEL_TEMPERATURE
+      - RABBITMQ_RESULT_ROUTING_KEY=ingest-website-result
+      - MISTRAL_API_KEY
+      - MISTRAL_BASE_URL
+      - MISTRAL_SMALL_MODEL_NAME
+      - LLM_BASE_URL
+      - SUMMARIZE_LLM_PROVIDER
+      - SUMMARIZE_LLM_MODEL
+      - SUMMARIZE_LLM_API_KEY
+      - SUMMARIZE_LLM_BASE_URL
+      - SUMMARIZE_LLM_TIMEOUT
+      - BOK_LLM_PROVIDER
+      - BOK_LLM_MODEL
+      - BOK_LLM_API_KEY
+      - BOK_LLM_BASE_URL
+      - BOK_LLM_TIMEOUT
+      - EMBEDDINGS_API_KEY
+      - EMBEDDINGS_ENDPOINT
+      - EMBEDDINGS_MODEL_NAME
       - LOG_LEVEL=DEBUG
-      - AZURE_OPENAI_ENDPOINT=https://alkemio-gpt.openai.azure.com
-      - AZURE_OPENAI_API_KEY
-      - LLM_DEPLOYMENT_NAME=deploy-gpt-35-turbo
-      - EMBEDDINGS_DEPLOYMENT_NAME=embedding
-      - LANGCHAIN_TRACING_V2
-      - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY
-      - LANGCHAIN_PROJECT=virtual-contributor-ingest-website
       - VECTOR_DB_PORT
       - VECTOR_DB_HOST
       - VECTOR_DB_CREDENTIALS
+      - VECTOR_DB_DISTANCE_FN
+      - INGEST_BATCH_SIZE=3
+      - PIPELINE_TIMEOUT=10800
 
   virtual_contributor_engine_libra_flow:
     extra_hosts:
@@ -161,6 +148,7 @@ services:
     container_name: alkemio_dev_virtual_contributor_engine_libra_flow
     hostname: virtual-contributor-engine-libra-flow
     image: alkemio/virtual-contributor-engine-libra-flow:v0.5.0
+    platform: linux/amd64
     restart: always
     volumes:
       - /dev/shm:/dev/shm
@@ -170,6 +158,8 @@ services:
       rabbitmq:
         condition: 'service_healthy'
     environment:
+      # libra-flow still uses its own SDK with Azure-format env vars.
+      # Migrate to provider_factory before retiring these.
       - RABBITMQ_HOST
       - RABBITMQ_USER
       - RABBITMQ_PASSWORD
@@ -187,10 +177,10 @@ services:
       - OPENAI_API_VERSION
       - AI_MODEL_TEMPERATURE
       - LOG_LEVEL=DEBUG
-      - AZURE_OPENAI_ENDPOINT=https://alkemio-gpt.openai.azure.com
+      - AZURE_OPENAI_ENDPOINT
       - AZURE_OPENAI_API_KEY
-      - LLM_DEPLOYMENT_NAME=deploy-gpt-35-turbo
-      - EMBEDDINGS_DEPLOYMENT_NAME=embedding
+      - LLM_DEPLOYMENT_NAME
+      - EMBEDDINGS_DEPLOYMENT_NAME
       - LANGCHAIN_TRACING_V2
       - LANGCHAIN_ENDPOINT
       - LANGCHAIN_API_KEY
@@ -200,50 +190,48 @@ services:
       - VECTOR_DB_CREDENTIALS
 
   virtual_contributor_ingest_space:
-    # the space-ingest service needs to download files from the server running on the host
-    # for that to work the container needs to run in network_mode: host and refer to other
-    # services trough localhost
+    # network_mode: host needed to download files from the server on the host
     network_mode: host
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_virtual_contributor_ingest_space
     hostname: virtual-contributor-ingest-space
-    image: alkemio/virtual-contributor-ingest-space:v0.17.0
+    image: alkemio/virtual-contributor:v0.1.2
     restart: always
-    volumes:
-      - /dev/shm:/dev/shm
-      - ~/alkemio/data:${AI_LOCAL_PATH:-/home/alkemio/data}
     depends_on:
       rabbitmq:
         condition: 'service_healthy'
     environment:
+      - PLUGIN_TYPE=ingest-space
       - RABBITMQ_HOST=localhost
       - RABBITMQ_USER
       - RABBITMQ_PASSWORD
       - RABBITMQ_PORT
-      - RABBITMQ_INGEST_BODY_OF_KNOWLEDGE_QUEUE
-      - RABBITMQ_INGEST_BODY_OF_KNOWLEDGE_RESULT_QUEUE
+      - RABBITMQ_QUEUE=${RABBITMQ_INGEST_BODY_OF_KNOWLEDGE_QUEUE}
       - RABBITMQ_EVENT_BUS_EXCHANGE
-      - ENVIRONMENT=dev
-      - LOG_LEVEL=debug
-      - EMBEDDINGS_DEPLOYMENT_NAME
-      - AZURE_OPENAI_API_KEY
-      - AZURE_OPENAI_ENDPOINT
-      - OPENAI_API_VERSION
-      - AZURE_MISTRAL_API_KEY
-      - AZURE_MISTRAL_ENDPOINT
-      - AZURE_MISTRAL_DEPLOYMENT_NAME
-      - AZURE_MISTRAL_API_VERSION
-      - AI_MODEL_TEMPERATURE
-      - AI_LOCAL_PATH
-      - LLM_DEPLOYMENT_NAME
-      - LANGCHAIN_TRACING_V2
-      - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY
-      - LANGCHAIN_PROJECT=virtual-contributor-ingest-space
+      - RABBITMQ_RESULT_ROUTING_KEY=IngestSpaceResult
+      - MISTRAL_API_KEY
+      - MISTRAL_BASE_URL
+      - MISTRAL_SMALL_MODEL_NAME
+      - LLM_BASE_URL
+      - SUMMARIZE_LLM_PROVIDER
+      - SUMMARIZE_LLM_MODEL
+      - SUMMARIZE_LLM_API_KEY
+      - SUMMARIZE_LLM_BASE_URL
+      - SUMMARIZE_LLM_TIMEOUT
+      - BOK_LLM_PROVIDER
+      - BOK_LLM_MODEL
+      - BOK_LLM_API_KEY
+      - BOK_LLM_BASE_URL
+      - BOK_LLM_TIMEOUT
+      - EMBEDDINGS_API_KEY
+      - EMBEDDINGS_ENDPOINT
+      - EMBEDDINGS_MODEL_NAME
+      - LOG_LEVEL=DEBUG
       - VECTOR_DB_HOST=localhost
       - VECTOR_DB_PORT=8765
       - VECTOR_DB_CREDENTIALS
+      - VECTOR_DB_DISTANCE_FN
       - AUTH_ADMIN_EMAIL
       - AUTH_ADMIN_PASSWORD
       - API_ENDPOINT_PRIVATE_GRAPHQL=http://localhost:3000/api/private/non-interactive/graphql
@@ -254,70 +242,44 @@ services:
   virtual_contributor_engine_generic:
     container_name: alkemio_dev_virtual_contributor_engine_generic
     hostname: virtual-contributor-engine-generic
-    image: alkemio/virtual-contributor-engine-generic:v0.7.0
+    image: alkemio/virtual-contributor:v0.1.2
     restart: always
-    volumes:
-      - /dev/shm:/dev/shm
     networks:
       - alkemio_dev_net
     depends_on:
       rabbitmq:
         condition: 'service_healthy'
     environment:
+      - PLUGIN_TYPE=generic
       - RABBITMQ_HOST
       - RABBITMQ_USER
       - RABBITMQ_PASSWORD
       - RABBITMQ_PORT
       - RABBITMQ_QUEUE=virtual-contributor-engine-generic
       - RABBITMQ_EVENT_BUS_EXCHANGE
-      - RABBITMQ_RESULT_QUEUE
       - RABBITMQ_RESULT_ROUTING_KEY
-      - LOCAL_PATH=./
+      - MISTRAL_API_KEY
+      - MISTRAL_BASE_URL
+      - MISTRAL_SMALL_MODEL_NAME
       - LOG_LEVEL=DEBUG
-      - LANGCHAIN_TRACING_V2
-      - LANGCHAIN_ENDPOINT
-      - LANGCHAIN_API_KEY
-      - LANGCHAIN_PROJECT=virtual-contributor-engine-generic
-      - HISTORY_LENGTH=20
-      - AZURE_OPENAI_API_KEY
-      - AZURE_OPENAI_ENDPOINT
-      - OPENAI_API_VERSION
-      - AZURE_MISTRAL_API_KEY
-      - AZURE_MISTRAL_ENDPOINT
-      - VECTOR_DB_PORT
-      - VECTOR_DB_HOST
-      - VECTOR_DB_CREDENTIALS
 
   virtual_contributor_engine_openai_assistant:
     container_name: alkemio_dev_virtual_contributor_engine_openai_assistant
     hostname: virtual-contributor-engine-openai-assistant
-    image: alkemio/virtual-contributor-engine-openai-assistant:v0.4.0
+    image: alkemio/virtual-contributor:v0.1.2
     restart: always
-    volumes:
-      - /dev/shm:/dev/shm
     networks:
       - alkemio_dev_net
     depends_on:
       rabbitmq:
         condition: 'service_healthy'
     environment:
+      - PLUGIN_TYPE=openai-assistant
       - RABBITMQ_HOST
       - RABBITMQ_USER
       - RABBITMQ_PASSWORD
       - RABBITMQ_PORT
       - RABBITMQ_QUEUE=virtual-contributor-engine-openai-assistant
       - RABBITMQ_EVENT_BUS_EXCHANGE
-      - RABBITMQ_RESULT_QUEUE
       - RABBITMQ_RESULT_ROUTING_KEY
-      - AZURE_OPENAI_API_KEY
-      - OPENAI_API_VERSION
-      - AZURE_OPENAI_ENDPOINT
-      - AZURE_MISTRAL_ENDPOINT
-      - AZURE_MISTRAL_API_KEY
-      - AZURE_MISTRAL_DEPLOYMENT_NAME
-      - AZURE_MISTRAL_API_VERSION
-      - LOCAL_PATH=./
       - LOG_LEVEL=DEBUG
-      - VECTOR_DB_PORT
-      - VECTOR_DB_HOST
-      - VECTOR_DB_CREDENTIALS

--- a/overlays/ai-stack.yml
+++ b/overlays/ai-stack.yml
@@ -21,7 +21,7 @@ services:
     container_name: alkemio_dev_chromadb
     hostname: chromadb
     volumes:
-      - chroma-data:/chroma/chroma
+      - chroma-data:/data
     networks:
       - alkemio_dev_net
     ports:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start:services": "docker compose -f quickstart-services.yml --env-file .env.docker up --build --force-recreate -d",
     "start:services:kratos:debug": "docker compose -f quickstart-services.yml -f overlays/kratos-debug.yml --env-file .env.docker up --build --force-recreate -d",
     "start:services:ai": "docker compose -f quickstart-services-ai.yml --env-file .env.docker up --build --force-recreate -d",
+    "start:services:ai:scaleway": "docker compose -f quickstart-services-ai.yml --env-file .env.docker.scaleway up --build --force-recreate -d",
     "start:services:ai:debug": "docker compose -f quickstart-services-ai.yml -f overlays/kratos-debug.yml --env-file .env.docker up --build --force-recreate -d",
     "lint": "tsc --noEmit && biome check src/",
     "lint:prod": "tsc --noEmit && biome ci src/",

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -499,7 +499,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.10
+    image: alkemio/file-service-go:v0.0.13
     depends_on:
       postgres:
         condition: service_healthy

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -499,7 +499,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.13
+    image: alkemio/file-service-go:v0.0.14
     depends_on:
       postgres:
         condition: service_healthy

--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -27,9 +27,19 @@ type Account implements ActorFull {
   """The ID of the Actor"""
   id: UUID!
   """The InnovationHubs for this Account."""
-  innovationHubs: [InnovationHub!]!
+  innovationHubs(
+    """
+    Filter InnovationHubs by SearchVisibility. If not specified, all InnovationHubs are returned.
+    """
+    searchVisibility: [SearchVisibility!]
+  ): [InnovationHub!]!
   """The InnovationPacks for this Account."""
-  innovationPacks: [InnovationPack!]!
+  innovationPacks(
+    """
+    Filter InnovationPacks by SearchVisibility. If not specified, all InnovationPacks are returned.
+    """
+    searchVisibility: [SearchVisibility!]
+  ): [InnovationPack!]!
   """The License operating on this Account."""
   license: License!
   """A name identifier of the Account, unique within the platform."""
@@ -625,6 +635,11 @@ enum ActorType {
   VIRTUAL_CONTRIBUTOR
 }
 
+input AddPollOptionInput {
+  pollID: UUID!
+  text: String!
+}
+
 input AddVisualToMediaGalleryInput {
   """The ID of the media gallery."""
   mediaGalleryID: String!
@@ -713,6 +728,13 @@ input ApplicationEventInput {
 input ApplyForEntryRoleOnRoleSetInput {
   questions: [CreateNVPInput!]!
   roleSetID: UUID!
+}
+
+input AssignConversationMemberInput {
+  """The ID of the conversation to add a member to."""
+  conversationID: UUID!
+  """The ID of the member (user or VC) to add."""
+  memberID: UUID!
 }
 
 input AssignLicensePlanToAccount {
@@ -882,6 +904,7 @@ enum AuthorizationPolicyType {
   ORGANIZATION
   ORGANIZATION_VERIFICATION
   PLATFORM
+  POLL
   POST
   PROFILE
   REFERENCE
@@ -1149,6 +1172,11 @@ type CalloutContributionsCountOutput {
   whiteboard: Float!
 }
 
+enum CalloutDescriptionDisplayMode {
+  COLLAPSED
+  EXPANDED
+}
+
 type CalloutFraming {
   """The authorization rules for the entity"""
   authorization: Authorization
@@ -1162,6 +1190,10 @@ type CalloutFraming {
   mediaGallery: MediaGallery
   """The Memo for framing the associated Callout."""
   memo: Memo
+  """
+  The Poll attached to this Callout Framing, if any. Present when framing.type = POLL.
+  """
+  poll: Poll
   """The Profile for framing the associated Callout."""
   profile: Profile!
   """
@@ -1179,6 +1211,7 @@ enum CalloutFramingType {
   MEDIA_GALLERY
   MEMO
   NONE
+  POLL
   WHITEBOARD
 }
 
@@ -1275,6 +1308,15 @@ type CalloutsSet {
 enum CalloutsSetType {
   COLLABORATION
   KNOWLEDGE_BASE
+}
+
+input CastPollVoteInput {
+  """The ID of the Poll to vote on."""
+  pollID: UUID!
+  """
+  The complete set of selected PollOption IDs. When updating an existing vote, the entire selection set must be provided. Count must be ≥ poll.minResponses and ≤ poll.maxResponses. All IDs must belong to the specified poll.
+  """
+  selectedOptionIDs: [UUID!]!
 }
 
 type Classification {
@@ -1391,11 +1433,6 @@ input CommunicationAdminUpdateRoomStateInput {
   isPublic: Boolean!
   isWorldVisible: Boolean!
   roomID: String!
-}
-
-enum CommunicationConversationType {
-  USER_USER
-  USER_VC
 }
 
 input CommunicationSendMessageToCommunityLeadsInput {
@@ -1578,27 +1615,17 @@ type Conversation {
   createdDate: DateTime!
   """The ID of the entity"""
   id: UUID!
+  """All members of this Conversation, returned as actors with their types."""
+  members: [Actor!]!
   messaging: Messaging!
   """The room for this Conversation."""
-  room: Room
-  """
-  The type of this Conversation (USER_USER or USER_VC), inferred from member agent types.
-  """
-  type: CommunicationConversationType!
+  room: Room!
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
-  """
-  The other user participating in this Conversation (excludes the current user).
-  """
-  user: User
-  """
-  The virtual contributor participating in this Conversation (only for USER_AGENT conversations).
-  """
-  virtualContributor: VirtualContributor
 }
 
 """
-Event fired when a new conversation is created. Each member receives a personalized event with the other participant resolved via conversation.user or conversation.virtualContributor.
+Event fired when a new conversation is created. All members receive the event with the full conversation and its members list.
 """
 type ConversationCreatedEvent {
   """The conversation that was created."""
@@ -1609,14 +1636,38 @@ type ConversationCreatedEvent {
   message: Message
 }
 
+"""
+The type of conversation to create. Maps to room type: DIRECT → DM room, GROUP → group room.
+"""
+enum ConversationCreationType {
+  DIRECT
+  GROUP
+}
+
+"""Event fired when a conversation is deleted. All members are notified."""
+type ConversationDeletedEvent {
+  """
+  The ID of the deleted conversation. UUID only — conversation no longer exists.
+  """
+  conversationID: UUID!
+}
+
 """Payload for conversation subscription events."""
 type ConversationEventSubscriptionResult {
   """Present when eventType is CONVERSATION_CREATED."""
   conversationCreated: ConversationCreatedEvent
+  """Present when eventType is CONVERSATION_DELETED."""
+  conversationDeleted: ConversationDeletedEvent
+  """Present when eventType is CONVERSATION_UPDATED."""
+  conversationUpdated: ConversationUpdatedEvent
   """
   The type of event. Use this to determine which payload field is populated.
   """
   eventType: ConversationEventType!
+  """Present when eventType is MEMBER_ADDED."""
+  memberAdded: ConversationMemberAddedEvent
+  """Present when eventType is MEMBER_REMOVED."""
+  memberRemoved: ConversationMemberRemovedEvent
   """Present when eventType is MESSAGE_RECEIVED."""
   messageReceived: ConversationMessageReceivedEvent
   """Present when eventType is MESSAGE_REMOVED."""
@@ -1628,9 +1679,33 @@ type ConversationEventSubscriptionResult {
 """The type of conversation event."""
 enum ConversationEventType {
   CONVERSATION_CREATED
+  CONVERSATION_DELETED
+  CONVERSATION_UPDATED
+  MEMBER_ADDED
+  MEMBER_REMOVED
   MESSAGE_RECEIVED
   MESSAGE_REMOVED
   READ_RECEIPT_UPDATED
+}
+
+"""Event fired when a member is added to a group conversation."""
+type ConversationMemberAddedEvent {
+  """The actor that was added as a member."""
+  addedMember: Actor!
+  """The conversation the member was added to."""
+  conversation: Conversation!
+}
+
+"""
+Event fired when a member is removed from or leaves a group conversation.
+"""
+type ConversationMemberRemovedEvent {
+  """The conversation the member was removed from."""
+  conversation: Conversation!
+  """
+  The ID of the removed member. UUID only — removed member may not be resolvable after removal.
+  """
+  removedMemberID: UUID!
 }
 
 """Event fired when a new message is received in a conversation."""
@@ -1655,6 +1730,12 @@ type ConversationReadReceiptUpdatedEvent {
   lastReadEventId: MessageID!
   """The room ID where the read receipt was updated."""
   roomId: UUID!
+}
+
+"""Event fired when a conversation is updated (displayName, avatarUrl)."""
+type ConversationUpdatedEvent {
+  """The conversation that was updated."""
+  conversation: Conversation!
 }
 
 input ConversationVcResetInput {
@@ -1771,6 +1852,10 @@ type CreateCalloutData {
 type CreateCalloutFramingData {
   link: CreateLinkData
   memo: CreateMemoData
+  """
+  Poll definition to attach to this Callout Framing. Required when type = POLL. Ignored for all other framing types.
+  """
+  poll: CreatePollData
   profile: CreateProfileData!
   tags: [String!]
   """
@@ -1783,6 +1868,10 @@ type CreateCalloutFramingData {
 input CreateCalloutFramingInput {
   link: CreateLinkInput
   memo: CreateMemoInput
+  """
+  Poll definition to attach to this Callout Framing. Required when type = POLL. Ignored for all other framing types.
+  """
+  poll: CreatePollInput
   profile: CreateProfileInput!
   tags: [String!]
   """
@@ -1940,9 +2029,22 @@ input CreateContributionOnCalloutInput {
 }
 
 input CreateConversationInput {
-  userID: UUID!
-  virtualContributorID: UUID
-  wellKnownVirtualContributor: VirtualContributorWellKnown
+  """
+  Optional avatar URL for GROUP conversations. Ignored for DIRECT conversations. Accepts mxc:// or https:// URLs.
+  """
+  avatarUrl: String
+  """
+  Optional display name for GROUP conversations. Ignored for DIRECT conversations (Synapse uses the other member name automatically).
+  """
+  displayName: String
+  """
+  IDs of members to add. For DIRECT: exactly 1 ID. For GROUP: 1+ IDs. Creator is auto-included.
+  """
+  memberIDs: [UUID!]!
+  """
+  The type of conversation to create: DIRECT for 1-on-1, GROUP for multi-party.
+  """
+  type: ConversationCreationType!
 }
 
 type CreateInnovationFlowData {
@@ -2113,6 +2215,36 @@ input CreateOrganizationInput {
   website: String
 }
 
+type CreatePollData {
+  """
+  Initial options for the poll. Minimum 2 options required. Options appear in the order provided.
+  """
+  options: [String!]!
+  """
+  Poll configuration settings (all immutable after creation). Optional; uses defaults for any unspecified settings.
+  """
+  settings: PollSettingsData
+  """
+  Poll title. Optional. Maximum length 512 characters. Becomes an empty string if not provided.
+  """
+  title: String
+}
+
+input CreatePollInput {
+  """
+  Initial options for the poll. Minimum 2 options required. Options appear in the order provided.
+  """
+  options: [String!]!
+  """
+  Poll configuration settings (all immutable after creation). Optional; uses defaults for any unspecified settings.
+  """
+  settings: PollSettingsInput
+  """
+  Poll title. Optional. Maximum length 512 characters. Becomes an empty string if not provided.
+  """
+  title: String
+}
+
 type CreatePostData {
   tags: [String!]
 }
@@ -2215,10 +2347,19 @@ input CreateSpaceSettingsCollaborationInput {
 input CreateSpaceSettingsInput {
   """"""
   collaboration: CreateSpaceSettingsCollaborationInput
+  """The layout settings for this Space."""
+  layout: CreateSpaceSettingsLayoutInput
   """"""
   membership: CreateSpaceSettingsMembershipInput
   """"""
   privacy: CreateSpaceSettingsPrivacyInput
+  """The sort mode for subspaces: Alphabetical or Custom."""
+  sortMode: SpaceSortMode
+}
+
+input CreateSpaceSettingsLayoutInput {
+  """The default display mode for callout descriptions."""
+  calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode!
 }
 
 input CreateSpaceSettingsMembershipInput {
@@ -2456,6 +2597,7 @@ enum CredentialType {
   ORGANIZATION_OWNER
   SPACE_ADMIN
   SPACE_FEATURE_MEMO_MULTI_USER
+  SPACE_FEATURE_OFFICE_DOCUMENTS
   SPACE_FEATURE_SAVE_AS_TEMPLATE
   SPACE_FEATURE_VIRTUAL_CONTRIBUTORS
   SPACE_FEATURE_WHITEBOARD_MULTI_USER
@@ -2981,6 +3123,19 @@ type InAppNotificationPayloadSpaceCollaborationCalloutPostComment implements InA
   type: NotificationEventPayload!
 }
 
+type InAppNotificationPayloadSpaceCollaborationPoll implements InAppNotificationPayload {
+  """The Callout that contains the poll."""
+  callout: Callout!
+  """The Poll this notification relates to."""
+  poll: Poll!
+  """The ID of the Poll this notification relates to."""
+  pollID: UUID!
+  """Where the callout is located."""
+  space: Space!
+  """The payload type."""
+  type: NotificationEventPayload!
+}
+
 type InAppNotificationPayloadSpaceCommunicationMessageDirect implements InAppNotificationPayload {
   """The message content."""
   message: String!
@@ -3302,6 +3457,11 @@ type LatestReleaseDiscussion {
   nameID: String!
 }
 
+input LeaveConversationInput {
+  """The ID of the conversation to leave."""
+  conversationID: UUID!
+}
+
 type Library {
   """The authorization rules for the entity"""
   authorization: Authorization
@@ -3386,6 +3546,7 @@ enum LicenseEntitlementType {
   ACCOUNT_SPACE_PREMIUM
   ACCOUNT_VIRTUAL_CONTRIBUTOR
   SPACE_FLAG_MEMO_MULTI_USER
+  SPACE_FLAG_OFFICE_DOCUMENTS
   SPACE_FLAG_SAVE_AS_TEMPLATE
   SPACE_FLAG_VIRTUAL_CONTRIBUTOR_ACCESS
   SPACE_FLAG_WHITEBOARD_MULTI_USER
@@ -3467,6 +3628,7 @@ type Licensing {
 enum LicensingCredentialBasedCredentialType {
   ACCOUNT_LICENSE_PLUS
   SPACE_FEATURE_MEMO_MULTI_USER
+  SPACE_FEATURE_OFFICE_DOCUMENTS
   SPACE_FEATURE_SAVE_AS_TEMPLATE
   SPACE_FEATURE_VIRTUAL_CONTRIBUTORS
   SPACE_FEATURE_WHITEBOARD_MULTI_USER
@@ -3716,14 +3878,10 @@ type LookupQueryResults {
 scalar Markdown
 
 type MeConversationsResult {
-  """Conversations between users."""
-  users: [Conversation!]!
   """
-  Get a conversation with a well-known virtual contributor for the current user.
+  All conversations (direct and group) for the current authenticated user. Client handles categorization by room type and member actor types.
   """
-  virtualContributor(wellKnown: VirtualContributorWellKnown!): Conversation
-  """Conversations between users and virtual contributors."""
-  virtualContributors: [Conversation!]!
+  conversations: [Conversation!]!
 }
 
 type MeQueryResults {
@@ -3960,11 +4118,43 @@ input MoveCalloutContributionInput {
   contributionID: UUID!
 }
 
+input MoveSpaceL1ToSpaceL0Input {
+  """
+  Send invitations to former community members who are also in the target L0 community.
+  """
+  autoInvite: Boolean = false
+  """Custom invitation message. Used only when autoInvite is true."""
+  invitationMessage: String
+  """The L1 subspace to move to a different L0 space."""
+  spaceL1ID: UUID!
+  """The target L0 space (must be different from the current parent L0)."""
+  targetSpaceL0ID: UUID!
+}
+
+input MoveSpaceL1ToSpaceL2Input {
+  """
+  Send invitations to former community members who are also in the target L0 community.
+  """
+  autoInvite: Boolean = false
+  """Custom invitation message. Used only when autoInvite is true."""
+  invitationMessage: String
+  """The L1 subspace to move and demote to L2."""
+  spaceL1ID: UUID!
+  """
+  The target L1 subspace in a different L0 (new parent for the demoted space).
+  """
+  targetSpaceL1ID: UUID!
+}
+
 type Mutation {
   """Adds an Iframe Allowed URL to the Platform Settings"""
   addIframeAllowedURL(whitelistedURL: String!): [String!]!
   """Adds a full email address to the platform notification blacklist"""
   addNotificationEmailToBlacklist(input: NotificationEmailAddressInput!): [String!]!
+  """
+  Add a new option to a Poll. Requires UPDATE privilege, or CONTRIBUTE privilege when the poll setting allowContributorsAddOptions is enabled. The new option is appended with the next available sort order.
+  """
+  addPollOption(optionData: AddPollOptionInput!): Poll!
   """Add a reaction to a message from the specified Room."""
   addReactionToMessageInRoom(reactionData: RoomAddReactionToMessageInput!): Reaction!
   """Adds a new visual to the specified media gallery."""
@@ -3977,6 +4167,10 @@ type Mutation {
   adminCommunicationMigrateOrphanedConversations: CommunicationAdminMigrateRoomsResult!
   """Remove an orphaned room from messaging platform."""
   adminCommunicationRemoveOrphanedRoom(orphanedRoomData: CommunicationAdminRemoveOrphanedRoomInput!): Boolean!
+  """
+  Synchronize all Alkemio spaces into the Matrix space hierarchy. Idempotent — safe to call multiple times.
+  """
+  adminCommunicationSyncSpaceHierarchy: Boolean!
   """Allow updating the state flags of a particular rule."""
   adminCommunicationUpdateRoomState(roomStateData: CommunicationAdminUpdateRoomStateInput!): Boolean!
   """Delete a Kratos identity by ID."""
@@ -4019,6 +4213,10 @@ type Mutation {
   aiServerUpdateAiPersona(aiPersonaData: UpdateAiPersonaInput!): AiPersona!
   """Apply to join the specified RoleSet in the entry Role."""
   applyForEntryRoleOnRoleSet(applicationData: ApplyForEntryRoleOnRoleSetInput!): Application!
+  """
+  Assign a member to a group conversation. Returns true when the RPC is sent. Actual membership change arrives via MEMBER_ADDED subscription event.
+  """
+  assignConversationMember(memberData: AssignConversationMemberInput!): Boolean!
   """Assign the specified LicensePlan to an Account."""
   assignLicensePlanToAccount(planData: AssignLicensePlanToAccount!): Account!
   """Assign the specified LicensePlan to a Space."""
@@ -4051,6 +4249,10 @@ type Mutation {
   authorizationPolicyResetOnUser(authorizationResetData: UserAuthorizationResetInput!): User!
   """Reset the specified Authorization Policy to global admin privileges"""
   authorizationPolicyResetToGlobalAdminsAccess(authorizationID: String!): Authorization!
+  """
+  Cast or update a vote on a Poll. Requires CONTRIBUTE privilege on the Poll (space member). If the calling user has already voted, their vote is REPLACED ENTIRELY with the new selection set.
+  """
+  castPollVote(voteData: CastPollVoteInput!): Poll!
   """Deletes collections nameID-..."""
   cleanupCollections: MigrateEmbeddings!
   """Move an L1 Space up in the hierarchy, to be a L0 Space."""
@@ -4069,7 +4271,9 @@ type Mutation {
   createCalloutOnCalloutsSet(calloutData: CreateCalloutOnCalloutsSetInput!): Callout!
   """Create a new Contribution on the Callout."""
   createContributionOnCallout(contributionData: CreateContributionOnCalloutInput!): CalloutContribution!
-  """Create a new Conversation on the Messaging."""
+  """
+  Create a new Conversation. Use type DIRECT for 1-on-1, GROUP for multi-party.
+  """
   createConversation(conversationData: CreateConversationInput!): Conversation!
   """Creates a new Discussion as part of this Forum."""
   createDiscussion(createData: ForumCreateDiscussionInput!): Discussion!
@@ -4122,7 +4326,7 @@ type Mutation {
   """Deletes a contribution."""
   deleteContribution(deleteData: DeleteContributionInput!): CalloutContribution!
   """
-  Deletes a Conversation. The Matrix room is only deleted if no reciprocal conversation exists.
+  Deletes a Conversation. All members are notified via CONVERSATION_DELETED event.
   """
   deleteConversation(deleteData: DeleteConversationInput!): Conversation!
   """Deletes the specified Discussion."""
@@ -4167,6 +4371,10 @@ type Mutation {
   deleteVisualFromMediaGallery(deleteData: DeleteVisualFromMediaGalleryInput!): Visual!
   """Deletes the specified Whiteboard."""
   deleteWhiteboard(whiteboardData: DeleteWhiteboardInput!): Whiteboard!
+  """
+  Re-enable a previously disabled push notification subscription for the current user.
+  """
+  enablePushSubscription(subscriptionData: UnsubscribeFromPushNotificationsInput!): PushSubscription!
   """Trigger an event on the Application."""
   eventOnApplication(eventData: ApplicationEventInput!): Application!
   """Trigger an event on the Invitation."""
@@ -4187,6 +4395,10 @@ type Mutation {
   Join the specified RoleSet using the entry Role, without going through an approval process.
   """
   joinRoleSet(joinData: JoinAsEntryRoleOnRoleSetInput!): RoleSet!
+  """
+  Leave a group conversation. Returns true when the RPC is sent. Actual membership change arrives via MEMBER_REMOVED subscription event. If the last member leaves, the conversation is auto-deleted and a CONVERSATION_DELETED event follows.
+  """
+  leaveConversation(leaveData: LeaveConversationInput!): Boolean!
   """Reset the License with Entitlements on the specified Account."""
   licenseResetOnAccount(resetData: AccountLicenseResetInput!): Account!
   """Marks a message as read for the current user."""
@@ -4201,6 +4413,14 @@ type Mutation {
   markNotificationsAsUnread(filter: NotificationEventsFilterInput): Boolean!
   """Moves the specified Contribution to another Callout."""
   moveContributionToCallout(moveContributionData: MoveCalloutContributionInput!): CalloutContribution!
+  """
+  Move an L1 subspace to a different L0 space. The subspace remains at level 1       but changes parent. All content moves with it. All community memberships are cleared.       Requires platform admin privileges.
+  """
+  moveSpaceL1ToSpaceL0(moveData: MoveSpaceL1ToSpaceL0Input!): Space!
+  """
+  Move an L1 subspace to become an L2 sub-subspace under a target L1 in a different L0 space.       The space is demoted from level 1 to level 2. All community roles are cleared.       Requires platform admin privileges.
+  """
+  moveSpaceL1ToSpaceL2(moveData: MoveSpaceL1ToSpaceL2Input!): Space!
   """Refresh the Bodies of Knowledge on All VCs"""
   refreshAllBodiesOfKnowledge: Boolean!
   """
@@ -4209,6 +4429,10 @@ type Mutation {
   refreshVirtualContributorBodyOfKnowledge(refreshData: RefreshVirtualContributorBodyOfKnowledgeInput!): Boolean!
   """Empties the CommunityGuidelines."""
   removeCommunityGuidelinesContent(communityGuidelinesData: RemoveCommunityGuidelinesContentInput!): CommunityGuidelines!
+  """
+  Remove a member from a group conversation. Returns true when the RPC is sent. Actual membership change arrives via MEMBER_REMOVED subscription event.
+  """
+  removeConversationMember(memberData: RemoveConversationMemberInput!): Boolean!
   """Remove the default callout template from an InnovationFlowState."""
   removeDefaultCalloutTemplateOnInnovationFlowState(removeData: RemoveDefaultCalloutTemplateOnInnovationFlowStateInput!): InnovationFlowState!
   """Removes an Iframe Allowed URL from the Platform Settings"""
@@ -4219,6 +4443,14 @@ type Mutation {
   removeNotificationEmailFromBlacklist(input: NotificationEmailAddressInput!): [String!]!
   """Removes a User from a Role on the Platform."""
   removePlatformRoleFromUser(roleData: RemovePlatformRoleInput!): User!
+  """
+  Remove an option from a Poll. Requires UPDATE privilege. Poll must retain at least 2 options. Votes that selected this option are deleted and affected voters are notified.
+  """
+  removePollOption(optionData: RemovePollOptionInput!): Poll!
+  """
+  Remove the current user vote from a Poll. Requires CONTRIBUTE privilege on the Poll. If the user has not voted, returns a validation error.
+  """
+  removePollVote(voteData: RemovePollVoteInput!): Poll!
   """Remove a reaction on a message from the specified Room."""
   removeReactionToMessageInRoom(reactionData: RoomRemoveReactionToMessageInput!): Boolean!
   """
@@ -4233,6 +4465,10 @@ type Mutation {
   removeRoleFromVirtualContributor(roleData: RemoveRoleOnRoleSetInput!): VirtualContributor!
   """Removes the specified User from specified user group"""
   removeUserFromGroup(membershipData: RemoveUserGroupMemberInput!): UserGroup!
+  """
+  Reorder Poll options. Requires UPDATE privilege. The provided list must contain exactly the same option IDs as the current poll options.
+  """
+  reorderPollOptions(optionData: ReorderPollOptionsInput!): Poll!
   """Resets the interaction with the VC by recreating the room."""
   resetConversationVc(input: ConversationVcResetInput!): Conversation!
   """Reset all license plans on Accounts"""
@@ -4264,6 +4500,10 @@ type Mutation {
   """
   setPlatformWellKnownVirtualContributor(mappingData: SetPlatformWellKnownVirtualContributorInput!): PlatformWellKnownVirtualContributors!
   """
+  Subscribe the current user's device to push notifications. If the subscription endpoint already exists, it is updated. If the user has reached the maximum number of subscriptions (10), the oldest subscription is automatically replaced.
+  """
+  subscribeToPushNotifications(subscriptionData: SubscribeToPushNotificationsInput!): PushSubscription!
+  """
   Transfer the specified Callout from its current CalloutsSet to the target CalloutsSet. Note: this is experimental, and only for GlobalAdmins. The user that executes the transfer becomes the creator of the Callout.
   """
   transferCallout(transferData: TransferCalloutInput!): Callout!
@@ -4275,6 +4515,10 @@ type Mutation {
   transferSpaceToAccount(transferData: TransferAccountSpaceInput!): Space!
   """Transfer the specified Virtual Contributor to another Account."""
   transferVirtualContributorToAccount(transferData: TransferAccountVirtualContributorInput!): InnovationPack!
+  """
+  Disable a push notification subscription for the current user. The subscription is retained but will not receive notifications until re-enabled.
+  """
+  unsubscribeFromPushNotifications(subscriptionData: UnsubscribeFromPushNotificationsInput!): PushSubscription!
   """Update the Application Form used by this RoleSet."""
   updateApplicationFormOnRoleSet(applicationFormData: UpdateApplicationFormOnRoleSetInput!): RoleSet!
   """Update the baseline License Plan on the specified Account."""
@@ -4303,6 +4547,10 @@ type Mutation {
   updateCommunityGuidelines(communityGuidelinesData: UpdateCommunityGuidelinesEntityInput!): CommunityGuidelines!
   """Update the sortOrder field of the Contributions of s Callout."""
   updateContributionsSortOrder(sortOrderData: UpdateContributionCalloutsSortOrderInput!): [CalloutContribution!]!
+  """
+  Update a group conversation (display name, avatar). Returns true when the RPC is sent. Actual changes arrive via CONVERSATION_UPDATED subscription events. When both fields are provided, clients may receive separate update events for each.
+  """
+  updateConversation(updateData: UpdateConversationInput!): Boolean!
   """Updates the specified Discussion."""
   updateDiscussion(updateData: UpdateDiscussionInput!): Discussion!
   """Updates the specified Document."""
@@ -4337,6 +4585,14 @@ type Mutation {
   updateOrganizationSettings(settingsData: UpdateOrganizationSettingsInput!): Organization!
   """Updates one of the Setting on the Platform"""
   updatePlatformSettings(settingsData: UpdatePlatformSettingsInput!): PlatformSettings!
+  """
+  Update the text of an existing Poll option. Requires UPDATE privilege. Votes that selected this option are deleted and affected voters are notified.
+  """
+  updatePollOption(optionData: UpdatePollOptionInput!): Poll!
+  """
+  Change the status of a Poll (OPEN ↔ CLOSED). Requires UPDATE privilege on the parent Callout. When a poll is CLOSED, all state-mutating operations are rejected. Idempotent: setting to current status succeeds without error.
+  """
+  updatePollStatus(statusData: UpdatePollStatusInput!): Poll!
   """Updates the specified Post."""
   updatePost(postData: UpdatePostInput!): Post!
   """Updates the specified Profile."""
@@ -4349,6 +4605,10 @@ type Mutation {
   updateSpacePlatformSettings(updateData: UpdateSpacePlatformSettingsInput!): Space!
   """Updates one of the Setting on a Space"""
   updateSpaceSettings(settingsData: UpdateSpaceSettingsInput!): Space!
+  """
+  Updates the pinned state of a Subspace within the specified Space. Returns the updated Subspace.
+  """
+  updateSubspacePinned(pinnedData: UpdateSubspacePinnedInput!): Space!
   """
   Update the sortOrder field of the supplied Subspaces to increase as per the order that they are provided in.
   """
@@ -4453,6 +4713,10 @@ enum NotificationEvent {
   SPACE_COLLABORATION_CALLOUT_CONTRIBUTION
   SPACE_COLLABORATION_CALLOUT_POST_CONTRIBUTION_COMMENT
   SPACE_COLLABORATION_CALLOUT_PUBLISHED
+  SPACE_COLLABORATION_POLL_MODIFIED_ON_POLL_I_VOTED_ON
+  SPACE_COLLABORATION_POLL_VOTE_AFFECTED_BY_OPTION_CHANGE
+  SPACE_COLLABORATION_POLL_VOTE_CAST_ON_OWN_POLL
+  SPACE_COLLABORATION_POLL_VOTE_CAST_ON_POLL_I_VOTED_ON
   SPACE_COMMUNICATION_UPDATE
   SPACE_COMMUNITY_CALENDAR_EVENT_COMMENT
   SPACE_COMMUNITY_CALENDAR_EVENT_CREATED
@@ -4494,6 +4758,7 @@ enum NotificationEventPayload {
   SPACE_COLLABORATION_CALLOUT
   SPACE_COLLABORATION_CALLOUT_COMMENT
   SPACE_COLLABORATION_CALLOUT_POST_COMMENT
+  SPACE_COLLABORATION_POLL
   SPACE_COMMUNICATION_MESSAGE_DIRECT
   SPACE_COMMUNICATION_UPDATE
   SPACE_COMMUNITY_ACTOR
@@ -4518,6 +4783,8 @@ type NotificationRecipientResult {
   emailRecipients: [User!]!
   """The in-app recipients for the notification."""
   inAppRecipients: [User!]!
+  """The push recipients for the notification."""
+  pushRecipients: [User!]!
   """The user that triggered the event."""
   triggeredBy: User
 }
@@ -4544,6 +4811,8 @@ input NotificationSettingInput {
   email: Boolean
   """Enable in-app notifications for this setting"""
   inApp: Boolean
+  """Enable push notifications for this setting"""
+  push: Boolean
 }
 
 enum OpenAIModel {
@@ -4807,6 +5076,10 @@ type PlatformAdminIdentityQueryResults {
 }
 
 type PlatformAdminQueryResults {
+  """
+  Retrieve all Accounts on the Platform. This is only available to Platform Admins.
+  """
+  accounts: [Account!]!
   """Lookup Communication related information."""
   communication: PlatformAdminCommunicationQueryResults!
   """Lookup Identity related information."""
@@ -5009,6 +5282,187 @@ type PlatformWellKnownVirtualContributors {
   mappings: [PlatformWellKnownVirtualContributorMapping!]!
 }
 
+type Poll {
+  """The authorization rules for the entity"""
+  authorization: Authorization
+  """
+  Whether the current user can see detailed results (visibility gate passed).
+  """
+  canSeeDetailedResults: Boolean!
+  """The date at which the entity was created."""
+  createdDate: DateTime!
+  """
+  [Future] Date/time after which the poll automatically closes. Always null in this iteration.
+  """
+  deadline: DateTime
+  """The ID of the entity"""
+  id: UUID!
+  """
+  The current user's vote on this poll, or null if the current user has not voted.
+  """
+  myVote: PollVote
+  """
+  The selectable options for this poll, always ordered by sortOrder ascending.
+  """
+  options: [PollOption!]!
+  """Configuration settings for this poll (immutable after creation)."""
+  settings: PollSettings!
+  """
+  Current lifecycle status of this poll. Always OPEN in this iteration; CLOSED reserved for future use.
+  """
+  status: PollStatus!
+  """Poll title."""
+  title: String!
+  """
+  Total number of votes cast on this poll. Null when resultsVisibility = HIDDEN and the current user has not voted.
+  """
+  totalVotes: Int
+  """The date at which the entity was last updated."""
+  updatedDate: DateTime!
+}
+
+"""The type of event that occurred on a poll."""
+enum PollEventType {
+  POLL_OPTIONS_CHANGED
+  POLL_STATUS_CHANGED
+  POLL_VOTE_UPDATED
+}
+
+type PollOption {
+  createdDate: DateTime!
+  id: UUID!
+  """
+  Position of this option in the creation order (used for tie-breaking in results).
+  """
+  sortOrder: Int!
+  text: String!
+  updatedDate: DateTime!
+  """
+  Number of votes this option has received. Null when results are hidden or resultsDetail = PERCENTAGE.
+  """
+  voteCount: Int
+  """
+  Percentage of total votes this option has received (0–100). Null when results are hidden or resultsDetail = COUNT. Null when totalVotes = 0.
+  """
+  votePercentage: Float
+  """
+  List of space members who voted for this option. Null when results are hidden or resultsDetail is not FULL.
+  """
+  voters: [User!]
+}
+
+type PollOptionsChangedSubscriptionResult {
+  """
+  The updated Poll. Fields are filtered per subscriber's visibility context.
+  """
+  poll: Poll!
+  """The type of poll event."""
+  pollEventType: PollEventType!
+}
+
+"""Controls the level of detail shown in poll results."""
+enum PollResultsDetail {
+  """Vote count per option; no voter identities."""
+  COUNT
+  """Counts and voter list per option — fully transparent (default)."""
+  FULL
+  """Only percentage per option; no vote counts or voter identities."""
+  PERCENTAGE
+}
+
+"""Controls when poll results become visible to voters."""
+enum PollResultsVisibility {
+  """Results hidden until the viewer has cast their own vote."""
+  HIDDEN
+  """
+  Only the total vote count is shown before voting; details (depending on PollResultsDetail) become available after voting.
+  """
+  TOTAL_ONLY
+  """
+  Full results always visible regardless of whether the viewer has voted (default).
+  """
+  VISIBLE
+}
+
+type PollSettings {
+  """
+  Whether users with CONTRIBUTE privilege can add new options to the poll. Immutable after poll creation. Default: false.
+  """
+  allowContributorsAddOptions: Boolean!
+  """
+  Maximum number of options a voter may select (0 = unlimited). Immutable after poll creation.
+  """
+  maxResponses: Int!
+  """
+  Minimum number of options a voter must select (≥ 1). Immutable after poll creation.
+  """
+  minResponses: Int!
+  """
+  Controls how much detail is shown in results. Immutable after poll creation.
+  """
+  resultsDetail: PollResultsDetail!
+  """
+  Controls when results become visible to voters. Immutable after poll creation.
+  """
+  resultsVisibility: PollResultsVisibility!
+}
+
+type PollSettingsData {
+  """Whether voters can add new options to the poll. Defaults to false."""
+  allowContributorsAddOptions: Boolean
+  """Maximum selections allowed. Defaults to 1. Set to 0 for unlimited."""
+  maxResponses: Int
+  """Minimum selections required. Defaults to 1."""
+  minResponses: Int
+  """How much detail is shown. Defaults to FULL."""
+  resultsDetail: PollResultsDetail
+  """When results become visible. Defaults to VISIBLE."""
+  resultsVisibility: PollResultsVisibility
+}
+
+input PollSettingsInput {
+  """Whether voters can add new options to the poll. Defaults to false."""
+  allowContributorsAddOptions: Boolean
+  """Maximum selections allowed. Defaults to 1. Set to 0 for unlimited."""
+  maxResponses: Int
+  """Minimum selections required. Defaults to 1."""
+  minResponses: Int
+  """How much detail is shown. Defaults to FULL."""
+  resultsDetail: PollResultsDetail
+  """When results become visible. Defaults to VISIBLE."""
+  resultsVisibility: PollResultsVisibility
+}
+
+"""
+Lifecycle status of a Poll. OPEN allows voting and option management; CLOSED prevents all state-mutating operations.
+"""
+enum PollStatus {
+  CLOSED
+  OPEN
+}
+
+type PollVote {
+  """ID of the user who cast this vote."""
+  createdBy: UUID!
+  """The date at which the entity was created."""
+  createdDate: DateTime!
+  """The ID of the entity"""
+  id: UUID!
+  """The options selected in this vote."""
+  selectedOptions: [PollOption!]!
+  """The date at which the entity was last updated."""
+  updatedDate: DateTime!
+}
+
+type PollVoteUpdatedSubscriptionResult {
+  """
+  The updated Poll. Fields are filtered per subscriber's visibility context.
+  """
+  poll: Poll!
+  """The type of poll event."""
+  pollEventType: PollEventType!
+}
+
 type Post {
   """The authorization rules for the entity"""
   authorization: Authorization
@@ -5202,11 +5656,32 @@ type PruneInAppNotificationAdminResult {
   removedCountOutsideRetentionPeriod: Int!
 }
 
+"""
+Represents a user's push notification subscription for a specific device/browser.
+"""
+type PushSubscription {
+  """When this subscription was created."""
+  createdDate: DateTime!
+  """Unique identifier for this subscription."""
+  id: UUID!
+  """
+  Last time a notification was successfully delivered to this subscription.
+  """
+  lastActiveDate: DateTime
+  """Current status of the subscription."""
+  status: PushSubscriptionStatus!
+  """Browser/device user agent string for display purposes."""
+  userAgent: String
+}
+
+"""Status of a push notification subscription."""
+enum PushSubscriptionStatus {
+  ACTIVE
+  DISABLED
+  EXPIRED
+}
+
 type Query {
-  """
-  The Accounts on this platform; If accessed through an Innovation Hub will return ONLY the Accounts defined in it.
-  """
-  accounts: [Account!]!
   """Activity events related to the current user."""
   activityFeed(
     """A pivot cursor after which items are selected"""
@@ -5245,6 +5720,10 @@ type Query {
   lookupByName: LookupByNameQueryResults!
   """Information about the current authenticated user"""
   me: MeQueryResults!
+  """
+  Returns the current user's push notification subscriptions (active and disabled). Requires authentication.
+  """
+  myPushSubscriptions: [PushSubscription!]!
   """The notificationRecipients for the provided event on the given entity."""
   notificationRecipients(eventData: NotificationRecipientsInput!): NotificationRecipientResult!
   """A particular Organization"""
@@ -5346,6 +5825,10 @@ type Query {
   ): PaginatedUsers!
   """All Users that hold credentials matching the supplied criteria."""
   usersWithAuthorizationCredential(credentialsCriteriaData: UsersWithAuthorizationCredentialInput!): [User!]!
+  """
+  Returns the VAPID public key needed by clients to subscribe to push notifications. Returns null if push notifications are not enabled on this server.
+  """
+  vapidPublicKey: String
   """A particular VirtualContributor"""
   virtualContributor(ID: UUID!): VirtualContributor!
   """
@@ -5429,6 +5912,8 @@ type RelayPaginatedSpace implements ActorFull {
   credentials: [Credential!]
   """The ID of the Actor"""
   id: UUID!
+  """The layout settings for this Space. Accessible without READ privilege."""
+  layout: SpaceSettingsLayout!
   """
   The level of this Space, representing the number of Spaces above this one.
   """
@@ -5439,12 +5924,18 @@ type RelayPaginatedSpace implements ActorFull {
   license: License!
   """A name identifier of the entity, unique within a given scope."""
   nameID: NameID!
+  """Whether this Space is pinned in its parent Space."""
+  pinned: Boolean!
   """The calculated platform access for this Space."""
   platformAccess: PlatformRolesAccess!
   """The profile for this Actor."""
   profile: Profile
   """The settings for this Space."""
   settings: SpaceSettings!
+  """
+  The sort mode for subspaces of this Space: Alphabetical or Custom. Accessible without READ privilege.
+  """
+  sortMode: SpaceSortMode!
   """The sorting order for this Space within its parent."""
   sortOrder: Int!
   """The StorageAggregator in use by this Space"""
@@ -5494,6 +5985,13 @@ input RemoveCommunityGuidelinesContentInput {
   communityGuidelinesID: UUID!
 }
 
+input RemoveConversationMemberInput {
+  """The ID of the conversation to remove a member from."""
+  conversationID: UUID!
+  """The ID of the member (user or VC) to remove."""
+  memberID: UUID!
+}
+
 input RemoveDefaultCalloutTemplateOnInnovationFlowStateInput {
   flowStateID: UUID!
 }
@@ -5501,6 +5999,16 @@ input RemoveDefaultCalloutTemplateOnInnovationFlowStateInput {
 input RemovePlatformRoleInput {
   actorID: UUID!
   role: RoleName!
+}
+
+input RemovePollOptionInput {
+  optionID: UUID!
+  pollID: UUID!
+}
+
+input RemovePollVoteInput {
+  """The ID of the Poll from which to remove the current user vote."""
+  pollID: UUID!
 }
 
 input RemoveRoleOnRoleSetInput {
@@ -5512,6 +6020,11 @@ input RemoveRoleOnRoleSetInput {
 input RemoveUserGroupMemberInput {
   groupID: UUID!
   userID: UUID!
+}
+
+input ReorderPollOptionsInput {
+  optionIDs: [UUID!]!
+  pollID: UUID!
 }
 
 input RevokeAuthorizationCredentialInput {
@@ -5809,6 +6322,8 @@ type RolesResultSpace {
 type Room {
   """The authorization rules for the entity"""
   authorization: Authorization
+  """The avatar URL of the Room (mxc:// or https://). Fetched from Matrix."""
+  avatarUrl: String
   """The date at which the entity was created."""
   createdDate: DateTime!
   """The display name of the Room."""
@@ -5821,6 +6336,10 @@ type Room {
   messages: [Message!]!
   """The number of messages in the Room."""
   messagesCount: Int!
+  """
+  The type of room (e.g., post, callout, conversation_direct, conversation_group).
+  """
+  type: RoomType!
   """
   Simple unread message count for the current user. Use unreadCounts for per-thread breakdown.
   """
@@ -5922,6 +6441,18 @@ type RoomThreadUnreadCount {
   count: Int!
   """The thread ID."""
   threadId: MessageID!
+}
+
+"""The type of room."""
+enum RoomType {
+  CALENDAR_EVENT
+  CALLOUT
+  CONVERSATION
+  CONVERSATION_DIRECT
+  CONVERSATION_GROUP
+  DISCUSSION_FORUM
+  POST
+  UPDATES
 }
 
 """Unread message counts for a Room."""
@@ -6183,6 +6714,8 @@ type Space implements ActorFull {
   credentials: [Credential!]
   """The ID of the Actor"""
   id: UUID!
+  """The layout settings for this Space. Accessible without READ privilege."""
+  layout: SpaceSettingsLayout!
   """
   The level of this Space, representing the number of Spaces above this one.
   """
@@ -6193,12 +6726,18 @@ type Space implements ActorFull {
   license: License!
   """A name identifier of the entity, unique within a given scope."""
   nameID: NameID!
+  """Whether this Space is pinned in its parent Space."""
+  pinned: Boolean!
   """The calculated platform access for this Space."""
   platformAccess: PlatformRolesAccess!
   """The profile for this Actor."""
   profile: Profile
   """The settings for this Space."""
   settings: SpaceSettings!
+  """
+  The sort mode for subspaces of this Space: Alphabetical or Custom. Accessible without READ privilege.
+  """
+  sortMode: SpaceSortMode!
   """The sorting order for this Space within its parent."""
   sortOrder: Int!
   """The StorageAggregator in use by this Space"""
@@ -6304,10 +6843,14 @@ enum SpacePrivacyMode {
 type SpaceSettings {
   """The collaboration settings for this Space."""
   collaboration: SpaceSettingsCollaboration!
+  """The layout settings for this Space."""
+  layout: SpaceSettingsLayout!
   """The membership settings for this Space."""
   membership: SpaceSettingsMembership!
   """The privacy settings for this Space"""
   privacy: SpaceSettingsPrivacy!
+  """The sort mode for subspaces of this Space: Alphabetical or Custom."""
+  sortMode: SpaceSortMode!
 }
 
 type SpaceSettingsCollaboration {
@@ -6329,6 +6872,11 @@ type SpaceSettingsCollaboration {
   inheritMembershipRights: Boolean!
 }
 
+type SpaceSettingsLayout {
+  """The default display mode for callout descriptions in this Space."""
+  calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode!
+}
+
 type SpaceSettingsMembership {
   """Allow subspace admins to invite to this Space."""
   allowSubspaceAdminsToInviteMembers: Boolean!
@@ -6343,6 +6891,11 @@ type SpaceSettingsPrivacy {
   allowPlatformSupportAsAdmin: Boolean!
   """The privacy mode for this Space"""
   mode: SpacePrivacyMode!
+}
+
+enum SpaceSortMode {
+  ALPHABETICAL
+  CUSTOM
 }
 
 type SpaceSubscription {
@@ -6478,6 +7031,21 @@ type StorageConfig {
   file: FileStorageConfig!
 }
 
+input SubscribeToPushNotificationsInput {
+  """The auth key from PushSubscription.getKey('auth'), Base64URL-encoded"""
+  auth: String!
+  """The push service endpoint URL from PushSubscription.endpoint"""
+  endpoint: String!
+  """
+  The p256dh key from PushSubscription.getKey('p256dh'), Base64URL-encoded
+  """
+  p256dh: String!
+  """
+  Optional browser/device user agent for display in subscription management UI
+  """
+  userAgent: String
+}
+
 type Subscription {
   activityCreated(input: ActivityCreatedSubscriptionInput!): ActivityCreatedSubscriptionResult!
   """
@@ -6488,7 +7056,7 @@ type Subscription {
     calloutID: UUID!
   ): CalloutPostCreated!
   """
-  Receive conversation events for the authenticated user. Includes new conversations, messages, and read receipts.
+  Receive conversation events for the authenticated user. Includes conversation lifecycle (created, updated, deleted), messages (received, removed), membership changes (member added, removed), and read receipts.
   """
   conversationEvents: ConversationEventSubscriptionResult!
   """Receive updates on Discussions"""
@@ -6502,6 +7070,20 @@ type Subscription {
   Counter of unread in-app notifications for the currently authenticated user.
   """
   notificationsUnreadCount: Int!
+  """
+  Subscribe to option changes on a specific Poll. Fires when options are added, removed, updated, or reordered. Always delivered regardless of resultsVisibility.
+  """
+  pollOptionsChanged(
+    """The ID of the Poll to subscribe to."""
+    pollID: UUID!
+  ): PollOptionsChangedSubscriptionResult!
+  """
+  Subscribe to vote updates on a specific Poll. Fires when votes are cast or updated. When resultsVisibility = HIDDEN and the subscriber has not voted, events are suppressed.
+  """
+  pollVoteUpdated(
+    """The ID of the Poll to subscribe to."""
+    pollID: UUID!
+  ): PollVoteUpdatedSubscriptionResult!
   """Receive Room event"""
   roomEvents(
     """The Room to receive the events from."""
@@ -6802,6 +7384,11 @@ input TransferCalloutInput {
 """A uuid identifier. Length 36 characters."""
 scalar UUID
 
+input UnsubscribeFromPushNotificationsInput {
+  """The ID of the push subscription to remove."""
+  subscriptionID: UUID!
+}
+
 input UpdateAiPersonaInput {
   ID: UUID!
   engine: AiPersonaEngine
@@ -6884,6 +7471,10 @@ input UpdateCalloutFramingInput {
   link: UpdateLinkInput
   """The new markdown content for the Memo."""
   memoContent: Markdown
+  """
+  Updates for the Poll attached to this Framing. Only applies when type = POLL.
+  """
+  poll: UpdatePollInput
   """The Profile of the Template."""
   profile: UpdateProfileInput
   """The type of additional content attached to the framing of the callout."""
@@ -6979,6 +7570,19 @@ input UpdateContributionCalloutsSortOrderInput {
   contributionIDs: [UUID!]!
 }
 
+input UpdateConversationInput {
+  """
+  Avatar URL for the conversation. Accepts mxc:// or https:// URLs. Pass empty string to remove.
+  """
+  avatarUrl: String
+  """The ID of the conversation to update."""
+  conversationID: UUID!
+  """
+  New display name for the conversation. Only GROUP conversations support custom names.
+  """
+  displayName: String
+}
+
 input UpdateDiscussionInput {
   ID: UUID!
   """The category for the Discussion"""
@@ -6993,8 +7597,10 @@ input UpdateDiscussionInput {
 
 input UpdateDocumentInput {
   ID: UUID!
-  """The display name for the Document."""
-  displayName: String!
+  """
+  The display name for the Document. Not supported — rejected with a ValidationException if provided.
+  """
+  displayName: String
   tagset: UpdateTagsetInput
 }
 
@@ -7222,6 +7828,26 @@ input UpdatePlatformSettingsIntegrationInput {
   notificationEmailBlacklist: [String!]
 }
 
+input UpdatePollInput {
+  """
+  Updated title for the Poll (max 512 chars). This is the only mutable property once a poll is created; options are managed via separate mutations.
+  """
+  title: String
+}
+
+input UpdatePollOptionInput {
+  optionID: UUID!
+  pollID: UUID!
+  text: String!
+}
+
+input UpdatePollStatusInput {
+  """The ID of the Poll to update."""
+  pollID: UUID!
+  """The new status for the poll."""
+  status: PollStatus!
+}
+
 input UpdatePostInput {
   ID: UUID!
   """
@@ -7306,10 +7932,14 @@ input UpdateSpaceSettingsCollaborationInput {
 input UpdateSpaceSettingsEntityInput {
   """"""
   collaboration: UpdateSpaceSettingsCollaborationInput
+  """The layout settings for this Space."""
+  layout: UpdateSpaceSettingsLayoutInput
   """"""
   membership: UpdateSpaceSettingsMembershipInput
   """"""
   privacy: UpdateSpaceSettingsPrivacyInput
+  """The sort mode for subspaces: Alphabetical or Custom."""
+  sortMode: SpaceSortMode
 }
 
 input UpdateSpaceSettingsInput {
@@ -7317,6 +7947,11 @@ input UpdateSpaceSettingsInput {
   settings: UpdateSpaceSettingsEntityInput!
   """The identifier for the Space whose settings are to be updated."""
   spaceID: String!
+}
+
+input UpdateSpaceSettingsLayoutInput {
+  """The default display mode for callout descriptions."""
+  calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode!
 }
 
 input UpdateSpaceSettingsMembershipInput {
@@ -7333,6 +7968,15 @@ input UpdateSpaceSettingsPrivacyInput {
   allowPlatformSupportAsAdmin: Boolean
   """"""
   mode: SpacePrivacyMode
+}
+
+input UpdateSubspacePinnedInput {
+  """Whether the subspace should be pinned (true) or unpinned (false)."""
+  pinned: Boolean!
+  """The ID of the parent Space containing the subspace."""
+  spaceID: UUID!
+  """The ID of the subspace to pin or unpin."""
+  subspaceID: UUID!
 }
 
 input UpdateSubspacesSortOrderInput {
@@ -7514,6 +8158,18 @@ input UpdateUserSettingsNotificationSpaceInput {
   collaborationCalloutPostContributionComment: NotificationSettingInput
   """Receive a notification when a callout is published"""
   collaborationCalloutPublished: NotificationSettingInput
+  """Receive a notification when a poll you voted on is modified"""
+  collaborationPollModifiedOnPollIVotedOn: NotificationSettingInput
+  """
+  Receive a notification when a poll option you voted for is changed or removed
+  """
+  collaborationPollVoteAffectedByOptionChange: NotificationSettingInput
+  """Receive a notification when a vote is cast on a poll you created"""
+  collaborationPollVoteCastOnOwnPoll: NotificationSettingInput
+  """
+  Receive a notification when another user votes on a poll you already voted on
+  """
+  collaborationPollVoteCastOnPollIVotedOn: NotificationSettingInput
   """Receive a notification for community updates"""
   communicationUpdates: NotificationSettingInput
   """Receive a notification when a calendar event is created"""
@@ -7890,6 +8546,8 @@ type UserSettingsNotificationChannels {
   email: Boolean!
   """Receive notifications by inApp."""
   inApp: Boolean!
+  """Receive push notifications."""
+  push: Boolean!
 }
 
 type UserSettingsNotificationOrganization {
@@ -7938,6 +8596,18 @@ type UserSettingsNotificationSpace {
   collaborationCalloutPostContributionComment: UserSettingsNotificationChannels!
   """Receive a notification when a callout is published"""
   collaborationCalloutPublished: UserSettingsNotificationChannels!
+  """Receive a notification when a poll you voted on is modified"""
+  collaborationPollModifiedOnPollIVotedOn: UserSettingsNotificationChannels!
+  """
+  Receive a notification when a poll option you voted for is changed or removed
+  """
+  collaborationPollVoteAffectedByOptionChange: UserSettingsNotificationChannels!
+  """Receive a notification when a vote is cast on a poll you created"""
+  collaborationPollVoteCastOnOwnPoll: UserSettingsNotificationChannels!
+  """
+  Receive a notification when another user votes on a poll you already voted on
+  """
+  collaborationPollVoteCastOnPollIVotedOn: UserSettingsNotificationChannels!
   """Receive a notification for community updates"""
   communicationUpdates: UserSettingsNotificationChannels!
   """Receive a notification when a calendar event is created"""

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -132,6 +132,22 @@ export class CalloutContributionService {
     contribution: ICalloutContribution,
     contributionData: CreateCalloutContributionInput
   ): Promise<ICalloutContribution> {
+    // Fail fast on shape divergence: a persisted post/whiteboard without
+    // matching input means the caller wired up the contribution but lost
+    // the original input data. Silent skip would leave the post/whiteboard
+    // un-materialized (description URLs unre-homed, visuals unattached).
+    if (contribution.post && !contributionData.post) {
+      throw new ValidationException(
+        'Post materialization input missing for post contribution',
+        LogContext.COLLABORATION
+      );
+    }
+    if (contribution.whiteboard && !contributionData.whiteboard) {
+      throw new ValidationException(
+        'Whiteboard materialization input missing for whiteboard contribution',
+        LogContext.COLLABORATION
+      );
+    }
     if (contribution.post && contributionData.post) {
       await this.postService.materializePostContent(
         contribution.post,

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -121,6 +121,32 @@ export class CalloutContributionService {
     return contribution;
   }
 
+  /**
+   * Phase 2: post-save content materialization for the contribution's
+   * inner content entity (post / whiteboard). Memo materializes itself
+   * inside `createMemo`; Link has no profile content. Caller must invoke
+   * AFTER the contribution has been persisted (cascade-saving the inner
+   * entity's profile + storageBucket).
+   */
+  public async materializeCalloutContributionContent(
+    contribution: ICalloutContribution,
+    contributionData: CreateCalloutContributionInput
+  ): Promise<ICalloutContribution> {
+    if (contribution.post && contributionData.post) {
+      await this.postService.materializePostContent(
+        contribution.post,
+        contributionData.post
+      );
+    }
+    if (contribution.whiteboard && contributionData.whiteboard) {
+      await this.whiteboardService.materializeWhiteboardContent(
+        contribution.whiteboard,
+        contributionData.whiteboard
+      );
+    }
+    return contribution;
+  }
+
   private validateContributionType(
     calloutContributionData: CreateCalloutContributionInput,
     contributionSettings: ICalloutSettingsContribution

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -199,15 +199,15 @@ export class CalloutFramingService {
       `${memoData.profile?.displayName ?? 'memo'}`,
       reservedNameIDs
     );
+    // Memo's framing context wants both CARD (its own default) and BANNER
+    // (framing-specific). Pass the union so createMemo materializes both
+    // post-save in one shot, instead of attaching BANNER on a separately-
+    // saved memo profile (which would need an additional save round trip).
     calloutFraming.memo = await this.memoService.createMemo(
       memoData,
       storageAggregator,
-      userID
-    );
-    await this.profileService.addVisualsOnProfile(
-      calloutFraming.memo.profile,
-      memoData.profile?.visuals,
-      [VisualType.BANNER]
+      userID,
+      [VisualType.CARD, VisualType.BANNER]
     );
   }
 

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -617,10 +617,18 @@ export class CalloutService {
     const saved = await this.contributionService.save(contribution);
     // Phase 2: now that the contribution + nested entity profile + bucket
     // are persisted, re-home any internal Alkemio URLs and attach visuals.
-    await this.contributionService.materializeCalloutContributionContent(
-      saved,
-      contributionData
-    );
+    // If materialization fails after persistence, compensate by deleting
+    // the saved contribution so the mutation appears atomic to the caller —
+    // otherwise the half-materialized contribution would linger in the DB.
+    try {
+      await this.contributionService.materializeCalloutContributionContent(
+        saved,
+        contributionData
+      );
+    } catch (error) {
+      await this.contributionService.delete(saved.id).catch(() => undefined);
+      throw error;
+    }
     return saved;
   }
 

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -614,7 +614,14 @@ export class CalloutService {
       );
     contribution.callout = callout;
 
-    return await this.contributionService.save(contribution);
+    const saved = await this.contributionService.save(contribution);
+    // Phase 2: now that the contribution + nested entity profile + bucket
+    // are persisted, re-home any internal Alkemio URLs and attach visuals.
+    await this.contributionService.materializeCalloutContributionContent(
+      saved,
+      contributionData
+    );
+    return saved;
   }
 
   public async getStorageBucket(calloutID: string): Promise<IStorageBucket> {

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -96,11 +96,12 @@ export class InnovationFlowService {
     }
     const saved = await this.save(innovationFlow);
     // First save populated profile.storageBucket.id; now materialize.
-    await this.profileService.materializeProfileContentAndVisuals(
-      saved.profile,
-      innovationFlowData.profile.visuals,
-      [VisualType.CARD]
-    );
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        saved.profile,
+        innovationFlowData.profile.visuals,
+        [VisualType.CARD]
+      );
 
     saved.currentStateID = saved.states[0].id;
     if (innovationFlowData.currentStateDisplayName) {

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -81,12 +81,6 @@ export class InnovationFlowService {
       storageAggregator
     );
 
-    await this.profileService.addVisualsOnProfile(
-      innovationFlow.profile,
-      innovationFlowData.profile.visuals,
-      [VisualType.CARD]
-    );
-
     innovationFlow.states = [];
     let sortOrder = 0;
     for (const stateData of innovationFlowData.states) {
@@ -100,20 +94,26 @@ export class InnovationFlowService {
       innovationFlow.states.push(state);
       sortOrder = state.sortOrder;
     }
-    await this.save(innovationFlow);
+    const saved = await this.save(innovationFlow);
+    // First save populated profile.storageBucket.id; now materialize.
+    await this.profileService.materializeProfileContentAndVisuals(
+      saved.profile,
+      innovationFlowData.profile.visuals,
+      [VisualType.CARD]
+    );
 
-    innovationFlow.currentStateID = innovationFlow.states[0].id;
+    saved.currentStateID = saved.states[0].id;
     if (innovationFlowData.currentStateDisplayName) {
-      const currentState = innovationFlow.states.find(
+      const currentState = saved.states.find(
         state =>
           state.displayName === innovationFlowData.currentStateDisplayName
       );
       if (currentState) {
-        innovationFlow.currentStateID = currentState.id;
+        saved.currentStateID = currentState.id;
       }
     }
 
-    return await this.save(innovationFlow);
+    return await this.save(saved);
   }
 
   async save(innovationFlow: IInnovationFlow): Promise<IInnovationFlow> {

--- a/src/domain/collaboration/post/post.service.spec.ts
+++ b/src/domain/collaboration/post/post.service.spec.ts
@@ -70,9 +70,10 @@ describe('PostService', () => {
       const createdRoom = { id: 'room-1' } as any;
 
       vi.mocked(profileService.createProfile).mockResolvedValue(createdProfile);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        undefined as any
-      );
+      vi.mocked(
+        profileService.materializeProfileContentAndVisuals
+      ).mockImplementation(async profile => profile);
+      vi.mocked(repository.save).mockImplementation(async (post: any) => post);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );
@@ -89,11 +90,12 @@ describe('PostService', () => {
         ProfileType.POST,
         storageAggregator
       );
-      expect(profileService.addVisualsOnProfile).toHaveBeenCalledWith(
-        createdProfile,
-        postInput.profileData.visuals,
-        [VisualType.BANNER, VisualType.CARD]
-      );
+      expect(
+        profileService.materializeProfileContentAndVisuals
+      ).toHaveBeenCalledWith(createdProfile, postInput.profileData.visuals, [
+        VisualType.BANNER,
+        VisualType.CARD,
+      ]);
       expect(profileService.addOrUpdateTagsetOnProfile).toHaveBeenCalledWith(
         createdProfile,
         { name: TagsetReservedName.DEFAULT, tags: ['tag1', 'tag2'] }
@@ -108,9 +110,10 @@ describe('PostService', () => {
 
     it('should set createdBy to the provided userID', async () => {
       vi.mocked(profileService.createProfile).mockResolvedValue({} as any);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        undefined as any
-      );
+      vi.mocked(
+        profileService.materializeProfileContentAndVisuals
+      ).mockImplementation(async profile => profile);
+      vi.mocked(repository.save).mockImplementation(async (post: any) => post);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );
@@ -132,9 +135,10 @@ describe('PostService', () => {
       } as any;
 
       vi.mocked(profileService.createProfile).mockResolvedValue({} as any);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        undefined as any
-      );
+      vi.mocked(
+        profileService.materializeProfileContentAndVisuals
+      ).mockImplementation(async profile => profile);
+      vi.mocked(repository.save).mockImplementation(async (post: any) => post);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );

--- a/src/domain/collaboration/post/post.service.spec.ts
+++ b/src/domain/collaboration/post/post.service.spec.ts
@@ -1,7 +1,6 @@
 import { ProfileType } from '@common/enums';
 import { RoomType } from '@common/enums/room.type';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
-import { VisualType } from '@common/enums/visual.type';
 import { EntityNotFoundException } from '@common/exceptions';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { ProfileService } from '@domain/common/profile/profile.service';
@@ -73,7 +72,6 @@ describe('PostService', () => {
       vi.mocked(
         profileService.materializeProfileContentAndVisuals
       ).mockImplementation(async profile => profile);
-      vi.mocked(repository.save).mockImplementation(async (post: any) => post);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );
@@ -90,12 +88,10 @@ describe('PostService', () => {
         ProfileType.POST,
         storageAggregator
       );
+      // Phase 1 returns unsaved; materialize is the parent's post-save call.
       expect(
         profileService.materializeProfileContentAndVisuals
-      ).toHaveBeenCalledWith(createdProfile, postInput.profileData.visuals, [
-        VisualType.BANNER,
-        VisualType.CARD,
-      ]);
+      ).not.toHaveBeenCalled();
       expect(profileService.addOrUpdateTagsetOnProfile).toHaveBeenCalledWith(
         createdProfile,
         { name: TagsetReservedName.DEFAULT, tags: ['tag1', 'tag2'] }
@@ -113,7 +109,6 @@ describe('PostService', () => {
       vi.mocked(
         profileService.materializeProfileContentAndVisuals
       ).mockImplementation(async profile => profile);
-      vi.mocked(repository.save).mockImplementation(async (post: any) => post);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );
@@ -138,7 +133,6 @@ describe('PostService', () => {
       vi.mocked(
         profileService.materializeProfileContentAndVisuals
       ).mockImplementation(async profile => profile);
-      vi.mocked(repository.save).mockImplementation(async (post: any) => post);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );

--- a/src/domain/collaboration/post/post.service.ts
+++ b/src/domain/collaboration/post/post.service.ts
@@ -30,6 +30,12 @@ export class PostService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
+  /**
+   * Phase 1: in-memory entity construction. The returned post is unsaved;
+   * persistence happens via cascade from the parent (CalloutContribution).
+   * Phase 2 lives in {@link materializePostContent} and must be invoked
+   * after the parent aggregate has been persisted.
+   */
   public async createPost(
     postInput: CreatePostInput,
     storageAggregator: IStorageAggregator,
@@ -55,15 +61,25 @@ export class PostService {
       parentContextId: parentSpaceId,
     });
 
-    // Save so the profile's storageBucket gets a real id, then materialize
-    // markdown/refs/visuals. Parent cascade save will no-op on this post.
-    const saved = await this.postRepository.save(post);
+    return post;
+  }
+
+  /**
+   * Phase 2: post-save content materialization. Re-homes any internal
+   * Alkemio URLs in the post profile's description/references and attaches
+   * BANNER + CARD visuals. Caller must invoke AFTER the parent aggregate
+   * has been persisted (cascade-saving this post's profile + storageBucket).
+   */
+  public async materializePostContent(
+    post: IPost,
+    postInput: CreatePostInput
+  ): Promise<IPost> {
     await this.profileService.materializeProfileContentAndVisuals(
-      saved.profile,
+      post.profile,
       postInput.profileData.visuals,
       [VisualType.BANNER, VisualType.CARD]
     );
-    return saved;
+    return post;
   }
 
   public async deletePost(postId: string): Promise<IPost> {

--- a/src/domain/collaboration/post/post.service.ts
+++ b/src/domain/collaboration/post/post.service.ts
@@ -84,11 +84,12 @@ export class PostService {
         { postId: post.id }
       );
     }
-    await this.profileService.materializeProfileContentAndVisuals(
-      post.profile,
-      postInput.profileData.visuals,
-      [VisualType.BANNER, VisualType.CARD]
-    );
+    post.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        post.profile,
+        postInput.profileData.visuals,
+        [VisualType.BANNER, VisualType.CARD]
+      );
     return post;
   }
 

--- a/src/domain/collaboration/post/post.service.ts
+++ b/src/domain/collaboration/post/post.service.ts
@@ -42,11 +42,6 @@ export class PostService {
       ProfileType.POST,
       storageAggregator
     );
-    await this.profileService.addVisualsOnProfile(
-      post.profile,
-      postInput.profileData.visuals,
-      [VisualType.BANNER, VisualType.CARD]
-    );
     await this.profileService.addOrUpdateTagsetOnProfile(post.profile, {
       name: TagsetReservedName.DEFAULT,
       tags: postInput.tags || [],
@@ -60,7 +55,15 @@ export class PostService {
       parentContextId: parentSpaceId,
     });
 
-    return post;
+    // Save so the profile's storageBucket gets a real id, then materialize
+    // markdown/refs/visuals. Parent cascade save will no-op on this post.
+    const saved = await this.postRepository.save(post);
+    await this.profileService.materializeProfileContentAndVisuals(
+      saved.profile,
+      postInput.profileData.visuals,
+      [VisualType.BANNER, VisualType.CARD]
+    );
+    return saved;
   }
 
   public async deletePost(postId: string): Promise<IPost> {

--- a/src/domain/collaboration/post/post.service.ts
+++ b/src/domain/collaboration/post/post.service.ts
@@ -3,7 +3,10 @@ import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type
 import { RoomType } from '@common/enums/room.type';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { VisualType } from '@common/enums/visual.type';
-import { EntityNotFoundException } from '@common/exceptions';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+} from '@common/exceptions';
 import { Post } from '@domain/collaboration/post/post.entity';
 import { IPost } from '@domain/collaboration/post/post.interface';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy';
@@ -74,6 +77,13 @@ export class PostService {
     post: IPost,
     postInput: CreatePostInput
   ): Promise<IPost> {
+    if (!post.profile) {
+      throw new RelationshipNotFoundException(
+        'Post profile not initialized',
+        LogContext.COLLABORATION,
+        { postId: post.id }
+      );
+    }
     await this.profileService.materializeProfileContentAndVisuals(
       post.profile,
       postInput.profileData.visuals,

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -74,11 +74,12 @@ export class MemoService {
     // attaches visuals. Single internal save means callers continue to get a
     // fully-materialized memo.
     const saved = await this.save(memo);
-    await this.profileService.materializeProfileContentAndVisuals(
-      saved.profile,
-      restOfMemoData.profile?.visuals,
-      visualTypes
-    );
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        saved.profile,
+        restOfMemoData.profile?.visuals,
+        visualTypes
+      );
     return saved;
   }
 

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -44,7 +44,8 @@ export class MemoService {
   async createMemo(
     { markdown, ...restOfMemoData }: CreateMemoInput,
     storageAggregator: IStorageAggregator,
-    userID?: string
+    userID?: string,
+    visualTypes: VisualType[] = [VisualType.CARD]
   ): Promise<IMemo> {
     const binaryUpdateV2 = this.markdownToStateUpdate(markdown);
     const content = binaryUpdateV2 ? Buffer.from(binaryUpdateV2) : undefined;
@@ -63,17 +64,22 @@ export class MemoService {
       ProfileType.MEMO,
       storageAggregator
     );
-    await this.profileService.addVisualsOnProfile(
-      memo.profile,
-      restOfMemoData.profile?.visuals,
-      [VisualType.CARD]
-    );
     await this.profileService.addOrUpdateTagsetOnProfile(memo.profile, {
       name: TagsetReservedName.DEFAULT,
       tags: [],
     });
 
-    return this.save(memo);
+    // Phase 1 + persist + phase 2: cascade save populates the bucket id, then
+    // post-save materialization re-homes any internal markdown URLs and
+    // attaches visuals. Single internal save means callers continue to get a
+    // fully-materialized memo.
+    const saved = await this.save(memo);
+    await this.profileService.materializeProfileContentAndVisuals(
+      saved.profile,
+      restOfMemoData.profile?.visuals,
+      visualTypes
+    );
+    return saved;
   }
 
   async getMemoOrFail(

--- a/src/domain/common/profile/profile.service.spec.ts
+++ b/src/domain/common/profile/profile.service.spec.ts
@@ -79,11 +79,14 @@ describe('ProfileService', () => {
   });
 
   describe('createProfile', () => {
-    it('should create profile with authorization, storage bucket, location, visuals, and tagsets', async () => {
+    it('builds an in-memory profile and does NOT call file-service helpers (phase 1)', async () => {
+      // Phase 1 must be pure: file-service-go calls happen in phase 2
+      // (materializeProfileContent), AFTER the parent's cascade save has
+      // persisted the storageBucket id. See ProfileService docs.
       const storageAggregator = {
         id: 'sa-1',
       } as unknown as IStorageAggregator;
-      const storageBucket = { id: 'sb-1' };
+      const storageBucket = { id: undefined, documents: [] };
       const location = { id: 'loc-1' };
 
       vi.mocked(storageBucketService.createStorageBucket).mockReturnValue(
@@ -92,12 +95,6 @@ describe('ProfileService', () => {
       vi.mocked(locationService.createLocation).mockResolvedValue(
         location as any
       );
-      vi.mocked(
-        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
-      ).mockResolvedValue('processed-description');
-      vi.mocked(
-        profileDocumentsService.reuploadFileOnStorageBucket
-      ).mockResolvedValue(undefined as any);
 
       const tagset = { id: 'ts-1', name: 'skills', tags: [] };
       vi.mocked(tagsetService.createTagsetWithName).mockReturnValue(
@@ -122,7 +119,15 @@ describe('ProfileService', () => {
       expect(result.location).toBe(location);
       expect(result.visuals).toEqual([]);
       expect(result.tagsets).toEqual([tagset]);
-      expect(result.description).toBe('processed-description');
+      // Description is preserved verbatim — no markdown re-upload at this stage.
+      expect(result.description).toBe('A test description');
+      expect(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).not.toHaveBeenCalled();
+      expect(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).not.toHaveBeenCalled();
+      expect(storageBucketService.save).not.toHaveBeenCalled();
     });
 
     it('should default tagsets to empty array when not provided', async () => {
@@ -186,6 +191,102 @@ describe('ProfileService', () => {
 
       expect(result.references).toHaveLength(1);
       expect(result.references![0].name).toBe('website');
+    });
+  });
+
+  describe('materializeProfileContent', () => {
+    it('throws when storageBucket is not persisted', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: undefined },
+        description: '',
+        references: [],
+      } as any;
+
+      await expect(service.materializeProfileContent(profile)).rejects.toThrow(
+        /must be persisted/
+      );
+    });
+
+    it('re-uploads markdown documents and reference URIs', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: 'sb-1', documents: [] },
+        description: '![](https://alkemio/files/abc)',
+        references: [
+          { id: 'r-1', uri: 'https://alkemio/files/xyz' },
+          { id: 'r-2', uri: 'https://external.example.com/img.png' },
+        ],
+      } as any;
+
+      vi.mocked(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).mockResolvedValue('![](https://alkemio/files/abc-rehomed)');
+      vi.mocked(profileDocumentsService.reuploadFileOnStorageBucket)
+        .mockResolvedValueOnce('https://alkemio/files/xyz-rehomed')
+        .mockResolvedValueOnce('https://external.example.com/img.png');
+
+      const result = await service.materializeProfileContent(profile);
+
+      expect(result.description).toBe('![](https://alkemio/files/abc-rehomed)');
+      expect(result.references![0].uri).toBe(
+        'https://alkemio/files/xyz-rehomed'
+      );
+      // External URL passes through unchanged.
+      expect(result.references![1].uri).toBe(
+        'https://external.example.com/img.png'
+      );
+    });
+  });
+
+  describe('materializeProfileContentAndVisuals', () => {
+    it('runs content materialization, visual attachment, and persists in order', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: 'sb-1', documents: [] },
+        description: '',
+        references: [],
+        visuals: [],
+      } as any;
+      const visualsData = [{ name: 'card', uri: 'x' }] as any;
+
+      vi.mocked(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).mockResolvedValue('');
+      const addVisualsSpy = vi
+        .spyOn(service, 'addVisualsOnProfile')
+        .mockResolvedValue(profile);
+      profileRepository.save = vi.fn().mockResolvedValue(profile) as any;
+
+      await service.materializeProfileContentAndVisuals(profile, visualsData, [
+        VisualType.CARD,
+      ]);
+
+      expect(addVisualsSpy).toHaveBeenCalledWith(profile, visualsData, [
+        VisualType.CARD,
+      ]);
+      expect(profileRepository.save).toHaveBeenCalledWith(profile);
+    });
+
+    it('skips addVisualsOnProfile when visualTypes is empty', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: 'sb-1', documents: [] },
+        description: '',
+        references: [],
+        visuals: [],
+      } as any;
+
+      vi.mocked(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).mockResolvedValue('');
+      const addVisualsSpy = vi.spyOn(service, 'addVisualsOnProfile');
+      profileRepository.save = vi.fn().mockResolvedValue(profile) as any;
+
+      await service.materializeProfileContentAndVisuals(profile, undefined, []);
+
+      expect(addVisualsSpy).not.toHaveBeenCalled();
+      expect(profileRepository.save).toHaveBeenCalledWith(profile);
     });
   });
 

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -113,8 +113,9 @@ export class ProfileService {
   public async materializeProfileContent(profile: IProfile): Promise<IProfile> {
     if (!profile.storageBucket?.id) {
       throw new EntityNotInitializedException(
-        `Profile storage bucket must be persisted before materializing content: profile ${profile.id}`,
-        LogContext.PROFILE
+        'Profile storage bucket must be persisted before materializing content',
+        LogContext.PROFILE,
+        { profileId: profile.id }
       );
     }
     if (profile.description) {

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -26,7 +26,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DEFAULT_AVATAR_SERVICE_URL } from '@services/external/avatar-creator/avatar.creator.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { FindOneOptions, Repository } from 'typeorm';
-import { CreateReferenceInput } from '../reference';
 import { CreateTagsetInput } from '../tagset';
 import { ITagsetTemplate } from '../tagset-template/tagset.template.interface';
 import { CreateProfileInput, UpdateProfileInput } from './dto';
@@ -48,8 +47,25 @@ export class ProfileService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  // Create an empty profile, that the creating entity then has to
-  // add tagets / visuals to.
+  /**
+   * Phase 1 of profile materialization: build the in-memory entity graph.
+   *
+   * No file-service-go calls happen here. The storageBucket is created
+   * unsaved and assigned to the profile; the caller is expected to assign
+   * the profile to a parent entity that cascades save (or to save it
+   * directly), then call {@link materializeProfileContent} to perform the
+   * post-save content re-uploads (markdown documents, references, etc).
+   *
+   * This split exists because the file-service-go migration (PR #5969)
+   * moved Document ownership outside the server's TypeORM transaction;
+   * any cross-service call needs a real persisted `storageBucket.id` to
+   * FK onto. Doing both phases in one method led to
+   * `StorageBucket not found: undefined` (issues #6004 / #6005).
+   *
+   * Tagsets and references are constructed with their input URIs as-is.
+   * `materializeProfileContent` is the place where any internal Alkemio
+   * URLs in the description/references are re-homed into the new bucket.
+   */
   public async createProfile(
     profileData: CreateProfileInput,
     profileType: ProfileType,
@@ -64,54 +80,83 @@ export class ProfileService {
     profile.authorization = new AuthorizationPolicy(
       AuthorizationPolicyType.PROFILE
     );
-    // the next statement fails if it's not saved
     profile.storageBucket = this.storageBucketService.createStorageBucket({
       storageAggregator: storageAggregator,
     });
-    profile.description =
-      await this.profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket(
-        profile.description ?? '',
-        profile.storageBucket
-      );
     profile.visuals = [];
     profile.location = await this.locationService.createLocation(
       profileData?.location
     );
-    await this.createReferencesOnProfile(profileData?.referencesData, profile);
-
-    const tagsetsFromInput = profileData?.tagsets?.map(tagsetData =>
+    profile.references = (profileData?.referencesData ?? []).map(reference =>
+      this.referenceService.createReference(reference)
+    );
+    profile.tagsets = (profileData?.tagsets ?? []).map(tagsetData =>
       this.tagsetService.createTagsetWithName([], tagsetData)
     );
-    profile.tagsets = tagsetsFromInput ?? [];
 
     return profile;
   }
 
-  private async createReferencesOnProfile(
-    references: CreateReferenceInput[] | undefined,
-    profile: IProfile
-  ) {
-    if (!profile.storageBucket) {
+  /**
+   * Phase 2: post-save content re-upload. Must be called AFTER the profile
+   * (and its storageBucket) has been persisted — typically via the parent
+   * entity's cascade save. Re-homes any internal Alkemio document URLs
+   * found in the description and references into the profile's bucket.
+   *
+   * Idempotent for content already in the destination bucket and a no-op
+   * if there's no internal URL to re-home, so it's safe to call from any
+   * caller whether or not the input data references existing documents.
+   *
+   * Throws `EntityNotInitializedException` if the bucket isn't persisted
+   * yet — that's a programmer error, not a runtime condition.
+   */
+  public async materializeProfileContent(profile: IProfile): Promise<IProfile> {
+    if (!profile.storageBucket?.id) {
       throw new EntityNotInitializedException(
-        `Storage bucket not initialized on profile: ${profile.id}`,
+        `Profile storage bucket must be persisted before materializing content: profile ${profile.id}`,
         LogContext.PROFILE
       );
     }
-    const newReferences = [];
-    for (const reference of references ?? []) {
-      const newReference = this.referenceService.createReference(reference);
+    if (profile.description) {
+      profile.description =
+        await this.profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket(
+          profile.description,
+          profile.storageBucket
+        );
+    }
+    for (const reference of profile.references ?? []) {
       const newUrl =
         await this.profileDocumentsService.reuploadFileOnStorageBucket(
-          newReference.uri,
+          reference.uri,
           profile.storageBucket,
           false
         );
       if (newUrl) {
-        newReference.uri = newUrl;
+        reference.uri = newUrl;
       }
-      newReferences.push(newReference);
     }
-    profile.references = newReferences;
+    return profile;
+  }
+
+  /**
+   * Convenience for the standard post-save materialization: re-home internal
+   * Alkemio URLs in description/references AND attach visuals. Idempotent and
+   * safe to call when there's nothing to materialize. Persists the result so
+   * callers don't need a follow-up `save`.
+   *
+   * Precondition: `profile.storageBucket` must be persisted (typically via
+   * the parent entity's cascade save). See {@link materializeProfileContent}.
+   */
+  public async materializeProfileContentAndVisuals(
+    profile: IProfile,
+    visualsData: CreateVisualOnProfileInput[] | undefined,
+    visualTypes: VisualType[]
+  ): Promise<IProfile> {
+    await this.materializeProfileContent(profile);
+    if (visualTypes.length > 0) {
+      await this.addVisualsOnProfile(profile, visualsData, visualTypes);
+    }
+    return await this.profileRepository.save(profile);
   }
 
   async updateProfile(

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -78,12 +78,17 @@ describe('WhiteboardService', () => {
 
     beforeEach(() => {
       vi.mocked(profileService.createProfile).mockResolvedValue(mockProfile);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        mockProfile
-      );
+      vi.mocked(
+        profileService.materializeProfileContentAndVisuals
+      ).mockResolvedValue(mockProfile);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         {} as any
       );
+      // createWhiteboard now persists the entity inline so its bucket id is
+      // populated before phase-2 materialization. The repository mock must
+      // round-trip the entity; otherwise we lose the in-memory state we just
+      // set up (authorization, profile, etc.).
+      whiteboardRepository.save!.mockImplementation(async (wb: any) => wb);
     });
 
     it('should create whiteboard with profile, visuals, tagset, and authorization', async () => {
@@ -107,7 +112,7 @@ describe('WhiteboardService', () => {
         mockStorageAggregator
       );
       expect(
-        vi.mocked(profileService.addVisualsOnProfile)
+        vi.mocked(profileService.materializeProfileContentAndVisuals)
       ).toHaveBeenCalledWith(mockProfile, undefined, [
         VisualType.CARD,
         VisualType.WHITEBOARD_PREVIEW,

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -3,7 +3,6 @@ import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type
 import { ContentUpdatePolicy } from '@common/enums/content.update.policy';
 import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
-import { VisualType } from '@common/enums/visual.type';
 import { WhiteboardPreviewMode } from '@common/enums/whiteboard.preview.mode';
 import {
   EntityNotFoundException,
@@ -78,17 +77,9 @@ describe('WhiteboardService', () => {
 
     beforeEach(() => {
       vi.mocked(profileService.createProfile).mockResolvedValue(mockProfile);
-      vi.mocked(
-        profileService.materializeProfileContentAndVisuals
-      ).mockResolvedValue(mockProfile);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         {} as any
       );
-      // createWhiteboard now persists the entity inline so its bucket id is
-      // populated before phase-2 materialization. The repository mock must
-      // round-trip the entity; otherwise we lose the in-memory state we just
-      // set up (authorization, profile, etc.).
-      whiteboardRepository.save!.mockImplementation(async (wb: any) => wb);
     });
 
     it('should create whiteboard with profile, visuals, tagset, and authorization', async () => {
@@ -111,12 +102,10 @@ describe('WhiteboardService', () => {
         ProfileType.WHITEBOARD,
         mockStorageAggregator
       );
+      // Phase 1 returns unsaved; materialize is the parent's post-save call.
       expect(
         vi.mocked(profileService.materializeProfileContentAndVisuals)
-      ).toHaveBeenCalledWith(mockProfile, undefined, [
-        VisualType.CARD,
-        VisualType.WHITEBOARD_PREVIEW,
-      ]);
+      ).not.toHaveBeenCalled();
       expect(
         vi.mocked(profileService.addOrUpdateTagsetOnProfile)
       ).toHaveBeenCalledWith(mockProfile, {

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -42,11 +42,18 @@ export class WhiteboardService {
     private licenseService: LicenseService
   ) {}
 
+  /**
+   * Phase 1: in-memory entity construction. The returned whiteboard is
+   * unsaved; persistence happens via cascade from the parent (Template,
+   * CalloutFraming, CalloutContribution) so the whole aggregate commits
+   * atomically. Phase 2 (markdown re-upload + visuals attachment) lives in
+   * {@link materializeWhiteboardContent} and must be invoked after the
+   * parent's save commits.
+   */
   async createWhiteboard(
     whiteboardData: CreateWhiteboardInput,
     storageAggregator: IStorageAggregator,
-    userID?: string,
-    visualTypes: VisualType[] = [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW]
+    userID?: string
   ): Promise<IWhiteboard> {
     const whiteboard: IWhiteboard = Whiteboard.create({
       ...whiteboardData,
@@ -74,17 +81,26 @@ export class WhiteboardService {
       coordinates: whiteboardData.previewSettings?.coordinates ?? null,
     };
 
-    // Save whiteboard so its profile.storageBucket gets a real id (cascade),
-    // then materialize markdown/refs/visuals against the persisted bucket.
-    // Caller's parent cascade save will be a no-op for this whiteboard since
-    // it's already persisted with its FKs intact.
-    const saved = await this.whiteboardRepository.save(whiteboard);
+    return whiteboard;
+  }
+
+  /**
+   * Phase 2: post-save content materialization. Re-homes any internal
+   * Alkemio URLs in the profile description/references and attaches the
+   * whiteboard's visuals. Caller must invoke AFTER the parent aggregate
+   * has been persisted (cascade-saving this whiteboard's profile +
+   * storageBucket).
+   */
+  async materializeWhiteboardContent(
+    whiteboard: IWhiteboard,
+    whiteboardData: CreateWhiteboardInput
+  ): Promise<IWhiteboard> {
     await this.profileService.materializeProfileContentAndVisuals(
-      saved.profile,
+      whiteboard.profile,
       whiteboardData.profile?.visuals,
-      visualTypes
+      [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW]
     );
-    return saved;
+    return whiteboard;
   }
 
   async getWhiteboardOrFail(

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -95,6 +95,13 @@ export class WhiteboardService {
     whiteboard: IWhiteboard,
     whiteboardData: CreateWhiteboardInput
   ): Promise<IWhiteboard> {
+    if (!whiteboard.profile) {
+      throw new RelationshipNotFoundException(
+        'Whiteboard profile not initialized',
+        LogContext.SPACES,
+        { whiteboardId: whiteboard.id }
+      );
+    }
     whiteboard.profile =
       await this.profileService.materializeProfileContentAndVisuals(
         whiteboard.profile,

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -95,11 +95,12 @@ export class WhiteboardService {
     whiteboard: IWhiteboard,
     whiteboardData: CreateWhiteboardInput
   ): Promise<IWhiteboard> {
-    await this.profileService.materializeProfileContentAndVisuals(
-      whiteboard.profile,
-      whiteboardData.profile?.visuals,
-      [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW]
-    );
+    whiteboard.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        whiteboard.profile,
+        whiteboardData.profile?.visuals,
+        [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW]
+      );
     return whiteboard;
   }
 

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -45,7 +45,8 @@ export class WhiteboardService {
   async createWhiteboard(
     whiteboardData: CreateWhiteboardInput,
     storageAggregator: IStorageAggregator,
-    userID?: string
+    userID?: string,
+    visualTypes: VisualType[] = [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW]
   ): Promise<IWhiteboard> {
     const whiteboard: IWhiteboard = Whiteboard.create({
       ...whiteboardData,
@@ -63,11 +64,6 @@ export class WhiteboardService {
       ProfileType.WHITEBOARD,
       storageAggregator
     );
-    await this.profileService.addVisualsOnProfile(
-      whiteboard.profile,
-      whiteboardData.profile?.visuals,
-      [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW]
-    );
     await this.profileService.addOrUpdateTagsetOnProfile(whiteboard.profile, {
       name: TagsetReservedName.DEFAULT,
       tags: [],
@@ -78,7 +74,17 @@ export class WhiteboardService {
       coordinates: whiteboardData.previewSettings?.coordinates ?? null,
     };
 
-    return whiteboard;
+    // Save whiteboard so its profile.storageBucket gets a real id (cascade),
+    // then materialize markdown/refs/visuals against the persisted bucket.
+    // Caller's parent cascade save will be a no-op for this whiteboard since
+    // it's already persisted with its FKs intact.
+    const saved = await this.whiteboardRepository.save(whiteboard);
+    await this.profileService.materializeProfileContentAndVisuals(
+      saved.profile,
+      whiteboardData.profile?.visuals,
+      visualTypes
+    );
+    return saved;
   }
 
   async getWhiteboardOrFail(

--- a/src/domain/community/community-guidelines/community.guidelines.service.spec.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.spec.ts
@@ -1,3 +1,4 @@
+import { VisualType } from '@common/enums/visual.type';
 import { EntityNotFoundException } from '@common/exceptions';
 import { ProfileService } from '@domain/common/profile/profile.service';
 import { TagsetService } from '@domain/common/tagset/tagset.service';
@@ -21,6 +22,7 @@ describe('CommunityGuidelinesService', () => {
   let profileService: {
     createProfile: Mock;
     addVisualsOnProfile: Mock;
+    materializeProfileContentAndVisuals: Mock;
     updateProfile: Mock;
     deleteProfile: Mock;
     deleteAllReferencesFromProfile: Mock;
@@ -70,11 +72,13 @@ describe('CommunityGuidelinesService', () => {
   });
 
   describe('createCommunityGuidelines', () => {
-    it('should create guidelines with authorization, profile, and visuals', async () => {
+    it('builds in-memory guidelines without calling addVisualsOnProfile (phase 1)', async () => {
+      // Phase-1 createCommunityGuidelines must be pure: no addVisualsOnProfile,
+      // no markdown re-upload. Visuals attach in phase 2 once the cascade save
+      // has populated the bucket id.
       const mockProfile = { id: 'profile-1' };
       tagsetService.updateTagsetInputs.mockReturnValue([]);
       profileService.createProfile.mockResolvedValue(mockProfile);
-      profileService.addVisualsOnProfile.mockResolvedValue(undefined);
 
       const storageAggregator = { id: 'storage-1' } as any;
       const result = await service.createCommunityGuidelines(
@@ -90,7 +94,30 @@ describe('CommunityGuidelinesService', () => {
       expect(result.authorization).toBeDefined();
       expect(result.profile).toBe(mockProfile);
       expect(profileService.createProfile).toHaveBeenCalled();
-      expect(profileService.addVisualsOnProfile).toHaveBeenCalled();
+      expect(profileService.addVisualsOnProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('materializeCommunityGuidelinesContent', () => {
+    it('delegates to profileService.materializeProfileContentAndVisuals with CARD visuals', async () => {
+      const guidelines = {
+        profile: { id: 'p-1', storageBucket: { id: 'sb-1' } },
+      } as any;
+      profileService.materializeProfileContentAndVisuals.mockResolvedValue(
+        guidelines.profile
+      );
+
+      const data = {
+        profile: { displayName: 'g', visuals: [{ name: 'card', uri: 'x' }] },
+      } as any;
+
+      await service.materializeCommunityGuidelinesContent(guidelines, data);
+
+      expect(
+        profileService.materializeProfileContentAndVisuals
+      ).toHaveBeenCalledWith(guidelines.profile, data.profile.visuals, [
+        VisualType.CARD,
+      ]);
     });
   });
 

--- a/src/domain/community/community-guidelines/community.guidelines.service.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.ts
@@ -27,6 +27,11 @@ export class CommunityGuidelinesService {
     private communityGuidelinesRepository: Repository<CommunityGuidelines>
   ) {}
 
+  /**
+   * Phase 1: in-memory entity construction. The returned guidelines must be
+   * persisted by the caller (typically via cascade from a parent entity)
+   * before {@link materializeCommunityGuidelinesContent} is invoked.
+   */
   async createCommunityGuidelines(
     communityGuidelinesData: CreateCommunityGuidelinesInput,
     storageAggregator: IStorageAggregator
@@ -53,12 +58,24 @@ export class CommunityGuidelinesService {
       storageAggregator
     );
 
-    await this.profileService.addVisualsOnProfile(
+    return communityGuidelines;
+  }
+
+  /**
+   * Phase 2: post-save content materialization. Re-homes any internal
+   * Alkemio URLs in the profile description/references into the guidelines'
+   * own bucket, then attaches visuals. Requires the parent entity to have
+   * been saved already (so `profile.storageBucket.id` is real).
+   */
+  async materializeCommunityGuidelinesContent(
+    communityGuidelines: ICommunityGuidelines,
+    communityGuidelinesData: CreateCommunityGuidelinesInput
+  ): Promise<ICommunityGuidelines> {
+    await this.profileService.materializeProfileContentAndVisuals(
       communityGuidelines.profile,
       communityGuidelinesData.profile.visuals,
       [VisualType.CARD]
     );
-
     return communityGuidelines;
   }
 

--- a/src/domain/community/community-guidelines/community.guidelines.service.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.ts
@@ -76,11 +76,12 @@ export class CommunityGuidelinesService {
     // doesn't supply any. Auto-created profiles still need post-save
     // materialization (re-home description URLs, etc.) — visuals just
     // happen to be absent in that case.
-    await this.profileService.materializeProfileContentAndVisuals(
-      communityGuidelines.profile,
-      communityGuidelinesData?.profile.visuals,
-      [VisualType.CARD]
-    );
+    communityGuidelines.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        communityGuidelines.profile,
+        communityGuidelinesData?.profile.visuals,
+        [VisualType.CARD]
+      );
     return communityGuidelines;
   }
 

--- a/src/domain/community/community-guidelines/community.guidelines.service.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.ts
@@ -3,7 +3,10 @@ import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { TagsetType } from '@common/enums/tagset.type';
 import { VisualType } from '@common/enums/visual.type';
-import { EntityNotFoundException } from '@common/exceptions';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+} from '@common/exceptions';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
 import { IProfile } from '@domain/common/profile/profile.interface';
 import { ProfileService } from '@domain/common/profile/profile.service';
@@ -71,6 +74,13 @@ export class CommunityGuidelinesService {
     communityGuidelines: ICommunityGuidelines,
     communityGuidelinesData?: CreateCommunityGuidelinesInput
   ): Promise<ICommunityGuidelines> {
+    if (!communityGuidelines.profile) {
+      throw new RelationshipNotFoundException(
+        'Community guidelines profile not initialized',
+        LogContext.COMMUNITY,
+        { communityGuidelinesId: communityGuidelines.id }
+      );
+    }
     // `communityGuidelinesData` is optional because composing services
     // (e.g. SpaceAboutService) auto-create empty guidelines when the caller
     // doesn't supply any. Auto-created profiles still need post-save

--- a/src/domain/community/community-guidelines/community.guidelines.service.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.ts
@@ -69,11 +69,16 @@ export class CommunityGuidelinesService {
    */
   async materializeCommunityGuidelinesContent(
     communityGuidelines: ICommunityGuidelines,
-    communityGuidelinesData: CreateCommunityGuidelinesInput
+    communityGuidelinesData?: CreateCommunityGuidelinesInput
   ): Promise<ICommunityGuidelines> {
+    // `communityGuidelinesData` is optional because composing services
+    // (e.g. SpaceAboutService) auto-create empty guidelines when the caller
+    // doesn't supply any. Auto-created profiles still need post-save
+    // materialization (re-home description URLs, etc.) — visuals just
+    // happen to be absent in that case.
     await this.profileService.materializeProfileContentAndVisuals(
       communityGuidelines.profile,
-      communityGuidelinesData.profile.visuals,
+      communityGuidelinesData?.profile.visuals,
       [VisualType.CARD]
     );
     return communityGuidelines;

--- a/src/domain/innovation-hub/innovation.hub.service.spec.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.spec.ts
@@ -84,6 +84,12 @@ describe('InnovationHubService', () => {
     ps.createProfile = vi.fn().mockResolvedValue(profile);
     ps.addOrUpdateTagsetOnProfile = vi.fn().mockResolvedValue({});
     ps.addVisualsOnProfile = vi.fn().mockResolvedValue({});
+    // Phase-2 materialize is invoked post-save by createInnovationHub and
+    // its return value is reassigned back onto saved.profile, so the mock
+    // must echo the input profile through.
+    ps.materializeProfileContentAndVisuals = vi
+      .fn()
+      .mockImplementation(async (p: any) => p);
   };
 
   /**

--- a/src/domain/innovation-hub/innovation.hub.service.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.ts
@@ -103,11 +103,12 @@ export class InnovationHubService {
     const saved = await this.save(hub);
     // Post-save: bucket has its id, materialize re-homes any internal URLs
     // and attaches the BANNER_WIDE visual.
-    await this.profileService.materializeProfileContentAndVisuals(
-      saved.profile,
-      createData.profileData.visuals,
-      [VisualType.BANNER_WIDE]
-    );
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        saved.profile,
+        createData.profileData.visuals,
+        [VisualType.BANNER_WIDE]
+      );
     return saved;
   }
 

--- a/src/domain/innovation-hub/innovation.hub.service.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.ts
@@ -100,13 +100,15 @@ export class InnovationHubService {
       tags: [],
     });
 
-    await this.profileService.addVisualsOnProfile(
-      hub.profile,
+    const saved = await this.save(hub);
+    // Post-save: bucket has its id, materialize re-homes any internal URLs
+    // and attaches the BANNER_WIDE visual.
+    await this.profileService.materializeProfileContentAndVisuals(
+      saved.profile,
       createData.profileData.visuals,
       [VisualType.BANNER_WIDE]
     );
-
-    return await this.save(hub);
+    return saved;
   }
 
   public save(hub: IInnovationHub): Promise<IInnovationHub> {

--- a/src/domain/profile-documents/profile.documents.service.spec.ts
+++ b/src/domain/profile-documents/profile.documents.service.spec.ts
@@ -101,12 +101,14 @@ describe('ProfileDocumentsService', () => {
           useValue: {
             addDocumentToStorageBucketOrFail: vi.fn(),
             uploadFileAsDocumentFromBuffer: vi.fn(),
+            copyDocumentToBucket: vi.fn(),
           },
         },
         {
           provide: FileServiceAdapter,
           useValue: {
             createDocument: vi.fn(),
+            copyDocument: vi.fn(),
             getDocumentContent: vi.fn(),
             updateDocument: vi.fn(),
             deleteDocument: vi.fn(),
@@ -239,21 +241,16 @@ describe('ProfileDocumentsService', () => {
       });
     });
 
-    it('should return a copy of the document in the new StorageBucket', async () => {
+    it('copies the document via copyDocumentToBucket and deletes the source', async () => {
+      // Different-bucket branch: under v0.0.14 we call file-service-go's
+      // /internal/file/copy via storageBucketService.copyDocumentToBucket;
+      // no bytes traverse the wire, no getDocumentContent round-trip.
       const fileUrl = `${ALKEMIO_URL}/api/private/rest/storage/document/${uniqueId()}`;
       const storageBucketOrigin: IStorageBucket = mockStorageBucket();
       const storageBucketDestination: IStorageBucket = mockStorageBucket();
-      // A few test documents
-      mockDocument(storageBucketOrigin);
-      mockDocument(storageBucketOrigin);
-      mockDocument(storageBucketDestination);
-      mockDocument(storageBucketDestination);
-      // the doc
       const doc = mockDocument(storageBucketOrigin, {
         temporaryLocation: false,
       });
-      mockDocument(storageBucketOrigin);
-      mockDocument(storageBucketDestination);
 
       vi.spyOn(documentService, 'isAlkemioDocumentURL').mockReturnValue(true);
       vi.spyOn(documentService, 'getDocumentFromURL').mockResolvedValue(doc);
@@ -262,19 +259,13 @@ describe('ProfileDocumentsService', () => {
         resultUrl
       );
 
-      const contentBuffer = Buffer.from('file-content');
-      vi.spyOn(fileServiceAdapter, 'getDocumentContent').mockResolvedValue(
-        contentBuffer
-      );
-
       const newDocMock = mockDocument(storageBucketDestination, {
         ...doc,
         id: uniqueId(),
       });
-      vi.spyOn(
-        storageBucketService,
-        'uploadFileAsDocumentFromBuffer'
-      ).mockResolvedValue(newDocMock);
+      vi.spyOn(storageBucketService, 'copyDocumentToBucket').mockResolvedValue(
+        newDocMock
+      );
 
       const result = await service.reuploadFileOnStorageBucket(
         fileUrl,
@@ -284,17 +275,10 @@ describe('ProfileDocumentsService', () => {
 
       expect(result).toBe(resultUrl);
       expect(result !== fileUrl).toBe(true);
-      expect(fileServiceAdapter.getDocumentContent).toHaveBeenCalledWith(
-        doc.id
-      );
-      expect(
-        storageBucketService.uploadFileAsDocumentFromBuffer
-      ).toHaveBeenCalledWith(
+      expect(fileServiceAdapter.getDocumentContent).not.toHaveBeenCalled();
+      expect(storageBucketService.copyDocumentToBucket).toHaveBeenCalledWith(
         storageBucketDestination.id,
-        contentBuffer,
-        doc.displayName,
-        doc.mimeType,
-        doc.createdBy
+        doc
       );
       // After copying to the new bucket, the original document in the old bucket
       // must be deleted to avoid orphaned storage.

--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -40,6 +40,18 @@ export class ProfileDocumentsService {
       }
     }
 
+    // Precondition: every path past here either calls file-service-go with
+    // the bucket id as an FK, or scans `bucket.documents` for an existing
+    // entry. Both fail incoherently on an unsaved bucket. Catch misuse here
+    // with a clear error rather than letting it surface from deep inside
+    // the storage-bucket service as "StorageBucket not found: undefined".
+    if (!storageBucket.id) {
+      throw new EntityNotInitializedException(
+        'Storage bucket must be persisted before document re-upload: caller must save the parent entity first (typically via parent.save() with cascade)',
+        LogContext.PROFILE
+      );
+    }
+
     if (!storageBucket.documents) {
       throw new EntityNotInitializedException(
         `Documents not initialized on storage bucket: '${storageBucket.id}'`,
@@ -83,24 +95,19 @@ export class ProfileDocumentsService {
       }
       return this.documentService.getPubliclyAccessibleURL(docInContent);
     } else {
-      // Different bucket: fetch content from Go service, re-upload to new bucket.
-      // After the new document is successfully uploaded, delete the old one so
-      // it doesn't leak in its original bucket as an orphan.
-      const content = await this.fileServiceAdapter.getDocumentContent(
-        docInContent.id
+      // Different bucket: ask file-service-go to materialize a new row in
+      // the destination bucket pointing at the same content. Single RPC,
+      // no bytes on the wire (content is content-addressed). After the
+      // new row is in place, delete the source so it doesn't leak as an
+      // orphan in its original bucket.
+      const newDoc = await this.storageBucketService.copyDocumentToBucket(
+        storageBucket.id,
+        docInContent
       );
-      const newDoc =
-        await this.storageBucketService.uploadFileAsDocumentFromBuffer(
-          storageBucket.id,
-          content,
-          docInContent.displayName,
-          docInContent.mimeType,
-          docInContent.createdBy
-        );
       try {
         await this.documentService.deleteDocument({ ID: docInContent.id });
       } catch (error) {
-        // Source delete failed after destination upload succeeded — compensate
+        // Source delete failed after destination copy succeeded — compensate
         // by removing the new copy so a caller retry doesn't accumulate
         // duplicates in the destination bucket. Swallow cleanup errors: the
         // original delete failure is what the caller needs to see.

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -105,6 +105,13 @@ export class SpaceAboutService {
     spaceAbout: ISpaceAbout,
     spaceAboutData: CreateSpaceAboutInput
   ): Promise<ISpaceAbout> {
+    if (!spaceAbout.profile) {
+      throw new RelationshipNotFoundException(
+        'SpaceAbout profile not initialized',
+        LogContext.SPACES,
+        { spaceAboutId: spaceAbout.id }
+      );
+    }
     spaceAbout.profile =
       await this.profileService.materializeProfileContentAndVisuals(
         spaceAbout.profile,

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -45,6 +45,16 @@ export class SpaceAboutService {
     private spaceAboutRepository: Repository<SpaceAbout>
   ) {}
 
+  /**
+   * Phase 1: in-memory entity construction. The returned spaceAbout (and its
+   * guidelines and profiles) must be persisted by the caller — typically via
+   * cascade from a parent Space — before
+   * {@link materializeSpaceAboutContent} is invoked.
+   *
+   * No file-service-go calls happen in this phase: visuals and any markdown
+   * re-uploads are deferred to phase 2 because they need a real
+   * `storageBucket.id`, which only exists after the cascade save.
+   */
   public async createSpaceAbout(
     spaceAboutData: CreateSpaceAboutInput,
     storageAggregator: IStorageAggregator
@@ -77,17 +87,35 @@ export class SpaceAboutService {
         storageAggregator
       );
 
-    // add the visuals
-    await this.profileService.addVisualsOnProfile(
-      spaceAbout.profile,
-      spaceAboutData.profileData.visuals,
-      [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
-    );
-
     // Do not save here — callers assign this to a parent entity with
     // cascade: true, so the parent's save handles persistence.
     // Saving via the default repository would bypass the caller's
     // transaction and cause FK violations on storageAggregator.
+    return spaceAbout;
+  }
+
+  /**
+   * Phase 2: post-save content materialization. Re-homes any internal
+   * Alkemio URLs in the profile description/references into the new
+   * bucket, attaches visuals, and cascades to the nested guidelines.
+   * Caller must invoke this AFTER the parent's cascade save persists
+   * `spaceAbout.profile.storageBucket` (and the guidelines' bucket).
+   */
+  public async materializeSpaceAboutContent(
+    spaceAbout: ISpaceAbout,
+    spaceAboutData: CreateSpaceAboutInput
+  ): Promise<ISpaceAbout> {
+    await this.profileService.materializeProfileContentAndVisuals(
+      spaceAbout.profile,
+      spaceAboutData.profileData.visuals,
+      [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
+    );
+    if (spaceAbout.guidelines && spaceAboutData.guidelines) {
+      await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
+        spaceAbout.guidelines,
+        spaceAboutData.guidelines
+      );
+    }
     return spaceAbout;
   }
 

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -105,11 +105,12 @@ export class SpaceAboutService {
     spaceAbout: ISpaceAbout,
     spaceAboutData: CreateSpaceAboutInput
   ): Promise<ISpaceAbout> {
-    await this.profileService.materializeProfileContentAndVisuals(
-      spaceAbout.profile,
-      spaceAboutData.profileData.visuals,
-      [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
-    );
+    spaceAbout.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        spaceAbout.profile,
+        spaceAboutData.profileData.visuals,
+        [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
+      );
     // createSpaceAbout always populates `spaceAbout.guidelines` (auto-creating
     // an empty one if `spaceAboutData.guidelines` wasn't supplied). Materialize
     // unconditionally so the auto-created profile gets its post-save work too;

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -110,7 +110,12 @@ export class SpaceAboutService {
       spaceAboutData.profileData.visuals,
       [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
     );
-    if (spaceAbout.guidelines && spaceAboutData.guidelines) {
+    // createSpaceAbout always populates `spaceAbout.guidelines` (auto-creating
+    // an empty one if `spaceAboutData.guidelines` wasn't supplied). Materialize
+    // unconditionally so the auto-created profile gets its post-save work too;
+    // materializeCommunityGuidelinesContent treats undefined input as "no
+    // visuals to attach".
+    if (spaceAbout.guidelines) {
       await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
         spaceAbout.guidelines,
         spaceAboutData.guidelines

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -238,6 +238,16 @@ export class SpaceService {
       await mgr.save(space as Space);
     });
 
+    // Phase 2: post-save content materialization. The transaction above
+    // committed the entity tree (including profile.storageBucket ids), so
+    // file-service-go calls now have real FKs to reference. This is the
+    // place where template-derived markdown URLs and visuals get re-homed
+    // into the new space's own bucket — fixes #6004 / #6005.
+    await this.spaceAboutService.materializeSpaceAboutContent(
+      space.about,
+      modifiedAbout
+    );
+
     if (spaceData.level === SpaceLevel.L0) {
       space.levelZeroSpaceID = space.id;
 

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -108,6 +108,7 @@ describe('StorageBucketService', () => {
           provide: FileServiceAdapter,
           useValue: {
             createDocument: vi.fn(),
+            copyDocument: vi.fn(),
             getDocumentContent: vi.fn(),
             updateDocument: vi.fn(),
             deleteDocument: vi.fn(),
@@ -607,6 +608,144 @@ describe('StorageBucketService', () => {
       });
       expect(tagsetService.removeTagset).toHaveBeenCalledWith(
         'tagset-saved-rrf'
+      );
+    });
+  });
+
+  // ── copyDocumentToBucket ───────────────────────────────────────
+
+  describe('copyDocumentToBucket', () => {
+    const makeSourceDoc = (overrides?: Partial<IDocument>): IDocument =>
+      mockDocument({
+        id: 'src-doc',
+        displayName: 'orig.png',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        externalID: 'ext-shared',
+        createdBy: 'user-orig',
+        ...overrides,
+      });
+
+    it('delegates to fileServiceAdapter.copyDocument with caller-supplied auth/tagset', async () => {
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc();
+      const newDoc = mockDocument({ id: 'doc-new' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-new',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: false,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(newDoc);
+
+      const result = await service.copyDocumentToBucket(
+        'bucket-dst',
+        source,
+        'user-caller'
+      );
+
+      expect(result).toBe(newDoc);
+      expect(fileServiceAdapter.copyDocument).toHaveBeenCalledWith({
+        sourceId: 'src-doc',
+        destinationBucketId: 'bucket-dst',
+        authorizationId: 'auth-saved',
+        tagsetId: 'tagset-saved',
+        createdBy: 'user-caller',
+      });
+      // Auth + tagset stay attached (fresh row, not reused)
+      expect(authorizationPolicyService.delete).not.toHaveBeenCalled();
+      expect(tagsetService.removeTagset).not.toHaveBeenCalled();
+    });
+
+    it('releases pre-created auth + tagset when Go responds reused:true', async () => {
+      // Same dedup-reuse contract as createDocument: when Go returns an
+      // existing row, our pre-created auth/tagset are orphans and must be
+      // released so they don't accumulate in the DB.
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc();
+      const reusedDoc = mockDocument({ id: 'doc-existing' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-existing',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: true,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(reusedDoc);
+
+      await service.copyDocumentToBucket('bucket-dst', source);
+
+      expect(authorizationPolicyService.delete).toHaveBeenCalledWith({
+        id: 'auth-saved',
+      });
+      expect(tagsetService.removeTagset).toHaveBeenCalledWith('tagset-saved');
+      // Existing doc must NOT be deleted on reuse — it belongs to another caller.
+      expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it('rolls back pre-created resources on copy failure', async () => {
+      // Full compensation when Go's copy call throws: delete the auth and
+      // tagset rows we pre-created. No Go-side document was created here so
+      // there's nothing to delete on that side.
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc();
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockRejectedValue(
+        new Error('copy failed')
+      );
+
+      await expect(
+        service.copyDocumentToBucket('bucket-dst', source)
+      ).rejects.toThrow('copy failed');
+
+      expect(authorizationPolicyService.delete).toHaveBeenCalledWith({
+        id: 'auth-saved',
+      });
+      expect(tagsetService.removeTagset).toHaveBeenCalledWith('tagset-saved');
+      expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it('falls back to source.createdBy when no userID is supplied', async () => {
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc({ createdBy: 'orig-user' });
+      const newDoc = mockDocument({ id: 'doc-new' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-new',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: false,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(newDoc);
+
+      await service.copyDocumentToBucket('bucket-dst', source);
+
+      expect(fileServiceAdapter.copyDocument).toHaveBeenCalledWith(
+        expect.objectContaining({ createdBy: 'orig-user' })
       );
     });
   });

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -23,6 +23,7 @@ import { TagsetService } from '@domain/common/tagset/tagset.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
+import type { CreateDocumentResult } from '@services/adapters/file-service-adapter/dto';
 import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
 import { AvatarCreatorService } from '@services/external/avatar-creator/avatar.creator.service';
 import { UrlGeneratorService } from '@services/infrastructure/url-generator/url.generator.service';
@@ -215,10 +216,84 @@ export class StorageBucketService {
     this.validateMimeTypes(storage, mimeType);
     this.validateSize(storage, buffer.length);
 
-    // Pre-create auth policy and tagset, call Go service, load result.
-    // Full compensation: any failure anywhere in the sequence rolls back all
-    // previously created resources (auth policy, tagset, Go-side document),
-    // each cleaned up independently so one rollback failure doesn't skip others.
+    return this.persistDocumentWithPreparedAuth(
+      storageBucketId,
+      mimeType,
+      (authId, tagsetId) =>
+        this.fileServiceAdapter.createDocument(buffer, {
+          displayName: filename,
+          mimeType,
+          storageBucketId,
+          authorizationId: authId,
+          tagsetId,
+          createdBy: userID || undefined,
+          temporaryLocation,
+          allowedMimeTypes: storage.allowedMimeTypes.join(','),
+          maxFileSize: storage.maxFileSize,
+          skipDedup: skipDedup || undefined,
+        })
+    );
+  }
+
+  /**
+   * Copy an existing document into another bucket via file-service-go's
+   * /internal/file/copy endpoint (v0.0.14+). No bytes traverse the wire —
+   * the new row references the same content. Replaces the legacy
+   * `getDocumentContent` + `uploadFileAsDocumentFromBuffer` round-trip.
+   *
+   * The destination bucket's allowed-mime-types and max-size policy are
+   * still enforced on the source's metadata, so a per-bucket policy that's
+   * tighter than the source bucket's still rejects the copy.
+   */
+  public async copyDocumentToBucket(
+    destinationBucketId: string,
+    sourceDocument: IDocument,
+    userID?: string,
+    skipDedup = false
+  ): Promise<IDocument> {
+    const destination = await this.getStorageBucketOrFail(destinationBucketId, {
+      relations: {},
+    });
+
+    this.validateMimeTypes(destination, sourceDocument.mimeType);
+    this.validateSize(destination, sourceDocument.size);
+
+    return this.persistDocumentWithPreparedAuth(
+      destinationBucketId,
+      sourceDocument.mimeType,
+      (authId, tagsetId) =>
+        this.fileServiceAdapter.copyDocument({
+          sourceId: sourceDocument.id,
+          destinationBucketId,
+          authorizationId: authId,
+          tagsetId,
+          createdBy: userID || sourceDocument.createdBy || undefined,
+          skipDedup: skipDedup || undefined,
+        })
+    );
+  }
+
+  /**
+   * Shared scaffolding for any operation that needs to materialize a new
+   * `Document` row in `bucketId`: pre-create the auth-policy + tagset that
+   * the document FK-references, run the caller-supplied file-service-go
+   * call, then either:
+   *   - on dedup-reuse (`result.reused === true`): release the pre-created
+   *     rows since Go ignored them and kept the existing row's values
+   *     authoritative;
+   *   - on error: roll back every pre-created resource AND, if Go did
+   *     create a fresh row before the failure, delete it too. On reuse
+   *     during a later failure, the source row belongs to another caller
+   *     and must be preserved.
+   *
+   * Both create and copy flows go through here so the auth/tagset
+   * lifecycle and dedup-reuse contract stay consistent across the two.
+   */
+  private async persistDocumentWithPreparedAuth(
+    bucketId: string,
+    _mimeTypeForLog: string,
+    goCall: (authId: string, tagsetId: string) => Promise<CreateDocumentResult>
+  ): Promise<IDocument> {
     let savedAuth;
     let savedTagset;
     let result;
@@ -235,22 +310,10 @@ export class StorageBucketService {
       });
       savedTagset = await this.tagsetService.save(tagset);
 
-      // Delegate to Go file-service-go
-      result = await this.fileServiceAdapter.createDocument(buffer, {
-        displayName: filename,
-        mimeType,
-        storageBucketId,
-        authorizationId: savedAuth.id,
-        tagsetId: savedTagset.id,
-        createdBy: userID || undefined,
-        temporaryLocation,
-        allowedMimeTypes: storage.allowedMimeTypes.join(','),
-        maxFileSize: storage.maxFileSize,
-        skipDedup: skipDedup || undefined,
-      });
+      result = await goCall(savedAuth.id, savedTagset.id);
 
-      // Load the document with relations needed for auth. On a dedup reuse
-      // this is an existing row; otherwise it's the freshly-inserted one.
+      // Load with relations needed for auth/tagset consumers. On dedup
+      // reuse this is an existing row; otherwise the freshly-inserted one.
       document = await this.documentService.getDocumentOrFail(result.id, {
         relations: {
           authorization: true,
@@ -259,9 +322,8 @@ export class StorageBucketService {
         },
       });
     } catch (error) {
-      // Rollback: delete each pre-created resource independently so one
-      // failure doesn't short-circuit the others. Bind narrowed values into
-      // const locals so the closures don't re-widen them.
+      // Independent rollbacks so one cleanup failure doesn't skip the rest.
+      // Bind narrowed values into const locals so the closures don't re-widen.
       //
       // Important: only delete the Go-side document if this request created
       // it (reused=false). On a dedup reuse, `result.id` refers to someone
@@ -296,10 +358,9 @@ export class StorageBucketService {
       throw error;
     }
 
-    // file-service-go returned an existing row: the caller-supplied
-    // authorizationId/tagsetId were ignored (the existing row keeps its
-    // own). Release our pre-created rows here rather than leaving them
-    // as DB orphans. Same const-rebind trick as above to keep narrowing.
+    // Dedup-reuse: caller-supplied authorizationId / tagsetId were ignored
+    // by Go (existing row authoritative). Release our pre-created rows so
+    // they don't become DB orphans.
     if (result.reused) {
       const reusedAuth = savedAuth;
       if (reusedAuth) {
@@ -322,7 +383,7 @@ export class StorageBucketService {
     }
 
     this.logger.verbose?.(
-      `Uploaded document '${result.externalID}' via file-service on storage bucket: ${storage.id}`,
+      `Materialized document '${result.externalID}' via file-service on storage bucket: ${bucketId}`,
       LogContext.STORAGE_BUCKET
     );
     return document;

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -205,7 +205,8 @@ export class StorageBucketService {
     filename: string,
     mimeType: string,
     userID?: string,
-    temporaryLocation = false
+    temporaryLocation = false,
+    skipDedup = false
   ): Promise<IDocument> {
     const storage = await this.getStorageBucketOrFail(storageBucketId, {
       relations: {},
@@ -245,6 +246,7 @@ export class StorageBucketService {
         temporaryLocation,
         allowedMimeTypes: storage.allowedMimeTypes.join(','),
         maxFileSize: storage.maxFileSize,
+        skipDedup: skipDedup || undefined,
       });
 
       // Load the document with relations needed for auth. On a dedup reuse

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -246,6 +246,23 @@ export class TemplateService {
         templateData.communityGuidelinesData
       );
     }
+    if (
+      template.type === TemplateType.WHITEBOARD &&
+      template.whiteboard &&
+      templateData.whiteboard
+    ) {
+      // Whiteboard templates ship a placeholder profile with internal-URL
+      // visuals that need re-homing into the template's own bucket.
+      await this.whiteboardService.materializeWhiteboardContent(
+        template.whiteboard,
+        {
+          profile: { displayName: 'Whiteboard Template' },
+          nameID: template.whiteboard.nameID,
+          content: templateData.whiteboard.content,
+          previewSettings: templateData.whiteboard.previewSettings,
+        }
+      );
+    }
     return template;
   }
 

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -209,7 +209,10 @@ export class TemplateService {
         );
     }
 
-    return await this.templateRepository.save(template);
+    // Phase 1 returns unsaved. The caller (TemplatesSetService) saves the
+    // template after wiring up the templatesSet relation, then calls
+    // materializeTemplateContent for post-save re-uploads.
+    return template;
   }
 
   /**

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -64,6 +64,14 @@ export class TemplateService {
     private readonly logger: LoggerService
   ) {}
 
+  /**
+   * Phase 1: in-memory entity construction. The returned template is unsaved;
+   * the caller must save it (see {@link save}) and then invoke
+   * {@link materializeTemplateContent} to perform post-save materialization
+   * (markdown re-upload, visuals, nested entities). Splitting these phases
+   * avoids the bug from #6004 / #6005 where file-service-go calls happened
+   * with an unsaved `storageBucket.id`.
+   */
   async createTemplate(
     templateData: CreateTemplateInput,
     storageAggregator: IStorageAggregator
@@ -82,11 +90,6 @@ export class TemplateService {
       name: TagsetReservedName.DEFAULT,
       tags: templateData.tags,
     });
-    await this.profileService.addVisualsOnProfile(
-      template.profile,
-      templateData.profileData.visuals,
-      [VisualType.CARD]
-    );
     switch (template.type) {
       case TemplateType.POST: {
         if (!templateData.postDefaultDescription) {
@@ -207,6 +210,40 @@ export class TemplateService {
     }
 
     return await this.templateRepository.save(template);
+  }
+
+  /**
+   * Phase 2: post-save content materialization. Re-homes any internal
+   * Alkemio URLs in the template profile's description/references into
+   * the template's own bucket and attaches its visuals. Caller must invoke
+   * AFTER {@link save} (or any equivalent persist) so the storageBucket id
+   * is real.
+   *
+   * Nested entities (community guidelines, content space, callout,
+   * whiteboard) own their own materialization where it matters; those are
+   * delegated as separate calls so each composing service stays
+   * responsible for its own slice of post-save work.
+   */
+  async materializeTemplateContent(
+    template: ITemplate,
+    templateData: CreateTemplateInput
+  ): Promise<ITemplate> {
+    await this.profileService.materializeProfileContentAndVisuals(
+      template.profile,
+      templateData.profileData.visuals,
+      [VisualType.CARD]
+    );
+    if (
+      template.type === TemplateType.COMMUNITY_GUIDELINES &&
+      template.communityGuidelines &&
+      templateData.communityGuidelinesData
+    ) {
+      await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
+        template.communityGuidelines,
+        templateData.communityGuidelinesData
+      );
+    }
+    return template;
   }
 
   private overrideCalloutSettingsForTemplate(calloutData: CreateCalloutInput) {

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -244,11 +244,12 @@ export class TemplateService {
         }
       );
     }
-    await this.profileService.materializeProfileContentAndVisuals(
-      template.profile,
-      templateData.profileData.visuals,
-      [VisualType.CARD]
-    );
+    template.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        template.profile,
+        templateData.profileData.visuals,
+        [VisualType.CARD]
+      );
     if (
       template.type === TemplateType.COMMUNITY_GUIDELINES &&
       template.communityGuidelines &&
@@ -269,7 +270,12 @@ export class TemplateService {
       await this.whiteboardService.materializeWhiteboardContent(
         template.whiteboard,
         {
-          profile: { displayName: 'Whiteboard Template' },
+          profile: {
+            displayName:
+              templateData.whiteboard.profile?.displayName ??
+              'Whiteboard Template',
+            visuals: templateData.whiteboard.profile?.visuals,
+          },
           nameID: template.whiteboard.nameID,
           content: templateData.whiteboard.content,
           previewSettings: templateData.whiteboard.previewSettings,

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -222,15 +222,28 @@ export class TemplateService {
    * AFTER {@link save} (or any equivalent persist) so the storageBucket id
    * is real.
    *
-   * Nested entities (community guidelines, content space, callout,
-   * whiteboard) own their own materialization where it matters; those are
-   * delegated as separate calls so each composing service stays
-   * responsible for its own slice of post-save work.
+   * Currently delegates only to community-guidelines and whiteboard
+   * templates — those are the bug-path types from #6004 / #6005 whose
+   * inputs commonly carry internal URLs. Other template types
+   * (POST, CALLOUT, SPACE) don't have a materialize hook yet; their
+   * profiles still get re-homed at the top of this method, but nested
+   * content within `contentSpace`/`callout` is not walked. Add explicit
+   * delegation here when those types start carrying internal URLs.
    */
   async materializeTemplateContent(
     template: ITemplate,
     templateData: CreateTemplateInput
   ): Promise<ITemplate> {
+    if (!template.profile?.storageBucket?.id) {
+      throw new EntityNotInitializedException(
+        'Template profile storage bucket must be persisted before materialization',
+        LogContext.TEMPLATES,
+        {
+          templateId: template.id,
+          profileId: template.profile?.id,
+        }
+      );
+    }
     await this.profileService.materializeProfileContentAndVisuals(
       template.profile,
       templateData.profileData.visuals,

--- a/src/domain/template/templates-set/templates.set.service.ts
+++ b/src/domain/template/templates-set/templates.set.service.ts
@@ -140,7 +140,12 @@ export class TemplatesSetService {
       storageAggregator
     );
     template.templatesSet = templatesSet;
-    return await this.templateService.save(template);
+    const saved = await this.templateService.save(template);
+    // Post-save: now that the template + its profile bucket are persisted,
+    // re-home any internal Alkemio URLs (markdown, references) and attach
+    // visuals. Fixes the unsaved-bucket failure reported as #6004.
+    await this.templateService.materializeTemplateContent(saved, templateInput);
+    return saved;
   }
 
   async createTemplateFromSpace(

--- a/src/library/innovation-pack/innovation.pack.service.ts
+++ b/src/library/innovation-pack/innovation.pack.service.ts
@@ -94,11 +94,12 @@ export class InnovationPackService {
     const saved = await this.save(innovationPack);
     // Post-save: profile.storageBucket has its id; re-home internal URLs
     // and attach AVATAR + CARD visuals.
-    await this.profileService.materializeProfileContentAndVisuals(
-      saved.profile,
-      innovationPackData.profileData.visuals,
-      [VisualType.AVATAR, VisualType.CARD]
-    );
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        saved.profile,
+        innovationPackData.profileData.visuals,
+        [VisualType.AVATAR, VisualType.CARD]
+      );
     return saved;
   }
 

--- a/src/library/innovation-pack/innovation.pack.service.ts
+++ b/src/library/innovation-pack/innovation.pack.service.ts
@@ -76,11 +76,6 @@ export class InnovationPackService {
       ProfileType.INNOVATION_PACK,
       storageAggregator
     );
-    await this.profileService.addVisualsOnProfile(
-      innovationPack.profile,
-      innovationPackData.profileData.visuals,
-      [VisualType.AVATAR, VisualType.CARD]
-    );
 
     innovationPack.listedInStore = true;
     innovationPack.searchVisibility = SearchVisibility.ACCOUNT;
@@ -96,7 +91,15 @@ export class InnovationPackService {
     innovationPack.templatesSet =
       await this.templatesSetService.createTemplatesSet();
 
-    return await this.save(innovationPack);
+    const saved = await this.save(innovationPack);
+    // Post-save: profile.storageBucket has its id; re-home internal URLs
+    // and attach AVATAR + CARD visuals.
+    await this.profileService.materializeProfileContentAndVisuals(
+      saved.profile,
+      innovationPackData.profileData.visuals,
+      [VisualType.AVATAR, VisualType.CARD]
+    );
+    return saved;
   }
 
   async save(innovationPack: IInnovationPack): Promise<IInnovationPack> {

--- a/src/services/adapters/file-service-adapter/dto/copy.document.input.ts
+++ b/src/services/adapters/file-service-adapter/dto/copy.document.input.ts
@@ -1,0 +1,21 @@
+/**
+ * Request body for `POST /internal/file/copy` on file-service-go (v0.0.14+).
+ *
+ * Materializes a new file row in `destinationBucketId` that references the
+ * same content as `sourceId`. file-service-go is content-addressed, so the
+ * underlying blob is shared — only ownership/placement changes. Avoids the
+ * legacy `getDocumentContent` + `createDocument` round-trip that used to
+ * pull and push file bytes through the server pod for no reason.
+ */
+export interface CopyDocumentInput {
+  sourceId: string;
+  destinationBucketId: string;
+  authorizationId: string;
+  tagsetId?: string;
+  createdBy?: string;
+  /**
+   * Mirrors `CreateDocumentMetadata.skipDedup`. When true, bypass the
+   * destination bucket's per-content dedup lookup and force a fresh row.
+   */
+  skipDedup?: boolean;
+}

--- a/src/services/adapters/file-service-adapter/dto/create.document.metadata.ts
+++ b/src/services/adapters/file-service-adapter/dto/create.document.metadata.ts
@@ -17,4 +17,13 @@ export interface CreateDocumentMetadata {
   temporaryLocation?: boolean;
   allowedMimeTypes?: string;
   maxFileSize?: number;
+  /**
+   * Bypass file-service-go's per-bucket content-hash dedup and force a fresh
+   * row even if an identical-content row already exists in the same bucket.
+   * Used by placeholder-then-edit flows (e.g. Collabora documents) where two
+   * logical documents must NOT share a backing row even though their initial
+   * content (often `Buffer.alloc(0)`) is identical. Default false preserves
+   * dedup for genuine content uploads.
+   */
+  skipDedup?: boolean;
 }

--- a/src/services/adapters/file-service-adapter/dto/index.ts
+++ b/src/services/adapters/file-service-adapter/dto/index.ts
@@ -1,3 +1,4 @@
+export { CopyDocumentInput } from './copy.document.input';
 export { CreateDocumentMetadata } from './create.document.metadata';
 export { CreateDocumentResult } from './create.document.result';
 export { DeleteDocumentResult } from './delete.document.result';

--- a/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
@@ -98,6 +98,59 @@ describe('FileServiceAdapter', () => {
       expect(callArgs.url).toBe('http://file-service:4003/internal/file');
     });
 
+    it('sends skipDedup=true as a multipart form field when set', async () => {
+      const responseData = {
+        id: 'doc-skip',
+        externalID: 'ext-skip',
+        mimeType: 'image/png',
+        size: 0,
+        reused: false,
+      };
+
+      (httpService.request as Mock).mockReturnValue(
+        of(axiosResponse(responseData, 201))
+      );
+
+      await adapter.createDocument(Buffer.alloc(0), {
+        displayName: 'placeholder.docx',
+        storageBucketId: 'bucket-1',
+        authorizationId: 'auth-1',
+        tagsetId: 'tagset-1',
+        skipDedup: true,
+      });
+
+      // FormData carries the field as a serialized stream; assert via the
+      // serialized buffer rather than introspection.
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      const serialized = callArgs.data.getBuffer().toString('utf8');
+      expect(serialized).toContain('name="skipDedup"');
+      expect(serialized).toMatch(/name="skipDedup"\r\n\r\ntrue/);
+    });
+
+    it('omits skipDedup when not set (preserves dedup default)', async () => {
+      const responseData = {
+        id: 'doc-default',
+        externalID: 'ext-default',
+        mimeType: 'image/png',
+        size: 4,
+        reused: false,
+      };
+
+      (httpService.request as Mock).mockReturnValue(
+        of(axiosResponse(responseData, 201))
+      );
+
+      await adapter.createDocument(Buffer.from('data'), {
+        displayName: 'avatar.png',
+        storageBucketId: 'bucket-1',
+        authorizationId: 'auth-1',
+      });
+
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      const serialized = callArgs.data.getBuffer().toString('utf8');
+      expect(serialized).not.toContain('name="skipDedup"');
+    });
+
     it('should throw FileServiceAdapterException on 4xx error', async () => {
       const axiosError = new AxiosError('Bad Request', '400', undefined, null, {
         status: 400,

--- a/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
@@ -271,6 +271,92 @@ describe('FileServiceAdapter', () => {
     });
   });
 
+  describe('copyDocument', () => {
+    it('POSTs JSON body to /internal/file/copy', async () => {
+      const responseData = {
+        id: 'doc-copy',
+        externalID: 'ext-shared',
+        mimeType: 'image/png',
+        size: 1024,
+        reused: false,
+      };
+
+      (httpService.request as Mock).mockReturnValue(
+        of(axiosResponse(responseData, 201))
+      );
+
+      const result = await adapter.copyDocument({
+        sourceId: 'src-1',
+        destinationBucketId: 'bucket-2',
+        authorizationId: 'auth-2',
+        tagsetId: 'tagset-2',
+        createdBy: 'user-1',
+      });
+
+      expect(result).toEqual(responseData);
+
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      expect(callArgs.method).toBe('post');
+      expect(callArgs.url).toBe('http://file-service:4003/internal/file/copy');
+      expect(callArgs.data).toEqual({
+        sourceId: 'src-1',
+        destinationBucketId: 'bucket-2',
+        authorizationId: 'auth-2',
+        tagsetId: 'tagset-2',
+        createdBy: 'user-1',
+      });
+    });
+
+    it('passes skipDedup when true', async () => {
+      (httpService.request as Mock).mockReturnValue(
+        of(
+          axiosResponse(
+            {
+              id: 'doc-copy',
+              externalID: 'ext',
+              mimeType: 'image/png',
+              size: 1,
+              reused: false,
+            },
+            201
+          )
+        )
+      );
+
+      await adapter.copyDocument({
+        sourceId: 'src-1',
+        destinationBucketId: 'bucket-2',
+        authorizationId: 'auth-2',
+        skipDedup: true,
+      });
+
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      expect(callArgs.data.skipDedup).toBe(true);
+    });
+
+    it('surfaces 404 from file-service-go as FileServiceAdapterException', async () => {
+      const axiosError = new AxiosError('Not Found', '404', undefined, null, {
+        status: 404,
+        data: { error: 'source document not found' },
+        statusText: 'Not Found',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+      });
+
+      (httpService.request as Mock).mockReturnValue(
+        throwError(() => axiosError)
+      );
+
+      await expect(
+        adapter.copyDocument({
+          sourceId: 'missing',
+          destinationBucketId: 'bucket-2',
+          authorizationId: 'auth-2',
+        })
+      ).rejects.toThrow(FileServiceAdapterException);
+    });
+  });
+
   describe('deleteDocument', () => {
     it('should DELETE and return authorizationId and tagsetId', async () => {
       const responseData = {

--- a/src/services/adapters/file-service-adapter/file.service.adapter.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.ts
@@ -11,6 +11,7 @@ import { isAxiosError } from 'axios';
 import FormData from 'form-data';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import type {
+  CopyDocumentInput,
   CreateDocumentMetadata,
   CreateDocumentResult,
   DeleteDocumentResult,
@@ -106,6 +107,27 @@ export class FileServiceAdapter extends HttpClientBase {
       FILE_PATH_PREFIX,
       form,
       form.getHeaders()
+    );
+  }
+
+  /**
+   * Copy an existing document into another bucket on file-service-go (v0.0.14+).
+   * No bytes traverse the wire — content is content-addressed, the new row
+   * just points at the existing blob. Replaces the legacy
+   * `getDocumentContent` + `createDocument` round-trip.
+   *
+   * Per-bucket dedup applies by default; on dedup hit the response carries
+   * `reused: true` and the caller-supplied `authorizationId` / `tagsetId`
+   * are ignored, matching `createDocument`'s contract.
+   */
+  async copyDocument(input: CopyDocumentInput): Promise<CreateDocumentResult> {
+    this.checkEnabledAndCircuit('copyDocument');
+
+    return this.sendRequest<CreateDocumentResult>(
+      'copyDocument',
+      'post',
+      `${FILE_PATH_PREFIX}/copy`,
+      input
     );
   }
 

--- a/src/services/adapters/file-service-adapter/file.service.adapter.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.ts
@@ -96,6 +96,9 @@ export class FileServiceAdapter extends HttpClientBase {
     if (metadata.maxFileSize !== undefined) {
       form.append('maxFileSize', String(metadata.maxFileSize));
     }
+    if (metadata.skipDedup) {
+      form.append('skipDedup', 'true');
+    }
 
     return this.sendRequest<CreateDocumentResult>(
       'createDocument',

--- a/src/services/infrastructure/event-bus/event.bus.module.ts
+++ b/src/services/infrastructure/event-bus/event.bus.module.ts
@@ -112,6 +112,19 @@ import { Subscriber } from './subscriber';
               routingKey: 'libra-flow',
               durable: true,
             },
+            {
+              // Engine result queue — external VC engines publish to
+              // the `event-bus` exchange with routing key
+              // `invoke-engine-result`.  Declaring it here makes
+              // golevelup re-assert the binding on every reconnect,
+              // eliminating the drift where the queue was recreated
+              // (via Subscriber.createSubscriber) without its binding
+              // and engine replies silently vanished.
+              name: eventBusConfig.invoke_engine_result,
+              exchange: eventBusConfig.exchange,
+              routingKey: 'invoke-engine-result',
+              durable: true,
+            },
           ],
         };
       },


### PR DESCRIPTION
## Summary

Replaces the prior eager-bucket-save patch with the proper structural fix.

- File-service-go migration (PR #5969) moved Document ownership outside the server's TypeORM transaction. Any flow that calls into Go from inside an in-memory entity graph hits the same wall — the destination `storageBucket.id` is `undefined` until cascade save, and the call fails with `StorageBucket not found: undefined`. Surfaces whenever a template's description/visuals carry internal Alkemio URLs (#6004 / #6005).
- The honest post-#5969 model is **two phases**:
  - **Phase 1**: pure in-memory entity construction (no file-service calls)
  - **Phase 2**: post-save content materialization (file-service calls with persisted FKs in hand)
- Cross-bucket document copies switch to file-service-go v0.0.14's new [`POST /internal/file/copy`](https://github.com/alkem-io/file-service-go/pull/15) — no bytes traverse the wire, the new row just references the same content (content-addressed storage).

## Concrete pieces

- New `CopyDocumentInput` DTO + `FileServiceAdapter.copyDocument`
- `StorageBucketService.copyDocumentToBucket` mirrors `uploadFileAsDocumentFromBuffer`'s auth/tagset preparation, dedup-reuse cleanup, and rollback compensation. Both now go through a single private `persistDocumentWithPreparedAuth` helper — DRY across both flows.
- `ProfileService.createProfile` is **pure** — no file-service calls
- `ProfileService.materializeProfileContent` re-homes internal URLs in description/references; precondition fails loudly on unsaved bucket
- `ProfileService.materializeProfileContentAndVisuals` is the standard post-save call: content + visuals + persist
- `ProfileDocumentsService.reuploadFileOnStorageBucket` uses `copyDocumentToBucket` for the cross-bucket branch and adds a precondition that catches misuse at the helper boundary (clear error instead of `StorageBucket not found: undefined`)
- `CommunityGuidelinesService`, `SpaceAboutService`, `TemplateService` split into pure-create + materialize counterparts
- `SpaceService.createSpace` calls `spaceAboutService.materializeSpaceAboutContent` after the transaction commits — **fixes #6005**
- `templates.set.service.ts` calls `templateService.materializeTemplateContent` after save — **fixes #6004**
- `quickstart-services.yml` bumped to `alkemio/file-service-go:v0.0.14`

## Why this is structurally sound (not a duct-tape)

1. **Acknowledges the cross-service boundary.** No method pretends in-memory entity composition spans file-service-go calls. The two phases are explicit and named.
2. **Uses the proper primitive.** `copyDocument` (single RPC, content-addressed) replaces the legacy `getDocumentContent` + `createDocument` round-trip that pulled bytes through the server pod for no reason.
3. **DRY.** The auth/tagset prep + dedup-reuse cleanup + rollback dance is now one private helper used by both upload and copy, instead of two copy-pastes that could drift.
4. **Defensive.** A helper-layer precondition in `reuploadFileOnStorageBucket` catches any future caller that passes an unsaved bucket — clean error at the right layer instead of confusing failure deep inside the upload helper.
5. **Test honesty.** Spec mocks now reflect production reality; new regression tests pin the call ordering and the contract of each phase.

## Out of scope (deferred)

The 4 services on the bug paths (`Template`, `SpaceAbout`, `CommunityGuidelines`, `Space`) are migrated to the two-phase pattern in this PR. Other ~14 services that also call `createProfile + addVisualsOnProfile` inline don't currently break in practice (their inputs typically don't carry internal URLs that would trigger reupload), but they're not yet on the new pattern. The new helper-layer precondition will catch them loudly if they ever do trigger the failure mode; migration of those callers is a follow-up.

## Test plan

- [x] `pnpm test:ci:no:coverage` — 6387 tests pass (9 new), 0 failures
- [x] `pnpm exec biome check` — clean on touched files (one pre-existing unused-import warning unrelated to this PR)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] New regression tests:
  - `FileServiceAdapter.copyDocument` POSTs JSON to `/internal/file/copy` with skipDedup support and proper error mapping
  - `StorageBucketService.copyDocumentToBucket` covers happy path, dedup-reuse cleanup, rollback on failure, and `createdBy` fallback to source's
  - `ProfileService.materializeProfileContent` precondition + actual re-upload
  - `ProfileService.materializeProfileContentAndVisuals` ordering and skip-when-no-visuals
  - `ProfileDocumentsService.reuploadFileOnStorageBucket` uses `copyDocumentToBucket` and skips the legacy `getDocumentContent` round-trip
  - `ProfileService.createProfile` is pure — does NOT call any file-service helper
  - `CommunityGuidelinesService.createCommunityGuidelines` is pure; `materializeCommunityGuidelinesContent` delegates correctly
- [ ] Manual verification on dev: import a template with visuals; create a space from a template with visuals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New phase‑2 "materialize" APIs to finalize markdown, rehome internal URLs, and attach visuals after entities are persisted.
  * Server‑side file‑copy support to move documents between storage buckets without client round‑trips; adapter/DTO added.

* **Bug Fixes**
  * Creation flows persist first, then materialize content/visuals for correct URL rehoming and safer retries.
  * Fail‑fast checks when storage/bucket IDs are missing; initial creation preserves original markdown/references.

* **Tests**
  * Added/updated unit tests for materialization, copy behavior, and compensation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->