### PR TITLE
fix: propagate vcInteractionID through VC invocation chain

### DIFF
--- a/src/domain/communication/virtual.contributor.message/virtual.contributor.message.service.ts
+++ b/src/domain/communication/virtual.contributor.message/virtual.contributor.message.service.ts
@@ -54,6 +54,7 @@ export class VirtualContributorMessageService {
           roomID: room.id,
           threadID,
           actorID: virtualContributorActorID,
+          vcInteractionID: '',
         },
       },
     };

--- a/src/domain/community/virtual-contributor/dto/virtual.contributor.dto.invocation.input.ts
+++ b/src/domain/community/virtual-contributor/dto/virtual.contributor.dto.invocation.input.ts
@@ -24,6 +24,11 @@ export class RoomDetails {
     description: 'The actor ID (agent.id) for the VC',
   })
   actorID!: string;
+  @Field(() => String, {
+    nullable: true,
+    description: 'The VC interaction ID for tracking.',
+  })
+  vcInteractionID?: string | null;
 }
 
 @InputType()

--- a/src/services/adapters/ai-server-adapter/dto/ai.server.adapter.dto.invocation.ts
+++ b/src/services/adapters/ai-server-adapter/dto/ai.server.adapter.dto.invocation.ts
@@ -14,7 +14,7 @@ export class RoomDetails {
   roomID!: string;
   threadID?: string;
   actorID!: string;
-  vcInteractionID?: string;
+  vcInteractionID?: string | null;
 }
 
 export class ResultHandler {

--- a/src/services/adapters/ai-server-adapter/dto/ai.server.adapter.dto.update.ai.persona.service.ts
+++ b/src/services/adapters/ai-server-adapter/dto/ai.server.adapter.dto.update.ai.persona.service.ts
@@ -14,7 +14,7 @@ export class RoomDetails {
   roomID!: string;
   threadID?: string;
   actorID!: string;
-  vcInteractionID?: string;
+  vcInteractionID?: string | null;
 }
 
 export class ResultHandler {

--- a/src/services/ai-server/ai-persona-engine-adapter/dto/ai.persona.engine.adapter.dto.invocation.input.ts
+++ b/src/services/ai-server/ai-persona-engine-adapter/dto/ai.persona.engine.adapter.dto.invocation.input.ts
@@ -15,6 +15,7 @@ export class RoomDetails {
   roomID!: string;
   threadID?: string;
   actorID!: string;
+  vcInteractionID?: string | null;
 }
 
 export class ResultHandler {

--- a/src/services/ai-server/ai-persona/dto/ai.persona.invocation/room.details.dto.ts
+++ b/src/services/ai-server/ai-persona/dto/ai.persona.invocation/room.details.dto.ts
@@ -17,4 +17,9 @@ export class RoomDetails {
     description: 'The actor ID (agent.id) for the VC',
   })
   actorID!: string;
+  @Field(() => String, {
+    nullable: true,
+    description: 'The VC interaction ID for tracking.',
+  })
+  vcInteractionID?: string | null;
 }


### PR DESCRIPTION
## Summary

The unified VC engine (`alkemio/virtual-contributor:v0.1.2`) declares `RoomDetails.vcInteractionID` as **required** (no default), so any chat-style invocation reaching the engine without it triggers Pydantic `ValidationError`, gets retried 3× and silently dies — dropping chat answers.

Confirmed live in the guidance engine logs:

```
ERROR Failed to parse message: 1 validation error for Input
  resultHandler.roomDetails.vcInteractionID
    Field required [type=missing, input_value={'roomID': ..., 'actorID': ...}]
```

This PR plumbs `vcInteractionID` through every `RoomDetails` construction site so the engine always receives a valid event (empty string is fine — the engine just needs the key present).

## Changes

- **`virtual.contributor.message.service.ts`** — pass `vcInteractionID: ''` at the construction site that was previously omitting the field. **This is the actual bug fix**; the other 5 files are type-system support so TS allows the new field.
- **`virtual.contributor.dto.invocation.input.ts`** — add `@Field`-decorated `vcInteractionID` to the `RoomDetails` input DTO.
- **`ai.persona.invocation/room.details.dto.ts`** — same on the AI-persona variant.
- **`ai.persona.engine.adapter.dto.invocation.input.ts`** — add the field on the engine-adapter DTO so it survives the hop into the published event.
- **`ai.server.adapter.dto.{invocation,update.ai.persona.service}.ts`** — widen `vcInteractionID` type from `string` to `string | null`.

## Schema impact

**None.** Both `@InputType`-decorated `RoomDetails` classes are orphan types in the codebase (not reachable from any registered resolver), so `@Field` additions don't surface in `schema.graphql`. Verified by `pnpm run schema:print` + diff — no `vcInteractionID` change in the SDL.

## Test plan

- [x] `pnpm test` — 6375 tests pass (pre-commit ran the full vitest suite)
- [x] **Live verified** — after this fix landed in the local working tree, the guidance engine stopped logging `Failed to parse message` errors, and "who is Rene" queries flow end-to-end (engine processes, response posted to the matrix room as the VC user).
- [ ] Confirm in dev/test environment that chat queries to VCs no longer get silently dropped.

## Related

- VC engine v0.1.2 image already deployed via `overlays/ai-stack.yml` — this PR makes the server side compatible with that image's stricter event schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing a virtual contributor interaction identifier for enhanced tracking and audit purposes. This optional field enables systems to reference and log virtual contributor interactions throughout the application workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->