### PR TITLE
Fix bootstrap crash: KB re-fetch dropped profile.storageBucket

### DIFF
--- a/src/domain/common/knowledge-base/knowledge.base.service.ts
+++ b/src/domain/common/knowledge-base/knowledge.base.service.ts
@@ -73,12 +73,12 @@ export class KnowledgeBaseService {
       storageAggregator
     );
 
-    await this.save(knowledgeBase);
-    knowledgeBase = await this.getKnowledgeBaseOrFail(knowledgeBase.id, {
-      relations: {
-        calloutsSet: { tagsetTemplateSet: true, callouts: true },
-      },
-    });
+    // Cascade save populates IDs on the in-memory tree (knowledgeBase,
+    // profile, profile.storageBucket, calloutsSet, calloutsSet.tagsetTemplateSet).
+    // Capture the return so we keep the same instance — re-fetching here
+    // with a partial relation graph would drop `profile.storageBucket`
+    // and break the phase-2 materialize at the bottom of this method.
+    knowledgeBase = await this.save(knowledgeBase);
 
     if (!knowledgeBase.calloutsSet) {
       throw new EntityNotFoundException(


### PR DESCRIPTION
## Summary

Bootstrap fails on `BootstrapService.ensureGuidanceChat` (called from VirtualContributorService → KnowledgeBaseService → ProfileService) with:

> Profile storage bucket must be persisted before materializing content

## Root cause

`KnowledgeBaseService.createKnowledgeBase` saved with cascade, then re-fetched via `getKnowledgeBaseOrFail` with `relations: { calloutsSet: { tagsetTemplateSet: true, callouts: true } }`. The re-fetched entity replaced the in-memory `knowledgeBase` reference, and the partial relation graph did **not** include `profile`/`profile.storageBucket`. The phase-2 materialize at the bottom of the method then received a profile whose `storageBucket.id` was undefined and threw `EntityNotInitializedException`.

## Fix

Drop the unnecessary re-fetch. The cascade save already mutates the in-memory tree with assigned IDs (KB id, profile id, profile.storageBucket id, calloutsSet id, calloutsSet.tagsetTemplateSet id); `calloutsSet.callouts` is initialized to `[]` by `createCalloutsSet`. We capture the save return for clarity but the same instance is preserved either way. The `calloutsSet` null-check stays as a defensive guard.

## Audit

Audited every other PR-touched create flow (Discussion, CalendarEvent, UserGroup, InnovationHub, InnovationPack, InnovationFlow, Post, Whiteboard, Memo, Template, Space, SpaceAbout, CommunityGuidelines) — none have the `save → re-fetch with partial relations → materialize` pattern. KB was the only site.

## Test plan

- [x] 6392 unit tests pass
- [x] lint and typecheck clean
- [ ] Verify bootstrap flow runs end-to-end on a fresh DB (reproducer was the merged PR #6014's runtime)

## Related

Fix-up for #6014.