### PR TITLE
Invalidate URL cache on space transfer and L1→L0 conversion

### DIFF
--- a/src/domain/space/account/account.resolver.mutations.spec.ts
+++ b/src/domain/space/account/account.resolver.mutations.spec.ts
@@ -484,8 +484,13 @@ describe('AccountResolverMutations', () => {
         undefined as any
       );
 
+      const invalidateSpy = vi
+        .mocked(spaceService.invalidateUrlCacheForSpaceSubtree)
+        .mockResolvedValue(undefined as any);
+
       await resolver.transferSpaceToAccount(actorContext, transferData);
       expect(space.account).toBe(targetAccount);
+      expect(invalidateSpy).toHaveBeenCalledWith('space-1');
     });
   });
 

--- a/src/domain/space/account/account.resolver.mutations.ts
+++ b/src/domain/space/account/account.resolver.mutations.ts
@@ -442,6 +442,9 @@ export class AccountResolverMutations {
     const spaceAuthorizations =
       await this.spaceAuthorizationService.applyAuthorizationPolicy(space.id);
     await this.authorizationPolicyService.saveAll(spaceAuthorizations);
+
+    await this.spaceService.invalidateUrlCacheForSpaceSubtree(space.id);
+
     // TODO: check if still needed later
     return await this.spaceService.getSpaceOrFail(space.id);
   }

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -134,12 +134,21 @@ describe('SpaceService', () => {
         }
         return Promise.resolve(null);
       });
-      vi.spyOn(spaceRepository, 'find').mockResolvedValue([mockSubspace]);
+      vi.spyOn(spaceRepository, 'find').mockResolvedValue([
+        mockSpace,
+        mockSubspace,
+      ]);
       vi.spyOn(service, 'save').mockResolvedValue(mockSpace);
+
+      const lookup = (service as any).spaceLookupService as any;
+      lookup.getAllDescendantSpaceIDs = vi.fn().mockResolvedValue([subspaceId]);
 
       // Mock the URL cache service - use direct assignment for mock objects
       const revokeUrlCacheSpy = vi.fn().mockResolvedValue(undefined);
       urlGeneratorCacheService.revokeUrlCache = revokeUrlCacheSpy;
+      (urlGeneratorCacheService as any).revokeUrlCachesForCalloutsInSpaces = vi
+        .fn()
+        .mockResolvedValue(undefined);
 
       // Act
       await service.updateSpacePlatformSettings(mockSpace, updateData);
@@ -231,12 +240,23 @@ describe('SpaceService', () => {
         }
         return Promise.resolve(null);
       });
-      vi.spyOn(spaceRepository, 'find').mockResolvedValue([mockChildSubspace]);
+      vi.spyOn(spaceRepository, 'find').mockResolvedValue([
+        mockSubspace,
+        mockChildSubspace,
+      ]);
       vi.spyOn(service, 'save').mockResolvedValue(mockSubspace);
+
+      const lookup = (service as any).spaceLookupService as any;
+      lookup.getAllDescendantSpaceIDs = vi
+        .fn()
+        .mockResolvedValue([childSubspaceId]);
 
       // Mock the URL cache service - use direct assignment for mock objects
       const revokeUrlCacheSpy = vi.fn().mockResolvedValue(undefined);
       urlGeneratorCacheService.revokeUrlCache = revokeUrlCacheSpy;
+      (urlGeneratorCacheService as any).revokeUrlCachesForCalloutsInSpaces = vi
+        .fn()
+        .mockResolvedValue(undefined);
 
       // Act
       await service.updateSpacePlatformSettings(mockSubspace, updateData);

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -362,6 +362,9 @@ describe('SpaceService', () => {
       const revokeSpy = vi
         .spyOn(urlGeneratorCacheService, 'revokeUrlCache')
         .mockResolvedValue(undefined);
+      const revokeCalloutsSpy = vi.fn().mockResolvedValue(undefined);
+      (urlGeneratorCacheService as any).revokeUrlCachesForCalloutsInSpaces =
+        revokeCalloutsSpy;
 
       await service.invalidateUrlCacheForSpaceSubtree(rootId);
 
@@ -370,6 +373,11 @@ describe('SpaceService', () => {
       expect(revokeSpy).toHaveBeenCalledWith(`profile-${rootId}`);
       expect(revokeSpy).toHaveBeenCalledWith(`profile-${childId}`);
       expect(revokeSpy).toHaveBeenCalledWith(`profile-${grandchildId}`);
+      expect(revokeCalloutsSpy).toHaveBeenCalledWith([
+        rootId,
+        childId,
+        grandchildId,
+      ]);
     });
 
     it('skips spaces that have no profile id', async () => {
@@ -384,10 +392,14 @@ describe('SpaceService', () => {
       const revokeSpy = vi
         .spyOn(urlGeneratorCacheService, 'revokeUrlCache')
         .mockResolvedValue(undefined);
+      const revokeCalloutsSpy = vi.fn().mockResolvedValue(undefined);
+      (urlGeneratorCacheService as any).revokeUrlCachesForCalloutsInSpaces =
+        revokeCalloutsSpy;
 
       await service.invalidateUrlCacheForSpaceSubtree(rootId);
 
       expect(revokeSpy).not.toHaveBeenCalled();
+      expect(revokeCalloutsSpy).toHaveBeenCalledWith([rootId]);
     });
   });
 

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -340,6 +340,57 @@ describe('SpaceService', () => {
     });
   });
 
+  describe('invalidateUrlCacheForSpaceSubtree', () => {
+    it('revokes URL cache for the space and all descendants in a single fetch', async () => {
+      const rootId = 'space-root';
+      const childId = 'space-child';
+      const grandchildId = 'space-grandchild';
+
+      const lookup = (service as any).spaceLookupService as any;
+      lookup.getAllDescendantSpaceIDs = vi
+        .fn()
+        .mockResolvedValue([childId, grandchildId]);
+
+      const findSpy = vi
+        .spyOn(spaceRepository, 'find')
+        .mockResolvedValue([
+          { about: { profile: { id: `profile-${rootId}` } } },
+          { about: { profile: { id: `profile-${childId}` } } },
+          { about: { profile: { id: `profile-${grandchildId}` } } },
+        ] as any);
+
+      const revokeSpy = vi
+        .spyOn(urlGeneratorCacheService, 'revokeUrlCache')
+        .mockResolvedValue(undefined);
+
+      await service.invalidateUrlCacheForSpaceSubtree(rootId);
+
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      expect(revokeSpy).toHaveBeenCalledTimes(3);
+      expect(revokeSpy).toHaveBeenCalledWith(`profile-${rootId}`);
+      expect(revokeSpy).toHaveBeenCalledWith(`profile-${childId}`);
+      expect(revokeSpy).toHaveBeenCalledWith(`profile-${grandchildId}`);
+    });
+
+    it('skips spaces that have no profile id', async () => {
+      const rootId = 'space-root';
+      const lookup = (service as any).spaceLookupService as any;
+      lookup.getAllDescendantSpaceIDs = vi.fn().mockResolvedValue([]);
+
+      vi.spyOn(spaceRepository, 'find').mockResolvedValue([
+        { about: undefined } as any,
+      ]);
+
+      const revokeSpy = vi
+        .spyOn(urlGeneratorCacheService, 'revokeUrlCache')
+        .mockResolvedValue(undefined);
+
+      await service.invalidateUrlCacheForSpaceSubtree(rootId);
+
+      expect(revokeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('shouldUpdateAuthorizationPolicy', () => {
     it('returns false if there is no difference in settings', async () => {
       const spaceId = '1';

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1007,6 +1007,31 @@ export class SpaceService {
     );
   }
 
+  /**
+   * Invalidates URL cache entries for a space and all of its descendant spaces.
+   * Used after operations that change a space's URL path (transfer, L1↔L0/L2 conversion).
+   */
+  public async invalidateUrlCacheForSpaceSubtree(
+    spaceId: string
+  ): Promise<void> {
+    const descendantIds =
+      await this.spaceLookupService.getAllDescendantSpaceIDs(spaceId);
+    const allSpaceIds = [spaceId, ...descendantIds];
+
+    const spaces = await this.spaceRepository.find({
+      where: { id: In(allSpaceIds) },
+      relations: { about: { profile: true } },
+    });
+
+    for (const space of spaces) {
+      if (space.about?.profile?.id) {
+        await this.urlGeneratorCacheService.revokeUrlCache(
+          space.about.profile.id
+        );
+      }
+    }
+  }
+
   private async getParentSpacePlatformRolesAccess(
     space: ISpace
   ): Promise<IPlatformRolesAccess | undefined> {

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -933,67 +933,15 @@ export class SpaceService {
         );
       }
 
-      // Store the old nameID for logging purposes
       const oldNameID = space.nameID;
       space.nameID = updateData.nameID;
 
-      // Invalidate URL cache for this space's profile
-      await this.urlGeneratorCacheService.revokeUrlCache(
-        space.about.profile.id
+      await this.invalidateUrlCacheForSpaceSubtree(space.id);
+
+      this.logger.verbose?.(
+        `Invalidated URL cache subtree for space ${space.id} (nameID: ${oldNameID} -> ${updateData.nameID})`,
+        LogContext.SPACES
       );
-
-      // Invalidate URL cache for all subspaces since their URLs include parent nameIDs
-      if (space.level === SpaceLevel.L0) {
-        // For L0 spaces, invalidate all subspaces in the entire space hierarchy
-        const allSubspaces = await this.spaceRepository.find({
-          where: {
-            levelZeroSpaceID: space.id,
-          },
-          relations: {
-            about: {
-              profile: true,
-            },
-          },
-        });
-
-        for (const subspace of allSubspaces) {
-          if (subspace.about?.profile?.id) {
-            await this.urlGeneratorCacheService.revokeUrlCache(
-              subspace.about.profile.id
-            );
-          }
-        }
-
-        this.logger.verbose?.(
-          `Invalidated URL cache for space ${space.id} (nameID: ${oldNameID} -> ${updateData.nameID}) and ${allSubspaces.length} subspaces`,
-          LogContext.SPACES
-        );
-      } else {
-        // For subspaces, also invalidate any child subspaces
-        const childSubspaces = await this.spaceRepository.find({
-          where: {
-            parentSpace: { id: space.id },
-          },
-          relations: {
-            about: {
-              profile: true,
-            },
-          },
-        });
-
-        for (const childSubspace of childSubspaces) {
-          if (childSubspace.about?.profile?.id) {
-            await this.urlGeneratorCacheService.revokeUrlCache(
-              childSubspace.about.profile.id
-            );
-          }
-        }
-
-        this.logger.verbose?.(
-          `Invalidated URL cache for subspace ${space.id} (nameID: ${oldNameID} -> ${updateData.nameID}) and ${childSubspaces.length} child subspaces`,
-          LogContext.SPACES
-        );
-      }
     }
 
     await this.save(space);

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1010,6 +1010,9 @@ export class SpaceService {
   /**
    * Invalidates URL cache entries for a space and all of its descendant spaces.
    * Used after operations that change a space's URL path (transfer, L1↔L0/L2 conversion).
+   * Sweeps space-about profiles AND every callout/contribution profile reachable
+   * from those spaces — activity-log entries surface callout-derived URLs, so the
+   * inner sweep is what keeps them from pointing at the old path.
    */
   public async invalidateUrlCacheForSpaceSubtree(
     spaceId: string
@@ -1044,6 +1047,10 @@ export class SpaceService {
         );
       }
     }
+
+    await this.urlGeneratorCacheService.revokeUrlCachesForCalloutsInSpaces(
+      allSpaceIds
+    );
   }
 
   private async getParentSpacePlatformRolesAccess(

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -1024,9 +1024,23 @@ export class SpaceService {
     });
 
     for (const space of spaces) {
-      if (space.about?.profile?.id) {
-        await this.urlGeneratorCacheService.revokeUrlCache(
-          space.about.profile.id
+      const profileId = space.about?.profile?.id;
+      if (!profileId) {
+        continue;
+      }
+
+      try {
+        await this.urlGeneratorCacheService.revokeUrlCache(profileId);
+      } catch (error) {
+        const stack = error instanceof Error ? (error.stack ?? '') : '';
+        this.logger.error(
+          {
+            message: 'Failed to invalidate URL cache for space subtree',
+            spaceId,
+            profileId,
+          },
+          stack,
+          LogContext.SPACES
         );
       }
     }

--- a/src/services/api/conversion/conversion.resolver.mutations.spec.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.spec.ts
@@ -24,6 +24,7 @@ describe('ConversionResolverMutations', () => {
     save: Mock;
     getSpaceOrFail: Mock;
     getAccountForLevelZeroSpaceOrFail: Mock;
+    invalidateUrlCacheForSpaceSubtree: Mock;
   };
   let spaceAuthorizationService: { applyAuthorizationPolicy: Mock };
   let authorizationPolicyService: {
@@ -85,6 +86,9 @@ describe('ConversionResolverMutations', () => {
       expect(
         conversionService.convertSpaceL1ToSpaceL0OrFail
       ).toHaveBeenCalledWith({ spaceL1ID: 'space-l1' });
+      expect(
+        spaceService.invalidateUrlCacheForSpaceSubtree
+      ).toHaveBeenCalledWith('space-l0');
       expect(result).toBe(convertedSpace);
     });
   });
@@ -111,6 +115,9 @@ describe('ConversionResolverMutations', () => {
       expect(
         conversionService.convertSpaceL2ToSpaceL1OrFail
       ).toHaveBeenCalledWith({ spaceL2ID: 'space-l2' });
+      expect(
+        spaceService.invalidateUrlCacheForSpaceSubtree
+      ).toHaveBeenCalledWith('space-l1');
       expect(result).toBe(convertedSpace);
     });
   });
@@ -141,6 +148,9 @@ describe('ConversionResolverMutations', () => {
         spaceL1ID: 'space-l1',
         parentSpaceL1ID: 'parent-l1',
       });
+      expect(
+        spaceService.invalidateUrlCacheForSpaceSubtree
+      ).toHaveBeenCalledWith('space-l2');
       expect(result).toBe(convertedSpace);
     });
   });

--- a/src/services/api/conversion/conversion.resolver.mutations.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.ts
@@ -81,6 +81,8 @@ export class ConversionResolverMutations {
       await this.spaceAuthorizationService.applyAuthorizationPolicy(space.id);
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
 
+    await this.spaceService.invalidateUrlCacheForSpaceSubtree(space.id);
+
     return this.spaceService.getSpaceOrFail(space.id);
   }
 
@@ -113,6 +115,9 @@ export class ConversionResolverMutations {
         parentAuthorization
       );
     await this.authorizationPolicyService.saveAll(spaceL1Authorizations);
+
+    await this.spaceService.invalidateUrlCacheForSpaceSubtree(spaceL1.id);
+
     return await this.spaceService.getSpaceOrFail(spaceL1.id);
   }
 
@@ -149,6 +154,9 @@ export class ConversionResolverMutations {
         parentAuthorization
       );
     await this.authorizationPolicyService.saveAll(spaceL1Authorizations);
+
+    await this.spaceService.invalidateUrlCacheForSpaceSubtree(spaceL2.id);
+
     return await this.spaceService.getSpaceOrFail(spaceL2.id);
   }
 
@@ -184,7 +192,7 @@ export class ConversionResolverMutations {
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
 
     // Post-commit: fire-and-forget
-    void this.conversionService.invalidateUrlCachesForSubtree(savedSpace.id);
+    await this.conversionService.invalidateUrlCachesForSubtree(savedSpace.id);
     void this.conversionService.moveRoomsService.handleRoomsDuringMove(
       savedSpace.id,
       removedActorIds
@@ -234,7 +242,7 @@ export class ConversionResolverMutations {
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
 
     // Post-commit: fire-and-forget
-    void this.conversionService.invalidateUrlCachesForSubtree(savedSpace.id);
+    await this.conversionService.invalidateUrlCachesForSubtree(savedSpace.id);
     void this.conversionService.moveRoomsService.handleRoomsDuringMove(
       savedSpace.id,
       removedActorIds

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -34,7 +34,6 @@ import { NotificationInputCommunityInvitation } from '@services/adapters/notific
 import { NotificationUserAdapter } from '@services/adapters/notification-adapter/notification.user.adapter';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { NamingService } from '@services/infrastructure/naming/naming.service';
-import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { EntityManager } from 'typeorm';
 import { InputCreatorService } from '../input-creator/input.creator.service';
@@ -58,7 +57,6 @@ export class ConversionService {
     private spaceLookupService: SpaceLookupService,
     private classificationService: ClassificationService,
     private calloutsSetService: CalloutsSetService,
-    private urlGeneratorCacheService: UrlGeneratorCacheService,
     private spaceMoveRoomsService: SpaceMoveRoomsService,
     private notificationUserAdapter: NotificationUserAdapter,
     private communityResolverService: CommunityResolverService,
@@ -1017,23 +1015,12 @@ export class ConversionService {
   }
 
   /**
-   * Invalidates URL caches for all space profiles in the moved subtree.
+   * Invalidates URL caches for the moved subtree. Delegates to SpaceService so
+   * convert/move/transfer mutations share the same sweep (space-about plus every
+   * callout/contribution profile inside the subtree).
    */
   async invalidateUrlCachesForSubtree(movedSpaceId: string): Promise<void> {
-    const descendantIds =
-      await this.spaceLookupService.getAllDescendantSpaceIDs(movedSpaceId);
-    const allSpaceIds = [movedSpaceId, ...descendantIds];
-
-    for (const spaceId of allSpaceIds) {
-      const space = await this.spaceService.getSpaceOrFail(spaceId, {
-        relations: { about: { profile: true } },
-      });
-      if (space.about?.profile?.id) {
-        await this.urlGeneratorCacheService.revokeUrlCache(
-          space.about.profile.id
-        );
-      }
-    }
+    await this.spaceService.invalidateUrlCacheForSpaceSubtree(movedSpaceId);
   }
 
   get moveRoomsService(): SpaceMoveRoomsService {

--- a/src/services/infrastructure/url-generator/url.generator.service.cache.spec.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.cache.spec.ts
@@ -1,23 +1,35 @@
 import { LogContext } from '@common/enums/logging.context';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getEntityManagerToken } from '@nestjs/typeorm';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { type Mock } from 'vitest';
+import { type Mock, vi } from 'vitest';
 import { UrlGeneratorCacheService } from './url.generator.service.cache';
 
 describe('UrlGeneratorCacheService', () => {
   let service: UrlGeneratorCacheService;
   let cacheManager: { get: Mock; set: Mock; del: Mock };
-  let logger: { verbose: Mock };
+  let logger: { verbose: Mock; error: Mock };
+  let entityManager: { connection: { query: Mock } };
 
   beforeEach(async () => {
+    entityManager = {
+      connection: {
+        query: vi.fn(),
+      },
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UrlGeneratorCacheService,
         MockCacheManager,
         MockWinstonProvider,
+        {
+          provide: getEntityManagerToken('default'),
+          useValue: entityManager,
+        },
       ],
     }).compile();
 
@@ -96,6 +108,55 @@ describe('UrlGeneratorCacheService', () => {
       await service.getUrlFromCache('entity-123');
 
       expect(logger.verbose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revokeUrlCachesForCalloutsInSpaces', () => {
+    it('is a no-op when no spaces are provided', async () => {
+      await service.revokeUrlCachesForCalloutsInSpaces([]);
+
+      expect(entityManager.connection.query).not.toHaveBeenCalled();
+      expect(cacheManager.del).not.toHaveBeenCalled();
+    });
+
+    it('runs a single SQL pass and revokes every distinct profile id', async () => {
+      entityManager.connection.query.mockResolvedValue([
+        { profileId: 'p-framing-1' },
+        { profileId: 'p-framing-2' },
+        { profileId: 'p-framing-1' }, // duplicate — must be deduped
+        { profileId: 'p-post-1' },
+        { profileId: null }, // null contribution profile — must be skipped
+        { profileId: 'p-memo-1' },
+      ]);
+      cacheManager.del.mockResolvedValue(undefined);
+
+      await service.revokeUrlCachesForCalloutsInSpaces(['space-a', 'space-b']);
+
+      expect(entityManager.connection.query).toHaveBeenCalledTimes(1);
+      const [, params] = entityManager.connection.query.mock.calls[0];
+      expect(params).toEqual([['space-a', 'space-b']]);
+
+      const deletedKeys = cacheManager.del.mock.calls.map(c => c[0]);
+      expect(deletedKeys).toContain('@url:urlGeneratorId:p-framing-1');
+      expect(deletedKeys).toContain('@url:urlGeneratorId:p-framing-2');
+      expect(deletedKeys).toContain('@url:urlGeneratorId:p-post-1');
+      expect(deletedKeys).toContain('@url:urlGeneratorId:p-memo-1');
+      expect(deletedKeys).toHaveLength(4); // dedup + null skipped
+    });
+
+    it('logs and continues when a single revoke fails', async () => {
+      entityManager.connection.query.mockResolvedValue([
+        { profileId: 'p-1' },
+        { profileId: 'p-2' },
+      ]);
+      cacheManager.del
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(undefined);
+
+      await service.revokeUrlCachesForCalloutsInSpaces(['space-a']);
+
+      expect(cacheManager.del).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/infrastructure/url-generator/url.generator.service.cache.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.cache.ts
@@ -1,8 +1,10 @@
 import { LogContext } from '@common/enums/logging.context';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
 import { Cache, CachingConfig } from 'cache-manager';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { EntityManager } from 'typeorm';
 
 @Injectable()
 export class UrlGeneratorCacheService {
@@ -14,7 +16,9 @@ export class UrlGeneratorCacheService {
     @Inject(CACHE_MANAGER)
     private readonly cacheManager: Cache,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService
+    private readonly logger: LoggerService,
+    @InjectEntityManager('default')
+    private readonly entityManager: EntityManager
   ) {}
 
   public getUrlIdCacheKey(entityId: string): string {
@@ -44,5 +48,104 @@ export class UrlGeneratorCacheService {
       );
     }
     return url;
+  }
+
+  // Revokes the per-profile URL cache for every callout, framing whiteboard,
+  // and contribution (post / link / whiteboard / memo) reachable from the given
+  // spaces. Used after a space subtree changes parent so that the URLs surfaced
+  // in the activity log stop pointing at the old path.
+  public async revokeUrlCachesForCalloutsInSpaces(
+    spaceIds: string[]
+  ): Promise<void> {
+    if (spaceIds.length === 0) {
+      return;
+    }
+
+    const rows: { profileId: string | null }[] =
+      await this.entityManager.connection.query(
+        `
+        SELECT cf."profileId" AS "profileId"
+        FROM "space" s
+        JOIN "collaboration" co ON co."id" = s."collaborationId"
+        JOIN "callout" c        ON c."calloutsSetId" = co."calloutsSetId"
+        JOIN "callout_framing" cf ON cf."id" = c."framingId"
+        WHERE s."id" = ANY($1)
+
+        UNION ALL
+
+        SELECT fwb."profileId" AS "profileId"
+        FROM "space" s
+        JOIN "collaboration" co ON co."id" = s."collaborationId"
+        JOIN "callout" c        ON c."calloutsSetId" = co."calloutsSetId"
+        JOIN "callout_framing" cf ON cf."id" = c."framingId"
+        JOIN "whiteboard" fwb   ON fwb."id" = cf."whiteboardId"
+        WHERE s."id" = ANY($1)
+
+        UNION ALL
+
+        SELECT p."profileId" AS "profileId"
+        FROM "space" s
+        JOIN "collaboration" co ON co."id" = s."collaborationId"
+        JOIN "callout" c        ON c."calloutsSetId" = co."calloutsSetId"
+        JOIN "callout_contribution" cc ON cc."calloutId" = c."id"
+        JOIN "post" p           ON p."id" = cc."postId"
+        WHERE s."id" = ANY($1)
+
+        UNION ALL
+
+        SELECT l."profileId" AS "profileId"
+        FROM "space" s
+        JOIN "collaboration" co ON co."id" = s."collaborationId"
+        JOIN "callout" c        ON c."calloutsSetId" = co."calloutsSetId"
+        JOIN "callout_contribution" cc ON cc."calloutId" = c."id"
+        JOIN "link" l           ON l."id" = cc."linkId"
+        WHERE s."id" = ANY($1)
+
+        UNION ALL
+
+        SELECT w."profileId" AS "profileId"
+        FROM "space" s
+        JOIN "collaboration" co ON co."id" = s."collaborationId"
+        JOIN "callout" c        ON c."calloutsSetId" = co."calloutsSetId"
+        JOIN "callout_contribution" cc ON cc."calloutId" = c."id"
+        JOIN "whiteboard" w     ON w."id" = cc."whiteboardId"
+        WHERE s."id" = ANY($1)
+
+        UNION ALL
+
+        SELECT m."profileId" AS "profileId"
+        FROM "space" s
+        JOIN "collaboration" co ON co."id" = s."collaborationId"
+        JOIN "callout" c        ON c."calloutsSetId" = co."calloutsSetId"
+        JOIN "callout_contribution" cc ON cc."calloutId" = c."id"
+        JOIN "memo" m           ON m."id" = cc."memoId"
+        WHERE s."id" = ANY($1)
+        `,
+        [spaceIds]
+      );
+
+    const profileIds = new Set<string>();
+    for (const row of rows) {
+      if (row.profileId) {
+        profileIds.add(row.profileId);
+      }
+    }
+
+    for (const profileId of profileIds) {
+      try {
+        await this.revokeUrlCache(profileId);
+      } catch (error) {
+        const stack = error instanceof Error ? (error.stack ?? '') : '';
+        this.logger.error(
+          {
+            message:
+              'Failed to invalidate URL cache for callout content profile',
+            profileId,
+          },
+          stack,
+          LogContext.URL_GENERATOR
+        );
+      }
+    }
   }
 }

--- a/src/services/infrastructure/url-generator/url.generator.service.cache.ts
+++ b/src/services/infrastructure/url-generator/url.generator.service.cache.ts
@@ -61,8 +61,9 @@ export class UrlGeneratorCacheService {
       return;
     }
 
-    const rows: { profileId: string | null }[] =
-      await this.entityManager.connection.query(
+    let rows: { profileId: string | null }[];
+    try {
+      rows = await this.entityManager.connection.query(
         `
         SELECT cf."profileId" AS "profileId"
         FROM "space" s
@@ -123,6 +124,18 @@ export class UrlGeneratorCacheService {
         `,
         [spaceIds]
       );
+    } catch (error) {
+      const stack = error instanceof Error ? (error.stack ?? '') : '';
+      this.logger.error(
+        {
+          message: 'Failed to invalidate URL caches for callout content',
+          spaceIds,
+        },
+        stack,
+        LogContext.URL_GENERATOR
+      );
+      return;
+    }
 
     const profileIds = new Set<string>();
     for (const row of rows) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL cache invalidation now runs and is awaited during space transfers, moves, and level conversions; per-profile failures are logged without aborting.

* **New Features**
  * Subtree cache sweep that revokes per-profile and callout-derived URL entries for all affected spaces, with deduplication and error isolation.

* **Tests**
  * Expanded coverage verifying subtree invalidation, callout revocations, and invocation after transfers/conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->