### PR TITLE
Fix #6004 / #6005: two-phase profile materialization + copyDocument (release/54)

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -499,7 +499,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.14
+    image: alkemio/file-service-go:v0.0.15
     depends_on:
       postgres:
         condition: service_healthy
@@ -579,7 +579,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_authorization_evaluation
     hostname: authorization-evaluation
-    image: alkemio/authorization-evaluation-service:v0.0.2
+    image: alkemio/authorization-evaluation-service:v0.0.4
     depends_on:
       postgres:
         condition: service_healthy

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -499,7 +499,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service-go:v0.0.13
+    image: alkemio/file-service-go:v0.0.14
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -97,6 +97,35 @@ export class RoleSetResolverMutationsMembership {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
+  /**
+   * Wraps a fire-and-forget notification dispatch with a `.catch` so an
+   * unhandled rejection from a downstream notification adapter (e.g. the
+   * in-app insert losing a race against an invitation deletion → FK
+   * violation) does not crash the Node process.
+   *
+   * The notification is still side-effectful: failures are logged at ERROR
+   * with structured details so monitoring can pick them up. Notifications
+   * are intentionally not awaited at the resolver level; we don't want a
+   * downstream notification problem to fail the user-facing mutation.
+   */
+  private dispatchNotification(
+    promise: Promise<unknown>,
+    eventLabel: string
+  ): void {
+    void promise.catch(error => {
+      const stack = error instanceof Error ? (error.stack ?? '') : '';
+      this.logger.error?.(
+        {
+          message: 'Notification dispatch failed',
+          event: eventLabel,
+          error: String(error),
+        },
+        stack,
+        LogContext.NOTIFICATIONS
+      );
+    });
+  }
+
   @Mutation(() => IRoleSet, {
     description:
       'Join the specified RoleSet using the entry Role, without going through an approval process.',
@@ -487,9 +516,12 @@ export class RoleSetResolverMutationsMembership {
             spaceID: space.id,
           };
 
-        void this.notificationUserAdapter.userSpaceCommunityApplicationDeclined(
-          notificationInput,
-          space
+        this.dispatchNotification(
+          this.notificationUserAdapter.userSpaceCommunityApplicationDeclined(
+            notificationInput,
+            space
+          ),
+          'userSpaceCommunityApplicationDeclined'
         );
       }
 
@@ -797,8 +829,11 @@ export class RoleSetResolverMutationsMembership {
             invitedUserEmail: platformInvitation.email,
             welcomeMessage: platformInvitation.welcomeMessage,
           };
-          void this.notificationPlatformAdapter.platformInvitationCreated(
-            notificationInput
+          this.dispatchNotification(
+            this.notificationPlatformAdapter.platformInvitationCreated(
+              notificationInput
+            ),
+            'platformInvitationCreated'
           );
           break;
         }
@@ -835,8 +870,11 @@ export class RoleSetResolverMutationsMembership {
                   welcomeMessage: invitation.welcomeMessage,
                 };
 
-              void this.notificationVirtualContributorAdapter.spaceCommunityInvitationVirtualContributorCreated(
-                notificationInput
+              this.dispatchNotification(
+                this.notificationVirtualContributorAdapter.spaceCommunityInvitationVirtualContributorCreated(
+                  notificationInput
+                ),
+                'spaceCommunityInvitationVirtualContributorCreated'
               );
               break;
             }
@@ -850,8 +888,11 @@ export class RoleSetResolverMutationsMembership {
                 welcomeMessage: invitation.welcomeMessage,
               };
 
-              void this.notificationUserAdapter.userSpaceCommunityInvitationCreated(
-                notificationInput
+              this.dispatchNotification(
+                this.notificationUserAdapter.userSpaceCommunityInvitationCreated(
+                  notificationInput
+                ),
+                'userSpaceCommunityInvitationCreated'
               );
               break;
             }

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -227,8 +227,11 @@ export class RoleSetResolverMutationsMembership {
       community,
       application,
     };
-    void this.notificationAdapterSpace.spaceCommunityApplicationCreated(
-      notificationInput
+    this.dispatchNotification(
+      this.notificationAdapterSpace.spaceCommunityApplicationCreated(
+        notificationInput
+      ),
+      'spaceCommunityApplicationCreated'
     );
 
     return await this.applicationService.getApplicationOrFail(application.id);
@@ -653,9 +656,12 @@ export class RoleSetResolverMutationsMembership {
               spaceID: space.id,
             };
 
-          void this.notificationAdapterSpace.spaceAdminVirtualContributorInvitationDeclined(
-            notificationInput,
-            space
+          this.dispatchNotification(
+            this.notificationAdapterSpace.spaceAdminVirtualContributorInvitationDeclined(
+              notificationInput,
+              space
+            ),
+            'spaceAdminVirtualContributorInvitationDeclined'
           );
         }
       }

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -73,10 +73,17 @@ export class CalloutContributionService {
     contributionData: CreateCalloutContributionInput | undefined,
     rollback: () => Promise<unknown>
   ): Promise<void> {
-    if (
-      contribution.type === CalloutContributionType.LINK &&
-      contribution.link
-    ) {
+    if (contribution.type === CalloutContributionType.LINK) {
+      if (!contribution.link) {
+        throw new RelationshipNotFoundException(
+          'Missing required relation for phase-2 materialization',
+          LogContext.COLLABORATION,
+          {
+            contributionId: contribution.id,
+            missing: ['link'],
+          }
+        );
+      }
       await this.linkService.materializeLinkContent(
         contribution.link,
         contributionData?.link,

--- a/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.service.ts
@@ -62,6 +62,29 @@ export class CalloutContributionService {
     return contributions;
   }
 
+  /**
+   * Phase-2 materialization for a CalloutContribution. Post/Whiteboard/Memo
+   * leaves are self-materializing inside their respective createX methods
+   * (already saved + materialized when this is called). Only LINK
+   * contributions need explicit materialize here.
+   */
+  public async materializeCalloutContributionContent(
+    contribution: ICalloutContribution,
+    contributionData: CreateCalloutContributionInput | undefined,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    if (
+      contribution.type === CalloutContributionType.LINK &&
+      contribution.link
+    ) {
+      await this.linkService.materializeLinkContent(
+        contribution.link,
+        contributionData?.link,
+        rollback
+      );
+    }
+  }
+
   public async createCalloutContribution(
     calloutContributionData: CreateCalloutContributionInput,
     storageAggregator: IStorageAggregator,

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -199,15 +199,14 @@ export class CalloutFramingService {
       `${memoData.profile?.displayName ?? 'memo'}`,
       reservedNameIDs
     );
+    // Memo's framing context wants both CARD (its own default) and BANNER
+    // (framing-specific). Pass the union so createMemo materializes both
+    // post-save in one shot.
     calloutFraming.memo = await this.memoService.createMemo(
       memoData,
       storageAggregator,
-      userID
-    );
-    await this.profileService.addVisualsOnProfile(
-      calloutFraming.memo.profile,
-      memoData.profile?.visuals,
-      [VisualType.BANNER]
+      userID,
+      [VisualType.CARD, VisualType.BANNER]
     );
   }
 

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -169,6 +169,40 @@ export class CalloutFramingService {
     return calloutFraming;
   }
 
+  /**
+   * Phase-2 materialization for a CalloutFraming. Composed under a parent
+   * (callout, template-callout, etc.); the parent's save persists the
+   * framing's bucket before this is called.
+   *
+   * Walks the framing's own profile and the LINK child if present.
+   * Whiteboard and Memo children are self-materializing inside their own
+   * createX flows (already saved + materialized). MediaGallery handles
+   * its own visuals inline via createMediaGallery (saves the bucket
+   * eagerly). Poll has no profile.
+   */
+  public async materializeCalloutFramingContent(
+    calloutFraming: ICalloutFraming,
+    calloutFramingData: CreateCalloutFramingInput | undefined,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      calloutFraming.profile,
+      calloutFramingData?.profile?.visuals,
+      [VisualType.CARD, VisualType.BANNER],
+      rollback
+    );
+    if (
+      calloutFraming.type === CalloutFramingType.LINK &&
+      calloutFraming.link
+    ) {
+      await this.linkService.materializeLinkContent(
+        calloutFraming.link,
+        calloutFramingData?.link,
+        rollback
+      );
+    }
+  }
+
   private async createNewWhiteboardInCalloutFraming(
     calloutFraming: ICalloutFraming,
     whiteboardData: CreateWhiteboardInput,

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -5,7 +5,10 @@ import { LogContext } from '@common/enums/logging.context';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { TagsetType } from '@common/enums/tagset.type';
 import { VisualType } from '@common/enums/visual.type';
-import { ValidationException } from '@common/exceptions';
+import {
+  RelationshipNotFoundException,
+  ValidationException,
+} from '@common/exceptions';
 import { EntityNotFoundException } from '@common/exceptions/entity.not.found.exception';
 import { CreateLinkInput } from '@domain/collaboration/link/dto/link.dto.create';
 import { LinkService } from '@domain/collaboration/link/link.service';
@@ -185,6 +188,29 @@ export class CalloutFramingService {
     calloutFramingData: CreateCalloutFramingInput | undefined,
     rollback: () => Promise<unknown>
   ): Promise<void> {
+    if (!calloutFraming.profile) {
+      throw new RelationshipNotFoundException(
+        'Missing required relation for phase-2 materialization',
+        LogContext.COLLABORATION,
+        {
+          calloutFramingId: calloutFraming.id,
+          missing: ['profile'],
+        }
+      );
+    }
+    if (
+      calloutFraming.type === CalloutFramingType.LINK &&
+      !calloutFraming.link
+    ) {
+      throw new RelationshipNotFoundException(
+        'Missing required relation for phase-2 materialization',
+        LogContext.COLLABORATION,
+        {
+          calloutFramingId: calloutFraming.id,
+          missing: ['link'],
+        }
+      );
+    }
     await this.profileService.materializeProfileContentAndVisualsOrRollback(
       calloutFraming.profile,
       calloutFramingData?.profile?.visuals,

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -298,6 +298,16 @@ export class CalloutResolverMutations {
 
     contribution = await this.calloutContributionService.save(contribution);
 
+    // Phase-2 materialize: re-home cross-bucket markdown URLs / refs in
+    // the contribution's leaf (LINK only — Post/Whiteboard/Memo are
+    // self-materializing inside their createX). Failure rolls back the
+    // just-saved contribution.
+    await this.calloutContributionService.materializeCalloutContributionContent(
+      contribution,
+      contributionData,
+      () => this.calloutContributionService.delete(contribution.id)
+    );
+
     const destinationStorageBucket =
       await this.calloutContributionService.getStorageBucketForContribution(
         contribution.id

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -139,6 +139,37 @@ export class CalloutService {
     return callout;
   }
 
+  /**
+   * Phase-2 materialization for a Callout. Composed under a parent
+   * (collaboration, template, knowledge-base); the parent's save persists
+   * the callout's framing/contribution buckets before this is called.
+   *
+   * Walks framing + each contribution. Failures bubble up via the supplied
+   * rollback callback (cleans up the top-level parent — cascade clears the
+   * rest).
+   */
+  public async materializeCalloutContent(
+    callout: ICallout,
+    calloutData: CreateCalloutInput | undefined,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    if (callout.framing) {
+      await this.calloutFramingService.materializeCalloutFramingContent(
+        callout.framing,
+        calloutData?.framing,
+        rollback
+      );
+    }
+    const contributions = callout.contributions ?? [];
+    for (let i = 0; i < contributions.length; i++) {
+      await this.contributionService.materializeCalloutContributionContent(
+        contributions[i],
+        calloutData?.contributions?.[i],
+        rollback
+      );
+    }
+  }
+
   private createCalloutSettings(
     settingsData?: CreateCalloutInput['settings']
   ): ICalloutSettings {

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -147,23 +147,40 @@ export class CalloutService {
    * Walks framing + each contribution. Failures bubble up via the supplied
    * rollback callback (cleans up the top-level parent — cascade clears the
    * rest).
+   *
+   * Both `framing` and `contributions` MUST be loaded on the input
+   * Callout. Silent skip would leave the entity persisted with
+   * unmaterialized children — phase-2 looks successful while content
+   * stays in the source bucket. We distinguish "not loaded" (undefined)
+   * from "loaded but empty" ([]) for the contributions relation.
    */
   public async materializeCalloutContent(
     callout: ICallout,
     calloutData: CreateCalloutInput | undefined,
     rollback: () => Promise<unknown>
   ): Promise<void> {
-    if (callout.framing) {
-      await this.calloutFramingService.materializeCalloutFramingContent(
-        callout.framing,
-        calloutData?.framing,
-        rollback
+    if (!callout.framing) {
+      throw new RelationshipNotFoundException(
+        'Missing required relation for phase-2 materialization',
+        LogContext.COLLABORATION,
+        { calloutId: callout.id, missing: ['framing'] }
       );
     }
-    const contributions = callout.contributions ?? [];
-    for (let i = 0; i < contributions.length; i++) {
+    if (callout.contributions === undefined) {
+      throw new RelationshipNotFoundException(
+        'Missing required relation for phase-2 materialization',
+        LogContext.COLLABORATION,
+        { calloutId: callout.id, missing: ['contributions'] }
+      );
+    }
+    await this.calloutFramingService.materializeCalloutFramingContent(
+      callout.framing,
+      calloutData?.framing,
+      rollback
+    );
+    for (let i = 0; i < callout.contributions.length; i++) {
       await this.contributionService.materializeCalloutContributionContent(
-        contributions[i],
+        callout.contributions[i],
         calloutData?.contributions?.[i],
         rollback
       );

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -17,6 +17,7 @@ import { limitAndShuffle } from '@common/utils';
 import { Callout } from '@domain/collaboration/callout/callout.entity';
 import { ICallout } from '@domain/collaboration/callout/callout.interface';
 import { CreateCalloutInput } from '@domain/collaboration/callout/dto/index';
+import { CreateCalloutContributionInput } from '@domain/collaboration/callout-contribution/dto/callout.contribution.dto.create';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { IClassification } from '@domain/common/classification/classification.interface';
@@ -42,7 +43,6 @@ import {
 } from 'typeorm';
 import { ICalloutContribution } from '../callout-contribution/callout.contribution.interface';
 import { CalloutContributionService } from '../callout-contribution/callout.contribution.service';
-import { CreateCalloutContributionInput } from '../callout-contribution/dto/callout.contribution.dto.create';
 import { UpdateContributionCalloutsSortOrderInput } from '../callout-contribution/dto/callout.contribution.dto.update.callouts.sort.order';
 import { ICalloutContributionDefaults } from '../callout-contribution-defaults/callout.contribution.defaults.interface';
 import { CalloutContributionDefaultsService } from '../callout-contribution-defaults/callout.contribution.defaults.service';

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -42,6 +42,7 @@ import {
 } from 'typeorm';
 import { ICalloutContribution } from '../callout-contribution/callout.contribution.interface';
 import { CalloutContributionService } from '../callout-contribution/callout.contribution.service';
+import { CreateCalloutContributionInput } from '../callout-contribution/dto/callout.contribution.dto.create';
 import { UpdateContributionCalloutsSortOrderInput } from '../callout-contribution/dto/callout.contribution.dto.update.callouts.sort.order';
 import { ICalloutContributionDefaults } from '../callout-contribution-defaults/callout.contribution.defaults.interface';
 import { CalloutContributionDefaultsService } from '../callout-contribution-defaults/callout.contribution.defaults.service';
@@ -178,12 +179,60 @@ export class CalloutService {
       calloutData?.framing,
       rollback
     );
-    for (let i = 0; i < callout.contributions.length; i++) {
+    // Pair persisted contributions to their input data by `type` + the
+    // nested entity's stable identifier (Link.uri for LINK, nameID for
+    // POST/WHITEBOARD/MEMO). Index-based pairing would silently misalign
+    // when the persisted relation order differs from the input order,
+    // attaching the wrong visuals to the wrong contribution. We consume
+    // matched inputs from a working list so duplicate-keyed inputs (same
+    // link.uri twice) pair one-to-one rather than collapsing.
+    const remainingInputs = [...(calloutData?.contributions ?? [])];
+    for (const contribution of callout.contributions) {
+      const matchIdx = remainingInputs.findIndex(input =>
+        this.isSameContribution(input, contribution)
+      );
+      const inputForContrib =
+        matchIdx >= 0 ? remainingInputs.splice(matchIdx, 1)[0] : undefined;
       await this.contributionService.materializeCalloutContributionContent(
-        callout.contributions[i],
-        calloutData?.contributions?.[i],
+        contribution,
+        inputForContrib,
         rollback
       );
+    }
+  }
+
+  private isSameContribution(
+    input: CreateCalloutContributionInput,
+    contribution: ICalloutContribution
+  ): boolean {
+    if (input.type !== contribution.type) return false;
+    switch (contribution.type) {
+      case CalloutContributionType.LINK:
+        return (
+          !!input.link?.uri &&
+          !!contribution.link?.uri &&
+          input.link.uri === contribution.link.uri
+        );
+      case CalloutContributionType.POST:
+        return (
+          !!input.post?.nameID &&
+          !!contribution.post?.nameID &&
+          input.post.nameID === contribution.post.nameID
+        );
+      case CalloutContributionType.WHITEBOARD:
+        return (
+          !!input.whiteboard?.nameID &&
+          !!contribution.whiteboard?.nameID &&
+          input.whiteboard.nameID === contribution.whiteboard.nameID
+        );
+      case CalloutContributionType.MEMO:
+        return (
+          !!input.memo?.nameID &&
+          !!contribution.memo?.nameID &&
+          input.memo.nameID === contribution.memo.nameID
+        );
+      default:
+        return false;
     }
   }
 

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
@@ -69,7 +69,16 @@ export class CalloutsSetResolverMutations {
     );
 
     // callout needs to be saved to apply the authorization policy
-    await this.calloutService.save(callout);
+    const savedCallout = await this.calloutService.save(callout);
+
+    // Phase-2 materialize: re-home cross-bucket markdown URLs / refs in
+    // the framing + contributions. Idempotent for the in-bucket and
+    // empty-content cases. Failure rolls back the just-saved callout.
+    await this.calloutService.materializeCalloutContent(
+      savedCallout,
+      calloutData,
+      () => this.calloutService.deleteCallout(savedCallout.id)
+    );
 
     // Now the contribution is saved, we can look to move any temporary documents
     // to be stored in the storage bucket of the profile.

--- a/src/domain/collaboration/callouts-set/callouts.set.service.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.service.ts
@@ -81,17 +81,36 @@ export class CalloutsSetService {
    * Phase-2 materialization for a CalloutsSet. Walks each callout in the
    * set and delegates to CalloutService.materializeCalloutContent.
    * Failures bubble up via the supplied rollback callback.
+   *
+   * Callouts are paired with their input by `nameID` (a stable identifier
+   * set during creation). Index-based pairing would silently misalign if
+   * the persisted order ever differs from the input order — e.g., when
+   * `addCallouts` reuses existing entries from the calloutsSet.
    */
   public async materializeCalloutsSetContent(
     calloutsSet: ICalloutsSet,
     calloutsData: CreateCalloutInput[] | undefined,
     rollback: () => Promise<unknown>
   ): Promise<void> {
-    const callouts = calloutsSet.callouts ?? [];
-    for (let i = 0; i < callouts.length; i++) {
+    if (!calloutsSet.callouts) {
+      throw new EntityNotInitializedException(
+        'Callouts relation not loaded on CalloutsSet for materialization',
+        LogContext.COLLABORATION,
+        {
+          phase: 'materializeCalloutsSetContent',
+          calloutsSetId: calloutsSet.id,
+          missing: 'callouts',
+        }
+      );
+    }
+    const inputByNameID = new Map<string, CreateCalloutInput>();
+    for (const data of calloutsData ?? []) {
+      if (data.nameID) inputByNameID.set(data.nameID, data);
+    }
+    for (const callout of calloutsSet.callouts) {
       await this.calloutService.materializeCalloutContent(
-        callouts[i],
-        calloutsData?.[i],
+        callout,
+        callout.nameID ? inputByNameID.get(callout.nameID) : undefined,
         rollback
       );
     }

--- a/src/domain/collaboration/callouts-set/callouts.set.service.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.service.ts
@@ -77,6 +77,26 @@ export class CalloutsSetService {
     return calloutsSet;
   }
 
+  /**
+   * Phase-2 materialization for a CalloutsSet. Walks each callout in the
+   * set and delegates to CalloutService.materializeCalloutContent.
+   * Failures bubble up via the supplied rollback callback.
+   */
+  public async materializeCalloutsSetContent(
+    calloutsSet: ICalloutsSet,
+    calloutsData: CreateCalloutInput[] | undefined,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    const callouts = calloutsSet.callouts ?? [];
+    for (let i = 0; i < callouts.length; i++) {
+      await this.calloutService.materializeCalloutContent(
+        callouts[i],
+        calloutsData?.[i],
+        rollback
+      );
+    }
+  }
+
   async getCalloutsSetOrFail(
     calloutsSetID: string,
     options?: FindOneOptions<CalloutsSet>

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -175,13 +175,22 @@ export class CollaborationService {
     collaborationData: CreateCollaborationInput | undefined,
     rollback: () => Promise<unknown>
   ): Promise<void> {
-    if (collaboration.calloutsSet) {
-      await this.calloutsSetService.materializeCalloutsSetContent(
-        collaboration.calloutsSet,
-        collaborationData?.calloutsSetData?.calloutsData,
-        rollback
+    if (!collaboration.calloutsSet) {
+      throw new EntityNotInitializedException(
+        'CalloutsSet not initialized on Collaboration',
+        LogContext.COLLABORATION,
+        {
+          phase: 'materializeCollaborationContent',
+          collaborationId: collaboration.id,
+          missing: 'calloutsSet',
+        }
       );
     }
+    await this.calloutsSetService.materializeCalloutsSetContent(
+      collaboration.calloutsSet,
+      collaborationData?.calloutsSetData?.calloutsData,
+      rollback
+    );
   }
 
   private createInnovationFlowStatesTagsetTemplateInput(

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -164,6 +164,26 @@ export class CollaborationService {
     return collaboration;
   }
 
+  /**
+   * Phase-2 materialization for a Collaboration. Walks the callouts set and
+   * delegates to CalloutsSetService. Caller supplies a rollback that cleans
+   * up the top-level parent (Space, TemplateContentSpace, etc.) so a
+   * failed walk doesn't leave a partially-materialized tree behind.
+   */
+  public async materializeCollaborationContent(
+    collaboration: ICollaboration,
+    collaborationData: CreateCollaborationInput | undefined,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    if (collaboration.calloutsSet) {
+      await this.calloutsSetService.materializeCalloutsSetContent(
+        collaboration.calloutsSet,
+        collaborationData?.calloutsSetData?.calloutsData,
+        rollback
+      );
+    }
+  }
+
   private createInnovationFlowStatesTagsetTemplateInput(
     innovationFlowData: CreateInnovationFlowInput
   ): CreateTagsetTemplateInput {

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -114,7 +114,7 @@ export class InnovationFlowService {
     saved.profile =
       await this.profileService.materializeProfileContentAndVisualsOrRollback(
         saved.profile,
-        innovationFlowData.profile.visuals,
+        innovationFlowData.profile?.visuals,
         [VisualType.CARD],
         () => this.deleteInnovationFlow(saved.id)
       );

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -75,16 +75,11 @@ export class InnovationFlowService {
       innovationFlowData.settings
     );
 
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     innovationFlow.profile = await this.profileService.createProfile(
       innovationFlowData.profile,
       ProfileType.INNOVATION_FLOW,
       storageAggregator
-    );
-
-    await this.profileService.addVisualsOnProfile(
-      innovationFlow.profile,
-      innovationFlowData.profile.visuals,
-      [VisualType.CARD]
     );
 
     innovationFlow.states = [];
@@ -100,20 +95,30 @@ export class InnovationFlowService {
       innovationFlow.states.push(state);
       sortOrder = state.sortOrder;
     }
-    await this.save(innovationFlow);
 
-    innovationFlow.currentStateID = innovationFlow.states[0].id;
+    // First save populates state ids; pick currentStateID from saved states.
+    let saved = await this.save(innovationFlow);
+    saved.currentStateID = saved.states[0].id;
     if (innovationFlowData.currentStateDisplayName) {
-      const currentState = innovationFlow.states.find(
+      const currentState = saved.states.find(
         state =>
           state.displayName === innovationFlowData.currentStateDisplayName
       );
       if (currentState) {
-        innovationFlow.currentStateID = currentState.id;
+        saved.currentStateID = currentState.id;
       }
     }
+    saved = await this.save(saved);
 
-    return await this.save(innovationFlow);
+    // Phase 2: materialize via the shared helper. Rolls back on failure.
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisualsOrRollback(
+        saved.profile,
+        innovationFlowData.profile.visuals,
+        [VisualType.CARD],
+        () => this.deleteInnovationFlow(saved.id)
+      );
+    return saved;
   }
 
   async save(innovationFlow: IInnovationFlow): Promise<IInnovationFlow> {

--- a/src/domain/collaboration/link/link.service.ts
+++ b/src/domain/collaboration/link/link.service.ts
@@ -41,6 +41,26 @@ export class LinkService {
     return link;
   }
 
+  /**
+   * Phase-2 materialization for a Link. Composed under callout-framing or
+   * callout-contribution; the parent entity's save persists the bucket
+   * before this is called. Re-homes any markdown URLs/references in
+   * `link.profile` and lets the supplied `rollback` cascade to the
+   * top-level parent on failure.
+   */
+  public async materializeLinkContent(
+    link: ILink,
+    linkData: CreateLinkInput | undefined,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      link.profile,
+      linkData?.profile?.visuals,
+      [],
+      rollback
+    );
+  }
+
   public async updateLink(linkData: UpdateLinkInput): Promise<ILink> {
     const link = await this.getLinkOrFail(linkData.ID, {
       relations: { profile: true },

--- a/src/domain/collaboration/post/post.service.spec.ts
+++ b/src/domain/collaboration/post/post.service.spec.ts
@@ -70,9 +70,10 @@ describe('PostService', () => {
       const createdRoom = { id: 'room-1' } as any;
 
       vi.mocked(profileService.createProfile).mockResolvedValue(createdProfile);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        undefined as any
-      );
+      vi.mocked(
+        profileService.materializeProfileContentAndVisualsOrRollback
+      ).mockImplementation(async profile => profile);
+      vi.mocked(repository.save).mockImplementation(async (p: any) => p);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );
@@ -89,10 +90,13 @@ describe('PostService', () => {
         ProfileType.POST,
         storageAggregator
       );
-      expect(profileService.addVisualsOnProfile).toHaveBeenCalledWith(
+      expect(
+        profileService.materializeProfileContentAndVisualsOrRollback
+      ).toHaveBeenCalledWith(
         createdProfile,
         postInput.profileData.visuals,
-        [VisualType.BANNER, VisualType.CARD]
+        [VisualType.BANNER, VisualType.CARD],
+        expect.any(Function)
       );
       expect(profileService.addOrUpdateTagsetOnProfile).toHaveBeenCalledWith(
         createdProfile,
@@ -108,9 +112,10 @@ describe('PostService', () => {
 
     it('should set createdBy to the provided userID', async () => {
       vi.mocked(profileService.createProfile).mockResolvedValue({} as any);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        undefined as any
-      );
+      vi.mocked(
+        profileService.materializeProfileContentAndVisualsOrRollback
+      ).mockImplementation(async profile => profile);
+      vi.mocked(repository.save).mockImplementation(async (p: any) => p);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );
@@ -132,9 +137,10 @@ describe('PostService', () => {
       } as any;
 
       vi.mocked(profileService.createProfile).mockResolvedValue({} as any);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        undefined as any
-      );
+      vi.mocked(
+        profileService.materializeProfileContentAndVisualsOrRollback
+      ).mockImplementation(async profile => profile);
+      vi.mocked(repository.save).mockImplementation(async (p: any) => p);
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         undefined as any
       );

--- a/src/domain/collaboration/post/post.service.ts
+++ b/src/domain/collaboration/post/post.service.ts
@@ -56,10 +56,22 @@ export class PostService {
       parentContextId: parentSpaceId,
     });
 
-    // Phase 2: persist + materialize via the shared helper. Rolls back on
-    // failure so callers see either a fully-materialized post or a thrown
-    // error, never a half-state.
-    const saved = await this.postRepository.save(post);
+    // Phase 2: persist + materialize via the shared helper. The Matrix
+    // room created above isn't part of the DB transaction; if the save
+    // fails it's already orphaned in Matrix, so we delete it explicitly
+    // before propagating the error. After save, the OrRollback helper
+    // handles the post-save phase (cascade-deleting the room via
+    // deletePost on failure).
+    let saved: IPost;
+    try {
+      saved = await this.postRepository.save(post);
+    } catch (error) {
+      await this.cleanupOrphanRoom(
+        post.comments.id,
+        'Post save failed before materialize'
+      );
+      throw error;
+    }
     // Helper mutates the profile in place; no explicit reassignment needed.
     await this.profileService.materializeProfileContentAndVisualsOrRollback(
       saved.profile,
@@ -68,6 +80,28 @@ export class PostService {
       () => this.deletePost(saved.id)
     );
     return saved;
+  }
+
+  private async cleanupOrphanRoom(
+    roomID: string,
+    context: string
+  ): Promise<void> {
+    try {
+      await this.roomService.deleteRoom({ roomID });
+    } catch (cleanupError) {
+      const stack =
+        cleanupError instanceof Error ? (cleanupError.stack ?? '') : '';
+      this.logger.error?.(
+        {
+          message: 'Cleanup of orphan Matrix room also failed',
+          context,
+          roomID,
+          cleanupError: String(cleanupError),
+        },
+        stack,
+        LogContext.SPACES
+      );
+    }
   }
 
   public async deletePost(postId: string): Promise<IPost> {

--- a/src/domain/collaboration/post/post.service.ts
+++ b/src/domain/collaboration/post/post.service.ts
@@ -36,16 +36,12 @@ export class PostService {
     userID: string,
     parentSpaceId?: string
   ): Promise<IPost> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     const post: IPost = Post.create(postInput);
     post.profile = await this.profileService.createProfile(
       postInput.profileData,
       ProfileType.POST,
       storageAggregator
-    );
-    await this.profileService.addVisualsOnProfile(
-      post.profile,
-      postInput.profileData.visuals,
-      [VisualType.BANNER, VisualType.CARD]
     );
     await this.profileService.addOrUpdateTagsetOnProfile(post.profile, {
       name: TagsetReservedName.DEFAULT,
@@ -60,7 +56,18 @@ export class PostService {
       parentContextId: parentSpaceId,
     });
 
-    return post;
+    // Phase 2: persist + materialize via the shared helper. Rolls back on
+    // failure so callers see either a fully-materialized post or a thrown
+    // error, never a half-state.
+    const saved = await this.postRepository.save(post);
+    // Helper mutates the profile in place; no explicit reassignment needed.
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      saved.profile,
+      postInput.profileData.visuals,
+      [VisualType.BANNER, VisualType.CARD],
+      () => this.deletePost(saved.id)
+    );
+    return saved;
   }
 
   public async deletePost(postId: string): Promise<IPost> {

--- a/src/domain/common/knowledge-base/knowledge.base.service.ts
+++ b/src/domain/common/knowledge-base/knowledge.base.service.ts
@@ -43,6 +43,7 @@ export class KnowledgeBaseService {
     storageAggregator: IStorageAggregator,
     userID: string | undefined
   ): Promise<IKnowledgeBase> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     let knowledgeBase: IKnowledgeBase = KnowledgeBase.create(knowledgeBaseData);
 
     knowledgeBase.authorization = new AuthorizationPolicy(
@@ -94,6 +95,29 @@ export class KnowledgeBaseService {
           storageAggregator,
           userID
         );
+      // Persist the newly-added callouts so their bucket ids are real
+      // before phase-2 materialization tries to FK onto them.
+      knowledgeBase = await this.save(knowledgeBase);
+    }
+
+    // Phase 2: materialize own profile + walk calloutsSet. On failure,
+    // delete the KB; cascade clears nested entities (callouts/profiles/
+    // buckets) and the parent caller (VirtualContributorService) will
+    // see the thrown error and abort its own creation flow.
+    const rollbackKnowledgeBase = (): Promise<unknown> =>
+      this.delete(knowledgeBase);
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      knowledgeBase.profile,
+      knowledgeBaseData.profile?.visuals,
+      [],
+      rollbackKnowledgeBase
+    );
+    if (knowledgeBase.calloutsSet) {
+      await this.calloutsSetService.materializeCalloutsSetContent(
+        knowledgeBase.calloutsSet,
+        knowledgeBaseData.calloutsSetData?.calloutsData,
+        rollbackKnowledgeBase
+      );
     }
 
     return knowledgeBase;

--- a/src/domain/common/knowledge-base/knowledge.base.service.ts
+++ b/src/domain/common/knowledge-base/knowledge.base.service.ts
@@ -82,8 +82,9 @@ export class KnowledgeBaseService {
 
     if (!knowledgeBase.calloutsSet) {
       throw new EntityNotFoundException(
-        `CalloutsSet not found for KnowledgeBase: ${knowledgeBase.id}`,
-        LogContext.COLLABORATION
+        'CalloutsSet not found for KnowledgeBase',
+        LogContext.COLLABORATION,
+        { knowledgeBaseId: knowledgeBase.id }
       );
     }
 

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -44,8 +44,10 @@ export class MemoService {
   async createMemo(
     { markdown, ...restOfMemoData }: CreateMemoInput,
     storageAggregator: IStorageAggregator,
-    userID?: string
+    userID?: string,
+    visualTypes: VisualType[] = [VisualType.CARD]
   ): Promise<IMemo> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     const binaryUpdateV2 = this.markdownToStateUpdate(markdown);
     const content = binaryUpdateV2 ? Buffer.from(binaryUpdateV2) : undefined;
     const memo: IMemo = Memo.create({
@@ -63,17 +65,24 @@ export class MemoService {
       ProfileType.MEMO,
       storageAggregator
     );
-    await this.profileService.addVisualsOnProfile(
-      memo.profile,
-      restOfMemoData.profile?.visuals,
-      [VisualType.CARD]
-    );
     await this.profileService.addOrUpdateTagsetOnProfile(memo.profile, {
       name: TagsetReservedName.DEFAULT,
       tags: [],
     });
 
-    return this.save(memo);
+    // Phase 2: persist + materialize via the shared helper.
+    // `visualTypes` is parameterised so callout-framing can request the
+    // [CARD, BANNER] union (otherwise the framing context would lose
+    // BANNER without re-running materialize).
+    const saved = await this.save(memo);
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisualsOrRollback(
+        saved.profile,
+        restOfMemoData.profile?.visuals,
+        visualTypes,
+        () => this.deleteMemo(saved.id)
+      );
+    return saved;
   }
 
   async getMemoOrFail(

--- a/src/domain/common/profile/profile.service.spec.ts
+++ b/src/domain/common/profile/profile.service.spec.ts
@@ -203,9 +203,9 @@ describe('ProfileService', () => {
         references: [],
       } as any;
 
-      await expect(service.materializeProfileContent(profile)).rejects.toThrow(
-        /must be persisted/
-      );
+      await expect(
+        (service as any).materializeProfileContent(profile)
+      ).rejects.toThrow(/must be persisted/);
     });
 
     it('re-uploads markdown documents and reference URIs', async () => {
@@ -226,7 +226,7 @@ describe('ProfileService', () => {
         .mockResolvedValueOnce('https://alkemio/files/xyz-rehomed')
         .mockResolvedValueOnce('https://external.example.com/img.png');
 
-      const result = await service.materializeProfileContent(profile);
+      const result = await (service as any).materializeProfileContent(profile);
 
       expect(result.description).toBe('![](https://alkemio/files/abc-rehomed)');
       expect(result.references![0].uri).toBe(

--- a/src/domain/common/profile/profile.service.spec.ts
+++ b/src/domain/common/profile/profile.service.spec.ts
@@ -79,11 +79,14 @@ describe('ProfileService', () => {
   });
 
   describe('createProfile', () => {
-    it('should create profile with authorization, storage bucket, location, visuals, and tagsets', async () => {
+    it('builds an in-memory profile and does NOT call file-service helpers (phase 1)', async () => {
+      // Phase 1 must be pure: file-service-go calls happen in phase 2
+      // (materializeProfileContent), AFTER the parent's cascade save has
+      // persisted the storageBucket id. See ProfileService docs.
       const storageAggregator = {
         id: 'sa-1',
       } as unknown as IStorageAggregator;
-      const storageBucket = { id: 'sb-1' };
+      const storageBucket = { id: undefined, documents: [] };
       const location = { id: 'loc-1' };
 
       vi.mocked(storageBucketService.createStorageBucket).mockReturnValue(
@@ -92,12 +95,6 @@ describe('ProfileService', () => {
       vi.mocked(locationService.createLocation).mockResolvedValue(
         location as any
       );
-      vi.mocked(
-        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
-      ).mockResolvedValue('processed-description');
-      vi.mocked(
-        profileDocumentsService.reuploadFileOnStorageBucket
-      ).mockResolvedValue(undefined as any);
 
       const tagset = { id: 'ts-1', name: 'skills', tags: [] };
       vi.mocked(tagsetService.createTagsetWithName).mockReturnValue(
@@ -122,7 +119,15 @@ describe('ProfileService', () => {
       expect(result.location).toBe(location);
       expect(result.visuals).toEqual([]);
       expect(result.tagsets).toEqual([tagset]);
-      expect(result.description).toBe('processed-description');
+      // Description is preserved verbatim — no markdown re-upload at this stage.
+      expect(result.description).toBe('A test description');
+      expect(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).not.toHaveBeenCalled();
+      expect(
+        profileDocumentsService.reuploadFileOnStorageBucket
+      ).not.toHaveBeenCalled();
+      expect(storageBucketService.save).not.toHaveBeenCalled();
     });
 
     it('should default tagsets to empty array when not provided', async () => {
@@ -186,6 +191,102 @@ describe('ProfileService', () => {
 
       expect(result.references).toHaveLength(1);
       expect(result.references![0].name).toBe('website');
+    });
+  });
+
+  describe('materializeProfileContent', () => {
+    it('throws when storageBucket is not persisted', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: undefined },
+        description: '',
+        references: [],
+      } as any;
+
+      await expect(service.materializeProfileContent(profile)).rejects.toThrow(
+        /must be persisted/
+      );
+    });
+
+    it('re-uploads markdown documents and reference URIs', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: 'sb-1', documents: [] },
+        description: '![](https://alkemio/files/abc)',
+        references: [
+          { id: 'r-1', uri: 'https://alkemio/files/xyz' },
+          { id: 'r-2', uri: 'https://external.example.com/img.png' },
+        ],
+      } as any;
+
+      vi.mocked(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).mockResolvedValue('![](https://alkemio/files/abc-rehomed)');
+      vi.mocked(profileDocumentsService.reuploadFileOnStorageBucket)
+        .mockResolvedValueOnce('https://alkemio/files/xyz-rehomed')
+        .mockResolvedValueOnce('https://external.example.com/img.png');
+
+      const result = await service.materializeProfileContent(profile);
+
+      expect(result.description).toBe('![](https://alkemio/files/abc-rehomed)');
+      expect(result.references![0].uri).toBe(
+        'https://alkemio/files/xyz-rehomed'
+      );
+      // External URL passes through unchanged.
+      expect(result.references![1].uri).toBe(
+        'https://external.example.com/img.png'
+      );
+    });
+  });
+
+  describe('materializeProfileContentAndVisuals', () => {
+    it('runs content materialization, visual attachment, and persists in order', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: 'sb-1', documents: [] },
+        description: '',
+        references: [],
+        visuals: [],
+      } as any;
+      const visualsData = [{ name: 'card', uri: 'x' }] as any;
+
+      vi.mocked(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).mockResolvedValue('');
+      const addVisualsSpy = vi
+        .spyOn(service, 'addVisualsOnProfile')
+        .mockResolvedValue(profile);
+      profileRepository.save = vi.fn().mockResolvedValue(profile) as any;
+
+      await service.materializeProfileContentAndVisuals(profile, visualsData, [
+        VisualType.CARD,
+      ]);
+
+      expect(addVisualsSpy).toHaveBeenCalledWith(profile, visualsData, [
+        VisualType.CARD,
+      ]);
+      expect(profileRepository.save).toHaveBeenCalledWith(profile);
+    });
+
+    it('skips addVisualsOnProfile when visualTypes is empty', async () => {
+      const profile = {
+        id: 'p-1',
+        storageBucket: { id: 'sb-1', documents: [] },
+        description: '',
+        references: [],
+        visuals: [],
+      } as any;
+
+      vi.mocked(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).mockResolvedValue('');
+      const addVisualsSpy = vi.spyOn(service, 'addVisualsOnProfile');
+      profileRepository.save = vi.fn().mockResolvedValue(profile) as any;
+
+      await service.materializeProfileContentAndVisuals(profile, undefined, []);
+
+      expect(addVisualsSpy).not.toHaveBeenCalled();
+      expect(profileRepository.save).toHaveBeenCalledWith(profile);
     });
   });
 

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -26,7 +26,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DEFAULT_AVATAR_SERVICE_URL } from '@services/external/avatar-creator/avatar.creator.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { FindOneOptions, Repository } from 'typeorm';
-import { CreateReferenceInput } from '../reference';
 import { CreateTagsetInput } from '../tagset';
 import { ITagsetTemplate } from '../tagset-template/tagset.template.interface';
 import { CreateProfileInput, UpdateProfileInput } from './dto';
@@ -48,8 +47,25 @@ export class ProfileService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  // Create an empty profile, that the creating entity then has to
-  // add tagets / visuals to.
+  /**
+   * Phase 1 of profile materialization: build the in-memory entity graph.
+   *
+   * No file-service-go calls happen here. The storageBucket is created
+   * unsaved and assigned to the profile; the caller is expected to assign
+   * the profile to a parent entity that cascades save (or to save it
+   * directly), then call {@link materializeProfileContent} to perform the
+   * post-save content re-uploads (markdown documents, references, etc).
+   *
+   * This split exists because the file-service-go migration (PR #5969)
+   * moved Document ownership outside the server's TypeORM transaction;
+   * any cross-service call needs a real persisted `storageBucket.id` to
+   * FK onto. Doing both phases in one method led to
+   * `StorageBucket not found: undefined` (issues #6004 / #6005).
+   *
+   * Tagsets and references are constructed with their input URIs as-is.
+   * `materializeProfileContent` is the place where any internal Alkemio
+   * URLs in the description/references are re-homed into the new bucket.
+   */
   public async createProfile(
     profileData: CreateProfileInput,
     profileType: ProfileType,
@@ -64,54 +80,134 @@ export class ProfileService {
     profile.authorization = new AuthorizationPolicy(
       AuthorizationPolicyType.PROFILE
     );
-    // the next statement fails if it's not saved
     profile.storageBucket = this.storageBucketService.createStorageBucket({
       storageAggregator: storageAggregator,
     });
-    profile.description =
-      await this.profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket(
-        profile.description ?? '',
-        profile.storageBucket
-      );
     profile.visuals = [];
     profile.location = await this.locationService.createLocation(
       profileData?.location
     );
-    await this.createReferencesOnProfile(profileData?.referencesData, profile);
-
-    const tagsetsFromInput = profileData?.tagsets?.map(tagsetData =>
+    profile.references = (profileData?.referencesData ?? []).map(reference =>
+      this.referenceService.createReference(reference)
+    );
+    profile.tagsets = (profileData?.tagsets ?? []).map(tagsetData =>
       this.tagsetService.createTagsetWithName([], tagsetData)
     );
-    profile.tagsets = tagsetsFromInput ?? [];
 
     return profile;
   }
 
-  private async createReferencesOnProfile(
-    references: CreateReferenceInput[] | undefined,
-    profile: IProfile
-  ) {
-    if (!profile.storageBucket) {
+  /**
+   * Phase 2: post-save content re-upload. Must be called AFTER the profile
+   * (and its storageBucket) has been persisted — typically via the parent
+   * entity's cascade save. Re-homes any internal Alkemio document URLs
+   * found in the description and references into the profile's bucket.
+   *
+   * Idempotent for content already in the destination bucket and a no-op
+   * if there's no internal URL to re-home, so it's safe to call from any
+   * caller whether or not the input data references existing documents.
+   *
+   * Throws `EntityNotInitializedException` if the bucket isn't persisted
+   * yet — that's a programmer error, not a runtime condition.
+   */
+  public async materializeProfileContent(profile: IProfile): Promise<IProfile> {
+    if (!profile.storageBucket?.id) {
       throw new EntityNotInitializedException(
-        `Storage bucket not initialized on profile: ${profile.id}`,
-        LogContext.PROFILE
+        'Profile storage bucket must be persisted before materializing content',
+        LogContext.PROFILE,
+        { profileId: profile.id }
       );
     }
-    const newReferences = [];
-    for (const reference of references ?? []) {
-      const newReference = this.referenceService.createReference(reference);
+    if (profile.description) {
+      profile.description =
+        await this.profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket(
+          profile.description,
+          profile.storageBucket
+        );
+    }
+    for (const reference of profile.references ?? []) {
       const newUrl =
         await this.profileDocumentsService.reuploadFileOnStorageBucket(
-          newReference.uri,
+          reference.uri,
           profile.storageBucket,
           false
         );
       if (newUrl) {
-        newReference.uri = newUrl;
+        reference.uri = newUrl;
       }
-      newReferences.push(newReference);
     }
-    profile.references = newReferences;
+    return profile;
+  }
+
+  /**
+   * Convenience for the standard post-save materialization: re-home internal
+   * Alkemio URLs in description/references AND attach visuals. Idempotent and
+   * safe to call when there's nothing to materialize. Persists the result so
+   * callers don't need a follow-up `save`.
+   *
+   * Precondition: `profile.storageBucket` must be persisted (typically via
+   * the parent entity's cascade save). See {@link materializeProfileContent}.
+   */
+  public async materializeProfileContentAndVisuals(
+    profile: IProfile,
+    visualsData: CreateVisualOnProfileInput[] | undefined,
+    visualTypes: VisualType[]
+  ): Promise<IProfile> {
+    await this.materializeProfileContent(profile);
+    if (visualTypes.length > 0) {
+      // Filter out visualTypes the profile already has — `addVisualsOnProfile`
+      // doesn't dedupe internally, so without this filter every re-invocation
+      // would push duplicates. Also dedupe the request itself in case the
+      // caller supplied the same VisualType twice.
+      const requested = Array.from(new Set(visualTypes));
+      const existing = new Set(profile.visuals?.map(v => v.name) ?? []);
+      const missing = requested.filter(type => !existing.has(type));
+      if (missing.length > 0) {
+        await this.addVisualsOnProfile(profile, visualsData, missing);
+      }
+    }
+    return await this.profileRepository.save(profile);
+  }
+
+  /**
+   * Self-contained "atomic-ish" wrapper around
+   * {@link materializeProfileContentAndVisuals} for callers that have just
+   * persisted a parent entity and need a single primitive that either:
+   *   - completes phase-2 materialization (markdown/refs re-home + visuals
+   *     attached + profile saved), or
+   *   - rolls back the parent entity via the supplied callback and rethrows
+   *     the original error.
+   *
+   * This keeps the rollback semantic in one place — callers don't write
+   * try/catch blocks around the materialize call. Cleanup failures are logged
+   * (best-effort) so the original materialize error is what the caller sees.
+   *
+   * Use this from any leaf service whose `createX` follows the
+   * `build → save → materialize-or-rollback` shape.
+   */
+  public async materializeProfileContentAndVisualsOrRollback(
+    profile: IProfile,
+    visualsData: CreateVisualOnProfileInput[] | undefined,
+    visualTypes: VisualType[],
+    rollback: () => Promise<unknown>
+  ): Promise<IProfile> {
+    try {
+      return await this.materializeProfileContentAndVisuals(
+        profile,
+        visualsData,
+        visualTypes
+      );
+    } catch (error) {
+      try {
+        await rollback();
+      } catch (rollbackError) {
+        this.logger.warn?.(
+          `Rollback after materialization failure also failed for profile ${profile.id}: ${rollbackError}`,
+          LogContext.PROFILE
+        );
+      }
+      throw error;
+    }
   }
 
   async updateProfile(

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -203,12 +203,21 @@ export class ProfileService {
       try {
         await rollback();
       } catch (rollbackError) {
-        this.logger.warn?.(
+        // Operational failure: the entity is in an inconsistent state and
+        // operators must intervene. Log at ERROR (alert-worthy) but rethrow
+        // the original materialization error so callers' retry/abort logic
+        // sees the same shape as a "succeeded rollback" failure. The codebase
+        // has no AggregateError convention, and surfacing two competing
+        // errors at this layer would diverge from every other rollback site.
+        const stack =
+          rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+        this.logger.error?.(
           {
             message: 'Rollback after materialization failure also failed',
             profileId: profile.id,
             rollbackError: String(rollbackError),
           },
+          stack,
           LogContext.PROFILE
         );
       }

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -110,7 +110,9 @@ export class ProfileService {
    * Throws `EntityNotInitializedException` if the bucket isn't persisted
    * yet — that's a programmer error, not a runtime condition.
    */
-  public async materializeProfileContent(profile: IProfile): Promise<IProfile> {
+  private async materializeProfileContent(
+    profile: IProfile
+  ): Promise<IProfile> {
     if (!profile.storageBucket?.id) {
       throw new EntityNotInitializedException(
         'Profile storage bucket must be persisted before materializing content',
@@ -202,7 +204,11 @@ export class ProfileService {
         await rollback();
       } catch (rollbackError) {
         this.logger.warn?.(
-          `Rollback after materialization failure also failed for profile ${profile.id}: ${rollbackError}`,
+          {
+            message: 'Rollback after materialization failure also failed',
+            profileId: profile.id,
+            rollbackError: String(rollbackError),
+          },
           LogContext.PROFILE
         );
       }

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -78,12 +78,15 @@ describe('WhiteboardService', () => {
 
     beforeEach(() => {
       vi.mocked(profileService.createProfile).mockResolvedValue(mockProfile);
-      vi.mocked(profileService.addVisualsOnProfile).mockResolvedValue(
-        mockProfile
-      );
       vi.mocked(profileService.addOrUpdateTagsetOnProfile).mockResolvedValue(
         {} as any
       );
+      // createWhiteboard saves+materializes internally; round-trip the
+      // entity so the test sees the same in-memory state we set up.
+      whiteboardRepository.save!.mockImplementation(async (wb: any) => wb);
+      vi.mocked(
+        profileService.materializeProfileContentAndVisualsOrRollback
+      ).mockImplementation(async profile => profile);
     });
 
     it('should create whiteboard with profile, visuals, tagset, and authorization', async () => {
@@ -107,11 +110,13 @@ describe('WhiteboardService', () => {
         mockStorageAggregator
       );
       expect(
-        vi.mocked(profileService.addVisualsOnProfile)
-      ).toHaveBeenCalledWith(mockProfile, undefined, [
-        VisualType.CARD,
-        VisualType.WHITEBOARD_PREVIEW,
-      ]);
+        vi.mocked(profileService.materializeProfileContentAndVisualsOrRollback)
+      ).toHaveBeenCalledWith(
+        mockProfile,
+        undefined,
+        [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW],
+        expect.any(Function)
+      );
       expect(
         vi.mocked(profileService.addOrUpdateTagsetOnProfile)
       ).toHaveBeenCalledWith(mockProfile, {

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -47,6 +47,7 @@ export class WhiteboardService {
     storageAggregator: IStorageAggregator,
     userID?: string
   ): Promise<IWhiteboard> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     const whiteboard: IWhiteboard = Whiteboard.create({
       ...whiteboardData,
     });
@@ -63,11 +64,6 @@ export class WhiteboardService {
       ProfileType.WHITEBOARD,
       storageAggregator
     );
-    await this.profileService.addVisualsOnProfile(
-      whiteboard.profile,
-      whiteboardData.profile?.visuals,
-      [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW]
-    );
     await this.profileService.addOrUpdateTagsetOnProfile(whiteboard.profile, {
       name: TagsetReservedName.DEFAULT,
       tags: [],
@@ -78,7 +74,21 @@ export class WhiteboardService {
       coordinates: whiteboardData.previewSettings?.coordinates ?? null,
     };
 
-    return whiteboard;
+    // Phase 2: persist + materialize. The shared helper runs the file-service
+    // work and rolls back the saved entity on failure so callers receive a
+    // fully-materialized whiteboard or a thrown error, never a half-state.
+    const saved = await this.whiteboardRepository.save(whiteboard);
+    // The helper mutates the profile in place AND saves it; the saved
+    // whiteboard's `.profile` reference is the same instance, so no
+    // explicit reassignment is required (TypeORM Profile entity type
+    // wouldn't accept the IProfile return shape anyway).
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      saved.profile,
+      whiteboardData.profile?.visuals,
+      [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW],
+      () => this.deleteWhiteboard(saved.id)
+    );
+    return saved;
   }
 
   async getWhiteboardOrFail(

--- a/src/domain/community/community-guidelines/community.guidelines.service.spec.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.spec.ts
@@ -1,3 +1,4 @@
+import { VisualType } from '@common/enums/visual.type';
 import { EntityNotFoundException } from '@common/exceptions';
 import { ProfileService } from '@domain/common/profile/profile.service';
 import { TagsetService } from '@domain/common/tagset/tagset.service';
@@ -21,6 +22,7 @@ describe('CommunityGuidelinesService', () => {
   let profileService: {
     createProfile: Mock;
     addVisualsOnProfile: Mock;
+    materializeProfileContentAndVisuals: Mock;
     updateProfile: Mock;
     deleteProfile: Mock;
     deleteAllReferencesFromProfile: Mock;
@@ -70,11 +72,13 @@ describe('CommunityGuidelinesService', () => {
   });
 
   describe('createCommunityGuidelines', () => {
-    it('should create guidelines with authorization, profile, and visuals', async () => {
+    it('builds in-memory guidelines without calling addVisualsOnProfile (phase 1)', async () => {
+      // Phase-1 createCommunityGuidelines must be pure: no addVisualsOnProfile,
+      // no markdown re-upload. Visuals attach in phase 2 once the cascade save
+      // has populated the bucket id.
       const mockProfile = { id: 'profile-1' };
       tagsetService.updateTagsetInputs.mockReturnValue([]);
       profileService.createProfile.mockResolvedValue(mockProfile);
-      profileService.addVisualsOnProfile.mockResolvedValue(undefined);
 
       const storageAggregator = { id: 'storage-1' } as any;
       const result = await service.createCommunityGuidelines(
@@ -90,7 +94,30 @@ describe('CommunityGuidelinesService', () => {
       expect(result.authorization).toBeDefined();
       expect(result.profile).toBe(mockProfile);
       expect(profileService.createProfile).toHaveBeenCalled();
-      expect(profileService.addVisualsOnProfile).toHaveBeenCalled();
+      expect(profileService.addVisualsOnProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('materializeCommunityGuidelinesContent', () => {
+    it('delegates to profileService.materializeProfileContentAndVisuals with CARD visuals', async () => {
+      const guidelines = {
+        profile: { id: 'p-1', storageBucket: { id: 'sb-1' } },
+      } as any;
+      profileService.materializeProfileContentAndVisuals.mockResolvedValue(
+        guidelines.profile
+      );
+
+      const data = {
+        profile: { displayName: 'g', visuals: [{ name: 'card', uri: 'x' }] },
+      } as any;
+
+      await service.materializeCommunityGuidelinesContent(guidelines, data);
+
+      expect(
+        profileService.materializeProfileContentAndVisuals
+      ).toHaveBeenCalledWith(guidelines.profile, data.profile.visuals, [
+        VisualType.CARD,
+      ]);
     });
   });
 

--- a/src/domain/community/community-guidelines/community.guidelines.service.ts
+++ b/src/domain/community/community-guidelines/community.guidelines.service.ts
@@ -3,7 +3,10 @@ import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { TagsetType } from '@common/enums/tagset.type';
 import { VisualType } from '@common/enums/visual.type';
-import { EntityNotFoundException } from '@common/exceptions';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+} from '@common/exceptions';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
 import { IProfile } from '@domain/common/profile/profile.interface';
 import { ProfileService } from '@domain/common/profile/profile.service';
@@ -27,6 +30,11 @@ export class CommunityGuidelinesService {
     private communityGuidelinesRepository: Repository<CommunityGuidelines>
   ) {}
 
+  /**
+   * Phase 1: in-memory entity construction. The returned guidelines must be
+   * persisted by the caller (typically via cascade from a parent entity)
+   * before {@link materializeCommunityGuidelinesContent} is invoked.
+   */
   async createCommunityGuidelines(
     communityGuidelinesData: CreateCommunityGuidelinesInput,
     storageAggregator: IStorageAggregator
@@ -53,12 +61,37 @@ export class CommunityGuidelinesService {
       storageAggregator
     );
 
-    await this.profileService.addVisualsOnProfile(
-      communityGuidelines.profile,
-      communityGuidelinesData.profile.visuals,
-      [VisualType.CARD]
-    );
+    return communityGuidelines;
+  }
 
+  /**
+   * Phase 2: post-save content materialization. Re-homes any internal
+   * Alkemio URLs in the profile description/references into the guidelines'
+   * own bucket, then attaches visuals. Requires the parent entity to have
+   * been saved already (so `profile.storageBucket.id` is real).
+   */
+  async materializeCommunityGuidelinesContent(
+    communityGuidelines: ICommunityGuidelines,
+    communityGuidelinesData?: CreateCommunityGuidelinesInput
+  ): Promise<ICommunityGuidelines> {
+    if (!communityGuidelines.profile) {
+      throw new RelationshipNotFoundException(
+        'Community guidelines profile not initialized',
+        LogContext.COMMUNITY,
+        { communityGuidelinesId: communityGuidelines.id }
+      );
+    }
+    // `communityGuidelinesData` is optional because composing services
+    // (e.g. SpaceAboutService) auto-create empty guidelines when the caller
+    // doesn't supply any. Auto-created profiles still need post-save
+    // materialization (re-home description URLs, etc.) — visuals just
+    // happen to be absent in that case.
+    communityGuidelines.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        communityGuidelines.profile,
+        communityGuidelinesData?.profile.visuals,
+        [VisualType.CARD]
+      );
     return communityGuidelines;
   }
 

--- a/src/domain/community/user-group/user-group.service.ts
+++ b/src/domain/community/user-group/user-group.service.ts
@@ -47,17 +47,28 @@ export class UserGroupService {
     userGroupData: CreateUserGroupInput,
     storageAggregator: IStorageAggregator
   ): Promise<IUserGroup> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     const group = UserGroup.create(userGroupData);
     group.authorization = new AuthorizationPolicy(
       AuthorizationPolicyType.USER_GROUP
     );
 
-    (group as IUserGroup).profile = await this.profileService.createProfile(
+    const profile = await this.profileService.createProfile(
       userGroupData.profile,
       ProfileType.USER_GROUP,
       storageAggregator
     );
+    (group as IUserGroup).profile = profile;
+    // Phase 2: persist + materialize. Helper rolls back the saved group
+    // on failure so callers receive a fully-materialized group or an
+    // error, never half-state.
     const savedUserGroup = await this.userGroupRepository.save(group);
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      profile,
+      userGroupData.profile?.visuals,
+      [],
+      () => this.removeUserGroup({ ID: savedUserGroup.id })
+    );
     this.logger.verbose?.(
       `Created new group (${group.id}) with name: ${group.profile?.displayName}`,
       LogContext.COMMUNITY

--- a/src/domain/innovation-hub/innovation.hub.service.spec.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.spec.ts
@@ -84,6 +84,11 @@ describe('InnovationHubService', () => {
     ps.createProfile = vi.fn().mockResolvedValue(profile);
     ps.addOrUpdateTagsetOnProfile = vi.fn().mockResolvedValue({});
     ps.addVisualsOnProfile = vi.fn().mockResolvedValue({});
+    // createInnovationHub now uses the rollback helper for phase-2; mock it
+    // to echo the input profile so saved.profile stays defined.
+    ps.materializeProfileContentAndVisualsOrRollback = vi
+      .fn()
+      .mockImplementation(async (p: any) => p);
   };
 
   /**

--- a/src/domain/innovation-hub/innovation.hub.service.ts
+++ b/src/domain/innovation-hub/innovation.hub.service.ts
@@ -89,6 +89,7 @@ export class InnovationHubService {
     hub.searchVisibility = SearchVisibility.ACCOUNT;
     hub.account = account;
 
+    // Phase 1: build entity in memory.
     hub.profile = await this.profileService.createProfile(
       createData.profileData,
       ProfileType.INNOVATION_HUB,
@@ -100,13 +101,17 @@ export class InnovationHubService {
       tags: [],
     });
 
-    await this.profileService.addVisualsOnProfile(
-      hub.profile,
-      createData.profileData.visuals,
-      [VisualType.BANNER_WIDE]
-    );
-
-    return await this.save(hub);
+    // Phase 2: persist + materialize via the shared helper. Rolls back the
+    // saved hub on materialization failure.
+    const saved = await this.save(hub);
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisualsOrRollback(
+        saved.profile,
+        createData.profileData.visuals,
+        [VisualType.BANNER_WIDE],
+        () => this.delete(saved.id)
+      );
+    return saved;
   }
 
   public save(hub: IInnovationHub): Promise<IInnovationHub> {

--- a/src/domain/profile-documents/profile.documents.service.spec.ts
+++ b/src/domain/profile-documents/profile.documents.service.spec.ts
@@ -101,12 +101,14 @@ describe('ProfileDocumentsService', () => {
           useValue: {
             addDocumentToStorageBucketOrFail: vi.fn(),
             uploadFileAsDocumentFromBuffer: vi.fn(),
+            copyDocumentToBucket: vi.fn(),
           },
         },
         {
           provide: FileServiceAdapter,
           useValue: {
             createDocument: vi.fn(),
+            copyDocument: vi.fn(),
             getDocumentContent: vi.fn(),
             updateDocument: vi.fn(),
             deleteDocument: vi.fn(),
@@ -239,21 +241,16 @@ describe('ProfileDocumentsService', () => {
       });
     });
 
-    it('should return a copy of the document in the new StorageBucket', async () => {
+    it('copies the document via copyDocumentToBucket and deletes the source', async () => {
+      // Different-bucket branch: under v0.0.14 we call file-service-go's
+      // /internal/file/copy via storageBucketService.copyDocumentToBucket;
+      // no bytes traverse the wire, no getDocumentContent round-trip.
       const fileUrl = `${ALKEMIO_URL}/api/private/rest/storage/document/${uniqueId()}`;
       const storageBucketOrigin: IStorageBucket = mockStorageBucket();
       const storageBucketDestination: IStorageBucket = mockStorageBucket();
-      // A few test documents
-      mockDocument(storageBucketOrigin);
-      mockDocument(storageBucketOrigin);
-      mockDocument(storageBucketDestination);
-      mockDocument(storageBucketDestination);
-      // the doc
       const doc = mockDocument(storageBucketOrigin, {
         temporaryLocation: false,
       });
-      mockDocument(storageBucketOrigin);
-      mockDocument(storageBucketDestination);
 
       vi.spyOn(documentService, 'isAlkemioDocumentURL').mockReturnValue(true);
       vi.spyOn(documentService, 'getDocumentFromURL').mockResolvedValue(doc);
@@ -262,19 +259,13 @@ describe('ProfileDocumentsService', () => {
         resultUrl
       );
 
-      const contentBuffer = Buffer.from('file-content');
-      vi.spyOn(fileServiceAdapter, 'getDocumentContent').mockResolvedValue(
-        contentBuffer
-      );
-
       const newDocMock = mockDocument(storageBucketDestination, {
         ...doc,
         id: uniqueId(),
       });
-      vi.spyOn(
-        storageBucketService,
-        'uploadFileAsDocumentFromBuffer'
-      ).mockResolvedValue(newDocMock);
+      vi.spyOn(storageBucketService, 'copyDocumentToBucket').mockResolvedValue(
+        newDocMock
+      );
 
       const result = await service.reuploadFileOnStorageBucket(
         fileUrl,
@@ -284,17 +275,14 @@ describe('ProfileDocumentsService', () => {
 
       expect(result).toBe(resultUrl);
       expect(result !== fileUrl).toBe(true);
-      expect(fileServiceAdapter.getDocumentContent).toHaveBeenCalledWith(
-        doc.id
-      );
-      expect(
-        storageBucketService.uploadFileAsDocumentFromBuffer
-      ).toHaveBeenCalledWith(
+      expect(fileServiceAdapter.getDocumentContent).not.toHaveBeenCalled();
+      // skipDedup=true is required so the rollback path can never delete
+      // an unrelated reused destination row (see service comment).
+      expect(storageBucketService.copyDocumentToBucket).toHaveBeenCalledWith(
         storageBucketDestination.id,
-        contentBuffer,
-        doc.displayName,
-        doc.mimeType,
-        doc.createdBy
+        doc,
+        undefined,
+        true
       );
       // After copying to the new bucket, the original document in the old bucket
       // must be deleted to avoid orphaned storage.

--- a/src/domain/profile-documents/profile.documents.service.spec.ts
+++ b/src/domain/profile-documents/profile.documents.service.spec.ts
@@ -7,6 +7,7 @@ import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.in
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { uniqueId } from 'lodash';
 import { vi } from 'vitest';
 import { IAuthorizationPolicy } from '../common/authorization-policy';
@@ -114,6 +115,7 @@ describe('ProfileDocumentsService', () => {
             deleteDocument: vi.fn(),
           },
         },
+        MockWinstonProvider,
       ],
     }).compile();
 

--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -6,15 +6,18 @@ import {
 import { DocumentService } from '@domain/storage/document/document.service';
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 @Injectable()
 export class ProfileDocumentsService {
   constructor(
     private documentService: DocumentService,
     private storageBucketService: StorageBucketService,
-    private fileServiceAdapter: FileServiceAdapter
+    private fileServiceAdapter: FileServiceAdapter,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
   ) {}
 
   /***
@@ -116,11 +119,27 @@ export class ProfileDocumentsService {
       } catch (error) {
         // Source delete failed after destination copy succeeded — compensate
         // by removing the new copy so a caller retry doesn't accumulate
-        // duplicates in the destination bucket. Swallow cleanup errors: the
-        // original delete failure is what the caller needs to see.
+        // duplicates in the destination bucket. Cleanup-failure is
+        // alert-worthy (logger.error) but does not replace the original
+        // source-delete error — same convention as the OrRollback helper
+        // and other rollback sites in the codebase.
         await this.documentService
           .deleteDocument({ ID: newDoc.id })
-          .catch(() => undefined);
+          .catch(cleanupError => {
+            const stack =
+              cleanupError instanceof Error ? (cleanupError.stack ?? '') : '';
+            this.logger.error?.(
+              {
+                message:
+                  'Cleanup of destination copy after source-delete failure also failed',
+                sourceDocumentId: docInContent.id,
+                destinationDocumentId: newDoc.id,
+                cleanupError: String(cleanupError),
+              },
+              stack,
+              LogContext.PROFILE
+            );
+          });
         throw error;
       }
       // Keep in-memory bucket state in sync so subsequent re-uploads in the

--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -52,17 +52,6 @@ export class ProfileDocumentsService {
       );
     }
 
-    // Precondition: every path past here invokes file-service-go with the
-    // bucket id as an FK. Catch unsaved-bucket misuse here rather than
-    // letting it surface as a confusing "StorageBucket not found: undefined"
-    // from deep inside StorageBucketService.uploadFileAsDocumentFromBuffer.
-    if (!storageBucket.id) {
-      throw new EntityNotInitializedException(
-        'Storage bucket must be persisted before document re-upload: caller must save the parent entity first (typically via parent.save() with cascade)',
-        LogContext.PROFILE
-      );
-    }
-
     if (!storageBucket.documents) {
       throw new EntityNotInitializedException(
         `Documents not initialized on storage bucket: '${storageBucket.id}'`,

--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -40,6 +40,29 @@ export class ProfileDocumentsService {
       }
     }
 
+    // Precondition: every path past here either calls file-service-go with
+    // the bucket id as an FK, or scans `bucket.documents` for an existing
+    // entry. Both fail incoherently on an unsaved bucket. Catch misuse here
+    // with a clear error rather than letting it surface from deep inside
+    // the storage-bucket service as "StorageBucket not found: undefined".
+    if (!storageBucket.id) {
+      throw new EntityNotInitializedException(
+        'Storage bucket must be persisted before document re-upload: caller must save the parent entity first (typically via parent.save() with cascade)',
+        LogContext.PROFILE
+      );
+    }
+
+    // Precondition: every path past here invokes file-service-go with the
+    // bucket id as an FK. Catch unsaved-bucket misuse here rather than
+    // letting it surface as a confusing "StorageBucket not found: undefined"
+    // from deep inside StorageBucketService.uploadFileAsDocumentFromBuffer.
+    if (!storageBucket.id) {
+      throw new EntityNotInitializedException(
+        'Storage bucket must be persisted before document re-upload: caller must save the parent entity first (typically via parent.save() with cascade)',
+        LogContext.PROFILE
+      );
+    }
+
     if (!storageBucket.documents) {
       throw new EntityNotInitializedException(
         `Documents not initialized on storage bucket: '${storageBucket.id}'`,
@@ -83,24 +106,26 @@ export class ProfileDocumentsService {
       }
       return this.documentService.getPubliclyAccessibleURL(docInContent);
     } else {
-      // Different bucket: fetch content from Go service, re-upload to new bucket.
-      // After the new document is successfully uploaded, delete the old one so
-      // it doesn't leak in its original bucket as an orphan.
-      const content = await this.fileServiceAdapter.getDocumentContent(
-        docInContent.id
+      // Different bucket: ask file-service-go to materialize a new row in
+      // the destination bucket pointing at the same content. Single RPC,
+      // no bytes on the wire (content is content-addressed). After the
+      // new row is in place, delete the source so it doesn't leak as an
+      // orphan in its original bucket.
+      //
+      // skipDedup=true is critical for safety: without it, dedup-reuse could
+      // return another caller's existing row, and the rollback below would
+      // delete THEIR document on source-delete failure. Forcing a fresh row
+      // guarantees `newDoc` is exclusively ours.
+      const newDoc = await this.storageBucketService.copyDocumentToBucket(
+        storageBucket.id,
+        docInContent,
+        undefined,
+        true
       );
-      const newDoc =
-        await this.storageBucketService.uploadFileAsDocumentFromBuffer(
-          storageBucket.id,
-          content,
-          docInContent.displayName,
-          docInContent.mimeType,
-          docInContent.createdBy
-        );
       try {
         await this.documentService.deleteDocument({ ID: docInContent.id });
       } catch (error) {
-        // Source delete failed after destination upload succeeded — compensate
+        // Source delete failed after destination copy succeeded — compensate
         // by removing the new copy so a caller retry doesn't accumulate
         // duplicates in the destination bucket. Swallow cleanup errors: the
         // original delete failure is what the caller needs to see.
@@ -108,6 +133,18 @@ export class ProfileDocumentsService {
           .deleteDocument({ ID: newDoc.id })
           .catch(() => undefined);
         throw error;
+      }
+      // Keep in-memory bucket state in sync so subsequent re-uploads in the
+      // same request (e.g. multiple internal URLs in the same markdown) see
+      // the moved doc and don't trigger redundant copy/delete churn.
+      const sourceIndex = storageBucket.documents.findIndex(
+        doc => doc.id === docInContent.id
+      );
+      if (sourceIndex !== -1) {
+        storageBucket.documents.splice(sourceIndex, 1);
+      }
+      if (!storageBucket.documents.some(doc => doc.id === newDoc.id)) {
+        storageBucket.documents.push(newDoc);
       }
       return this.documentService.getPubliclyAccessibleURL(newDoc);
     }

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -129,36 +129,40 @@ export class SpaceAboutService {
         rollback
       );
     // createSpaceAbout always populates `spaceAbout.guidelines` (auto-creating
-    // an empty one if `spaceAboutData.guidelines` wasn't supplied). Materialize
-    // unconditionally so the auto-created profile gets its post-save work too;
-    // materializeCommunityGuidelinesContent treats undefined input as "no
-    // visuals to attach".
-    if (spaceAbout.guidelines) {
-      try {
-        await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
-          spaceAbout.guidelines,
-          spaceAboutData.guidelines
+    // an empty one if `spaceAboutData.guidelines` wasn't supplied), so a
+    // missing relation here is a programmer error or a bad caller load —
+    // fail fast rather than silently skipping nested materialization.
+    if (!spaceAbout.guidelines) {
+      throw new RelationshipNotFoundException(
+        'SpaceAbout guidelines not initialized for materialization',
+        LogContext.SPACES,
+        { spaceAboutId: spaceAbout.id }
+      );
+    }
+    try {
+      await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
+        spaceAbout.guidelines,
+        spaceAboutData.guidelines
+      );
+    } catch (error) {
+      // Same convention as the OrRollback helper: rollback-failure is
+      // alert-worthy (logger.error) but does not replace the original
+      // materialization error.
+      await rollback().catch(rollbackError => {
+        const stack =
+          rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+        this.logger.error?.(
+          {
+            message:
+              'Rollback after CommunityGuidelines materialization failure also failed',
+            spaceAboutId: spaceAbout.id,
+            rollbackError: String(rollbackError),
+          },
+          stack,
+          LogContext.SPACES
         );
-      } catch (error) {
-        // Same convention as the OrRollback helper: rollback-failure is
-        // alert-worthy (logger.error) but does not replace the original
-        // materialization error.
-        await rollback().catch(rollbackError => {
-          const stack =
-            rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
-          this.logger.error?.(
-            {
-              message:
-                'Rollback after CommunityGuidelines materialization failure also failed',
-              spaceAboutId: spaceAbout.id,
-              rollbackError: String(rollbackError),
-            },
-            stack,
-            LogContext.SPACES
-          );
-        });
-        throw error;
-      }
+      });
+      throw error;
     }
     return spaceAbout;
   }

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -22,9 +22,10 @@ import { CreateCommunityGuidelinesInput } from '@domain/community/community-guid
 import { ICommunityGuidelines } from '@domain/community/community-guidelines/community.guidelines.interface';
 import { CommunityGuidelinesService } from '@domain/community/community-guidelines/community.guidelines.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { InputCreatorService } from '@services/api/input-creator/input.creator.service';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { FindOneOptions, Repository } from 'typeorm';
 import { SpaceLookupService } from '../space.lookup/space.lookup.service';
 import { CreateSpaceAboutInput } from './dto/space.about.dto.create';
@@ -42,7 +43,9 @@ export class SpaceAboutService {
     private roleSetService: RoleSetService,
     private inputCreatorService: InputCreatorService,
     @InjectRepository(SpaceAbout)
-    private spaceAboutRepository: Repository<SpaceAbout>
+    private spaceAboutRepository: Repository<SpaceAbout>,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
   ) {}
 
   /**
@@ -100,10 +103,16 @@ export class SpaceAboutService {
    * bucket, attaches visuals, and cascades to the nested guidelines.
    * Caller must invoke this AFTER the parent's cascade save persists
    * `spaceAbout.profile.storageBucket` (and the guidelines' bucket).
+   *
+   * `rollback` is invoked by the OrRollback helper if the profile-level
+   * materialization fails, so callers receive a fully-materialized about
+   * or a rolled-back parent — never half-state. Nested guidelines failures
+   * also trigger `rollback`.
    */
   public async materializeSpaceAboutContent(
     spaceAbout: ISpaceAbout,
-    spaceAboutData: CreateSpaceAboutInput
+    spaceAboutData: CreateSpaceAboutInput,
+    rollback: () => Promise<unknown>
   ): Promise<ISpaceAbout> {
     if (!spaceAbout.profile) {
       throw new RelationshipNotFoundException(
@@ -113,10 +122,11 @@ export class SpaceAboutService {
       );
     }
     spaceAbout.profile =
-      await this.profileService.materializeProfileContentAndVisuals(
+      await this.profileService.materializeProfileContentAndVisualsOrRollback(
         spaceAbout.profile,
         spaceAboutData.profileData.visuals,
-        [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
+        [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD],
+        rollback
       );
     // createSpaceAbout always populates `spaceAbout.guidelines` (auto-creating
     // an empty one if `spaceAboutData.guidelines` wasn't supplied). Materialize
@@ -124,10 +134,25 @@ export class SpaceAboutService {
     // materializeCommunityGuidelinesContent treats undefined input as "no
     // visuals to attach".
     if (spaceAbout.guidelines) {
-      await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
-        spaceAbout.guidelines,
-        spaceAboutData.guidelines
-      );
+      try {
+        await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
+          spaceAbout.guidelines,
+          spaceAboutData.guidelines
+        );
+      } catch (error) {
+        await rollback().catch(rollbackError =>
+          this.logger.warn?.(
+            {
+              message:
+                'Rollback after CommunityGuidelines materialization failure also failed',
+              spaceAboutId: spaceAbout.id,
+              rollbackError: String(rollbackError),
+            },
+            LogContext.SPACES
+          )
+        );
+        throw error;
+      }
     }
     return spaceAbout;
   }

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -45,6 +45,16 @@ export class SpaceAboutService {
     private spaceAboutRepository: Repository<SpaceAbout>
   ) {}
 
+  /**
+   * Phase 1: in-memory entity construction. The returned spaceAbout (and its
+   * guidelines and profiles) must be persisted by the caller — typically via
+   * cascade from a parent Space — before
+   * {@link materializeSpaceAboutContent} is invoked.
+   *
+   * No file-service-go calls happen in this phase: visuals and any markdown
+   * re-uploads are deferred to phase 2 because they need a real
+   * `storageBucket.id`, which only exists after the cascade save.
+   */
   public async createSpaceAbout(
     spaceAboutData: CreateSpaceAboutInput,
     storageAggregator: IStorageAggregator
@@ -77,17 +87,48 @@ export class SpaceAboutService {
         storageAggregator
       );
 
-    // add the visuals
-    await this.profileService.addVisualsOnProfile(
-      spaceAbout.profile,
-      spaceAboutData.profileData.visuals,
-      [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
-    );
-
     // Do not save here — callers assign this to a parent entity with
     // cascade: true, so the parent's save handles persistence.
     // Saving via the default repository would bypass the caller's
     // transaction and cause FK violations on storageAggregator.
+    return spaceAbout;
+  }
+
+  /**
+   * Phase 2: post-save content materialization. Re-homes any internal
+   * Alkemio URLs in the profile description/references into the new
+   * bucket, attaches visuals, and cascades to the nested guidelines.
+   * Caller must invoke this AFTER the parent's cascade save persists
+   * `spaceAbout.profile.storageBucket` (and the guidelines' bucket).
+   */
+  public async materializeSpaceAboutContent(
+    spaceAbout: ISpaceAbout,
+    spaceAboutData: CreateSpaceAboutInput
+  ): Promise<ISpaceAbout> {
+    if (!spaceAbout.profile) {
+      throw new RelationshipNotFoundException(
+        'SpaceAbout profile not initialized',
+        LogContext.SPACES,
+        { spaceAboutId: spaceAbout.id }
+      );
+    }
+    spaceAbout.profile =
+      await this.profileService.materializeProfileContentAndVisuals(
+        spaceAbout.profile,
+        spaceAboutData.profileData.visuals,
+        [VisualType.AVATAR, VisualType.BANNER, VisualType.CARD]
+      );
+    // createSpaceAbout always populates `spaceAbout.guidelines` (auto-creating
+    // an empty one if `spaceAboutData.guidelines` wasn't supplied). Materialize
+    // unconditionally so the auto-created profile gets its post-save work too;
+    // materializeCommunityGuidelinesContent treats undefined input as "no
+    // visuals to attach".
+    if (spaceAbout.guidelines) {
+      await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
+        spaceAbout.guidelines,
+        spaceAboutData.guidelines
+      );
+    }
     return spaceAbout;
   }
 

--- a/src/domain/space/space.about/space.about.service.ts
+++ b/src/domain/space/space.about/space.about.service.ts
@@ -140,17 +140,23 @@ export class SpaceAboutService {
           spaceAboutData.guidelines
         );
       } catch (error) {
-        await rollback().catch(rollbackError =>
-          this.logger.warn?.(
+        // Same convention as the OrRollback helper: rollback-failure is
+        // alert-worthy (logger.error) but does not replace the original
+        // materialization error.
+        await rollback().catch(rollbackError => {
+          const stack =
+            rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+          this.logger.error?.(
             {
               message:
                 'Rollback after CommunityGuidelines materialization failure also failed',
               spaceAboutId: spaceAbout.id,
               rollbackError: String(rollbackError),
             },
+            stack,
             LogContext.SPACES
-          )
-        );
+          );
+        });
         throw error;
       }
     }

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -238,36 +238,6 @@ export class SpaceService {
       await mgr.save(space as Space);
     });
 
-    // Phase 2: post-save content materialization. The transaction above
-    // committed the entity tree (including profile.storageBucket ids), so
-    // file-service-go calls now have real FKs to reference. This is the
-    // place where template-derived markdown URLs and visuals get re-homed
-    // into the new space's own bucket — fixes #6004 / #6005.
-    //
-    // SpaceAbout is composed inside the transaction (can't save itself
-    // mid-transaction without breaking atomicity), so materialization runs
-    // here at the orchestrator level. On failure, delete the just-committed
-    // space so a partially-materialized space doesn't linger.
-    try {
-      await this.spaceAboutService.materializeSpaceAboutContent(
-        space.about,
-        modifiedAbout
-      );
-    } catch (error) {
-      await this.deleteSpaceOrFail({ ID: space.id }).catch(rollbackError =>
-        this.logger.warn?.(
-          {
-            message:
-              'Rollback after SpaceAbout materialization failure also failed',
-            spaceId: space.id,
-            rollbackError: String(rollbackError),
-          },
-          LogContext.SPACES
-        )
-      );
-      throw error;
-    }
-
     if (spaceData.level === SpaceLevel.L0) {
       space.levelZeroSpaceID = space.id;
 
@@ -340,34 +310,31 @@ export class SpaceService {
 
     const spaceUpdated = await this.save(space);
 
-    // Phase-2 materialize the collaboration tree now that the cascade save
-    // has persisted callouts/framings/contributions. Cross-bucket markdown
-    // URLs from the source template (and any temp-location uploads in the
-    // user input) get re-homed into the space's bucket. On failure we
-    // delete the just-committed space so a partially-materialized space
-    // doesn't linger — same contract as the spaceAbout materialize above.
+    // Phase 2: post-save content materialization. The full tree is now
+    // persisted (storage buckets have real FKs, collaboration is loadable
+    // for rollback), so file-service-go calls and a subsequent
+    // deleteSpaceOrFail-based rollback both work. We materialize the about
+    // and the collaboration tree together so any failure can be cleaned up
+    // by a single rollback path. Cross-bucket markdown URLs from the
+    // source template (and any temp-location uploads in the user input)
+    // get re-homed into the space's bucket here — fixes #6004 / #6005.
+    //
+    // The OrRollback helper inside each materialize step calls the rollback
+    // callback (delete space) on its own failure and rethrows the original
+    // error, so we don't need a redundant catch around the call.
+    const rollbackSpace = (): Promise<unknown> =>
+      this.deleteSpaceOrFail({ ID: spaceUpdated.id });
+    await this.spaceAboutService.materializeSpaceAboutContent(
+      spaceUpdated.about,
+      modifiedAbout,
+      rollbackSpace
+    );
     if (spaceUpdated.collaboration) {
-      try {
-        await this.collaborationService.materializeCollaborationContent(
-          spaceUpdated.collaboration,
-          updatedCollaborationData,
-          () => this.deleteSpaceOrFail({ ID: spaceUpdated.id })
-        );
-      } catch (error) {
-        await this.deleteSpaceOrFail({ ID: spaceUpdated.id }).catch(
-          rollbackError =>
-            this.logger.warn?.(
-              {
-                message:
-                  'Rollback after Collaboration materialization failure also failed',
-                spaceId: spaceUpdated.id,
-                rollbackError: String(rollbackError),
-              },
-              LogContext.SPACES
-            )
-        );
-        throw error;
-      }
+      await this.collaborationService.materializeCollaborationContent(
+        spaceUpdated.collaboration,
+        updatedCollaborationData,
+        rollbackSpace
+      );
     }
 
     // If template has child spaces, then create child spaces here

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -329,13 +329,37 @@ export class SpaceService {
       modifiedAbout,
       rollbackSpace
     );
-    if (spaceUpdated.collaboration) {
-      await this.collaborationService.materializeCollaborationContent(
-        spaceUpdated.collaboration,
-        updatedCollaborationData,
-        rollbackSpace
+    // Collaboration is always created earlier in this method (line 321);
+    // missing here would indicate a bad load or a programmer error.
+    // Fail fast rather than silently leaving the collaboration tree
+    // unmaterialized — that would persist a Space whose callouts still
+    // reference the source template's bucket.
+    if (!spaceUpdated.collaboration) {
+      await rollbackSpace().catch(rollbackError => {
+        const stack =
+          rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+        this.logger.error?.(
+          {
+            message:
+              'Rollback after missing-collaboration detection also failed',
+            spaceId: spaceUpdated.id,
+            rollbackError: String(rollbackError),
+          },
+          stack,
+          LogContext.SPACES
+        );
+      });
+      throw new RelationshipNotFoundException(
+        'Collaboration not initialized on Space for materialization',
+        LogContext.SPACES,
+        { spaceId: spaceUpdated.id }
       );
     }
+    await this.collaborationService.materializeCollaborationContent(
+      spaceUpdated.collaboration,
+      updatedCollaborationData,
+      rollbackSpace
+    );
 
     // If template has child spaces, then create child spaces here
     if (

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -256,7 +256,12 @@ export class SpaceService {
     } catch (error) {
       await this.deleteSpaceOrFail({ ID: space.id }).catch(rollbackError =>
         this.logger.warn?.(
-          `Rollback after SpaceAbout materialization failure also failed for space ${space.id}: ${rollbackError}`,
+          {
+            message:
+              'Rollback after SpaceAbout materialization failure also failed',
+            spaceId: space.id,
+            rollbackError: String(rollbackError),
+          },
           LogContext.SPACES
         )
       );
@@ -334,6 +339,37 @@ export class SpaceService {
     );
 
     const spaceUpdated = await this.save(space);
+
+    // Phase-2 materialize the collaboration tree now that the cascade save
+    // has persisted callouts/framings/contributions. Cross-bucket markdown
+    // URLs from the source template (and any temp-location uploads in the
+    // user input) get re-homed into the space's bucket. On failure we
+    // delete the just-committed space so a partially-materialized space
+    // doesn't linger — same contract as the spaceAbout materialize above.
+    if (spaceUpdated.collaboration) {
+      try {
+        await this.collaborationService.materializeCollaborationContent(
+          spaceUpdated.collaboration,
+          updatedCollaborationData,
+          () => this.deleteSpaceOrFail({ ID: spaceUpdated.id })
+        );
+      } catch (error) {
+        await this.deleteSpaceOrFail({ ID: spaceUpdated.id }).catch(
+          rollbackError =>
+            this.logger.warn?.(
+              {
+                message:
+                  'Rollback after Collaboration materialization failure also failed',
+                spaceId: spaceUpdated.id,
+                rollbackError: String(rollbackError),
+              },
+              LogContext.SPACES
+            )
+        );
+        throw error;
+      }
+    }
+
     // If template has child spaces, then create child spaces here
     if (
       templateContentSpace.subspaces &&

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -238,6 +238,31 @@ export class SpaceService {
       await mgr.save(space as Space);
     });
 
+    // Phase 2: post-save content materialization. The transaction above
+    // committed the entity tree (including profile.storageBucket ids), so
+    // file-service-go calls now have real FKs to reference. This is the
+    // place where template-derived markdown URLs and visuals get re-homed
+    // into the new space's own bucket — fixes #6004 / #6005.
+    //
+    // SpaceAbout is composed inside the transaction (can't save itself
+    // mid-transaction without breaking atomicity), so materialization runs
+    // here at the orchestrator level. On failure, delete the just-committed
+    // space so a partially-materialized space doesn't linger.
+    try {
+      await this.spaceAboutService.materializeSpaceAboutContent(
+        space.about,
+        modifiedAbout
+      );
+    } catch (error) {
+      await this.deleteSpaceOrFail({ ID: space.id }).catch(rollbackError =>
+        this.logger.warn?.(
+          `Rollback after SpaceAbout materialization failure also failed for space ${space.id}: ${rollbackError}`,
+          LogContext.SPACES
+        )
+      );
+      throw error;
+    }
+
     if (spaceData.level === SpaceLevel.L0) {
       space.levelZeroSpaceID = space.id;
 

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -748,6 +748,35 @@ describe('StorageBucketService', () => {
         expect.objectContaining({ createdBy: 'orig-user' })
       );
     });
+
+    it('forwards skipDedup=true to fileServiceAdapter.copyDocument', async () => {
+      // Pin the contract relied upon by profile-documents.service.ts: when the
+      // caller asks for a guaranteed-fresh row (skipDedup=true), the flag is
+      // propagated through to the adapter rather than dropped.
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc();
+      const newDoc = mockDocument({ id: 'doc-new' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-new',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: false,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(newDoc);
+
+      await service.copyDocumentToBucket('bucket-dst', source, 'user-1', true);
+
+      expect(fileServiceAdapter.copyDocument).toHaveBeenCalledWith(
+        expect.objectContaining({ skipDedup: true })
+      );
+    });
   });
 
   // ── uploadFileAsDocument (stream) ──────────────────────────────

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -108,6 +108,7 @@ describe('StorageBucketService', () => {
           provide: FileServiceAdapter,
           useValue: {
             createDocument: vi.fn(),
+            copyDocument: vi.fn(),
             getDocumentContent: vi.fn(),
             updateDocument: vi.fn(),
             deleteDocument: vi.fn(),
@@ -607,6 +608,144 @@ describe('StorageBucketService', () => {
       });
       expect(tagsetService.removeTagset).toHaveBeenCalledWith(
         'tagset-saved-rrf'
+      );
+    });
+  });
+
+  // ── copyDocumentToBucket ───────────────────────────────────────
+
+  describe('copyDocumentToBucket', () => {
+    const makeSourceDoc = (overrides?: Partial<IDocument>): IDocument =>
+      mockDocument({
+        id: 'src-doc',
+        displayName: 'orig.png',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        externalID: 'ext-shared',
+        createdBy: 'user-orig',
+        ...overrides,
+      });
+
+    it('delegates to fileServiceAdapter.copyDocument with caller-supplied auth/tagset', async () => {
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc();
+      const newDoc = mockDocument({ id: 'doc-new' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-new',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: false,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(newDoc);
+
+      const result = await service.copyDocumentToBucket(
+        'bucket-dst',
+        source,
+        'user-caller'
+      );
+
+      expect(result).toBe(newDoc);
+      expect(fileServiceAdapter.copyDocument).toHaveBeenCalledWith({
+        sourceId: 'src-doc',
+        destinationBucketId: 'bucket-dst',
+        authorizationId: 'auth-saved',
+        tagsetId: 'tagset-saved',
+        createdBy: 'user-caller',
+      });
+      // Auth + tagset stay attached (fresh row, not reused)
+      expect(authorizationPolicyService.delete).not.toHaveBeenCalled();
+      expect(tagsetService.removeTagset).not.toHaveBeenCalled();
+    });
+
+    it('releases pre-created auth + tagset when Go responds reused:true', async () => {
+      // Same dedup-reuse contract as createDocument: when Go returns an
+      // existing row, our pre-created auth/tagset are orphans and must be
+      // released so they don't accumulate in the DB.
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc();
+      const reusedDoc = mockDocument({ id: 'doc-existing' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-existing',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: true,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(reusedDoc);
+
+      await service.copyDocumentToBucket('bucket-dst', source);
+
+      expect(authorizationPolicyService.delete).toHaveBeenCalledWith({
+        id: 'auth-saved',
+      });
+      expect(tagsetService.removeTagset).toHaveBeenCalledWith('tagset-saved');
+      // Existing doc must NOT be deleted on reuse — it belongs to another caller.
+      expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it('rolls back pre-created resources on copy failure', async () => {
+      // Full compensation when Go's copy call throws: delete the auth and
+      // tagset rows we pre-created. No Go-side document was created here so
+      // there's nothing to delete on that side.
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc();
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockRejectedValue(
+        new Error('copy failed')
+      );
+
+      await expect(
+        service.copyDocumentToBucket('bucket-dst', source)
+      ).rejects.toThrow('copy failed');
+
+      expect(authorizationPolicyService.delete).toHaveBeenCalledWith({
+        id: 'auth-saved',
+      });
+      expect(tagsetService.removeTagset).toHaveBeenCalledWith('tagset-saved');
+      expect(fileServiceAdapter.deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it('falls back to source.createdBy when no userID is supplied', async () => {
+      const bucket = mockStorageBucket({ id: 'bucket-dst' });
+      const source = makeSourceDoc({ createdBy: 'orig-user' });
+      const newDoc = mockDocument({ id: 'doc-new' });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-new',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: false,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(newDoc);
+
+      await service.copyDocumentToBucket('bucket-dst', source);
+
+      expect(fileServiceAdapter.copyDocument).toHaveBeenCalledWith(
+        expect.objectContaining({ createdBy: 'orig-user' })
       );
     });
   });

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -23,6 +23,7 @@ import { TagsetService } from '@domain/common/tagset/tagset.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
+import type { CreateDocumentResult } from '@services/adapters/file-service-adapter/dto';
 import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
 import { AvatarCreatorService } from '@services/external/avatar-creator/avatar.creator.service';
 import { UrlGeneratorService } from '@services/infrastructure/url-generator/url.generator.service';
@@ -215,10 +216,84 @@ export class StorageBucketService {
     this.validateMimeTypes(storage, mimeType);
     this.validateSize(storage, buffer.length);
 
-    // Pre-create auth policy and tagset, call Go service, load result.
-    // Full compensation: any failure anywhere in the sequence rolls back all
-    // previously created resources (auth policy, tagset, Go-side document),
-    // each cleaned up independently so one rollback failure doesn't skip others.
+    return this.persistDocumentWithPreparedAuth(
+      storageBucketId,
+      mimeType,
+      (authId, tagsetId) =>
+        this.fileServiceAdapter.createDocument(buffer, {
+          displayName: filename,
+          mimeType,
+          storageBucketId,
+          authorizationId: authId,
+          tagsetId,
+          createdBy: userID || undefined,
+          temporaryLocation,
+          allowedMimeTypes: storage.allowedMimeTypes.join(','),
+          maxFileSize: storage.maxFileSize,
+          skipDedup: skipDedup || undefined,
+        })
+    );
+  }
+
+  /**
+   * Copy an existing document into another bucket via file-service-go's
+   * /internal/file/copy endpoint (v0.0.14+). No bytes traverse the wire —
+   * the new row references the same content. Replaces the legacy
+   * `getDocumentContent` + `uploadFileAsDocumentFromBuffer` round-trip.
+   *
+   * The destination bucket's allowed-mime-types and max-size policy are
+   * still enforced on the source's metadata, so a per-bucket policy that's
+   * tighter than the source bucket's still rejects the copy.
+   */
+  public async copyDocumentToBucket(
+    destinationBucketId: string,
+    sourceDocument: IDocument,
+    userID?: string,
+    skipDedup = false
+  ): Promise<IDocument> {
+    const destination = await this.getStorageBucketOrFail(destinationBucketId, {
+      relations: {},
+    });
+
+    this.validateMimeTypes(destination, sourceDocument.mimeType);
+    this.validateSize(destination, sourceDocument.size);
+
+    return this.persistDocumentWithPreparedAuth(
+      destinationBucketId,
+      sourceDocument.mimeType,
+      (authId, tagsetId) =>
+        this.fileServiceAdapter.copyDocument({
+          sourceId: sourceDocument.id,
+          destinationBucketId,
+          authorizationId: authId,
+          tagsetId,
+          createdBy: userID || sourceDocument.createdBy || undefined,
+          skipDedup: skipDedup || undefined,
+        })
+    );
+  }
+
+  /**
+   * Shared scaffolding for any operation that needs to materialize a new
+   * `Document` row in `bucketId`: pre-create the auth-policy + tagset that
+   * the document FK-references, run the caller-supplied file-service-go
+   * call, then either:
+   *   - on dedup-reuse (`result.reused === true`): release the pre-created
+   *     rows since Go ignored them and kept the existing row's values
+   *     authoritative;
+   *   - on error: roll back every pre-created resource AND, if Go did
+   *     create a fresh row before the failure, delete it too. On reuse
+   *     during a later failure, the source row belongs to another caller
+   *     and must be preserved.
+   *
+   * Both create and copy flows go through here so the auth/tagset
+   * lifecycle and dedup-reuse contract stay consistent across the two.
+   */
+  private async persistDocumentWithPreparedAuth(
+    bucketId: string,
+    _mimeTypeForLog: string,
+    goCall: (authId: string, tagsetId: string) => Promise<CreateDocumentResult>
+  ): Promise<IDocument> {
     let savedAuth;
     let savedTagset;
     let result;
@@ -235,22 +310,10 @@ export class StorageBucketService {
       });
       savedTagset = await this.tagsetService.save(tagset);
 
-      // Delegate to Go file-service-go
-      result = await this.fileServiceAdapter.createDocument(buffer, {
-        displayName: filename,
-        mimeType,
-        storageBucketId,
-        authorizationId: savedAuth.id,
-        tagsetId: savedTagset.id,
-        createdBy: userID || undefined,
-        temporaryLocation,
-        allowedMimeTypes: storage.allowedMimeTypes.join(','),
-        maxFileSize: storage.maxFileSize,
-        skipDedup: skipDedup || undefined,
-      });
+      result = await goCall(savedAuth.id, savedTagset.id);
 
-      // Load the document with relations needed for auth. On a dedup reuse
-      // this is an existing row; otherwise it's the freshly-inserted one.
+      // Load with relations needed for auth/tagset consumers. On dedup
+      // reuse this is an existing row; otherwise the freshly-inserted one.
       document = await this.documentService.getDocumentOrFail(result.id, {
         relations: {
           authorization: true,
@@ -259,9 +322,8 @@ export class StorageBucketService {
         },
       });
     } catch (error) {
-      // Rollback: delete each pre-created resource independently so one
-      // failure doesn't short-circuit the others. Bind narrowed values into
-      // const locals so the closures don't re-widen them.
+      // Independent rollbacks so one cleanup failure doesn't skip the rest.
+      // Bind narrowed values into const locals so the closures don't re-widen.
       //
       // Important: only delete the Go-side document if this request created
       // it (reused=false). On a dedup reuse, `result.id` refers to someone
@@ -296,10 +358,9 @@ export class StorageBucketService {
       throw error;
     }
 
-    // file-service-go returned an existing row: the caller-supplied
-    // authorizationId/tagsetId were ignored (the existing row keeps its
-    // own). Release our pre-created rows here rather than leaving them
-    // as DB orphans. Same const-rebind trick as above to keep narrowing.
+    // Dedup-reuse: caller-supplied authorizationId / tagsetId were ignored
+    // by Go (existing row authoritative). Release our pre-created rows so
+    // they don't become DB orphans.
     if (result.reused) {
       const reusedAuth = savedAuth;
       if (reusedAuth) {
@@ -322,7 +383,7 @@ export class StorageBucketService {
     }
 
     this.logger.verbose?.(
-      `Uploaded document '${result.externalID}' via file-service on storage bucket: ${storage.id}`,
+      `Materialized document '${result.externalID}' via file-service on storage bucket: ${bucketId}`,
       LogContext.STORAGE_BUCKET
     );
     return document;

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -218,7 +218,6 @@ export class StorageBucketService {
 
     return this.persistDocumentWithPreparedAuth(
       storageBucketId,
-      mimeType,
       (authId, tagsetId) =>
         this.fileServiceAdapter.createDocument(buffer, {
           displayName: filename,
@@ -260,7 +259,6 @@ export class StorageBucketService {
 
     return this.persistDocumentWithPreparedAuth(
       destinationBucketId,
-      sourceDocument.mimeType,
       (authId, tagsetId) =>
         this.fileServiceAdapter.copyDocument({
           sourceId: sourceDocument.id,
@@ -291,7 +289,6 @@ export class StorageBucketService {
    */
   private async persistDocumentWithPreparedAuth(
     bucketId: string,
-    _mimeTypeForLog: string,
     goCall: (authId: string, tagsetId: string) => Promise<CreateDocumentResult>
   ): Promise<IDocument> {
     let savedAuth;

--- a/src/domain/template/template-content-space/template.content.space.service.ts
+++ b/src/domain/template/template-content-space/template.content.space.service.ts
@@ -169,17 +169,23 @@ export class TemplateContentSpaceService {
     error: Error,
     templateContentSpaceId: string
   ): Promise<never> {
-    await rollback().catch(rollbackError =>
-      this.logger.warn?.(
+    // Same convention as the OrRollback helper: rollback-failure is
+    // alert-worthy (logger.error) but does not replace the original
+    // materialization error.
+    await rollback().catch(rollbackError => {
+      const stack =
+        rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+      this.logger.error?.(
         {
           message:
             'Rollback after TemplateContentSpace materialization failure also failed',
           templateContentSpaceId,
           rollbackError: String(rollbackError),
         },
+        stack,
         LogContext.TEMPLATES
-      )
-    );
+      );
+    });
     throw error;
   }
 

--- a/src/domain/template/template-content-space/template.content.space.service.ts
+++ b/src/domain/template/template-content-space/template.content.space.service.ts
@@ -92,42 +92,95 @@ export class TemplateContentSpaceService {
     templateContentSpaceData: CreateTemplateContentSpaceInput | undefined,
     rollback: () => Promise<unknown>
   ): Promise<void> {
-    if (templateContentSpace.about && templateContentSpaceData?.about) {
-      try {
-        await this.spaceAboutService.materializeSpaceAboutContent(
-          templateContentSpace.about,
-          templateContentSpaceData.about
-        );
-      } catch (error) {
-        await rollback().catch(rollbackError =>
-          this.logger.warn?.(
-            {
-              message:
-                'Rollback after TemplateContentSpace.about materialization failure also failed',
-              templateContentSpaceId: templateContentSpace.id,
-              rollbackError: String(rollbackError),
-            },
-            LogContext.TEMPLATES
-          )
-        );
-        throw error;
-      }
-    }
-    if (templateContentSpace.collaboration) {
-      await this.collaborationService.materializeCollaborationContent(
-        templateContentSpace.collaboration,
-        templateContentSpaceData?.collaborationData,
-        rollback
+    // Fail-fast on partial loads or DTO mismatches — silently skipping
+    // would leave content unmaterialized while the call still succeeds.
+    if (!templateContentSpaceData) {
+      await this.rollbackAndThrow(
+        rollback,
+        new EntityNotInitializedException(
+          'TemplateContentSpace materialization data not provided',
+          LogContext.TEMPLATES,
+          { templateContentSpaceId: templateContentSpace.id }
+        ),
+        templateContentSpace.id
       );
     }
-    const subspaces = templateContentSpace.subspaces ?? [];
-    for (let i = 0; i < subspaces.length; i++) {
+    if (!templateContentSpace.about) {
+      await this.rollbackAndThrow(
+        rollback,
+        new RelationshipNotFoundException(
+          'TemplateContentSpace about not initialized',
+          LogContext.TEMPLATES,
+          { templateContentSpaceId: templateContentSpace.id }
+        ),
+        templateContentSpace.id
+      );
+    }
+    if (!templateContentSpace.collaboration) {
+      await this.rollbackAndThrow(
+        rollback,
+        new RelationshipNotFoundException(
+          'TemplateContentSpace collaboration not initialized',
+          LogContext.TEMPLATES,
+          { templateContentSpaceId: templateContentSpace.id }
+        ),
+        templateContentSpace.id
+      );
+    }
+    const persistedSubspaces = templateContentSpace.subspaces ?? [];
+    const inputSubspaces = templateContentSpaceData!.subspaces ?? [];
+    if (persistedSubspaces.length !== inputSubspaces.length) {
+      await this.rollbackAndThrow(
+        rollback,
+        new EntityNotInitializedException(
+          'TemplateContentSpace subspaces are out of sync with materialization data',
+          LogContext.TEMPLATES,
+          {
+            templateContentSpaceId: templateContentSpace.id,
+            persistedSubspaces: persistedSubspaces.length,
+            inputSubspaces: inputSubspaces.length,
+          }
+        ),
+        templateContentSpace.id
+      );
+    }
+
+    await this.spaceAboutService.materializeSpaceAboutContent(
+      templateContentSpace.about!,
+      templateContentSpaceData!.about,
+      rollback
+    );
+    await this.collaborationService.materializeCollaborationContent(
+      templateContentSpace.collaboration!,
+      templateContentSpaceData!.collaborationData,
+      rollback
+    );
+    for (let i = 0; i < persistedSubspaces.length; i++) {
       await this.materializeTemplateContentSpaceContent(
-        subspaces[i],
-        templateContentSpaceData?.subspaces?.[i],
+        persistedSubspaces[i],
+        inputSubspaces[i],
         rollback
       );
     }
+  }
+
+  private async rollbackAndThrow(
+    rollback: () => Promise<unknown>,
+    error: Error,
+    templateContentSpaceId: string
+  ): Promise<never> {
+    await rollback().catch(rollbackError =>
+      this.logger.warn?.(
+        {
+          message:
+            'Rollback after TemplateContentSpace materialization failure also failed',
+          templateContentSpaceId,
+          rollbackError: String(rollbackError),
+        },
+        LogContext.TEMPLATES
+      )
+    );
+    throw error;
   }
 
   async save(

--- a/src/domain/template/template-content-space/template.content.space.service.ts
+++ b/src/domain/template/template-content-space/template.content.space.service.ts
@@ -78,6 +78,58 @@ export class TemplateContentSpaceService {
     return await this.save(templateContentSpace);
   }
 
+  /**
+   * Phase-2 materialization for a TemplateContentSpace. Composed under a
+   * Template (SPACE type); the Template's save persists the entire tree
+   * before this is called.
+   *
+   * Walks the about + collaboration + recursive subspaces. Failures bubble
+   * up via the supplied rollback callback (typically deletes the top-level
+   * Template — cascade clears the rest).
+   */
+  public async materializeTemplateContentSpaceContent(
+    templateContentSpace: ITemplateContentSpace,
+    templateContentSpaceData: CreateTemplateContentSpaceInput | undefined,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    if (templateContentSpace.about && templateContentSpaceData?.about) {
+      try {
+        await this.spaceAboutService.materializeSpaceAboutContent(
+          templateContentSpace.about,
+          templateContentSpaceData.about
+        );
+      } catch (error) {
+        await rollback().catch(rollbackError =>
+          this.logger.warn?.(
+            {
+              message:
+                'Rollback after TemplateContentSpace.about materialization failure also failed',
+              templateContentSpaceId: templateContentSpace.id,
+              rollbackError: String(rollbackError),
+            },
+            LogContext.TEMPLATES
+          )
+        );
+        throw error;
+      }
+    }
+    if (templateContentSpace.collaboration) {
+      await this.collaborationService.materializeCollaborationContent(
+        templateContentSpace.collaboration,
+        templateContentSpaceData?.collaborationData,
+        rollback
+      );
+    }
+    const subspaces = templateContentSpace.subspaces ?? [];
+    for (let i = 0; i < subspaces.length; i++) {
+      await this.materializeTemplateContentSpaceContent(
+        subspaces[i],
+        templateContentSpaceData?.subspaces?.[i],
+        rollback
+      );
+    }
+  }
+
   async save(
     templateContentSpace: ITemplateContentSpace
   ): Promise<ITemplateContentSpace> {

--- a/src/domain/template/template/template.service.spec.ts
+++ b/src/domain/template/template/template.service.spec.ts
@@ -301,6 +301,102 @@ describe('TemplateService', () => {
       expect(calloutData.isTemplate).toBe(true);
     });
 
+    it('should walk nested callout content for CALLOUT template type', async () => {
+      calloutService.createCallout.mockResolvedValue({ id: 'co-1' } as any);
+
+      const calloutData = { nameID: 'cb', isTemplate: false, sortOrder: 0 };
+      const input = baseInput(TemplateType.CALLOUT, { calloutData });
+
+      await service.createTemplate(input as any, storageAggregator);
+
+      expect(calloutService.materializeCalloutContent).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'co-1' }),
+        calloutData,
+        expect.any(Function)
+      );
+    });
+
+    it('should walk nested contentSpace for SPACE template type', async () => {
+      templateContentSpaceService.createTemplateContentSpace.mockResolvedValue({
+        id: 'tcs-1',
+      } as any);
+
+      const contentSpaceData = {
+        collaborationData: {
+          calloutsSetData: { calloutsData: [] },
+          innovationFlowData: { states: [{ displayName: 'State' }] },
+        },
+        about: {},
+        subspaces: [],
+      };
+      const input = baseInput(TemplateType.SPACE, { contentSpaceData });
+
+      await service.createTemplate(input as any, storageAggregator);
+
+      expect(
+        templateContentSpaceService.materializeTemplateContentSpaceContent
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'tcs-1' }),
+        contentSpaceData,
+        expect.any(Function)
+      );
+    });
+
+    it('rolls back the saved template when nested CALLOUT materialize fails', async () => {
+      calloutService.createCallout.mockResolvedValue({ id: 'co-1' } as any);
+      // Simulate the helper invoking rollback then re-throwing — same
+      // contract as materializeProfileContentAndVisualsOrRollback inside
+      // CalloutService.materializeCalloutContent.
+      calloutService.materializeCalloutContent.mockImplementation(
+        async (_callout, _data, rollback) => {
+          await rollback();
+          throw new Error('framing materialize failed');
+        }
+      );
+      const deleteSpy = vi
+        .spyOn(service, 'delete')
+        .mockResolvedValue({} as any);
+
+      const calloutData = { nameID: 'cb', isTemplate: false, sortOrder: 0 };
+      const input = baseInput(TemplateType.CALLOUT, { calloutData });
+
+      await expect(
+        service.createTemplate(input as any, storageAggregator)
+      ).rejects.toThrow('framing materialize failed');
+      expect(deleteSpy).toHaveBeenCalled();
+    });
+
+    it('rolls back the saved template when nested SPACE materialize fails', async () => {
+      templateContentSpaceService.createTemplateContentSpace.mockResolvedValue({
+        id: 'tcs-1',
+      } as any);
+      templateContentSpaceService.materializeTemplateContentSpaceContent.mockImplementation(
+        async (_cs, _data, rollback) => {
+          await rollback();
+          throw new Error('contentSpace materialize failed');
+        }
+      );
+      const deleteSpy = vi
+        .spyOn(service, 'delete')
+        .mockResolvedValue({} as any);
+
+      const input = baseInput(TemplateType.SPACE, {
+        contentSpaceData: {
+          collaborationData: {
+            calloutsSetData: { calloutsData: [] },
+            innovationFlowData: { states: [{ displayName: 'State' }] },
+          },
+          about: {},
+          subspaces: [],
+        },
+      });
+
+      await expect(
+        service.createTemplate(input as any, storageAggregator)
+      ).rejects.toThrow('contentSpace materialize failed');
+      expect(deleteSpy).toHaveBeenCalled();
+    });
+
     it('should throw ValidationException for unknown template type', async () => {
       await expect(
         service.createTemplate(

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -235,19 +235,31 @@ export class TemplateService {
       () => this.delete(saved)
     );
 
-    const rollbackTemplate = (): Promise<unknown> =>
-      this.delete(saved).catch(rollbackError => {
-        this.logger.warn?.(
+    // rollbackTemplate logs at ERROR (not WARN) when delete itself fails,
+    // and rethrows so callers awaiting it are not silently lied to about
+    // a successful rollback. The OrRollback helper already wraps its
+    // rollback() call in its own try/catch, so any rethrow here is
+    // observed via that path; the COMMUNITY_GUIDELINES branch below
+    // wraps explicitly so the original materialization error wins.
+    const rollbackTemplate = async (): Promise<void> => {
+      try {
+        await this.delete(saved);
+      } catch (rollbackError) {
+        const stack =
+          rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+        this.logger.error?.(
           {
             message:
               'Rollback after nested template-content materialization failure also failed',
             templateId: saved.id,
             templateType: saved.type,
-            rollbackError: String(rollbackError),
           },
+          stack,
           LogContext.TEMPLATES
         );
-      });
+        throw rollbackError;
+      }
+    };
 
     if (
       saved.type === TemplateType.COMMUNITY_GUIDELINES &&
@@ -260,7 +272,13 @@ export class TemplateService {
           templateData.communityGuidelinesData
         );
       } catch (error) {
-        await rollbackTemplate();
+        // Awaited inside its own try/catch so the rethrown rollback error
+        // doesn't replace the original materialization error.
+        try {
+          await rollbackTemplate();
+        } catch {
+          // already logged by rollbackTemplate
+        }
         throw error;
       }
     }

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -98,8 +98,9 @@ export class TemplateService {
       case TemplateType.POST: {
         if (!templateData.postDefaultDescription) {
           throw new ValidationException(
-            `Post Template requires default description input: ${JSON.stringify(templateData)}`,
-            LogContext.TEMPLATES
+            'Post Template requires default description input',
+            LogContext.TEMPLATES,
+            { templateType: template.type, missing: 'postDefaultDescription' }
           );
         }
         template.postDefaultDescription = templateData.postDefaultDescription;
@@ -108,8 +109,9 @@ export class TemplateService {
       case TemplateType.COMMUNITY_GUIDELINES: {
         if (!templateData.communityGuidelinesData) {
           throw new ValidationException(
-            `Community Guidelines Template requires the community guidelines input: ${JSON.stringify(templateData)}`,
-            LogContext.TEMPLATES
+            'Community Guidelines Template requires guidelines input',
+            LogContext.TEMPLATES,
+            { templateType: template.type, missing: 'communityGuidelinesData' }
           );
         }
         const guidelinesInput: CreateCommunityGuidelinesInput =
@@ -125,8 +127,9 @@ export class TemplateService {
       case TemplateType.SPACE: {
         if (!templateData.contentSpaceData) {
           throw new ValidationException(
-            `Space Template requires space input: ${JSON.stringify(templateData)}`,
-            LogContext.TEMPLATES
+            'Space Template requires content-space input',
+            LogContext.TEMPLATES,
+            { templateType: template.type, missing: 'contentSpaceData' }
           );
         }
         const spaceData = templateData.contentSpaceData;
@@ -173,8 +176,9 @@ export class TemplateService {
       case TemplateType.WHITEBOARD: {
         if (!templateData.whiteboard) {
           throw new ValidationException(
-            `Whiteboard Template requires whiteboard input: ${JSON.stringify(templateData)}`,
-            LogContext.TEMPLATES
+            'Whiteboard Template requires whiteboard input',
+            LogContext.TEMPLATES,
+            { templateType: template.type, missing: 'whiteboard' }
           );
         }
         template.whiteboard = await this.whiteboardService.createWhiteboard(
@@ -193,8 +197,9 @@ export class TemplateService {
       case TemplateType.CALLOUT: {
         if (!templateData.calloutData) {
           throw new ValidationException(
-            `Callout Template requires callout input: ${JSON.stringify(templateData)}`,
-            LogContext.TEMPLATES
+            'Callout Template requires callout input',
+            LogContext.TEMPLATES,
+            { templateType: template.type, missing: 'calloutData' }
           );
         }
         this.overrideCalloutSettingsForTemplate(templateData.calloutData);

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -64,10 +64,22 @@ export class TemplateService {
     private readonly logger: LoggerService
   ) {}
 
+  /**
+   * Self-contained: builds the template (with any nested entity for the
+   * declared TemplateType), persists, then runs phase-2 materialization
+   * (markdown re-upload, references, visuals, and any nested
+   * COMMUNITY_GUIDELINES profile materialization). On materialization
+   * failure the template is deleted before rethrowing — callers receive
+   * a fully-materialized template or an error, never half-state.
+   *
+   * Caller (e.g. TemplatesSetService) only needs to attach the
+   * `templatesSet` relation and re-save; no phase-2 coordination required.
+   */
   async createTemplate(
     templateData: CreateTemplateInput,
     storageAggregator: IStorageAggregator
   ): Promise<ITemplate> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     const template: ITemplate = Template.create(templateData);
     template.authorization = new AuthorizationPolicy(
       AuthorizationPolicyType.TEMPLATE
@@ -82,11 +94,6 @@ export class TemplateService {
       name: TagsetReservedName.DEFAULT,
       tags: templateData.tags,
     });
-    await this.profileService.addVisualsOnProfile(
-      template.profile,
-      templateData.profileData.visuals,
-      [VisualType.CARD]
-    );
     switch (template.type) {
       case TemplateType.POST: {
         if (!templateData.postDefaultDescription) {
@@ -206,7 +213,49 @@ export class TemplateService {
         );
     }
 
-    return await this.templateRepository.save(template);
+    // Phase 2: persist + materialize own profile + cascade-materialize
+    // nested entities. The materializeProfileContentAndVisualsOrRollback
+    // helper handles own-profile rollback. Nested guidelines materialization
+    // is wrapped in a follow-up try/catch so any failure there also rolls
+    // back the parent template (otherwise we'd leave a partially-
+    // materialized template behind).
+    //
+    // Other template types (POST, CALLOUT, SPACE, WHITEBOARD): their nested
+    // content lives in deeper trees that don't yet have explicit
+    // materialize hooks. Those types' profiles are still re-homed via the
+    // own-profile call above; nested-content materialization is a follow-up.
+    const saved = await this.templateRepository.save(template);
+
+    // Helper mutates the profile in place; no explicit reassignment needed.
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      saved.profile,
+      templateData.profileData.visuals,
+      [VisualType.CARD],
+      () => this.delete(saved)
+    );
+
+    if (
+      saved.type === TemplateType.COMMUNITY_GUIDELINES &&
+      saved.communityGuidelines &&
+      templateData.communityGuidelinesData
+    ) {
+      try {
+        await this.communityGuidelinesService.materializeCommunityGuidelinesContent(
+          saved.communityGuidelines,
+          templateData.communityGuidelinesData
+        );
+      } catch (error) {
+        await this.delete(saved).catch(rollbackError =>
+          this.logger.warn?.(
+            `Rollback after nested-guidelines materialization failure also failed for template ${saved.id}: ${rollbackError}`,
+            LogContext.TEMPLATES
+          )
+        );
+        throw error;
+      }
+    }
+
+    return saved;
   }
 
   private overrideCalloutSettingsForTemplate(calloutData: CreateCalloutInput) {

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -230,7 +230,23 @@ export class TemplateService {
     // only postDefaultDescription, not a Post entity) need no extra walk.
     // CALLOUT, SPACE, COMMUNITY_GUIDELINES carry deeper trees and walk
     // through their dedicated materialize chain.
-    const saved = await this.templateRepository.save(template);
+    //
+    // For WHITEBOARD type the whiteboard was already saved+materialized by
+    // WhiteboardService.createWhiteboard above; if the templateRepository
+    // save fails the whiteboard is orphaned (no parent template references
+    // it any more), so we delete it explicitly before propagating.
+    let saved: ITemplate;
+    try {
+      saved = await this.templateRepository.save(template);
+    } catch (error) {
+      if (template.type === TemplateType.WHITEBOARD && template.whiteboard) {
+        await this.cleanupOrphanWhiteboard(
+          template.whiteboard.id,
+          'Template save failed after whiteboard create'
+        );
+      }
+      throw error;
+    }
 
     // Helper mutates the profile in place; no explicit reassignment needed.
     await this.profileService.materializeProfileContentAndVisualsOrRollback(
@@ -313,6 +329,28 @@ export class TemplateService {
     }
 
     return saved;
+  }
+
+  private async cleanupOrphanWhiteboard(
+    whiteboardID: string,
+    context: string
+  ): Promise<void> {
+    try {
+      await this.whiteboardService.deleteWhiteboard(whiteboardID);
+    } catch (cleanupError) {
+      const stack =
+        cleanupError instanceof Error ? (cleanupError.stack ?? '') : '';
+      this.logger.error?.(
+        {
+          message: 'Cleanup of orphan whiteboard also failed',
+          context,
+          whiteboardID,
+          cleanupError: String(cleanupError),
+        },
+        stack,
+        LogContext.TEMPLATES
+      );
+    }
   }
 
   private overrideCalloutSettingsForTemplate(calloutData: CreateCalloutInput) {

--- a/src/domain/template/template/template.service.ts
+++ b/src/domain/template/template/template.service.ts
@@ -214,16 +214,17 @@ export class TemplateService {
     }
 
     // Phase 2: persist + materialize own profile + cascade-materialize
-    // nested entities. The materializeProfileContentAndVisualsOrRollback
-    // helper handles own-profile rollback. Nested guidelines materialization
-    // is wrapped in a follow-up try/catch so any failure there also rolls
-    // back the parent template (otherwise we'd leave a partially-
-    // materialized template behind).
+    // any nested entity tree that the type carries. The
+    // materializeProfileContentAndVisualsOrRollback helper handles
+    // own-profile rollback; nested materialization is wrapped in a
+    // follow-up try/catch that rolls back the entire template on failure
+    // (otherwise we'd leave a partially-materialized template behind).
     //
-    // Other template types (POST, CALLOUT, SPACE, WHITEBOARD): their nested
-    // content lives in deeper trees that don't yet have explicit
-    // materialize hooks. Those types' profiles are still re-homed via the
-    // own-profile call above; nested-content materialization is a follow-up.
+    // Self-materializing leaves (WHITEBOARD via WhiteboardService.create*,
+    // POST as part of POST template type — but that template type stores
+    // only postDefaultDescription, not a Post entity) need no extra walk.
+    // CALLOUT, SPACE, COMMUNITY_GUIDELINES carry deeper trees and walk
+    // through their dedicated materialize chain.
     const saved = await this.templateRepository.save(template);
 
     // Helper mutates the profile in place; no explicit reassignment needed.
@@ -233,6 +234,20 @@ export class TemplateService {
       [VisualType.CARD],
       () => this.delete(saved)
     );
+
+    const rollbackTemplate = (): Promise<unknown> =>
+      this.delete(saved).catch(rollbackError => {
+        this.logger.warn?.(
+          {
+            message:
+              'Rollback after nested template-content materialization failure also failed',
+            templateId: saved.id,
+            templateType: saved.type,
+            rollbackError: String(rollbackError),
+          },
+          LogContext.TEMPLATES
+        );
+      });
 
     if (
       saved.type === TemplateType.COMMUNITY_GUIDELINES &&
@@ -245,14 +260,33 @@ export class TemplateService {
           templateData.communityGuidelinesData
         );
       } catch (error) {
-        await this.delete(saved).catch(rollbackError =>
-          this.logger.warn?.(
-            `Rollback after nested-guidelines materialization failure also failed for template ${saved.id}: ${rollbackError}`,
-            LogContext.TEMPLATES
-          )
-        );
+        await rollbackTemplate();
         throw error;
       }
+    }
+
+    if (
+      saved.type === TemplateType.CALLOUT &&
+      saved.callout &&
+      templateData.calloutData
+    ) {
+      await this.calloutService.materializeCalloutContent(
+        saved.callout,
+        templateData.calloutData,
+        rollbackTemplate
+      );
+    }
+
+    if (
+      saved.type === TemplateType.SPACE &&
+      saved.contentSpace &&
+      templateData.contentSpaceData
+    ) {
+      await this.templateContentSpaceService.materializeTemplateContentSpaceContent(
+        saved.contentSpace,
+        templateData.contentSpaceData,
+        rollbackTemplate
+      );
     }
 
     return saved;

--- a/src/domain/template/templates-set/templates.set.service.ts
+++ b/src/domain/template/templates-set/templates.set.service.ts
@@ -135,6 +135,9 @@ export class TemplatesSetService {
 
     const storageAggregator = await this.getStorageAggregator(templatesSet);
 
+    // createTemplate is self-contained: it persists the template AND runs
+    // phase-2 materialization (with rollback on failure). All we need to do
+    // here is attach the templatesSet relation and re-save to record it.
     const template = await this.templateService.createTemplate(
       templateInput,
       storageAggregator

--- a/src/domain/template/templates-set/templates.set.service.ts
+++ b/src/domain/template/templates-set/templates.set.service.ts
@@ -136,14 +136,37 @@ export class TemplatesSetService {
     const storageAggregator = await this.getStorageAggregator(templatesSet);
 
     // createTemplate is self-contained: it persists the template AND runs
-    // phase-2 materialization (with rollback on failure). All we need to do
-    // here is attach the templatesSet relation and re-save to record it.
+    // phase-2 materialization (with rollback on failure). The attach-save
+    // here is a separate operation; if it fails after createTemplate has
+    // already committed, the template is left orphaned (no templatesSet
+    // attached). Wrap the attach in a compensating delete so failures
+    // don't leak partially-attached templates.
     const template = await this.templateService.createTemplate(
       templateInput,
       storageAggregator
     );
     template.templatesSet = templatesSet;
-    return await this.templateService.save(template);
+    try {
+      return await this.templateService.save(template);
+    } catch (error) {
+      try {
+        await this.templateService.delete(template);
+      } catch (cleanupError) {
+        const stack =
+          cleanupError instanceof Error ? (cleanupError.stack ?? '') : '';
+        this.logger.error?.(
+          {
+            message:
+              'Cleanup of template after templatesSet attach failure also failed',
+            templateId: template.id,
+            cleanupError: String(cleanupError),
+          },
+          stack,
+          LogContext.TEMPLATES
+        );
+      }
+      throw error;
+    }
   }
 
   async createTemplateFromSpace(

--- a/src/domain/timeline/event/event.service.ts
+++ b/src/domain/timeline/event/event.service.ts
@@ -67,10 +67,21 @@ export class CalendarEventService {
       type: RoomType.CALENDAR_EVENT,
     });
 
-    // Phase 2: persist + materialize. Helper rolls back the saved
-    // event on failure so callers receive a fully-materialized event
-    // or an error, never half-state.
-    const saved = await this.save(calendarEvent);
+    // Phase 2: persist + materialize. The Matrix room created above isn't
+    // part of the DB transaction; if the save fails it's already orphaned
+    // in Matrix, so we delete it explicitly before propagating the error.
+    // After save, the OrRollback helper handles the post-save phase
+    // (cascade-deleting the room via deleteCalendarEvent on failure).
+    let saved: ICalendarEvent;
+    try {
+      saved = await this.save(calendarEvent);
+    } catch (error) {
+      await this.cleanupOrphanRoom(
+        calendarEvent.comments.id,
+        'CalendarEvent save failed before materialize'
+      );
+      throw error;
+    }
     await this.profileService.materializeProfileContentAndVisualsOrRollback(
       saved.profile,
       calendarEventInput.profileData?.visuals,
@@ -78,6 +89,28 @@ export class CalendarEventService {
       () => this.deleteCalendarEvent({ ID: saved.id })
     );
     return saved;
+  }
+
+  private async cleanupOrphanRoom(
+    roomID: string,
+    context: string
+  ): Promise<void> {
+    try {
+      await this.roomService.deleteRoom({ roomID });
+    } catch (cleanupError) {
+      const stack =
+        cleanupError instanceof Error ? (cleanupError.stack ?? '') : '';
+      this.logger.error?.(
+        {
+          message: 'Cleanup of orphan Matrix room also failed',
+          context,
+          roomID,
+          cleanupError: String(cleanupError),
+        },
+        stack,
+        LogContext.CALENDAR
+      );
+    }
   }
 
   public async save(calendarEvent: ICalendarEvent): Promise<CalendarEvent> {

--- a/src/domain/timeline/event/event.service.ts
+++ b/src/domain/timeline/event/event.service.ts
@@ -42,6 +42,7 @@ export class CalendarEventService {
     storageAggregator: IStorageAggregator,
     userID: string
   ): Promise<ICalendarEvent> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     const calendarEvent: ICalendarEvent =
       CalendarEvent.create(calendarEventInput);
     calendarEvent.profile = await this.profileService.createProfile(
@@ -66,7 +67,17 @@ export class CalendarEventService {
       type: RoomType.CALENDAR_EVENT,
     });
 
-    return await this.save(calendarEvent);
+    // Phase 2: persist + materialize. Helper rolls back the saved
+    // event on failure so callers receive a fully-materialized event
+    // or an error, never half-state.
+    const saved = await this.save(calendarEvent);
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      saved.profile,
+      calendarEventInput.profileData?.visuals,
+      [],
+      () => this.deleteCalendarEvent({ ID: saved.id })
+    );
+    return saved;
   }
 
   public async save(calendarEvent: ICalendarEvent): Promise<CalendarEvent> {

--- a/src/library/innovation-pack/innovation.pack.service.ts
+++ b/src/library/innovation-pack/innovation.pack.service.ts
@@ -71,15 +71,11 @@ export class InnovationPackService {
       AuthorizationPolicyType.INNOVATION_PACK
     );
 
+    // Phase 1: build entity in memory.
     innovationPack.profile = await this.profileService.createProfile(
       innovationPackData.profileData,
       ProfileType.INNOVATION_PACK,
       storageAggregator
-    );
-    await this.profileService.addVisualsOnProfile(
-      innovationPack.profile,
-      innovationPackData.profileData.visuals,
-      [VisualType.AVATAR, VisualType.CARD]
     );
 
     innovationPack.listedInStore = true;
@@ -96,7 +92,17 @@ export class InnovationPackService {
     innovationPack.templatesSet =
       await this.templatesSetService.createTemplatesSet();
 
-    return await this.save(innovationPack);
+    // Phase 2: persist + materialize via the shared helper. Rolls back on
+    // materialization failure.
+    const saved = await this.save(innovationPack);
+    saved.profile =
+      await this.profileService.materializeProfileContentAndVisualsOrRollback(
+        saved.profile,
+        innovationPackData.profileData?.visuals,
+        [VisualType.AVATAR, VisualType.CARD],
+        () => this.deleteInnovationPack({ ID: saved.id })
+      );
+    return saved;
   }
 
   async save(innovationPack: IInnovationPack): Promise<IInnovationPack> {

--- a/src/platform/forum-discussion/discussion.service.ts
+++ b/src/platform/forum-discussion/discussion.service.ts
@@ -64,10 +64,21 @@ export class DiscussionService {
 
     discussion.createdBy = userID;
 
-    // Phase 2: persist + materialize. Helper rolls back the saved
-    // discussion on failure so callers receive a fully-materialized
-    // discussion or an error, never half-state.
-    const saved = await this.save(discussion);
+    // Phase 2: persist + materialize. The Matrix room created above isn't
+    // part of the DB transaction; if the save fails it's already orphaned
+    // in Matrix, so we delete it explicitly before propagating the error.
+    // After save, the OrRollback helper handles the post-save phase
+    // (cascade-deleting the room via removeDiscussion on failure).
+    let saved: IDiscussion;
+    try {
+      saved = await this.save(discussion);
+    } catch (error) {
+      await this.cleanupOrphanRoom(
+        discussion.comments.id,
+        'Discussion save failed before materialize'
+      );
+      throw error;
+    }
     await this.profileService.materializeProfileContentAndVisualsOrRollback(
       saved.profile,
       discussionData.profile?.visuals,
@@ -75,6 +86,28 @@ export class DiscussionService {
       () => this.removeDiscussion({ ID: saved.id })
     );
     return saved;
+  }
+
+  private async cleanupOrphanRoom(
+    roomID: string,
+    context: string
+  ): Promise<void> {
+    try {
+      await this.roomService.deleteRoom({ roomID });
+    } catch (cleanupError) {
+      const stack =
+        cleanupError instanceof Error ? (cleanupError.stack ?? '') : '';
+      this.logger.error?.(
+        {
+          message: 'Cleanup of orphan Matrix room also failed',
+          context,
+          roomID,
+          cleanupError: String(cleanupError),
+        },
+        stack,
+        LogContext.COMMUNICATION
+      );
+    }
   }
 
   async removeDiscussion(

--- a/src/platform/forum-discussion/discussion.service.ts
+++ b/src/platform/forum-discussion/discussion.service.ts
@@ -37,6 +37,7 @@ export class DiscussionService {
     roomType: RoomType,
     storageAggregator: IStorageAggregator
   ): Promise<IDiscussion> {
+    // Phase 1: build entity tree in memory (no file-service-go calls).
     const discussion: IDiscussion = Discussion.create(discussionData);
     discussion.profile = await this.profileService.createProfile(
       discussionData.profile,
@@ -63,7 +64,17 @@ export class DiscussionService {
 
     discussion.createdBy = userID;
 
-    return await this.save(discussion);
+    // Phase 2: persist + materialize. Helper rolls back the saved
+    // discussion on failure so callers receive a fully-materialized
+    // discussion or an error, never half-state.
+    const saved = await this.save(discussion);
+    await this.profileService.materializeProfileContentAndVisualsOrRollback(
+      saved.profile,
+      discussionData.profile?.visuals,
+      [],
+      () => this.removeDiscussion({ ID: saved.id })
+    );
+    return saved;
   }
 
   async removeDiscussion(

--- a/src/services/adapters/file-service-adapter/dto/copy.document.input.ts
+++ b/src/services/adapters/file-service-adapter/dto/copy.document.input.ts
@@ -1,0 +1,21 @@
+/**
+ * Request body for `POST /internal/file/copy` on file-service-go (v0.0.14+).
+ *
+ * Materializes a new file row in `destinationBucketId` that references the
+ * same content as `sourceId`. file-service-go is content-addressed, so the
+ * underlying blob is shared — only ownership/placement changes. Avoids the
+ * legacy `getDocumentContent` + `createDocument` round-trip that used to
+ * pull and push file bytes through the server pod for no reason.
+ */
+export interface CopyDocumentInput {
+  sourceId: string;
+  destinationBucketId: string;
+  authorizationId: string;
+  tagsetId?: string;
+  createdBy?: string;
+  /**
+   * Mirrors `CreateDocumentMetadata.skipDedup`. When true, bypass the
+   * destination bucket's per-content dedup lookup and force a fresh row.
+   */
+  skipDedup?: boolean;
+}

--- a/src/services/adapters/file-service-adapter/dto/index.ts
+++ b/src/services/adapters/file-service-adapter/dto/index.ts
@@ -1,3 +1,4 @@
+export { CopyDocumentInput } from './copy.document.input';
 export { CreateDocumentMetadata } from './create.document.metadata';
 export { CreateDocumentResult } from './create.document.result';
 export { DeleteDocumentResult } from './delete.document.result';

--- a/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.spec.ts
@@ -271,6 +271,92 @@ describe('FileServiceAdapter', () => {
     });
   });
 
+  describe('copyDocument', () => {
+    it('POSTs JSON body to /internal/file/copy', async () => {
+      const responseData = {
+        id: 'doc-copy',
+        externalID: 'ext-shared',
+        mimeType: 'image/png',
+        size: 1024,
+        reused: false,
+      };
+
+      (httpService.request as Mock).mockReturnValue(
+        of(axiosResponse(responseData, 201))
+      );
+
+      const result = await adapter.copyDocument({
+        sourceId: 'src-1',
+        destinationBucketId: 'bucket-2',
+        authorizationId: 'auth-2',
+        tagsetId: 'tagset-2',
+        createdBy: 'user-1',
+      });
+
+      expect(result).toEqual(responseData);
+
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      expect(callArgs.method).toBe('post');
+      expect(callArgs.url).toBe('http://file-service:4003/internal/file/copy');
+      expect(callArgs.data).toEqual({
+        sourceId: 'src-1',
+        destinationBucketId: 'bucket-2',
+        authorizationId: 'auth-2',
+        tagsetId: 'tagset-2',
+        createdBy: 'user-1',
+      });
+    });
+
+    it('passes skipDedup when true', async () => {
+      (httpService.request as Mock).mockReturnValue(
+        of(
+          axiosResponse(
+            {
+              id: 'doc-copy',
+              externalID: 'ext',
+              mimeType: 'image/png',
+              size: 1,
+              reused: false,
+            },
+            201
+          )
+        )
+      );
+
+      await adapter.copyDocument({
+        sourceId: 'src-1',
+        destinationBucketId: 'bucket-2',
+        authorizationId: 'auth-2',
+        skipDedup: true,
+      });
+
+      const callArgs = (httpService.request as Mock).mock.calls[0][0];
+      expect(callArgs.data.skipDedup).toBe(true);
+    });
+
+    it('surfaces 404 from file-service-go as FileServiceAdapterException', async () => {
+      const axiosError = new AxiosError('Not Found', '404', undefined, null, {
+        status: 404,
+        data: { error: 'source document not found' },
+        statusText: 'Not Found',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+      });
+
+      (httpService.request as Mock).mockReturnValue(
+        throwError(() => axiosError)
+      );
+
+      await expect(
+        adapter.copyDocument({
+          sourceId: 'missing',
+          destinationBucketId: 'bucket-2',
+          authorizationId: 'auth-2',
+        })
+      ).rejects.toThrow(FileServiceAdapterException);
+    });
+  });
+
   describe('deleteDocument', () => {
     it('should DELETE and return authorizationId and tagsetId', async () => {
       const responseData = {

--- a/src/services/adapters/file-service-adapter/file.service.adapter.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.ts
@@ -11,6 +11,7 @@ import { isAxiosError } from 'axios';
 import FormData from 'form-data';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import type {
+  CopyDocumentInput,
   CreateDocumentMetadata,
   CreateDocumentResult,
   DeleteDocumentResult,
@@ -106,6 +107,27 @@ export class FileServiceAdapter extends HttpClientBase {
       FILE_PATH_PREFIX,
       form,
       form.getHeaders()
+    );
+  }
+
+  /**
+   * Copy an existing document into another bucket on file-service-go (v0.0.14+).
+   * No bytes traverse the wire — content is content-addressed, the new row
+   * just points at the existing blob. Replaces the legacy
+   * `getDocumentContent` + `createDocument` round-trip.
+   *
+   * Per-bucket dedup applies by default; on dedup hit the response carries
+   * `reused: true` and the caller-supplied `authorizationId` / `tagsetId`
+   * are ignored, matching `createDocument`'s contract.
+   */
+  async copyDocument(input: CopyDocumentInput): Promise<CreateDocumentResult> {
+    this.checkEnabledAndCircuit('copyDocument');
+
+    return this.sendRequest<CreateDocumentResult>(
+      'copyDocument',
+      'post',
+      `${FILE_PATH_PREFIX}/copy`,
+      input
     );
   }
 

--- a/src/services/adapters/notification-in-app-adapter/notification.in.app.adapter.ts
+++ b/src/services/adapters/notification-in-app-adapter/notification.in.app.adapter.ts
@@ -139,12 +139,13 @@ export class NotificationInAppAdapter {
 
   private isForeignKeyViolation(error: unknown): boolean {
     if (!(error instanceof QueryFailedError)) return false;
-    const driverError = (error as QueryFailedError & { code?: string }).code;
-    if (driverError === '23503') return true;
-    // Newer driver instances surface the code on a nested driverError.
-    const nested = (
-      error as QueryFailedError & { driverError?: { code?: string } }
-    ).driverError;
-    return nested?.code === '23503';
+    // Different TypeORM/driver versions surface the SQLSTATE either on the
+    // top-level error or nested under `driverError`; check both.
+    const typedError = error as QueryFailedError & {
+      code?: string;
+      driverError?: { code?: string };
+    };
+    const code = typedError.code ?? typedError.driverError?.code;
+    return code === '23503';
   }
 }

--- a/src/services/adapters/notification-in-app-adapter/notification.in.app.adapter.ts
+++ b/src/services/adapters/notification-in-app-adapter/notification.in.app.adapter.ts
@@ -3,10 +3,12 @@ import { NotificationEvent } from '@common/enums/notification.event';
 import { NotificationEventCategory } from '@common/enums/notification.event.category';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { CreateInAppNotificationInput } from '@platform/in-app-notification/dto/in.app.notification.create';
+import { IInAppNotification } from '@platform/in-app-notification/in.app.notification.interface';
 import { InAppNotificationService } from '@platform/in-app-notification/in.app.notification.service';
 import { IInAppNotificationPayload } from '@platform/in-app-notification-payload/in.app.notification.payload.interface';
 import { SubscriptionPublishService } from '@services/subscriptions/subscription-service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { QueryFailedError } from 'typeorm';
 
 @Injectable()
 export class NotificationInAppAdapter {
@@ -63,8 +65,32 @@ export class NotificationInAppAdapter {
     });
 
     // filtering out notifications that are not for beta users now done by platform privilege
-    const savedNotifications =
-      await this.inAppNotificationService.saveInAppNotifications(inApps);
+    let savedNotifications: IInAppNotification[];
+    try {
+      savedNotifications =
+        await this.inAppNotificationService.saveInAppNotifications(inApps);
+    } catch (error) {
+      // Postgres FK violation (23503): the referenced entity (e.g.
+      // invitation) was deleted between dispatch and insert. The
+      // notification target is gone, so the notification itself is moot
+      // — log a warn and skip rather than letting the rejection escape
+      // to the fire-and-forget call site.
+      if (this.isForeignKeyViolation(error)) {
+        this.logger.warn?.(
+          {
+            message:
+              'In-app notification target was deleted before insert; skipping',
+            event: type,
+            triggeredByID,
+            receiverIDs,
+            error: String(error),
+          },
+          LogContext.IN_APP_NOTIFICATION
+        );
+        return;
+      }
+      throw error;
+    }
 
     // notify
     this.logger.verbose?.(
@@ -109,5 +135,16 @@ export class NotificationInAppAdapter {
         );
       }
     });
+  }
+
+  private isForeignKeyViolation(error: unknown): boolean {
+    if (!(error instanceof QueryFailedError)) return false;
+    const driverError = (error as QueryFailedError & { code?: string }).code;
+    if (driverError === '23503') return true;
+    // Newer driver instances surface the code on a nested driverError.
+    const nested = (
+      error as QueryFailedError & { driverError?: { code?: string } }
+    ).driverError;
+    return nested?.code === '23503';
   }
 }


### PR DESCRIPTION
## Summary

Cherry-picked replacement for [#6011](https://github.com/alkem-io/server/pull/6011), targeting `release/54`. Fresh-branch approach to avoid the develop-only commits (`Mistral migration`, `chromadb fix`, `provider_factory env vars`, `queue binding fix`, `schema baseline regen`) that were riding the merge into the release branch via #6011's base history.

Same 7 PR-intent commits, applied cleanly on top of `release/54` with no conflicts (release/54 already has the dedup-reuse #6000 and skipDedup #6010 cherry-picks the work depends on).

## What's in this PR

The proper structural fix for #6004 / #6005:

- **Two-phase profile materialization** — `createProfile` is pure (in-memory only); a new `materializeProfileContent` / `materializeProfileContentAndVisuals` runs post-save once the cascade has populated `storageBucket.id`. Eliminates the `StorageBucket not found: undefined` failure for templates with internal-URL visuals.
- **`copyDocument` primitive** — file-service-go v0.0.14's new `POST /internal/file/copy` endpoint, wired through `FileServiceAdapter.copyDocument` and `StorageBucketService.copyDocumentToBucket`. Replaces the legacy `getDocumentContent + uploadFileAsDocumentFromBuffer` round-trip in `reuploadFileOnStorageBucket`'s cross-bucket branch — no bytes traverse the wire any more.
- **DRY helper** — `StorageBucketService.persistDocumentWithPreparedAuth` extracts the auth/tagset prep + dedup-reuse cleanup + rollback dance, used by both `uploadFileAsDocumentFromBuffer` and `copyDocumentToBucket`.
- **Composing services split** — `CommunityGuidelinesService`, `SpaceAboutService`, `TemplateService` now expose pure `createX` + `materializeXContent` counterparts. `SpaceService.createSpace` and `templates.set.service.createTemplateOnTemplatesSet` invoke the materialize after their respective save.
- **Leaf-service migration** (CR-driven) — Whiteboard / Post phase-1 only with `materializeWhiteboardContent` / `materializePostContent`; Memo / InnovationFlow / InnovationHub / InnovationPack save+materialize internally (matches their pre-PR save behavior). `CalloutContributionService.materializeCalloutContributionContent` delegates to whiteboard + post post-save.
- **Defensive preconditions** at every materialize entry point: `RelationshipNotFoundException` if the entity's profile isn't loaded, `EntityNotInitializedException` if the bucket isn't persisted. Static messages, identifiers in structured `details` (CLAUDE.md compliant).
- **Bumps `quickstart-services.yml`** to `alkemio/file-service-go:v0.0.14`.

## Why not just merge release/54 into #6011?

#6011 was based on develop and carried 5 develop-only commits via its base history:

- `057211e29` fix: redeclare invoke_engine_result queue binding on reconnect
- `3466cdf8b` feat: migrate VC engines to Mistral API + Scaleway
- `65dabd991` fix: mount chromadb data volume at /data, not /chroma/chroma
- `05988c0f5` chore: update schema baseline (#6008)
- `f80bfaa7d` fix: add provider_factory env vars to .env.docker for unified VC engines

These don't belong in `release/54` — too risky / off-scope for a release stabilization branch. Surgically removing 5 commits from a branch that already had merges, force-pushes and conflict resolution baked into its history is fragile. A fresh cherry-picked branch is cleaner and easier to verify.

#6011 to be closed in favor of this one.

## Verification

- All 7 cherry-picks applied cleanly on top of `release/54` (no conflicts — release/54 already has the prerequisite #6000 + #6010 cherry-picks)
- 6387 tests pass
- Lint clean (1 pre-existing `EntityManager` unused-import warning in `space.service.ts` unrelated to this PR)
- Typecheck clean
- Diff vs `release/54`: exactly 29 files, all in scope (file-service-adapter, storage-bucket, profile, profile-documents, the migrated leaves, and `quickstart-services.yml`)

## Test plan

- [x] `pnpm test:ci:no:coverage` — 6387 pass
- [x] `pnpm exec biome check src/` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] CI green
- [ ] Manual on dev/acc: import a template with visuals (#6004); create a space from a template with visuals (#6005)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side document copy for faster, reliable file moves between storage buckets.
  * System-wide two-phase save + post-save materialization with automatic rollback to prevent partially persisted content across profiles, posts, templates, spaces, callouts, links, communities, and related items.

* **Chores**
  * Updated file-service image to v0.0.15 and authorization-evaluation image to v0.0.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->