### PR TITLE
Clone-flow resilience: COPY semantics + eager WB content re-home + stale-URL tolerance

### DIFF
--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -88,7 +88,55 @@ export class WhiteboardService {
       [VisualType.CARD, VisualType.WHITEBOARD_PREVIEW],
       () => this.deleteWhiteboard(saved.id)
     );
+
+    // Phase 3: re-home the WB content's embedded file references into
+    // the new whiteboard's bucket. Without this, cloned WBs (template
+    // creation, space-from-template, callout-from-template, etc.)
+    // permanently reference the source's bucket — which becomes
+    // dangling the moment the source is deleted, and silently
+    // gets MOVED out of the source on the first user save. Doing it
+    // eagerly at clone time gives the new WB its own copies of
+    // referenced docs (the helper now uses COPY semantics, leaving
+    // the source intact).
+    if (saved.content) {
+      try {
+        const reuploaded = await this.reuploadDocumentsIfNotInBucket(
+          this.parseWhiteboardContent(saved.content),
+          saved.profile.id
+        );
+        const reuploadedJson = JSON.stringify(reuploaded);
+        if (reuploadedJson !== saved.content) {
+          saved.content = reuploadedJson;
+          await this.whiteboardRepository.save(saved);
+        }
+      } catch (error) {
+        await this.deleteWhiteboard(saved.id).catch(rollbackError => {
+          const stack =
+            rollbackError instanceof Error ? (rollbackError.stack ?? '') : '';
+          this.logger.error?.(
+            {
+              message: 'Rollback after WB content reupload failure also failed',
+              whiteboardId: saved.id,
+              rollbackError: String(rollbackError),
+            },
+            stack,
+            LogContext.WHITEBOARDS
+          );
+        });
+        throw error;
+      }
+    }
     return saved;
+  }
+
+  private parseWhiteboardContent(raw: string): ExcalidrawContent {
+    try {
+      return JSON.parse(raw) as ExcalidrawContent;
+    } catch {
+      // Empty / non-JSON content (legacy or fresh WB) — return a shape
+      // the reupload walker treats as a no-op (no `files` map).
+      return { elements: [], files: {} } as unknown as ExcalidrawContent;
+    }
   }
 
   async getWhiteboardOrFail(

--- a/src/domain/profile-documents/profile.documents.service.spec.ts
+++ b/src/domain/profile-documents/profile.documents.service.spec.ts
@@ -302,10 +302,6 @@ describe('ProfileDocumentsService', () => {
       // remaining intact; deletion would corrupt the source's content
       // and any other clones that reference the same source doc.
       expect(documentService.deleteDocument).not.toHaveBeenCalled();
-      // Destination's in-memory state is updated for coherent re-reads.
-      expect(
-        storageBucketDestination.documents.some(d => d.id === newDocMock.id)
-      ).toBe(true);
     });
 
     describe('reuploadDocumentsInMarkdownProfile', () => {

--- a/src/domain/profile-documents/profile.documents.service.spec.ts
+++ b/src/domain/profile-documents/profile.documents.service.spec.ts
@@ -220,12 +220,16 @@ describe('ProfileDocumentsService', () => {
       mockDocument(storageBucketOrigin);
       mockDocument(storageBucketDestination);
       mockDocument(storageBucketDestination);
-      // the doc
-      const doc = mockDocument(storageBucketOrigin, {
-        temporaryLocation: true,
-      });
+      // the doc — registered on the source bucket only (not destination)
+      const doc = mockDocument(
+        storageBucketOrigin,
+        { temporaryLocation: true },
+        true /* addToStorageBucket */
+      );
       mockDocument(storageBucketOrigin);
       mockDocument(storageBucketDestination);
+
+      const destDocsBefore = [...storageBucketDestination.documents];
 
       vi.spyOn(documentService, 'isAlkemioDocumentURL').mockReturnValue(true);
       vi.spyOn(documentService, 'getDocumentFromURL').mockResolvedValue(doc);
@@ -249,6 +253,15 @@ describe('ProfileDocumentsService', () => {
         storageBucketId: storageBucketDestination.id,
         temporaryLocation: false,
       });
+      // The helper must NOT mutate `bucket.documents` in memory — that's
+      // what triggers TypeORM's bidirectional FK-sync write on the next
+      // parent save (DocumentWriteGuard rejects it). file-service-go has
+      // already updated the FK in DB; in-memory state must stay neutral.
+      expect(storageBucketDestination.documents).toEqual(destDocsBefore);
+      // The helper must NOT mutate the loaded Document instance —
+      // TypeORM tracks loaded entities and any property change on a
+      // tracked Document is a candidate for an UPDATE on the next save.
+      expect(doc.temporaryLocation).toBe(true);
     });
 
     it('copies the document via copyDocumentToBucket and leaves the source intact', async () => {

--- a/src/domain/profile-documents/profile.documents.service.spec.ts
+++ b/src/domain/profile-documents/profile.documents.service.spec.ts
@@ -251,10 +251,14 @@ describe('ProfileDocumentsService', () => {
       });
     });
 
-    it('copies the document via copyDocumentToBucket and deletes the source', async () => {
-      // Different-bucket branch: under v0.0.14 we call file-service-go's
-      // /internal/file/copy via storageBucketService.copyDocumentToBucket;
-      // no bytes traverse the wire, no getDocumentContent round-trip.
+    it('copies the document via copyDocumentToBucket and leaves the source intact', async () => {
+      // Different-bucket branch: COPY semantics. The previous MOVE
+      // semantics (copy + delete-source) destroyed the source's content
+      // during clone flows: editing a cloned WB silently deleted the
+      // original doc, breaking the source's WB visuals and leaving
+      // subsequent clones from the same source referencing now-gone
+      // docs (404 visuals on later space-from-template creations).
+      // Source ownership is the caller's concern.
       const fileUrl = `${ALKEMIO_URL}/api/private/rest/storage/document/${uniqueId()}`;
       const storageBucketOrigin: IStorageBucket = mockStorageBucket();
       const storageBucketDestination: IStorageBucket = mockStorageBucket();
@@ -286,19 +290,22 @@ describe('ProfileDocumentsService', () => {
       expect(result).toBe(resultUrl);
       expect(result !== fileUrl).toBe(true);
       expect(fileServiceAdapter.getDocumentContent).not.toHaveBeenCalled();
-      // skipDedup=true is required so the rollback path can never delete
-      // an unrelated reused destination row (see service comment).
+      // skipDedup=true is required so we never bind the new bucket's
+      // reference to a doc owned by another caller (see service comment).
       expect(storageBucketService.copyDocumentToBucket).toHaveBeenCalledWith(
         storageBucketDestination.id,
         doc,
         undefined,
         true
       );
-      // After copying to the new bucket, the original document in the old bucket
-      // must be deleted to avoid orphaned storage.
-      expect(documentService.deleteDocument).toHaveBeenCalledWith({
-        ID: doc.id,
-      });
+      // Source must NOT be deleted. Cloning flows depend on the source
+      // remaining intact; deletion would corrupt the source's content
+      // and any other clones that reference the same source doc.
+      expect(documentService.deleteDocument).not.toHaveBeenCalled();
+      // Destination's in-memory state is updated for coherent re-reads.
+      expect(
+        storageBucketDestination.documents.some(d => d.id === newDocMock.id)
+      ).toBe(true);
     });
 
     describe('reuploadDocumentsInMarkdownProfile', () => {

--- a/src/domain/profile-documents/profile.documents.service.spec.ts
+++ b/src/domain/profile-documents/profile.documents.service.spec.ts
@@ -139,7 +139,12 @@ describe('ProfileDocumentsService', () => {
       ).rejects.toThrow('Documents not initialized on storage bucket');
     });
 
-    it('should throw EntityNotFoundException when document is not found by URL', async () => {
+    it('returns undefined (with WARN log) when the Alkemio document URL is stale', async () => {
+      // Stale/orphan URL handling: the helper used to throw, which crashed
+      // entire clone flows on a single dead reference. Now it logs a
+      // warning and returns undefined; callers (markdown walker,
+      // references, visuals, mediaGallery, whiteboard) all handle
+      // undefined gracefully.
       const fileUrl = EXAMPLE_ALKEMIO_DOCUMENT_URL;
       const storageBucket = mockStorageBucket();
 
@@ -148,9 +153,12 @@ describe('ProfileDocumentsService', () => {
         undefined as any
       );
 
-      await expect(
-        service.reuploadFileOnStorageBucket(fileUrl, storageBucket, true)
-      ).rejects.toThrow('not found');
+      const result = await service.reuploadFileOnStorageBucket(
+        fileUrl,
+        storageBucket,
+        true
+      );
+      expect(result).toBeUndefined();
     });
 
     it('should return fileUrl if internalUrlRequired is false and URL is not an Alkemio document', async () => {

--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -1,8 +1,5 @@
 import { LogContext } from '@common/enums';
-import {
-  EntityNotFoundException,
-  EntityNotInitializedException,
-} from '@common/exceptions';
+import { EntityNotInitializedException } from '@common/exceptions';
 import { DocumentService } from '@domain/storage/document/document.service';
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
@@ -21,13 +18,37 @@ export class ProfileDocumentsService {
   ) {}
 
   /***
-   * Checks if a url is living under the storage bucket
-   * of a profile and re-uploads it if not there
+   * Checks if a url is living under the storage bucket of a profile
+   * and re-uploads it if not there.
+   *
    * @param fileUrl The url of the file to check
    * @param storageBucket The StorageBucket in which the file should be
-   * @param internalUrlRequired If true, the file must be inside Alkemio: if the url passed is outside Alkemio will return undefined.
-   * If false, the file can be outside Alkemio: if the url passed is outside Alkemio will return the same url (will never download it, just let it pass)
-   * @throws {EntityNotFoundException} If the document is not found
+   * @param internalUrlRequired If true, the file must be inside Alkemio:
+   *   non-Alkemio URLs return undefined.
+   *   If false, non-Alkemio URLs pass through unchanged.
+   *
+   * Return values:
+   * - `string` — the resolved URL (may be the same as input if already
+   *   in the destination bucket; may be a new URL after re-home or
+   *   cross-bucket copy).
+   * - `undefined` — handled gracefully by all callers (markdown walker
+   *   leaves the URL as-is, references leave their uri unchanged,
+   *   visuals get pushed without a uri + a warning). Returned in three
+   *   cases: external URL with `internalUrlRequired`, **stale Alkemio
+   *   URL whose target document no longer exists** (logged at WARN),
+   *   or — historically — an empty string input.
+   *
+   * Stale URL tolerance: cloning flows (template-from-space, etc.)
+   * carry the source's markdown/visuals/references verbatim. If the
+   * source content references a document that has since been deleted,
+   * we log a warning with the offending url + bucket id and let the
+   * caller continue rather than aborting the entire clone on a single
+   * dead reference. Other failure modes (file-service-go errors,
+   * permissions, infrastructure) still propagate.
+   *
+   * @throws {EntityNotInitializedException} if the bucket isn't
+   *   persisted or its documents relation isn't loaded — that's a
+   *   programmer error in the call site, not a runtime data issue.
    */
   public async reuploadFileOnStorageBucket(
     fileUrl: string,
@@ -70,11 +91,20 @@ export class ProfileDocumentsService {
     );
 
     if (!docInContent) {
-      throw new EntityNotFoundException(
-        'File with URL not found',
-        LogContext.COLLABORATION,
-        { fileUrl }
+      // Stale/orphan reference — the URL points to an Alkemio doc UUID
+      // that no longer exists. Don't throw: callers (markdown walker,
+      // references, visuals, etc.) all handle undefined gracefully and
+      // we don't want a single dead link to abort entire clone flows.
+      this.logger.warn?.(
+        {
+          message:
+            'Reupload skipped: Alkemio document URL points to a non-existent file',
+          fileUrl,
+          storageBucketId: storageBucket.id,
+        },
+        LogContext.PROFILE
       );
+      return undefined;
     }
 
     const docInThisBucket = storageBucket.documents.find(
@@ -159,16 +189,13 @@ export class ProfileDocumentsService {
   }
 
   /***
-   * Checks if a markdown text has documents living under the
-   * specified storage bucket and re-uploads them if not there.
+   * Walks every Alkemio document URL in the markdown and re-homes it
+   * into `storageBucket` via {@link reuploadFileOnStorageBucket}.
    *
-   * Per-URL resilience: a dead/orphaned reference (e.g. when cloning
-   * from a source space whose document was deleted, or a cross-tenant
-   * URL) is logged at WARN and the URL is left untouched in the
-   * markdown — the clone ends up with the same dead link the source
-   * had, instead of failing the entire create flow on a single broken
-   * reference. Other errors (e.g. file-service-go failures) still
-   * propagate.
+   * Stale/dead URLs are tolerated by the helper itself (logged at WARN,
+   * returns undefined). When the helper returns undefined or the same
+   * URL, we leave the URL untouched in the markdown so the clone
+   * preserves the source's shape.
    */
   public async reuploadDocumentsInMarkdownToStorageBucket(
     markdown: string,
@@ -184,28 +211,11 @@ export class ProfileDocumentsService {
     const matches = markdown.match(regex);
     if (matches?.length) {
       for (const match of matches) {
-        let newUrl: string | undefined;
-        try {
-          newUrl = await this.reuploadFileOnStorageBucket(
-            match,
-            storageBucket,
-            false
-          );
-        } catch (error) {
-          if (error instanceof EntityNotFoundException) {
-            this.logger.warn?.(
-              {
-                message:
-                  'Markdown document URL points to a non-existent file; leaving URL as-is',
-                fileUrl: match,
-                storageBucketId: storageBucket.id,
-              },
-              LogContext.PROFILE
-            );
-            continue;
-          }
-          throw error;
-        }
+        const newUrl = await this.reuploadFileOnStorageBucket(
+          match,
+          storageBucket,
+          false
+        );
         if (newUrl && newUrl !== match) {
           markdown = this.replaceAll(markdown, match, newUrl);
         }

--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -115,17 +115,20 @@ export class ProfileDocumentsService {
       // It should be just `fileUrl` but rewrite it just in case
       return this.documentService.getPubliclyAccessibleURL(docInThisBucket);
     } else if (docInContent.temporaryLocation) {
-      // Move temporary document to the new bucket via Go file-service-go
+      // Move temporary document to the new bucket via Go file-service-go.
+      // file-service-go updates the row's `storageBucketId` and clears
+      // `temporaryLocation` in the DB.
       await this.fileServiceAdapter.updateDocument(docInContent.id, {
         storageBucketId: storageBucket.id,
         temporaryLocation: false,
       });
-      // Keep in-memory state in sync so subsequent hits in the same pass
-      // find the document in the destination bucket
-      docInContent.temporaryLocation = false;
-      if (!storageBucket.documents.some(doc => doc.id === docInContent.id)) {
-        storageBucket.documents.push(docInContent);
-      }
+      // Deliberately NOT mutating the loaded `docInContent` entity or
+      // pushing it into `storageBucket.documents`. TypeORM's bidirectional
+      // relation management would react to those in-memory changes by
+      // emitting an UPDATE on the file row when the parent is later
+      // saved (profile cascade), which DocumentWriteGuard correctly
+      // rejects (file table is owned by file-service-go). The DB state
+      // is already correct after the updateDocument call above.
       return this.documentService.getPubliclyAccessibleURL(docInContent);
     } else {
       // Different bucket: COPY the doc into the destination bucket.
@@ -156,13 +159,25 @@ export class ProfileDocumentsService {
         undefined,
         true
       );
-      // Keep destination bucket's in-memory state coherent so
-      // subsequent re-uploads in the same request (e.g. multiple
-      // internal URLs in the same markdown) see the new doc and
-      // don't trigger a redundant copy.
-      if (!storageBucket.documents.some(doc => doc.id === newDoc.id)) {
-        storageBucket.documents.push(newDoc);
-      }
+      // Deliberately NOT mutating `storageBucket.documents` in memory.
+      // file-service-go owns the `file` table (DocumentWriteGuard
+      // enforces this), but TypeORM's bidirectional relation
+      // management on the OneToMany inverse side reacts to in-memory
+      // array mutations by emitting an UPDATE on the child's FK
+      // column to "sync" the relation. With our `cascade: false` on
+      // `StorageBucket.documents` the cascade itself is suppressed,
+      // but the FK-sync write still fires when the parent is later
+      // saved (e.g. profileRepository.save inside materialize), and
+      // the guard correctly rejects it. Skipping the in-memory push
+      // avoids triggering that FK-sync write entirely; the new doc's
+      // `storageBucketId` was already set correctly by file-service-go
+      // at copy time, so there's no real state to sync.
+      //
+      // Trade-off: same-pass repeats of the same source URL won't
+      // short-circuit via the `documents.find` check above and will
+      // re-issue the cross-bucket copy. Acceptable — repeat URLs in
+      // a single markdown/visual pass are rare and idempotent enough
+      // (skipDedup=true makes each copy a unique new row).
       return this.documentService.getPubliclyAccessibleURL(newDoc);
     }
   }

--- a/src/domain/profile-documents/profile.documents.service.ts
+++ b/src/domain/profile-documents/profile.documents.service.ts
@@ -128,59 +128,38 @@ export class ProfileDocumentsService {
       }
       return this.documentService.getPubliclyAccessibleURL(docInContent);
     } else {
-      // Different bucket: ask file-service-go to materialize a new row in
-      // the destination bucket pointing at the same content. Single RPC,
-      // no bytes on the wire (content is content-addressed). After the
-      // new row is in place, delete the source so it doesn't leak as an
-      // orphan in its original bucket.
+      // Different bucket: COPY the doc into the destination bucket.
+      // Source is left intact — never delete it from the helper. The
+      // previous MOVE semantics (copy + delete-source) destroyed the
+      // source's content during clone flows: when a Space was created
+      // from a Template (or a Template from a source Space), edits on
+      // the cloned WB / profile would silently delete the original
+      // doc, breaking the source's WB visuals and leaving subsequent
+      // clones from the same Template referencing now-gone docs (404
+      // visuals on later space-from-template creations).
       //
-      // skipDedup=true is critical for safety: without it, dedup-reuse could
-      // return another caller's existing row, and the rollback below would
-      // delete THEIR document on source-delete failure. Forcing a fresh row
-      // guarantees `newDoc` is exclusively ours.
+      // Source ownership is the caller's concern — if a flow needs
+      // true MOVE semantics (e.g. an admin migration tool, or the
+      // temp-doc-to-permanent special case above), it can call
+      // FileServiceAdapter.deleteDocument explicitly after this
+      // helper returns. The helper itself stays neutral: copy what
+      // we need into the destination, leave the source for whoever
+      // owns it.
+      //
+      // skipDedup=true: without it, dedup-reuse could return another
+      // caller's existing row, which would silently bind the new
+      // bucket's reference to a doc owned by someone else. Forcing a
+      // fresh row guarantees `newDoc` is exclusively ours.
       const newDoc = await this.storageBucketService.copyDocumentToBucket(
         storageBucket.id,
         docInContent,
         undefined,
         true
       );
-      try {
-        await this.documentService.deleteDocument({ ID: docInContent.id });
-      } catch (error) {
-        // Source delete failed after destination copy succeeded — compensate
-        // by removing the new copy so a caller retry doesn't accumulate
-        // duplicates in the destination bucket. Cleanup-failure is
-        // alert-worthy (logger.error) but does not replace the original
-        // source-delete error — same convention as the OrRollback helper
-        // and other rollback sites in the codebase.
-        await this.documentService
-          .deleteDocument({ ID: newDoc.id })
-          .catch(cleanupError => {
-            const stack =
-              cleanupError instanceof Error ? (cleanupError.stack ?? '') : '';
-            this.logger.error?.(
-              {
-                message:
-                  'Cleanup of destination copy after source-delete failure also failed',
-                sourceDocumentId: docInContent.id,
-                destinationDocumentId: newDoc.id,
-                cleanupError: String(cleanupError),
-              },
-              stack,
-              LogContext.PROFILE
-            );
-          });
-        throw error;
-      }
-      // Keep in-memory bucket state in sync so subsequent re-uploads in the
-      // same request (e.g. multiple internal URLs in the same markdown) see
-      // the moved doc and don't trigger redundant copy/delete churn.
-      const sourceIndex = storageBucket.documents.findIndex(
-        doc => doc.id === docInContent.id
-      );
-      if (sourceIndex !== -1) {
-        storageBucket.documents.splice(sourceIndex, 1);
-      }
+      // Keep destination bucket's in-memory state coherent so
+      // subsequent re-uploads in the same request (e.g. multiple
+      // internal URLs in the same markdown) see the new doc and
+      // don't trigger a redundant copy.
       if (!storageBucket.documents.some(doc => doc.id === newDoc.id)) {
         storageBucket.documents.push(newDoc);
       }

--- a/src/domain/storage/storage-bucket/storage.bucket.entity.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.entity.ts
@@ -12,16 +12,28 @@ export class StorageBucket
 {
   // Document is owned by file-service-go; the server's TypeORM is
   // read-only for the `file` table (enforced by DocumentWriteGuard).
-  // `cascade: false` prevents repository.save(bucket) from walking into
-  // bucket.documents and emitting UPDATE/INSERT — every Document write
-  // must go through FileServiceAdapter. The in-memory `documents` array
-  // is still read/mutated for state coherence within a request.
+  //
+  // `cascade: false` alone is NOT enough — TypeORM's OneToManySubjectBuilder
+  // walks every OneToMany relation regardless of cascade, diffs the
+  // database state against the in-memory `documents` array, and synthesizes
+  // UPDATE subjects for any binding changes (or even loaded-but-unmodified
+  // entries reached during diff). This bypasses cascade and triggers
+  // DocumentWriteGuard on any save() that walks through StorageBucket
+  // (profile cascade, aggregator cascade, mediaGallery cascade).
+  //
+  // `persistence: false` is the documented TypeORM switch that fully
+  // disables that bidirectional FK management for this relation, leaving
+  // the `documents` collection as a pure read-side projection. The DB FK
+  // is owned by file-service-go and updated via FileServiceAdapter; the
+  // physical-row cascade is preserved by `onDelete: 'CASCADE'` on the
+  // Document side.
   @OneToMany(
     () => Document,
     document => document.storageBucket,
     {
       eager: false,
       cascade: false,
+      persistence: false,
     }
   )
   documents!: Document[];


### PR DESCRIPTION
## Summary

Three related fixes covering the full set of clone-time data-rot scenarios QA has been hitting (`createTemplateFromSpace`, `createTemplateFromContentSpace`, space-from-template, etc.). All shipped together because each alone leaves the others uncovered.

## (1) Centralize stale-doc-URL tolerance (commit 1)

Source: a missing/orphaned Alkemio doc URL inside markdown / references / visuals / mediaGallery / WB-content was crashing the entire clone (whichever code path hit it first — markdown walker, `addVisualsOnProfile`, etc.).

Per-site try/catch was the wrong scope. Every clone-fragile flow goes through `reuploadFileOnStorageBucket`. The helper now logs WARN and returns `undefined` when the referenced doc is missing, instead of throwing. All six call sites already handle `undefined` gracefully — no per-site code changes needed.

Removed the now-redundant try/catch in `reuploadDocumentsInMarkdownToStorageBucket` (PR #6025) — replaced by the centralized helper-level fix.

## (2) Stop destroying the source on cross-bucket reupload (commit 2)

Source: `reuploadFileOnStorageBucket` cross-bucket case was doing **MOVE** semantics (copy + delete-source). For clone flows this was destructive.

Cascade observed by QA:

1. Source space's WB has doc D in source bucket.
2. Template cloned from source — template's WB references D.
3. Space A cloned from template — still references D.
4. User edits Space A's WB and saves → reupload moves D into Space A's bucket and **deletes D from the source**.
5. Source space's WB now broken; template's WB now broken.
6. Space B cloned from same template later → references the now-deleted D → **404 visuals** (the user's exact report).

Fix: helper drops the source-delete + its rollback compensation. COPY into dest, leave source alone. Source ownership is the caller's concern — if a flow needs true MOVE (admin migration, etc.), it can call `FileServiceAdapter.deleteDocument` explicitly after.

## (3) Eagerly re-home WB content at clone time (commit 2)

Source: `WhiteboardService.createWhiteboard` didn't walk the WB content's embedded file refs at clone time — only `updateWhiteboardContent` (user-save path) did. So cloned WBs silently kept referencing the source's bucket until someone edited them. Combined with bug (2), the first edit corrupted the source.

Fix: phase-3 re-home of embedded file refs in `createWhiteboard`, after the existing profile materialize. Cloned WBs eagerly own their docs. On failure, deletes the just-created WB and rethrows — same OrRollback semantics as the profile materialize.

## Audit

Every clone-fragile call site of the helper:

| Site | Pattern | Handles undefined? |
|------|---------|--------------------|
| `profile.service.ts` (markdown via walker) | walker leaves URL | ✓ |
| `profile.service.ts` (references) | `if (newUrl) reference.uri = newUrl` | ✓ |
| `profile.service.ts` (visuals via `addVisualsOnProfile`) | `if (url) visual.uri = url else warn` | ✓ |
| `callout-contribution-defaults.service.ts` (postDescription) | walker | ✓ |
| `callout-framing.service.ts` (mediaGallery) | own try/catch + skip | ✓ |
| `whiteboard.service.ts` (whiteboard files via `reuploadDocumentsIfNotInBucket`) | own try/catch + skip | ✓ |

All six benefit from the COPY-semantics change. None wanted MOVE.

## What still throws

- `EntityNotInitializedException` — bucket not persisted yet (programmer error, intentional guard).
- File-service-go errors (network, 5xx, permissions) — propagate.
- Cross-bucket `copyDocumentToBucket` failures — propagate.

## Test plan

- [x] 6394 unit tests pass (helper spec rewritten to assert COPY semantics; new test for stale-URL undefined-return contract)
- [x] lint and typecheck clean
- [ ] Verify clone flows end-to-end:
  - Source space with WB → create Template from space → both source and template render WB visuals correctly.
  - Template with WB → create Space from template → space renders WB visuals; source/template still intact.
  - Edit cloned WB and save → source/template unchanged.

## Pre-existing damage

WBs already corrupted by previous MOVE-semantics behavior won't auto-heal — those docs are gone. Going forward, no new corruption occurs.

## Related

Continuation of post-merge fixes for #6014:
- #6016 (KB bootstrap) — merged
- #6017 (createTemplateFromContentSpace phase split) — merged
- #6024 (DocumentWriteGuard cascade) — merged
- #6025 (markdown dead-link, per-site try/catch) — merged
- this PR — replaces #6025's per-site approach with centralized resilience, plus COPY-not-MOVE, plus eager WB content re-home