### PR TITLE
Fix createTemplateFromContentSpace crash: split contributionDefaults phase-1/phase-2

### DIFF
--- a/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.spec.ts
+++ b/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.spec.ts
@@ -158,6 +158,40 @@ describe('CalloutContributionDefaultsService', () => {
       ).rejects.toThrow('reupload failed');
       expect(rollback).toHaveBeenCalled();
     });
+
+    it('logs and preserves the original error when rollback itself fails', async () => {
+      const defaults = {
+        id: 'defaults-id',
+        postDescription: 'markdown with ![image](http://old-url)',
+      } as CalloutContributionDefaults;
+      const originalFailure = new Error('reupload failed');
+      const rollbackFailure = new Error('rollback also failed');
+      const failingRollback = vi.fn().mockRejectedValue(rollbackFailure);
+
+      vi.mocked(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).mockRejectedValue(originalFailure);
+      const errorLog = vi.spyOn(
+        service['logger'] as unknown as { error: (...args: unknown[]) => void },
+        'error'
+      );
+
+      // Original reupload error must propagate; the rollback failure is
+      // logged at ERROR but never replaces the materialization error.
+      await expect(
+        service.materializeCalloutContributionDefaultsContent(
+          defaults,
+          storageBucket,
+          failingRollback
+        )
+      ).rejects.toBe(originalFailure);
+      expect(failingRollback).toHaveBeenCalled();
+      expect(errorLog).toHaveBeenCalled();
+      const logPayload = errorLog.mock.calls[0]?.[0] as
+        | { rollbackError?: string }
+        | undefined;
+      expect(logPayload?.rollbackError).toContain('rollback also failed');
+    });
   });
 
   describe('updateCalloutContributionDefaults', () => {

--- a/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.spec.ts
+++ b/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.spec.ts
@@ -35,50 +35,76 @@ describe('CalloutContributionDefaultsService', () => {
   });
 
   describe('createCalloutContributionDefaults', () => {
-    it('should return empty defaults when no input data is provided', async () => {
-      const result = await service.createCalloutContributionDefaults(
-        undefined,
-        undefined
-      );
+    it('should return empty defaults when no input data is provided', () => {
+      const result = service.createCalloutContributionDefaults(undefined);
 
       expect(result).toBeInstanceOf(CalloutContributionDefaults);
       expect(result.defaultDisplayName).toBeUndefined();
+      // entity default for `postDescription` is '' (see entity column)
       expect(result.postDescription).toBe('');
       expect(result.whiteboardContent).toBeUndefined();
     });
 
-    it('should set defaultDisplayName and whiteboardContent from input data', async () => {
+    it('should copy fields from input data without invoking file-service', () => {
       const inputData = {
         defaultDisplayName: 'Test Display Name',
-        postDescription: 'Test Description',
+        postDescription: 'markdown with ![image](http://old-url)',
         whiteboardContent: '{"elements":[]}',
       };
 
-      const result = await service.createCalloutContributionDefaults(
-        inputData,
-        undefined
-      );
+      const result = service.createCalloutContributionDefaults(inputData);
 
       expect(result.defaultDisplayName).toBe('Test Display Name');
+      expect(result.postDescription).toBe(
+        'markdown with ![image](http://old-url)'
+      );
       expect(result.whiteboardContent).toBe('{"elements":[]}');
+      expect(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('materializeCalloutContributionDefaultsContent', () => {
+    const rollback = vi.fn().mockResolvedValue(undefined);
+    const storageBucket = { id: 'bucket-id' } as IStorageBucket;
+
+    beforeEach(() => {
+      rollback.mockClear();
     });
 
-    it('should reupload documents in markdown when storage bucket is provided', async () => {
-      const inputData = {
-        defaultDisplayName: 'Test',
+    it('is a no-op when postDescription is missing', async () => {
+      const defaults = {
+        id: 'defaults-id',
+      } as CalloutContributionDefaults;
+
+      await service.materializeCalloutContributionDefaultsContent(
+        defaults,
+        storageBucket,
+        rollback
+      );
+
+      expect(
+        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
+      ).not.toHaveBeenCalled();
+      expect(repository.save).not.toHaveBeenCalled();
+    });
+
+    it('re-homes markdown URLs and saves when content changed', async () => {
+      const defaults = {
+        id: 'defaults-id',
         postDescription: 'markdown with ![image](http://old-url)',
-        whiteboardContent: undefined,
-      };
-      const storageBucket = { id: 'bucket-id' } as IStorageBucket;
-      const reuploadedMarkdown = 'markdown with ![image](http://new-url)';
+      } as CalloutContributionDefaults;
+      const reuploaded = 'markdown with ![image](http://new-url)';
 
       vi.mocked(
         profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
-      ).mockResolvedValue(reuploadedMarkdown);
+      ).mockResolvedValue(reuploaded);
 
-      const result = await service.createCalloutContributionDefaults(
-        inputData,
-        storageBucket
+      await service.materializeCalloutContributionDefaultsContent(
+        defaults,
+        storageBucket,
+        rollback
       );
 
       expect(
@@ -87,44 +113,50 @@ describe('CalloutContributionDefaultsService', () => {
         'markdown with ![image](http://old-url)',
         storageBucket
       );
-      expect(result.postDescription).toBe(reuploadedMarkdown);
+      expect(defaults.postDescription).toBe(reuploaded);
+      expect(repository.save).toHaveBeenCalledWith(defaults);
     });
 
-    it('should use empty string for postDescription when it is undefined and storage bucket is provided', async () => {
-      const inputData = {
-        defaultDisplayName: 'Test',
-        postDescription: undefined,
-        whiteboardContent: undefined,
-      };
-      const storageBucket = { id: 'bucket-id' } as IStorageBucket;
+    it('skips the save when re-upload returned identical markdown', async () => {
+      const original = 'markdown with no internal urls';
+      const defaults = {
+        id: 'defaults-id',
+        postDescription: original,
+      } as CalloutContributionDefaults;
 
       vi.mocked(
         profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
-      ).mockResolvedValue('');
+      ).mockResolvedValue(original);
 
-      await service.createCalloutContributionDefaults(inputData, storageBucket);
-
-      expect(
-        profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
-      ).toHaveBeenCalledWith('', storageBucket);
-    });
-
-    it('should assign postDescription directly when no storage bucket is provided', async () => {
-      const inputData = {
-        defaultDisplayName: 'Test',
-        postDescription: 'Direct description',
-        whiteboardContent: undefined,
-      };
-
-      const result = await service.createCalloutContributionDefaults(
-        inputData,
-        undefined
+      await service.materializeCalloutContributionDefaultsContent(
+        defaults,
+        storageBucket,
+        rollback
       );
 
-      expect(result.postDescription).toBe('Direct description');
-      expect(
+      expect(defaults.postDescription).toBe(original);
+      expect(repository.save).not.toHaveBeenCalled();
+    });
+
+    it('invokes rollback and rethrows on materialization failure', async () => {
+      const defaults = {
+        id: 'defaults-id',
+        postDescription: 'markdown with ![image](http://old-url)',
+      } as CalloutContributionDefaults;
+      const failure = new Error('reupload failed');
+
+      vi.mocked(
         profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket
-      ).not.toHaveBeenCalled();
+      ).mockRejectedValue(failure);
+
+      await expect(
+        service.materializeCalloutContributionDefaultsContent(
+          defaults,
+          storageBucket,
+          rollback
+        )
+      ).rejects.toThrow('reupload failed');
+      expect(rollback).toHaveBeenCalled();
     });
   });
 

--- a/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.ts
+++ b/src/domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.service.ts
@@ -1,3 +1,4 @@
+import { LogContext } from '@common/enums';
 import { ProfileDocumentsService } from '@domain/profile-documents/profile.documents.service';
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
@@ -21,34 +22,79 @@ export class CalloutContributionDefaultsService {
     private calloutContributionDefaultsRepository: Repository<CalloutContributionDefaults>
   ) {}
 
-  public async createCalloutContributionDefaults(
+  /**
+   * Phase 1: in-memory build only. The `postDescription` markdown may
+   * contain Alkemio document URLs that need re-homing into the parent
+   * callout's storage bucket, but file-service-go work needs a persisted
+   * bucket id — that's deferred to
+   * {@link materializeCalloutContributionDefaultsContent}, called by
+   * `CalloutService.materializeCalloutContent` after the parent's cascade
+   * save populates real ids.
+   */
+  public createCalloutContributionDefaults(
     calloutContributionDefaultsData:
       | CreateCalloutContributionDefaultsInput
-      | undefined,
-    storageBucket: IStorageBucket | undefined
-  ): Promise<ICalloutContributionDefaults> {
+      | undefined
+  ): ICalloutContributionDefaults {
     const calloutContributionDefaults = new CalloutContributionDefaults();
     if (calloutContributionDefaultsData) {
       calloutContributionDefaults.defaultDisplayName =
         calloutContributionDefaultsData.defaultDisplayName;
-
-      // Reupload documents in markdown if the storage bucket is provided
-      if (storageBucket) {
-        calloutContributionDefaults.postDescription =
-          await this.profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket(
-            calloutContributionDefaultsData.postDescription ?? '',
-            storageBucket
-          );
-      } else {
-        calloutContributionDefaults.postDescription =
-          calloutContributionDefaultsData.postDescription;
-      }
-
+      calloutContributionDefaults.postDescription =
+        calloutContributionDefaultsData.postDescription;
       calloutContributionDefaults.whiteboardContent =
         calloutContributionDefaultsData.whiteboardContent;
     }
 
     return calloutContributionDefaults;
+  }
+
+  /**
+   * Phase 2: re-home internal Alkemio URLs in `postDescription` into the
+   * parent callout's bucket. No-op if there's no description or no URL
+   * to re-home. Saves the entity directly because the cascade-saved
+   * parent isn't re-saved by the caller post-materialize.
+   *
+   * `rollback` is invoked on failure so a partial materialization rolls
+   * back the top-level parent (e.g. the Template). Same convention as
+   * the OrRollback helper: rollback failures are alert-worthy
+   * (logger.error) but do not replace the original error.
+   */
+  public async materializeCalloutContributionDefaultsContent(
+    defaults: ICalloutContributionDefaults,
+    storageBucket: IStorageBucket,
+    rollback: () => Promise<unknown>
+  ): Promise<void> {
+    if (!defaults.postDescription) return;
+    try {
+      const reuploaded =
+        await this.profileDocumentsService.reuploadDocumentsInMarkdownToStorageBucket(
+          defaults.postDescription,
+          storageBucket
+        );
+      if (reuploaded !== defaults.postDescription) {
+        defaults.postDescription = reuploaded;
+        await this.calloutContributionDefaultsRepository.save(
+          defaults as CalloutContributionDefaults
+        );
+      }
+    } catch (error) {
+      await rollback().catch(rollbackError => {
+        const stack =
+          rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+        this.logger.error?.(
+          {
+            message:
+              'Rollback after CalloutContributionDefaults materialization failure also failed',
+            calloutContributionDefaultsId: defaults.id,
+            rollbackError: String(rollbackError),
+          },
+          stack,
+          LogContext.COLLABORATION
+        );
+      });
+      throw error;
+    }
   }
 
   public updateCalloutContributionDefaults(

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -182,16 +182,36 @@ export class CalloutService {
     // reference documents in another bucket (template clone) or in a
     // temporary location (just-uploaded image). Re-home them now that
     // the framing's storageBucket has a real id from the cascade save.
-    if (
-      callout.contributionDefaults &&
-      callout.framing.profile?.storageBucket
-    ) {
-      await this.contributionDefaultsService.materializeCalloutContributionDefaultsContent(
-        callout.contributionDefaults,
-        callout.framing.profile.storageBucket,
-        rollback
+    //
+    // contributionDefaults is always populated by createCallout (the
+    // entity is initialized with default `postDescription = ''`) and
+    // framing.profile.storageBucket is always loaded by the time
+    // materializeCalloutContent runs (we just materialized framing two
+    // lines above). A missing relation here means a partial load —
+    // fail fast rather than silently leaving postDescription URLs
+    // unresolved.
+    if (!callout.contributionDefaults) {
+      throw new RelationshipNotFoundException(
+        'Missing required relation for phase-2 materialization',
+        LogContext.COLLABORATION,
+        { calloutId: callout.id, missing: ['contributionDefaults'] }
       );
     }
+    if (!callout.framing.profile?.storageBucket) {
+      throw new RelationshipNotFoundException(
+        'Missing required relation for phase-2 materialization',
+        LogContext.COLLABORATION,
+        {
+          calloutId: callout.id,
+          missing: ['framing.profile.storageBucket'],
+        }
+      );
+    }
+    await this.contributionDefaultsService.materializeCalloutContributionDefaultsContent(
+      callout.contributionDefaults,
+      callout.framing.profile.storageBucket,
+      rollback
+    );
     // Pair persisted contributions to their input data by `type` + the
     // nested entity's stable identifier (Link.uri for LINK, nameID for
     // POST/WHITEBOARD/MEMO). Index-based pairing would silently misalign

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -113,9 +113,8 @@ export class CalloutService {
     );
 
     callout.contributionDefaults =
-      await this.contributionDefaultsService.createCalloutContributionDefaults(
-        calloutData.contributionDefaults,
-        callout.framing.profile.storageBucket
+      this.contributionDefaultsService.createCalloutContributionDefaults(
+        calloutData.contributionDefaults
       );
 
     if (userID && calloutData.contributions && callout.settings.contribution) {
@@ -179,6 +178,20 @@ export class CalloutService {
       calloutData?.framing,
       rollback
     );
+    // contributionDefaults.postDescription may carry markdown URLs that
+    // reference documents in another bucket (template clone) or in a
+    // temporary location (just-uploaded image). Re-home them now that
+    // the framing's storageBucket has a real id from the cascade save.
+    if (
+      callout.contributionDefaults &&
+      callout.framing.profile?.storageBucket
+    ) {
+      await this.contributionDefaultsService.materializeCalloutContributionDefaultsContent(
+        callout.contributionDefaults,
+        callout.framing.profile.storageBucket,
+        rollback
+      );
+    }
     // Pair persisted contributions to their input data by `type` + the
     // nested entity's stable identifier (Link.uri for LINK, nameID for
     // POST/WHITEBOARD/MEMO). Index-based pairing would silently misalign


### PR DESCRIPTION
## Summary

`createTemplateFromContentSpace` crashes with:

> Storage bucket must be persisted before document re-upload: caller must save the parent entity first

## Root cause

`CalloutContributionDefaultsService.createCalloutContributionDefaults` was running file-service-go work (`reuploadDocumentsInMarkdownToStorageBucket`) inline on `callout.framing.profile.storageBucket` — which is in-memory at that point and has no DB id yet.

Stack from the user's report:

```
ProfileDocumentsService.reuploadFileOnStorageBucket  (storageBucket.id undefined)
  ← CalloutContributionDefaultsService.createCalloutContributionDefaults
    ← CalloutService.createCallout
      ← CalloutsSetService.addCallouts
        ← CollaborationService.createCollaboration
          ← TemplateContentSpaceService.createTemplateContentSpace
            ← TemplateService.createTemplate
              ← TemplatesSetService.createTemplateFromContentSpace
```

Latent since #5969; surfaced now because PR #6014's fail-fast guard in `ProfileDocumentsService.reuploadFileOnStorageBucket` turns the previously-silent misuse into a hard error.

## Fix

Same root pattern as PR #6014: split phase-1 (in-memory build) from phase-2 (file-service work post-save).

- `createCalloutContributionDefaults` is now synchronous, in-memory only; drops the `storageBucket` parameter. Stores `postDescription` raw.
- New `materializeCalloutContributionDefaultsContent(defaults, storageBucket, rollback)` does the markdown re-home and saves the entity directly when content changes (the parent callout isn't re-saved by the caller post-materialize, so we save here). Same rollback convention as the OrRollback helper.
- `CalloutService.createCallout` calls phase-1 only.
- `CalloutService.materializeCalloutContent` calls phase-2 right after the framing materialize, using the now-persisted `callout.framing.profile.storageBucket`.

## Audit

Searched every call site of `profileDocumentsService.reupload*` and `fileServiceAdapter.*` from create flows. The only remaining phase-1-on-unsaved-bucket site was `callout-contribution-defaults`. Other reupload call sites are either:

- Update paths (`whiteboard.service.ts:297`, `memo.service.ts:211`) — entity already persisted
- `callout-framing.service.ts:308` (mediaGallery) — bucket is saved eagerly inside `createMediaGallery` before reupload runs
- `profile.service.ts:400` (`addVisualsOnProfile`) — only invoked from phase-2 `materializeProfileContentAndVisuals`

So this is the only remaining occurrence of the same pattern.

## Test plan

- [x] 6393 unit tests pass (1 new for the materialize method's rollback path)
- [x] lint and typecheck clean
- [ ] Verify `createTemplateFromContentSpace` flow end-to-end on a fresh DB

## Related

Fix-up for #6014. Companion to #6016 (KB bootstrap fix, already merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal architecture by separating content creation and materialization into distinct phases, improving initialization efficiency and system reliability. Contribution defaults content is now processed in a deferred phase to ensure proper bucket assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->