### PR TITLE
Fix DocumentWriteGuard crash: drop cascade-write to file table

### DIFF
--- a/src/domain/storage/storage-bucket/storage.bucket.entity.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.entity.ts
@@ -10,12 +10,18 @@ export class StorageBucket
   extends AuthorizableEntity
   implements IStorageBucket
 {
+  // Document is owned by file-service-go; the server's TypeORM is
+  // read-only for the `file` table (enforced by DocumentWriteGuard).
+  // `cascade: false` prevents repository.save(bucket) from walking into
+  // bucket.documents and emitting UPDATE/INSERT — every Document write
+  // must go through FileServiceAdapter. The in-memory `documents` array
+  // is still read/mutated for state coherence within a request.
   @OneToMany(
     () => Document,
     document => document.storageBucket,
     {
       eager: false,
-      cascade: true,
+      cascade: false,
     }
   )
   documents!: Document[];


### PR DESCRIPTION
## Summary

`createCalloutOnCalloutsSet` (and any other entity-create flow that triggers phase-2 markdown re-upload) crashes with:

> Direct UPDATE to file table is forbidden. Use FileServiceAdapter.updateDocument() to delegate to the Go file-service-go.

## Root cause

After #5969 the `file` table is owned by file-service-go and `DocumentWriteGuard` blocks any direct TypeORM INSERT/UPDATE/DELETE on it. But `StorageBucket.documents` was left with `cascade: true` from before the migration. So any `repository.save()` on an entity that transitively owns a StorageBucket walks the cascade chain and tries to UPDATE every Document in the in-memory `bucket.documents` array.

Surfaced by the post-save `materializeProfileContentAndVisuals`: it pushes a new Document into `framing.profile.storageBucket.documents` (cross-bucket re-upload) and then calls `profileRepository.save(profile)` to persist the materialized profile. Cascade walks `profile → storageBucket → documents` → guard fires.

**Cascade graph reaching Document (every TypeORM-mediated path):**

```
Profile.storageBucket          (cascade: true) ┐
MediaGallery.storageBucket     (cascade: true) ├── → StorageBucket
StorageAggregator.directStorage (cascade: true) ┘       ↓ documents (cascade: true)  ← LEAK
                                                        ↓
                                                     Document
```

## Fix

`StorageBucket.documents`: `cascade: true` → `cascade: false`. Document writes go exclusively through `FileServiceAdapter`; the in-memory `documents` array is still read/mutated for state coherence within a request. No schema change needed (cascade is a TypeORM behavior, not a DB-level setting; the DB FK already has `onDelete: CASCADE` on the Document side).

## Audit (every other write attack surface)

| Surface | Status |
|---|---|
| `documentRepository.save()` | Read-only (`findOne` only). No writes. |
| `manager.save(document)` | None. |
| Other cascade chains reaching Document | None. `Document.tagset`/`Document.storageBucket` inverse-side cascade is already false. |
| TypeORM subscribers re-emitting | Only `DocumentWriteGuard` exists, and it throws (doesn't emit). |
| Raw SQL via QueryRunner | Only in migrations (deliberate). |
| `addDocumentToStorageBucketOrFail` (mutates `bucket.documents`) | Dead code. Only its own sibling calls it. |
| `storageBucketService.save` callers | callout-transfer / storage.aggregator / media.gallery — save bucket attributes only, never relied on cascade-write to documents. |
| `deleteStorageBucket` | Already deletes documents via `FileServiceAdapter` before removing the bucket — never relied on cascade-delete. |

## Test plan

- [x] 6394 unit tests pass
- [x] lint and typecheck clean
- [ ] Verify `createCalloutOnCalloutsSet` end-to-end on a request where the markdown contains a cross-bucket Alkemio document URL (the path that triggered the user's report)

## Related

Continuation of post-merge fixes for #6014:
- #6016 (KB bootstrap fix) — merged
- #6017 (createTemplateFromContentSpace fix) — merged
- this PR — DocumentWriteGuard cascade fix