### PR TITLE
Fix createTemplateFromSpace crash on dead/orphan markdown URLs

### DIFF
--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -161,6 +161,14 @@ export class ProfileDocumentsService {
   /***
    * Checks if a markdown text has documents living under the
    * specified storage bucket and re-uploads them if not there.
+   *
+   * Per-URL resilience: a dead/orphaned reference (e.g. when cloning
+   * from a source space whose document was deleted, or a cross-tenant
+   * URL) is logged at WARN and the URL is left untouched in the
+   * markdown — the clone ends up with the same dead link the source
+   * had, instead of failing the entire create flow on a single broken
+   * reference. Other errors (e.g. file-service-go failures) still
+   * propagate.
    */
   public async reuploadDocumentsInMarkdownToStorageBucket(
     markdown: string,
@@ -176,11 +184,28 @@ export class ProfileDocumentsService {
     const matches = markdown.match(regex);
     if (matches?.length) {
       for (const match of matches) {
-        const newUrl = await this.reuploadFileOnStorageBucket(
-          match,
-          storageBucket,
-          false
-        );
+        let newUrl: string | undefined;
+        try {
+          newUrl = await this.reuploadFileOnStorageBucket(
+            match,
+            storageBucket,
+            false
+          );
+        } catch (error) {
+          if (error instanceof EntityNotFoundException) {
+            this.logger.warn?.(
+              {
+                message:
+                  'Markdown document URL points to a non-existent file; leaving URL as-is',
+                fileUrl: match,
+                storageBucketId: storageBucket.id,
+              },
+              LogContext.PROFILE
+            );
+            continue;
+          }
+          throw error;
+        }
         if (newUrl && newUrl !== match) {
           markdown = this.replaceAll(markdown, match, newUrl);
         }


### PR DESCRIPTION
## Summary

`createTemplateFromSpace` (and any other clone flow that triggers markdown re-upload) crashes when the source space carries a markdown URL pointing to a Document UUID that doesn't exist in the DB (deleted source doc, orphan ref, cross-tenant URL):

```
EntityNotFoundException: File with URL not found
  details: { fileUrl: 'http://localhost:3000/api/private/rest/storage/document/019dd922-…' }
```

Stack:

```
ProfileDocumentsService.reuploadFileOnStorageBucket             ← throws here
  ← reuploadDocumentsInMarkdownToStorageBucket
    ← ProfileService.materializeProfileContent
      ← materializeProfileContentAndVisuals
        ← materializeProfileContentAndVisualsOrRollback
          ← CalloutFramingService.materializeCalloutFramingContent
            ← CalloutService.materializeCalloutContent
              ← (template-clone flow)
```

## Root cause

`reuploadDocumentsInMarkdownToStorageBucket` iterates every Alkemio document URL match in the markdown and calls `reuploadFileOnStorageBucket` per match. The per-match call throws `EntityNotFoundException` when `getDocumentFromURL` returns nothing — and that throw aborts the whole markdown walk, the whole profile materialize, and the whole template clone.

That's too brittle for cloning. The source space can carry stale URLs and the cloner has no way to know in advance. Failing the whole clone on a single dead link forces the user to manually scrub the source before they can clone it.

## Fix

Per-URL resilience. Catch `EntityNotFoundException` for the specific URL, log at WARN with the offending `fileUrl` + bucket id, leave the URL as-is in the markdown, continue with the next match. Other errors (file-service-go failures, etc.) still propagate.

The clone ends up with the same dead link the source had — a faithful copy. Operators can use the warning logs to clean up source content if they want.

## Test plan

- [x] 6394 unit tests pass
- [x] lint and typecheck clean
- [ ] Verify `createTemplateFromSpace` end-to-end on a source space whose markdown has a dead document URL (the path that triggered the user's report)

## Related

Continuation of post-merge fixes for #6014:
- #6016 (KB bootstrap) — merged
- #6017 (createTemplateFromContentSpace phase split) — merged
- #6024 (DocumentWriteGuard cascade) — merged
- this PR — markdown dead-link resilience