### PR TITLE
Remove pending invitations and applications on space/subspace conversion

### DIFF
--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -2075,4 +2075,123 @@ describe('RoleSetService', () => {
       ).toHaveBeenCalledWith([{ type: 'space-member', resourceID: 'res-V' }]);
     });
   });
+
+  describe('removePendingInvitationsAndApplications', () => {
+    const stubRoleSet = (overrides: Record<string, unknown> = {}) => {
+      const roleSet = {
+        id: 'roleset-1',
+        applications: [],
+        invitations: [],
+        platformInvitations: [],
+        ...overrides,
+      };
+      vi.spyOn(service, 'getRoleSetOrFail').mockResolvedValue(roleSet as never);
+      return roleSet;
+    };
+
+    it('deletes pending applications and skips finalized ones', async () => {
+      stubRoleSet({
+        applications: [
+          { id: 'app-pending' },
+          { id: 'app-accepted' },
+          { id: 'app-rejected' },
+        ],
+      });
+      vi.mocked(applicationService.isApplicationFinalized).mockImplementation(
+        (a: { id: string }) => a.id !== 'app-pending'
+      );
+
+      await service.removePendingInvitationsAndApplications('roleset-1');
+
+      expect(applicationService.deleteApplication).toHaveBeenCalledTimes(1);
+      expect(applicationService.deleteApplication).toHaveBeenCalledWith({
+        ID: 'app-pending',
+      });
+    });
+
+    it('deletes pending invitations and skips finalized ones', async () => {
+      stubRoleSet({
+        invitations: [{ id: 'inv-pending' }, { id: 'inv-accepted' }],
+      });
+      vi.mocked(invitationService.isInvitationFinalized).mockImplementation(
+        (i: { id: string }) => i.id !== 'inv-pending'
+      );
+
+      await service.removePendingInvitationsAndApplications('roleset-1');
+
+      expect(invitationService.deleteInvitation).toHaveBeenCalledTimes(1);
+      expect(invitationService.deleteInvitation).toHaveBeenCalledWith({
+        ID: 'inv-pending',
+      });
+    });
+
+    it('deletes every platform invitation unconditionally', async () => {
+      stubRoleSet({
+        platformInvitations: [{ id: 'plat-1' }, { id: 'plat-2' }],
+      });
+
+      await service.removePendingInvitationsAndApplications('roleset-1');
+
+      expect(
+        platformInvitationService.deletePlatformInvitation
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        platformInvitationService.deletePlatformInvitation
+      ).toHaveBeenCalledWith({ ID: 'plat-1' });
+      expect(
+        platformInvitationService.deletePlatformInvitation
+      ).toHaveBeenCalledWith({ ID: 'plat-2' });
+    });
+
+    it('is a no-op when role set has no pending records', async () => {
+      stubRoleSet();
+
+      await service.removePendingInvitationsAndApplications('roleset-1');
+
+      expect(applicationService.deleteApplication).not.toHaveBeenCalled();
+      expect(invitationService.deleteInvitation).not.toHaveBeenCalled();
+      expect(
+        platformInvitationService.deletePlatformInvitation
+      ).not.toHaveBeenCalled();
+    });
+
+    it('loads applications, invitations and platformInvitations', async () => {
+      stubRoleSet();
+      const spy = vi.spyOn(service, 'getRoleSetOrFail');
+
+      await service.removePendingInvitationsAndApplications('roleset-1');
+
+      expect(spy).toHaveBeenCalledWith('roleset-1', {
+        relations: {
+          applications: true,
+          invitations: true,
+          platformInvitations: true,
+        },
+      });
+    });
+
+    it('clears every category in a single call', async () => {
+      stubRoleSet({
+        applications: [{ id: 'app-1' }],
+        invitations: [{ id: 'inv-1' }],
+        platformInvitations: [{ id: 'plat-1' }],
+      });
+      vi.mocked(applicationService.isApplicationFinalized).mockReturnValue(
+        false
+      );
+      vi.mocked(invitationService.isInvitationFinalized).mockReturnValue(false);
+
+      await service.removePendingInvitationsAndApplications('roleset-1');
+
+      expect(applicationService.deleteApplication).toHaveBeenCalledWith({
+        ID: 'app-1',
+      });
+      expect(invitationService.deleteInvitation).toHaveBeenCalledWith({
+        ID: 'inv-1',
+      });
+      expect(
+        platformInvitationService.deletePlatformInvitation
+      ).toHaveBeenCalledWith({ ID: 'plat-1' });
+    });
+  });
 });

--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -2085,7 +2085,7 @@ describe('RoleSetService', () => {
         platformInvitations: [],
         ...overrides,
       };
-      vi.spyOn(service, 'getRoleSetOrFail').mockResolvedValue(roleSet as never);
+      vi.spyOn(roleSetRepository, 'find').mockResolvedValue([roleSet as never]);
       return roleSet;
     };
 
@@ -2157,17 +2157,114 @@ describe('RoleSetService', () => {
 
     it('loads applications, invitations and platformInvitations', async () => {
       stubRoleSet();
-      const spy = vi.spyOn(service, 'getRoleSetOrFail');
+      const spy = vi.spyOn(roleSetRepository, 'find');
 
       await service.removePendingInvitationsAndApplications('roleset-1');
 
-      expect(spy).toHaveBeenCalledWith('roleset-1', {
-        relations: {
-          applications: true,
-          invitations: true,
-          platformInvitations: true,
-        },
+      expect(spy).toHaveBeenCalledTimes(1);
+      const call = spy.mock.calls[0][0] as unknown as {
+        where: { id: { _value: string[] } };
+        relations: Record<string, boolean>;
+      };
+      expect(call.where.id._value).toEqual(['roleset-1']);
+      expect(call.relations).toEqual({
+        applications: true,
+        invitations: true,
+        platformInvitations: true,
       });
+    });
+
+    it('accepts an array of roleSet IDs and processes them in one query', async () => {
+      const roleSets = [
+        {
+          id: 'roleset-1',
+          applications: [{ id: 'app-1' }],
+          invitations: [],
+          platformInvitations: [{ id: 'plat-1' }],
+        },
+        {
+          id: 'roleset-2',
+          applications: [],
+          invitations: [{ id: 'inv-2' }],
+          platformInvitations: [],
+        },
+      ];
+      vi.spyOn(roleSetRepository, 'find').mockResolvedValue(
+        roleSets as never[]
+      );
+      vi.mocked(applicationService.isApplicationFinalized).mockReturnValue(
+        false
+      );
+      vi.mocked(invitationService.isInvitationFinalized).mockReturnValue(false);
+
+      await service.removePendingInvitationsAndApplications([
+        'roleset-1',
+        'roleset-2',
+      ]);
+
+      expect(roleSetRepository.find).toHaveBeenCalledTimes(1);
+      expect(applicationService.deleteApplication).toHaveBeenCalledWith({
+        ID: 'app-1',
+      });
+      expect(invitationService.deleteInvitation).toHaveBeenCalledWith({
+        ID: 'inv-2',
+      });
+      expect(
+        platformInvitationService.deletePlatformInvitation
+      ).toHaveBeenCalledWith({ ID: 'plat-1' });
+    });
+
+    it('filters finalized entities across multiple roleSets after flattening', async () => {
+      const roleSets = [
+        {
+          id: 'roleset-1',
+          applications: [{ id: 'app-1-pending' }, { id: 'app-1-final' }],
+          invitations: [],
+          platformInvitations: [],
+        },
+        {
+          id: 'roleset-2',
+          applications: [],
+          invitations: [{ id: 'inv-2-pending' }, { id: 'inv-2-final' }],
+          platformInvitations: [],
+        },
+      ];
+      vi.spyOn(roleSetRepository, 'find').mockResolvedValue(
+        roleSets as never[]
+      );
+      vi.mocked(applicationService.isApplicationFinalized).mockImplementation(
+        (a: { id: string }) => a.id.endsWith('final')
+      );
+      vi.mocked(invitationService.isInvitationFinalized).mockImplementation(
+        (i: { id: string }) => i.id.endsWith('final')
+      );
+
+      await service.removePendingInvitationsAndApplications([
+        'roleset-1',
+        'roleset-2',
+      ]);
+
+      expect(applicationService.deleteApplication).toHaveBeenCalledTimes(1);
+      expect(applicationService.deleteApplication).toHaveBeenCalledWith({
+        ID: 'app-1-pending',
+      });
+      expect(invitationService.deleteInvitation).toHaveBeenCalledTimes(1);
+      expect(invitationService.deleteInvitation).toHaveBeenCalledWith({
+        ID: 'inv-2-pending',
+      });
+    });
+
+    it('is a no-op when given an empty roleSet ID array', async () => {
+      const findSpy = vi.spyOn(roleSetRepository, 'find');
+
+      await service.removePendingInvitationsAndApplications([]);
+
+      expect(findSpy).not.toHaveBeenCalled();
+      expect(applicationService.deleteApplication).not.toHaveBeenCalled();
+      expect(invitationService.deleteInvitation).not.toHaveBeenCalled();
+      expect(
+        platformInvitationService.deletePlatformInvitation
+      ).not.toHaveBeenCalled();
     });
 
     it('clears every category in a single call', async () => {

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -53,7 +53,7 @@ import { InAppNotificationService } from '@platform/in-app-notification/in.app.n
 import { AiServerAdapter } from '@services/adapters/ai-server-adapter/ai.server.adapter';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, Not, Repository } from 'typeorm';
+import { FindOneOptions, In, Not, Repository } from 'typeorm';
 import { IActorRolePolicy } from '../role/actor.role.policy.interface';
 import { IRole } from '../role/role.interface';
 import { RoleService } from '../role/role.service';
@@ -212,15 +212,19 @@ export class RoleSetService {
   }
 
   /**
-   * Removes pending (non-finalized) invitations and applications on the given
-   * roleSet, plus all platform invitations. Used by space conversion / move
-   * flows so that recipients do not try to accept invites that point to a
-   * target whose hierarchy has changed (see alkem-io/server#5069).
+   * Removes pending (non-finalized) invitations and applications across the
+   * given roleSet(s), plus all platform invitations. Used by space conversion
+   * / move flows so that recipients do not try to accept invites that point
+   * to a target whose hierarchy has changed (see alkem-io/server#5069).
    */
   async removePendingInvitationsAndApplications(
-    roleSetID: string
+    roleSetID: string | string[]
   ): Promise<void> {
-    const roleSet = await this.getRoleSetOrFail(roleSetID, {
+    const ids = Array.isArray(roleSetID) ? roleSetID : [roleSetID];
+    if (ids.length === 0) return;
+
+    const roleSets = await this.roleSetRepository.find({
+      where: { id: In(ids) },
       relations: {
         applications: true,
         invitations: true,
@@ -228,33 +232,33 @@ export class RoleSetService {
       },
     });
 
-    if (roleSet.applications) {
-      for (const application of roleSet.applications) {
-        if (this.applicationService.isApplicationFinalized(application)) {
-          continue;
-        }
-        await this.applicationService.deleteApplication({
-          ID: application.id,
-        });
-      }
-    }
+    const pendingApplications = roleSets
+      .flatMap(rs => rs.applications ?? [])
+      .filter(app => !this.applicationService.isApplicationFinalized(app));
+    const pendingInvitations = roleSets
+      .flatMap(rs => rs.invitations ?? [])
+      .filter(inv => !this.invitationService.isInvitationFinalized(inv));
+    const platformInvitations = roleSets.flatMap(
+      rs => rs.platformInvitations ?? []
+    );
 
-    if (roleSet.invitations) {
-      for (const invitation of roleSet.invitations) {
-        if (this.invitationService.isInvitationFinalized(invitation)) {
-          continue;
-        }
-        await this.invitationService.deleteInvitation({ ID: invitation.id });
-      }
-    }
-
-    if (roleSet.platformInvitations) {
-      for (const platformInvitation of roleSet.platformInvitations) {
-        await this.platformInvitationService.deletePlatformInvitation({
-          ID: platformInvitation.id,
-        });
-      }
-    }
+    await Promise.all([
+      Promise.all(
+        pendingApplications.map(a =>
+          this.applicationService.deleteApplication({ ID: a.id })
+        )
+      ),
+      Promise.all(
+        pendingInvitations.map(i =>
+          this.invitationService.deleteInvitation({ ID: i.id })
+        )
+      ),
+      Promise.all(
+        platformInvitations.map(p =>
+          this.platformInvitationService.deletePlatformInvitation({ ID: p.id })
+        )
+      ),
+    ]);
   }
 
   async getParentRoleSet(roleSet: IRoleSet): Promise<IRoleSet | undefined> {

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -211,6 +211,52 @@ export class RoleSetService {
     return await this.roleSetRepository.save(roleSet);
   }
 
+  /**
+   * Removes pending (non-finalized) invitations and applications on the given
+   * roleSet, plus all platform invitations. Used by space conversion / move
+   * flows so that recipients do not try to accept invites that point to a
+   * target whose hierarchy has changed (see alkem-io/server#5069).
+   */
+  async removePendingInvitationsAndApplications(
+    roleSetID: string
+  ): Promise<void> {
+    const roleSet = await this.getRoleSetOrFail(roleSetID, {
+      relations: {
+        applications: true,
+        invitations: true,
+        platformInvitations: true,
+      },
+    });
+
+    if (roleSet.applications) {
+      for (const application of roleSet.applications) {
+        if (this.applicationService.isApplicationFinalized(application)) {
+          continue;
+        }
+        await this.applicationService.deleteApplication({
+          ID: application.id,
+        });
+      }
+    }
+
+    if (roleSet.invitations) {
+      for (const invitation of roleSet.invitations) {
+        if (this.invitationService.isInvitationFinalized(invitation)) {
+          continue;
+        }
+        await this.invitationService.deleteInvitation({ ID: invitation.id });
+      }
+    }
+
+    if (roleSet.platformInvitations) {
+      for (const platformInvitation of roleSet.platformInvitations) {
+        await this.platformInvitationService.deletePlatformInvitation({
+          ID: platformInvitation.id,
+        });
+      }
+    }
+  }
+
   async getParentRoleSet(roleSet: IRoleSet): Promise<IRoleSet | undefined> {
     const roleSetWithParent = await this.getRoleSetOrFail(roleSet.id, {
       relations: { parentRoleSet: true },

--- a/src/services/api/conversion/conversion.service.move.spec.ts
+++ b/src/services/api/conversion/conversion.service.move.spec.ts
@@ -299,6 +299,63 @@ describe('ConversionService — Cross-L0 Moves', () => {
         targetL0.community.roleSet
       );
     });
+
+    // Issue alkem-io/server#6019 — pending invites/apps must be cleared
+    // because old targets break (alkem-io/server#5069).
+    it('should clear pending invitations and applications on the source L1 roleSet', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL1())
+        .mockResolvedValueOnce(makeTargetL0());
+      setupHappyPathMocks();
+
+      await service.moveSpaceL1ToSpaceL0OrFail({
+        spaceL1ID: 'source-l1',
+        targetSpaceL0ID: 'target-l0',
+      });
+
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l1');
+    });
+
+    it('should clear pending invitations and applications on every descendant roleSet', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL1())
+        .mockResolvedValueOnce(makeTargetL0());
+      setupHappyPathMocks();
+      // Three lookups happen for descendants:
+      //  - clearing community roles (existing)
+      //  - clearing pending invites (new)
+      //  - bulk levelZeroSpaceID update (existing, no fetch)
+      // Plus syncInnovationFlowTagsetsForSubtree iterates as well.
+      vi.mocked(spaceLookupService.getAllDescendantSpaceIDs).mockResolvedValue([
+        'child-l2-a',
+      ]);
+      vi.mocked(spaceService.getSpaceOrFail).mockImplementation(
+        async (id: string) => {
+          if (id === 'child-l2-a') {
+            return {
+              id: 'child-l2-a',
+              community: { roleSet: { id: 'roleset-child-l2-a' } },
+              collaboration: { calloutsSet: { callouts: [] } },
+            } as never;
+          }
+          return makeSourceL1();
+        }
+      );
+
+      await service.moveSpaceL1ToSpaceL0OrFail({
+        spaceL1ID: 'source-l1',
+        targetSpaceL0ID: 'target-l0',
+      });
+
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l1');
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-child-l2-a');
+    });
   });
 
   // ── moveSpaceL1ToSpaceL2OrFail ──────────────────────────────────
@@ -450,6 +507,25 @@ describe('ConversionService — Cross-L0 Moves', () => {
         sourceL1.community.roleSet,
         targetL1.community.roleSet
       );
+    });
+
+    // Issue alkem-io/server#6019 — pending invites/apps must be cleared
+    // (alkem-io/server#5069).
+    it('should clear pending invitations and applications on the source L1 roleSet', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL1())
+        .mockResolvedValueOnce(makeTargetL1())
+        .mockResolvedValueOnce(makeTargetL0());
+      setupHappyPathMocks();
+
+      await service.moveSpaceL1ToSpaceL2OrFail({
+        spaceL1ID: 'source-l1',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l1');
     });
   });
 

--- a/src/services/api/conversion/conversion.service.move.spec.ts
+++ b/src/services/api/conversion/conversion.service.move.spec.ts
@@ -315,7 +315,7 @@ describe('ConversionService — Cross-L0 Moves', () => {
 
       expect(
         roleSetService.removePendingInvitationsAndApplications
-      ).toHaveBeenCalledWith('roleset-l1');
+      ).toHaveBeenCalledWith(['roleset-l1']);
     });
 
     it('should clear pending invitations and applications on every descendant roleSet', async () => {
@@ -323,26 +323,15 @@ describe('ConversionService — Cross-L0 Moves', () => {
         .mockResolvedValueOnce(makeSourceL1())
         .mockResolvedValueOnce(makeTargetL0());
       setupHappyPathMocks();
-      // Three lookups happen for descendants:
-      //  - clearing community roles (existing)
-      //  - clearing pending invites (new)
-      //  - bulk levelZeroSpaceID update (existing, no fetch)
-      // Plus syncInnovationFlowTagsetsForSubtree iterates as well.
       vi.mocked(spaceLookupService.getAllDescendantSpaceIDs).mockResolvedValue([
         'child-l2-a',
       ]);
-      vi.mocked(spaceService.getSpaceOrFail).mockImplementation(
-        async (id: string) => {
-          if (id === 'child-l2-a') {
-            return {
-              id: 'child-l2-a',
-              community: { roleSet: { id: 'roleset-child-l2-a' } },
-              collaboration: { calloutsSet: { callouts: [] } },
-            } as never;
-          }
-          return makeSourceL1();
-        }
-      );
+      vi.mocked(spaceService.getAllSpaces).mockResolvedValue([
+        {
+          id: 'child-l2-a',
+          community: { roleSet: { id: 'roleset-child-l2-a' } },
+        },
+      ] as never);
 
       await service.moveSpaceL1ToSpaceL0OrFail({
         spaceL1ID: 'source-l1',
@@ -351,10 +340,7 @@ describe('ConversionService — Cross-L0 Moves', () => {
 
       expect(
         roleSetService.removePendingInvitationsAndApplications
-      ).toHaveBeenCalledWith('roleset-l1');
-      expect(
-        roleSetService.removePendingInvitationsAndApplications
-      ).toHaveBeenCalledWith('roleset-child-l2-a');
+      ).toHaveBeenCalledWith(['roleset-l1', 'roleset-child-l2-a']);
     });
   });
 

--- a/src/services/api/conversion/conversion.service.spec.ts
+++ b/src/services/api/conversion/conversion.service.spec.ts
@@ -362,9 +362,17 @@ describe('ConversionService', () => {
       vi.mocked(spaceService.getSpaceOrFail)
         .mockResolvedValueOnce(spaceL1)
         .mockResolvedValueOnce(spaceL0);
-      vi.mocked(spaceService.getAllSpaces).mockResolvedValue([
-        descendantL2,
-      ] as never);
+      vi.mocked(spaceService.getAllSpaces).mockImplementation(((
+        options: any
+      ) => {
+        expect(options).toMatchObject({
+          relations: { community: { roleSet: true } },
+        });
+        expect(options?.where?.id?._value ?? options?.where?.id?.value).toEqual(
+          ['space-l2-a']
+        );
+        return Promise.resolve([descendantL2]);
+      }) as never);
       vi.mocked(spaceLookupService.getAllDescendantSpaceIDs).mockResolvedValue([
         'space-l2-a',
       ]);

--- a/src/services/api/conversion/conversion.service.spec.ts
+++ b/src/services/api/conversion/conversion.service.spec.ts
@@ -361,8 +361,10 @@ describe('ConversionService', () => {
       };
       vi.mocked(spaceService.getSpaceOrFail)
         .mockResolvedValueOnce(spaceL1)
-        .mockResolvedValueOnce(spaceL0)
-        .mockResolvedValueOnce(descendantL2);
+        .mockResolvedValueOnce(spaceL0);
+      vi.mocked(spaceService.getAllSpaces).mockResolvedValue([
+        descendantL2,
+      ] as never);
       vi.mocked(spaceLookupService.getAllDescendantSpaceIDs).mockResolvedValue([
         'space-l2-a',
       ]);
@@ -403,10 +405,7 @@ describe('ConversionService', () => {
 
       expect(
         roleSetService.removePendingInvitationsAndApplications
-      ).toHaveBeenCalledWith('roleset-l1');
-      expect(
-        roleSetService.removePendingInvitationsAndApplications
-      ).toHaveBeenCalledWith('roleset-l2-a');
+      ).toHaveBeenCalledWith(['roleset-l1', 'roleset-l2-a']);
     });
   });
 });

--- a/src/services/api/conversion/conversion.service.spec.ts
+++ b/src/services/api/conversion/conversion.service.spec.ts
@@ -3,19 +3,33 @@ import {
   ValidationException,
 } from '@common/exceptions';
 import { RoleSetService } from '@domain/access/role-set/role.set.service';
+import { InnovationFlowService } from '@domain/collaboration/innovation-flow/innovation.flow.service';
+import { AccountHostService } from '@domain/space/account.host/account.host.service';
 import { SpaceService } from '@domain/space/space/space.service';
+import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
+import { TemplateService } from '@domain/template/template/template.service';
+import { TemplatesManagerService } from '@domain/template/templates-manager/templates.manager.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import { PlatformService } from '@platform/platform/platform.service';
 import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { type Mock, vi } from 'vitest';
+import { InputCreatorService } from '../input-creator/input.creator.service';
 import { ConversionService } from './conversion.service';
 
 describe('ConversionService', () => {
   let service: ConversionService;
   let spaceService: Record<string, Mock>;
-  let _roleSetService: Record<string, Mock>;
+  let roleSetService: Record<string, Mock>;
   let _namingService: Record<string, Mock>;
+  let spaceLookupService: Record<string, Mock>;
+  let accountHostService: Record<string, Mock>;
+  let platformService: Record<string, Mock>;
+  let templatesManagerService: Record<string, Mock>;
+  let templateService: Record<string, Mock>;
+  let inputCreatorService: Record<string, Mock>;
+  let innovationFlowService: Record<string, Mock>;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -28,7 +42,7 @@ describe('ConversionService', () => {
 
     service = module.get(ConversionService);
     spaceService = module.get(SpaceService) as unknown as Record<string, Mock>;
-    _roleSetService = module.get(RoleSetService) as unknown as Record<
+    roleSetService = module.get(RoleSetService) as unknown as Record<
       string,
       Mock
     >;
@@ -36,7 +50,43 @@ describe('ConversionService', () => {
       string,
       Mock
     >;
+    spaceLookupService = module.get(SpaceLookupService) as unknown as Record<
+      string,
+      Mock
+    >;
+    accountHostService = module.get(AccountHostService) as unknown as Record<
+      string,
+      Mock
+    >;
+    platformService = module.get(PlatformService) as unknown as Record<
+      string,
+      Mock
+    >;
+    templatesManagerService = module.get(
+      TemplatesManagerService
+    ) as unknown as Record<string, Mock>;
+    templateService = module.get(TemplateService) as unknown as Record<
+      string,
+      Mock
+    >;
+    inputCreatorService = module.get(InputCreatorService) as unknown as Record<
+      string,
+      Mock
+    >;
+    innovationFlowService = module.get(
+      InnovationFlowService
+    ) as unknown as Record<string, Mock>;
   });
+
+  // Stubs every roleSetService accessor used by getSpaceCommunityRoles so
+  // happy-path conversion code reaches the structural updates.
+  const stubEmptyCommunityRoles = () => {
+    vi.mocked(roleSetService.getUsersWithRole).mockResolvedValue([]);
+    vi.mocked(roleSetService.getOrganizationsWithRole).mockResolvedValue([]);
+    vi.mocked(roleSetService.getVirtualContributorsWithRole).mockResolvedValue(
+      []
+    );
+  };
 
   describe('convertSpaceL1ToSpaceL0OrFail', () => {
     it('should throw EntityNotInitializedException when L1 space is missing community', async () => {
@@ -174,6 +224,41 @@ describe('ConversionService', () => {
         })
       ).rejects.toThrow(EntityNotInitializedException);
     });
+
+    // Issue alkem-io/server#6019 — pending invites/apps must be cleared on
+    // any conversion, otherwise accept-flow breaks (alkem-io/server#5069).
+    it('should clear pending invitations and applications on the converted L1 roleSet', async () => {
+      const roleSetL1 = { id: 'roleset-l1' };
+      const spaceL1 = {
+        id: 'space-l1',
+        levelZeroSpaceID: 'l0-a',
+        community: { roleSet: roleSetL1 },
+        storageAggregator: { id: 'sa-l1' },
+      };
+      const parentL1 = {
+        id: 'parent-l1',
+        levelZeroSpaceID: 'l0-a',
+        storageAggregator: { id: 'sa-parent-l1' },
+        community: { roleSet: { id: 'roleset-parent-l1' } },
+      };
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(spaceL1)
+        .mockResolvedValueOnce(parentL1);
+      stubEmptyCommunityRoles();
+      vi.mocked(
+        roleSetService.setParentRoleSetAndCredentials
+      ).mockResolvedValue(roleSetL1);
+      vi.mocked(spaceService.save).mockImplementation(async (s: unknown) => s);
+
+      await service.convertSpaceL1ToSpaceL2OrFail({
+        spaceL1ID: 'space-l1',
+        parentSpaceL1ID: 'parent-l1',
+      });
+
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l1');
+    });
   });
 
   describe('convertSpaceL2ToSpaceL1OrFail', () => {
@@ -206,6 +291,122 @@ describe('ConversionService', () => {
       await expect(
         service.convertSpaceL2ToSpaceL1OrFail({ spaceL2ID: 'space-l2' })
       ).rejects.toThrow(EntityNotInitializedException);
+    });
+
+    // Issue alkem-io/server#6019.
+    it('should clear pending invitations and applications on the promoted L2 roleSet', async () => {
+      const roleSetL2 = { id: 'roleset-l2' };
+      const spaceL2Initial = {
+        id: 'space-l2',
+        levelZeroSpaceID: 'space-l0',
+        community: { roleSet: roleSetL2 },
+      };
+      const spaceL0 = {
+        id: 'space-l0',
+        storageAggregator: { id: 'sa-l0' },
+        community: { roleSet: { id: 'roleset-l0' } },
+      };
+      // Inside updateChildSpaceL2ToL1 a fresh getSpaceOrFail loads richer data.
+      const spaceL2Loaded = {
+        id: 'space-l2',
+        storageAggregator: { id: 'sa-l2', parentStorageAggregator: null },
+        parentSpace: { id: 'former-parent' },
+        community: { roleSet: roleSetL2 },
+      };
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(spaceL2Initial)
+        .mockResolvedValueOnce(spaceL0)
+        .mockResolvedValueOnce(spaceL2Loaded)
+        .mockResolvedValueOnce(spaceL2Loaded); // final return
+      vi.mocked(roleSetService.getUsersWithRole).mockResolvedValue([]);
+      vi.mocked(
+        roleSetService.setParentRoleSetAndCredentials
+      ).mockResolvedValue(roleSetL2);
+      vi.mocked(spaceService.save).mockImplementation(async (s: unknown) => s);
+
+      await service.convertSpaceL2ToSpaceL1OrFail({ spaceL2ID: 'space-l2' });
+
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l2');
+    });
+  });
+
+  // ── L1 → L0 promotion: clears pending invites/apps for both the promoted
+  // space AND every L2 descendant (each becomes an L1 in the new tree).
+  describe('convertSpaceL1ToSpaceL0OrFail — pending invites cleanup', () => {
+    it('should clear pending invitations on the promoted L1 and every descendant', async () => {
+      const roleSetL1 = { id: 'roleset-l1' };
+      const spaceL1 = {
+        id: 'space-l1',
+        levelZeroSpaceID: 'space-l0',
+        community: { roleSet: roleSetL1 },
+        collaboration: { innovationFlow: { id: 'flow-l1', states: [] } },
+        storageAggregator: { id: 'sa-l1', parentStorageAggregator: null },
+        subspaces: [],
+        parentSpace: { id: 'old-l0' },
+      };
+      const spaceL0 = {
+        id: 'space-l0',
+        subspaces: [{ id: 'space-l1' }],
+        account: {
+          id: 'account',
+          accountType: 'BASIC',
+          storageAggregator: { id: 'sa-account' },
+        },
+      };
+      const descendantL2 = {
+        id: 'space-l2-a',
+        community: { roleSet: { id: 'roleset-l2-a' } },
+      };
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(spaceL1)
+        .mockResolvedValueOnce(spaceL0)
+        .mockResolvedValueOnce(descendantL2);
+      vi.mocked(spaceLookupService.getAllDescendantSpaceIDs).mockResolvedValue([
+        'space-l2-a',
+      ]);
+      vi.mocked(roleSetService.getUsersWithRole).mockResolvedValue([]);
+      vi.mocked(spaceService.save).mockImplementation(async (s: unknown) => s);
+      vi.mocked(spaceService.createLicenseForSpaceL0).mockReturnValue({});
+      vi.mocked(
+        spaceService.createTemplatesManagerForSpaceL0
+      ).mockResolvedValue({});
+      vi.mocked(platformService.getTemplatesManagerOrFail).mockResolvedValue({
+        id: 'platform-tm',
+      });
+      vi.mocked(
+        templatesManagerService.getTemplateFromTemplateDefault
+      ).mockResolvedValue({ id: 'template-id' });
+      vi.mocked(templateService.getTemplateOrFail).mockResolvedValue({
+        contentSpace: {
+          collaboration: { innovationFlow: { states: [] } },
+        },
+      });
+      vi.mocked(
+        inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState
+      ).mockReturnValue([]);
+      vi.mocked(
+        innovationFlowService.updateInnovationFlowStates
+      ).mockResolvedValue({ id: 'flow-l1', states: [] });
+      vi.mocked(
+        _namingService.getReservedNameIDsLevelZeroSpaces
+      ).mockResolvedValue([]);
+      vi.mocked(
+        _namingService.createNameIdAvoidingReservedNameIDs
+      ).mockReturnValue('promoted-name');
+      vi.mocked(accountHostService.assignLicensePlansToSpace).mockResolvedValue(
+        undefined
+      );
+
+      await service.convertSpaceL1ToSpaceL0OrFail({ spaceL1ID: 'space-l1' });
+
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l1');
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l2-a');
     });
   });
 });

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -36,7 +36,7 @@ import { CommunityResolverService } from '@services/infrastructure/entity-resolv
 import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { EntityManager } from 'typeorm';
+import { EntityManager, In } from 'typeorm';
 import { InputCreatorService } from '../input-creator/input.creator.service';
 import { ConvertSpaceL1ToSpaceL0Input } from './dto/convert.dto.space.l1.to.space.l0.input';
 import { ConvertSpaceL1ToSpaceL2Input } from './dto/convert.dto.space.l1.to.space.l2.input';
@@ -151,21 +151,24 @@ export class ConversionService {
     // Pending invitations / applications target the current space hierarchy;
     // after conversion they would resolve into a broken parent lookup
     // (alkem-io/server#5069), so drop them on this and every descendant.
-    await this.roleSetService.removePendingInvitationsAndApplications(
-      roleSetL1.id
-    );
     const descendantSpaceIDsForL0Promotion =
       await this.spaceLookupService.getAllDescendantSpaceIDs(spaceL1.id);
-    for (const descendantId of descendantSpaceIDsForL0Promotion) {
-      const descendant = await this.spaceService.getSpaceOrFail(descendantId, {
-        relations: { community: { roleSet: true } },
-      });
-      if (descendant.community?.roleSet) {
-        await this.roleSetService.removePendingInvitationsAndApplications(
-          descendant.community.roleSet.id
-        );
-      }
-    }
+    const descendantSpacesForL0Promotion =
+      descendantSpaceIDsForL0Promotion.length > 0
+        ? await this.spaceService.getAllSpaces({
+            where: { id: In(descendantSpaceIDsForL0Promotion) },
+            relations: { community: { roleSet: true } },
+          })
+        : [];
+    const roleSetIDsForL0Promotion = [
+      roleSetL1.id,
+      ...descendantSpacesForL0Promotion
+        .map(s => s.community?.roleSet?.id)
+        .filter((id): id is string => !!id),
+    ];
+    await this.roleSetService.removePendingInvitationsAndApplications(
+      roleSetIDsForL0Promotion
+    );
 
     const reservedNameIDs =
       await this.namingService.getReservedNameIDsLevelZeroSpaces();
@@ -641,19 +644,22 @@ export class ConversionService {
     // 7b. Drop pending invitations/applications across the moved subtree —
     // current invites resolve against the source L0's hierarchy
     // (alkem-io/server#5069).
+    const descendantSpacesForMove =
+      descendantSpaceIds.length > 0
+        ? await this.spaceService.getAllSpaces({
+            where: { id: In(descendantSpaceIds) },
+            relations: { community: { roleSet: true } },
+          })
+        : [];
+    const roleSetIDsForMove = [
+      roleSetL1.id,
+      ...descendantSpacesForMove
+        .map(s => s.community?.roleSet?.id)
+        .filter((id): id is string => !!id),
+    ];
     await this.roleSetService.removePendingInvitationsAndApplications(
-      roleSetL1.id
+      roleSetIDsForMove
     );
-    for (const descId of descendantSpaceIds) {
-      const descSpace = await this.spaceService.getSpaceOrFail(descId, {
-        relations: { community: { roleSet: true } },
-      });
-      if (descSpace.community?.roleSet) {
-        await this.roleSetService.removePendingInvitationsAndApplications(
-          descSpace.community.roleSet.id
-        );
-      }
-    }
 
     // 8. Update structural fields
     sourceL1.parentSpace = targetL0;

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -148,6 +148,25 @@ export class ConversionService {
       );
     }
 
+    // Pending invitations / applications target the current space hierarchy;
+    // after conversion they would resolve into a broken parent lookup
+    // (alkem-io/server#5069), so drop them on this and every descendant.
+    await this.roleSetService.removePendingInvitationsAndApplications(
+      roleSetL1.id
+    );
+    const descendantSpaceIDsForL0Promotion =
+      await this.spaceLookupService.getAllDescendantSpaceIDs(spaceL1.id);
+    for (const descendantId of descendantSpaceIDsForL0Promotion) {
+      const descendant = await this.spaceService.getSpaceOrFail(descendantId, {
+        relations: { community: { roleSet: true } },
+      });
+      if (descendant.community?.roleSet) {
+        await this.roleSetService.removePendingInvitationsAndApplications(
+          descendant.community.roleSet.id
+        );
+      }
+    }
+
     const reservedNameIDs =
       await this.namingService.getReservedNameIDsLevelZeroSpaces();
     const spaceL0NewNameID =
@@ -351,6 +370,12 @@ export class ConversionService {
       );
     }
 
+    // Drop pending invitations/applications: targets the L2's current parent
+    // chain, which is being rewritten (alkem-io/server#5069).
+    await this.roleSetService.removePendingInvitationsAndApplications(
+      roleSetL2.id
+    );
+
     spaceL2 = await this.updateChildSpaceL2ToL1(
       spaceL2.id,
       spaceL0,
@@ -427,6 +452,12 @@ export class ConversionService {
 
     const spaceCommunityRoles = await this.getSpaceCommunityRoles(roleSetL1);
     await this.removeContributors(roleSetL1, spaceCommunityRoles);
+
+    // Drop pending invitations/applications: targets the L1's existing
+    // hierarchy, invalid once it becomes an L2 (alkem-io/server#5069).
+    await this.roleSetService.removePendingInvitationsAndApplications(
+      roleSetL1.id
+    );
 
     spaceL1.level = SpaceLevel.L2;
     spaceL1.parentSpace = parentSpaceL1;
@@ -607,6 +638,23 @@ export class ConversionService {
       );
     }
 
+    // 7b. Drop pending invitations/applications across the moved subtree —
+    // current invites resolve against the source L0's hierarchy
+    // (alkem-io/server#5069).
+    await this.roleSetService.removePendingInvitationsAndApplications(
+      roleSetL1.id
+    );
+    for (const descId of descendantSpaceIds) {
+      const descSpace = await this.spaceService.getSpaceOrFail(descId, {
+        relations: { community: { roleSet: true } },
+      });
+      if (descSpace.community?.roleSet) {
+        await this.roleSetService.removePendingInvitationsAndApplications(
+          descSpace.community.roleSet.id
+        );
+      }
+    }
+
     // 8. Update structural fields
     sourceL1.parentSpace = targetL0;
     sourceL1.levelZeroSpaceID = targetL0.id;
@@ -766,6 +814,12 @@ export class ConversionService {
         false
       );
     }
+
+    // 8b. Drop pending invitations/applications — current invites point at
+    // the source L0's hierarchy (alkem-io/server#5069).
+    await this.roleSetService.removePendingInvitationsAndApplications(
+      roleSetL1.id
+    );
 
     // 9. Update structural fields — demote to L2
     sourceL1.level = SpaceLevel.L2;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pending invitations and applications are automatically removed during space promotions and cross-level moves (including subtree moves), preventing orphaned lifecycle artifacts and keeping role set state consistent.

* **Tests**
  * Expanded unit tests covering removal behavior across conversion and move flows, batch processing of multiple role sets, and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->