### PR TITLE
fix: template content space settings now editable

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3827,14 +3827,6 @@ type Mutation {
   markNotificationsAsUnread(filter: NotificationEventsFilterInput): Boolean!
   """Moves the specified Contribution to another Callout."""
   moveContributionToCallout(moveContributionData: MoveCalloutContributionInput!): CalloutContribution!
-  """
-  Move an L1 subspace to a different L0 space. The subspace remains at level 1       but changes parent. All content moves with it. All community memberships are cleared.       Requires platform admin privileges.
-  """
-  moveSpaceL1ToSpaceL0(moveData: MoveSpaceL1ToSpaceL0Input!): Space!
-  """
-  Move an L1 subspace to become an L2 sub-subspace under a target L1 in a different L0 space.       The space is demoted from level 1 to level 2. All community roles are cleared.       Requires platform admin privileges.
-  """
-  moveSpaceL1ToSpaceL2(moveData: MoveSpaceL1ToSpaceL2Input!): Space!
   """Refresh the Bodies of Knowledge on All VCs"""
   refreshAllBodiesOfKnowledge: Boolean!
   """
@@ -4312,10 +4304,6 @@ type PlatformAdminIdentityQueryResults {
 }
 
 type PlatformAdminQueryResults {
-  """
-  Retrieve all Accounts on the Platform. This is only available to Platform Admins.
-  """
-  accounts: [Account!]!
   """Lookup Communication related information."""
   communication: PlatformAdminCommunicationQueryResults!
   """Lookup Identity related information."""
@@ -4789,6 +4777,10 @@ type PushSubscription {
 }
 
 type Query {
+  """
+  The Accounts on this platform; If accessed through an Innovation Hub will return ONLY the Accounts defined in it.
+  """
+  accounts: [Account!]!
   """Activity events related to the current user."""
   activityFeed(
     """A pivot cursor after which items are selected"""
@@ -7626,34 +7618,6 @@ input MoveCalloutContributionInput {
   contributionID: UUID!
 }
 
-input MoveSpaceL1ToSpaceL0Input {
-  """
-  Send invitations to former community members who are also in the target L0 community.
-  """
-  autoInvite: Boolean = false
-  """Custom invitation message. Used only when autoInvite is true."""
-  invitationMessage: String
-  """The L1 subspace to move to a different L0 space."""
-  spaceL1ID: UUID!
-  """The target L0 space (must be different from the current parent L0)."""
-  targetSpaceL0ID: UUID!
-}
-
-input MoveSpaceL1ToSpaceL2Input {
-  """
-  Send invitations to former community members who are also in the target L0 community.
-  """
-  autoInvite: Boolean = false
-  """Custom invitation message. Used only when autoInvite is true."""
-  invitationMessage: String
-  """The L1 subspace to move and demote to L2."""
-  spaceL1ID: UUID!
-  """
-  The target L1 subspace in a different L0 (new parent for the demoted space).
-  """
-  targetSpaceL1ID: UUID!
-}
-
 input NotificationEmailAddressInput {
   """Full email address to add/remove; lowercase enforced by server"""
   email: String!
@@ -8231,10 +8195,8 @@ input UpdateDiscussionInput {
 }
 
 input UpdateDocumentInput {
-  """
-  The display name for the Document. Not supported — rejected with a ValidationException if provided.
-  """
-  displayName: String
+  """The display name for the Document."""
+  displayName: String!
   ID: UUID!
   tagset: UpdateTagsetInput
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -3827,6 +3827,14 @@ type Mutation {
   markNotificationsAsUnread(filter: NotificationEventsFilterInput): Boolean!
   """Moves the specified Contribution to another Callout."""
   moveContributionToCallout(moveContributionData: MoveCalloutContributionInput!): CalloutContribution!
+  """
+  Move an L1 subspace to a different L0 space. The subspace remains at level 1       but changes parent. All content moves with it. All community memberships are cleared.       Requires platform admin privileges.
+  """
+  moveSpaceL1ToSpaceL0(moveData: MoveSpaceL1ToSpaceL0Input!): Space!
+  """
+  Move an L1 subspace to become an L2 sub-subspace under a target L1 in a different L0 space.       The space is demoted from level 1 to level 2. All community roles are cleared.       Requires platform admin privileges.
+  """
+  moveSpaceL1ToSpaceL2(moveData: MoveSpaceL1ToSpaceL2Input!): Space!
   """Refresh the Bodies of Knowledge on All VCs"""
   refreshAllBodiesOfKnowledge: Boolean!
   """
@@ -4304,6 +4312,10 @@ type PlatformAdminIdentityQueryResults {
 }
 
 type PlatformAdminQueryResults {
+  """
+  Retrieve all Accounts on the Platform. This is only available to Platform Admins.
+  """
+  accounts: [Account!]!
   """Lookup Communication related information."""
   communication: PlatformAdminCommunicationQueryResults!
   """Lookup Identity related information."""
@@ -4777,10 +4789,6 @@ type PushSubscription {
 }
 
 type Query {
-  """
-  The Accounts on this platform; If accessed through an Innovation Hub will return ONLY the Accounts defined in it.
-  """
-  accounts: [Account!]!
   """Activity events related to the current user."""
   activityFeed(
     """A pivot cursor after which items are selected"""
@@ -7618,6 +7626,34 @@ input MoveCalloutContributionInput {
   contributionID: UUID!
 }
 
+input MoveSpaceL1ToSpaceL0Input {
+  """
+  Send invitations to former community members who are also in the target L0 community.
+  """
+  autoInvite: Boolean = false
+  """Custom invitation message. Used only when autoInvite is true."""
+  invitationMessage: String
+  """The L1 subspace to move to a different L0 space."""
+  spaceL1ID: UUID!
+  """The target L0 space (must be different from the current parent L0)."""
+  targetSpaceL0ID: UUID!
+}
+
+input MoveSpaceL1ToSpaceL2Input {
+  """
+  Send invitations to former community members who are also in the target L0 community.
+  """
+  autoInvite: Boolean = false
+  """Custom invitation message. Used only when autoInvite is true."""
+  invitationMessage: String
+  """The L1 subspace to move and demote to L2."""
+  spaceL1ID: UUID!
+  """
+  The target L1 subspace in a different L0 (new parent for the demoted space).
+  """
+  targetSpaceL1ID: UUID!
+}
+
 input NotificationEmailAddressInput {
   """Full email address to add/remove; lowercase enforced by server"""
   email: String!
@@ -8195,8 +8231,10 @@ input UpdateDiscussionInput {
 }
 
 input UpdateDocumentInput {
-  """The display name for the Document."""
-  displayName: String!
+  """
+  The display name for the Document. Not supported — rejected with a ValidationException if provided.
+  """
+  displayName: String
   ID: UUID!
   tagset: UpdateTagsetInput
 }
@@ -8511,19 +8549,19 @@ input UpdateSpaceSettingsCollaborationInput {
   """
   Flag to control if events from Subspaces are visible on this Space calendar as well.
   """
-  allowEventsFromSubspaces: Boolean!
+  allowEventsFromSubspaces: Boolean
   """Flag to control if guest users can contribute to this Space."""
-  allowGuestContributions: Boolean!
+  allowGuestContributions: Boolean
   """Flag to control if members can create callouts."""
-  allowMembersToCreateCallouts: Boolean!
+  allowMembersToCreateCallouts: Boolean
   """Flag to control if members can create subspaces."""
-  allowMembersToCreateSubspaces: Boolean!
+  allowMembersToCreateSubspaces: Boolean
   """Flag to control if members can create video calls in this Space."""
-  allowMembersToVideoCall: Boolean!
+  allowMembersToVideoCall: Boolean
   """
   Flag to control if ability to contribute is inherited from parent Space.
   """
-  inheritMembershipRights: Boolean!
+  inheritMembershipRights: Boolean
 }
 
 input UpdateSpaceSettingsEntityInput {

--- a/src/domain/space/space.settings/dto/space.settings.collaboration.dto.update.ts
+++ b/src/domain/space/space.settings/dto/space.settings.collaboration.dto.update.ts
@@ -3,41 +3,41 @@ import { Field, InputType } from '@nestjs/graphql';
 @InputType()
 export class UpdateSpaceSettingsCollaborationInput {
   @Field(() => Boolean, {
-    nullable: false,
+    nullable: true,
     description: 'Flag to control if members can create subspaces.',
   })
-  allowMembersToCreateSubspaces!: boolean;
+  allowMembersToCreateSubspaces?: boolean;
 
   @Field(() => Boolean, {
-    nullable: false,
+    nullable: true,
     description: 'Flag to control if members can create callouts.',
   })
-  allowMembersToCreateCallouts!: boolean;
+  allowMembersToCreateCallouts?: boolean;
 
   @Field(() => Boolean, {
-    nullable: false,
+    nullable: true,
     description:
       'Flag to control if ability to contribute is inherited from parent Space.',
   })
-  inheritMembershipRights!: boolean;
+  inheritMembershipRights?: boolean;
 
   @Field(() => Boolean, {
-    nullable: false,
+    nullable: true,
     description:
       'Flag to control if events from Subspaces are visible on this Space calendar as well.',
   })
-  allowEventsFromSubspaces!: boolean;
+  allowEventsFromSubspaces?: boolean;
 
   @Field(() => Boolean, {
-    nullable: false,
+    nullable: true,
     description:
       'Flag to control if members can create video calls in this Space.',
   })
-  allowMembersToVideoCall!: boolean;
+  allowMembersToVideoCall?: boolean;
 
   @Field(() => Boolean, {
-    nullable: false,
+    nullable: true,
     description: 'Flag to control if guest users can contribute to this Space.',
   })
-  allowGuestContributions!: boolean;
+  allowGuestContributions?: boolean;
 }

--- a/src/domain/space/space.settings/space.settings.service.spec.ts
+++ b/src/domain/space/space.settings/space.settings.service.spec.ts
@@ -108,7 +108,7 @@ describe('SpaceSettingsService', () => {
       ]);
     });
 
-    it('should replace collaboration entirely when provided', () => {
+    it('should merge collaboration when full payload is provided', () => {
       // Arrange
       const settings = cloneSettings();
       const newCollaboration = {
@@ -127,9 +127,81 @@ describe('SpaceSettingsService', () => {
       const result = service.updateSettings(settings, updateData);
 
       // Assert
-      expect(result.collaboration).toBe(newCollaboration);
+      expect(result.collaboration).toEqual(newCollaboration);
       expect(result.collaboration.allowMembersToVideoCall).toBe(true);
       expect(result.collaboration.allowGuestContributions).toBe(true);
+    });
+
+    it('should preserve unspecified collaboration fields when subset is provided', () => {
+      // Arrange — reproduces issue alkem-io/client-web#9593:
+      // sending only one flag must not clobber the others to undefined.
+      const settings = cloneSettings();
+      const updateData: UpdateSpaceSettingsEntityInput = {
+        collaboration: {
+          allowGuestContributions: true,
+        },
+      };
+
+      // Act
+      const result = service.updateSettings(settings, updateData);
+
+      // Assert
+      expect(result.collaboration.allowGuestContributions).toBe(true);
+      expect(result.collaboration.inheritMembershipRights).toBe(true);
+      expect(result.collaboration.allowMembersToCreateSubspaces).toBe(true);
+      expect(result.collaboration.allowMembersToCreateCallouts).toBe(true);
+      expect(result.collaboration.allowEventsFromSubspaces).toBe(true);
+      expect(result.collaboration.allowMembersToVideoCall).toBe(false);
+    });
+
+    it('should treat explicit false as a real value (not skipped)', () => {
+      // Arrange
+      const settings = cloneSettings();
+      const updateData: UpdateSpaceSettingsEntityInput = {
+        collaboration: {
+          inheritMembershipRights: false,
+        },
+      };
+
+      // Act
+      const result = service.updateSettings(settings, updateData);
+
+      // Assert — false must overwrite the prior true
+      expect(result.collaboration.inheritMembershipRights).toBe(false);
+      expect(result.collaboration.allowMembersToCreateSubspaces).toBe(true);
+    });
+
+    it('should ignore explicit undefined fields in collaboration subset', () => {
+      // Arrange
+      const settings = cloneSettings();
+      const updateData: UpdateSpaceSettingsEntityInput = {
+        collaboration: {
+          allowMembersToVideoCall: true,
+          allowGuestContributions: undefined,
+        },
+      };
+
+      // Act
+      const result = service.updateSettings(settings, updateData);
+
+      // Assert — undefined entry must not clobber existing value
+      expect(result.collaboration.allowMembersToVideoCall).toBe(true);
+      expect(result.collaboration.allowGuestContributions).toBe(false);
+    });
+
+    it('should leave collaboration untouched when collaboration is omitted', () => {
+      // Arrange
+      const settings = cloneSettings();
+      const before = { ...settings.collaboration };
+      const updateData: UpdateSpaceSettingsEntityInput = {
+        privacy: { mode: SpacePrivacyMode.PRIVATE },
+      };
+
+      // Act
+      const result = service.updateSettings(settings, updateData);
+
+      // Assert
+      expect(result.collaboration).toEqual(before);
     });
 
     it('should not modify settings when updateData is empty', () => {

--- a/src/domain/space/space.settings/space.settings.service.ts
+++ b/src/domain/space/space.settings/space.settings.service.ts
@@ -48,7 +48,10 @@ export class SpaceSettingsService {
         ([, value]) => value !== undefined
       );
       const definedFields = Object.fromEntries(definedEntries);
-      Object.assign(settings.collaboration, definedFields);
+      settings.collaboration = {
+        ...(settings.collaboration ?? {}),
+        ...definedFields,
+      };
     }
     if (updateData.sortMode) {
       settings.sortMode = updateData.sortMode;

--- a/src/domain/space/space.settings/space.settings.service.ts
+++ b/src/domain/space/space.settings/space.settings.service.ts
@@ -45,7 +45,7 @@ export class SpaceSettingsService {
       const collaborationUpdates = updateData.collaboration;
       const allEntries = Object.entries(collaborationUpdates);
       const definedEntries = allEntries.filter(
-        ([, value]) => value !== undefined
+        ([, value]) => value !== undefined && value !== null
       );
       const definedFields = Object.fromEntries(definedEntries);
       settings.collaboration = {

--- a/src/domain/space/space.settings/space.settings.service.ts
+++ b/src/domain/space/space.settings/space.settings.service.ts
@@ -41,7 +41,14 @@ export class SpaceSettingsService {
       settings.membership = updateData.membership;
     }
     if (updateData.collaboration) {
-      settings.collaboration = updateData.collaboration;
+      // Apply only the fields the caller explicitly set, preserving the rest.
+      const collaborationUpdates = updateData.collaboration;
+      const allEntries = Object.entries(collaborationUpdates);
+      const definedEntries = allEntries.filter(
+        ([, value]) => value !== undefined
+      );
+      const definedFields = Object.fromEntries(definedEntries);
+      Object.assign(settings.collaboration, definedFields);
     }
     if (updateData.sortMode) {
       settings.sortMode = updateData.sortMode;

--- a/src/domain/template/template-content-space/template.content.space.module.ts
+++ b/src/domain/template/template-content-space/template.content.space.module.ts
@@ -3,6 +3,7 @@ import { CollaborationModule } from '@domain/collaboration/collaboration/collabo
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { LicenseModule } from '@domain/common/license/license.module';
 import { SpaceAboutModule } from '@domain/space/space.about/space.about.module';
+import { SpaceSettingsModule } from '@domain/space/space.settings/space.settings.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TemplateContentSpace } from './template.content.space.entity';
@@ -17,6 +18,7 @@ import { TemplateContentSpaceLicenseService } from './template.content.space.ser
     AuthorizationModule,
     AuthorizationPolicyModule,
     SpaceAboutModule,
+    SpaceSettingsModule,
     CollaborationModule,
     LicenseModule,
     TypeOrmModule.forFeature([TemplateContentSpace]),

--- a/src/domain/template/template-content-space/template.content.space.service.spec.ts
+++ b/src/domain/template/template-content-space/template.content.space.service.spec.ts
@@ -7,6 +7,7 @@ import { CollaborationService } from '@domain/collaboration/collaboration/collab
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { LicenseService } from '@domain/common/license/license.service';
 import { SpaceAboutService } from '@domain/space/space.about/space.about.service';
+import { SpaceSettingsService } from '@domain/space/space.settings/space.settings.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
@@ -24,6 +25,7 @@ describe('TemplateContentSpaceService', () => {
   let repository: Mocked<Repository<TemplateContentSpace>>;
   let collaborationService: Mocked<CollaborationService>;
   let spaceAboutService: Mocked<SpaceAboutService>;
+  let spaceSettingsService: Mocked<SpaceSettingsService>;
   let authorizationPolicyService: Mocked<AuthorizationPolicyService>;
   let licenseService: Mocked<LicenseService>;
 
@@ -60,6 +62,9 @@ describe('TemplateContentSpaceService', () => {
     spaceAboutService = module.get(
       SpaceAboutService
     ) as Mocked<SpaceAboutService>;
+    spaceSettingsService = module.get(
+      SpaceSettingsService
+    ) as Mocked<SpaceSettingsService>;
     authorizationPolicyService = module.get(
       AuthorizationPolicyService
     ) as Mocked<AuthorizationPolicyService>;
@@ -242,6 +247,112 @@ describe('TemplateContentSpaceService', () => {
 
       expect(spaceAboutService.updateSpaceAbout).not.toHaveBeenCalled();
       expect(repository.save).toHaveBeenCalledWith(tcs);
+    });
+
+    it('should apply settings via SpaceSettingsService when settings are provided', async () => {
+      // Reproduces issue alkem-io/client-web#9593:
+      // updateTemplateContentSpace was ignoring the settings input.
+      const existingSettings = {
+        privacy: { mode: 'PUBLIC', allowPlatformSupportAsAdmin: false },
+        membership: {
+          policy: 'OPEN',
+          trustedOrganizations: [],
+          allowSubspaceAdminsToInviteMembers: false,
+        },
+        collaboration: {
+          allowGuestContributions: false,
+          allowMembersToCreateCallouts: true,
+          allowMembersToCreateSubspaces: true,
+          allowMembersToVideoCall: false,
+          allowEventsFromSubspaces: true,
+          inheritMembershipRights: true,
+        },
+      };
+      const tcs = {
+        id: 'tcs-1',
+        about: { id: 'about-1' },
+        settings: existingSettings,
+      } as unknown as TemplateContentSpace;
+
+      const mergedSettings = {
+        ...existingSettings,
+        collaboration: {
+          ...existingSettings.collaboration,
+          allowGuestContributions: true,
+        },
+      };
+
+      repository.findOne.mockResolvedValue(tcs);
+      spaceSettingsService.updateSettings.mockReturnValue(
+        mergedSettings as any
+      );
+      repository.save.mockImplementation(async (entity: any) => entity);
+
+      const settingsInput = {
+        collaboration: { allowGuestContributions: true },
+      };
+
+      const result = await service.update({
+        ID: 'tcs-1',
+        settings: settingsInput,
+      } as any);
+
+      expect(spaceSettingsService.updateSettings).toHaveBeenCalledWith(
+        existingSettings,
+        settingsInput
+      );
+      expect(result.settings).toBe(mergedSettings);
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ settings: mergedSettings })
+      );
+    });
+
+    it('should not invoke SpaceSettingsService when settings are omitted', async () => {
+      const tcs = {
+        id: 'tcs-1',
+        about: { id: 'about-1' },
+        settings: { privacy: { mode: 'PUBLIC' } },
+      } as unknown as TemplateContentSpace;
+
+      repository.findOne.mockResolvedValue(tcs);
+      repository.save.mockResolvedValue(tcs);
+
+      await service.update({ ID: 'tcs-1' } as any);
+
+      expect(spaceSettingsService.updateSettings).not.toHaveBeenCalled();
+    });
+
+    it('should apply both about and settings updates in the same call', async () => {
+      const existingAbout = { id: 'about-1', profile: {} };
+      const existingSettings = {
+        privacy: { mode: 'PUBLIC' },
+      };
+      const tcs = {
+        id: 'tcs-1',
+        about: existingAbout,
+        settings: existingSettings,
+      } as unknown as TemplateContentSpace;
+
+      const updatedAbout = { id: 'about-1', profile: { displayName: 'new' } };
+      const updatedSettings = { privacy: { mode: 'PRIVATE' } };
+
+      repository.findOne.mockResolvedValue(tcs);
+      spaceAboutService.updateSpaceAbout.mockResolvedValue(updatedAbout as any);
+      spaceSettingsService.updateSettings.mockReturnValue(
+        updatedSettings as any
+      );
+      repository.save.mockImplementation(async (entity: any) => entity);
+
+      const result = await service.update({
+        ID: 'tcs-1',
+        about: { displayName: 'new' },
+        settings: { privacy: { mode: 'PRIVATE' } },
+      } as any);
+
+      expect(spaceAboutService.updateSpaceAbout).toHaveBeenCalled();
+      expect(spaceSettingsService.updateSettings).toHaveBeenCalled();
+      expect(result.about).toBe(updatedAbout);
+      expect(result.settings).toBe(updatedSettings);
     });
   });
 

--- a/src/domain/template/template-content-space/template.content.space.service.ts
+++ b/src/domain/template/template-content-space/template.content.space.service.ts
@@ -17,6 +17,7 @@ import { LicenseService } from '@domain/common/license/license.service';
 import { CreateSpaceAboutInput } from '@domain/space/space.about';
 import { ISpaceAbout } from '@domain/space/space.about/space.about.interface';
 import { SpaceAboutService } from '@domain/space/space.about/space.about.service';
+import { SpaceSettingsService } from '@domain/space/space.settings/space.settings.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -32,6 +33,7 @@ export class TemplateContentSpaceService {
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
     private spaceAboutService: SpaceAboutService,
+    private spaceSettingsService: SpaceSettingsService,
     private collaborationService: CollaborationService,
     private licenseService: LicenseService,
     @InjectRepository(TemplateContentSpace)
@@ -234,6 +236,13 @@ export class TemplateContentSpaceService {
           templateContentSpace.about,
           templateContentSpaceData.about
         );
+    }
+
+    if (templateContentSpaceData.settings) {
+      templateContentSpace.settings = this.spaceSettingsService.updateSettings(
+        templateContentSpace.settings,
+        templateContentSpaceData.settings
+      );
     }
 
     return await this.save(templateContentSpace);


### PR DESCRIPTION
## Summary
- `updateTemplateContentSpace` mutation silently ignored the `settings` field — only `about` was being saved. Wire `TemplateContentSpaceService.update` through `SpaceSettingsService.updateSettings` so settings actually persist.
- Made all fields on `UpdateSpaceSettingsCollaborationInput` optional and changed the merge in `SpaceSettingsService.updateSettings` to apply only the fields the caller explicitly set. Sending a subset (e.g. just `allowGuestContributions: true`) no longer wipes out the other flags.
- Added unit tests covering the partial-merge contract (subset, explicit `false`, explicit `undefined`) and the template-content-space settings application path.

## Test plan
- [x] `pnpm exec tsc --noEmit` → exit 0
- [x] `pnpm exec biome check src/domain/space/space.settings src/domain/template/template-content-space` → exit 0
- [x] `pnpm exec vitest run src/domain/space/space.settings/space.settings.service.spec.ts src/domain/template/template-content-space/template.content.space.service.spec.ts` → 38/38 pass
- [x] Pre-commit full suite → 6382 pass
- [x] Red-green check on new tests: reverting either fix turns the new tests red; restoring brings them back green

## Schema
Non-breaking input change: 6 fields on `UpdateSpaceSettingsCollaborationInput` flip from `Boolean!` → `Boolean`. Existing clients sending all fields keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collaboration settings now accept partial updates: individual options are optional so you can update specific choices without sending all values.
  * Omitting a setting preserves its current value; explicitly setting a value (including false) overwrites prior configuration.
  * Space settings can be updated together with other space properties in a single operation.

* **Tests**
  * Expanded tests to verify partial-update/merge behaviors and combined settings updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->