### PR TITLE
fix: assign Free license on L1→L0 promotion (#6022)

### DIFF
--- a/src/services/api/conversion/conversion.module.ts
+++ b/src/services/api/conversion/conversion.module.ts
@@ -5,6 +5,7 @@ import { CalloutsSetModule } from '@domain/collaboration/callouts-set/callouts.s
 import { InnovationFlowModule } from '@domain/collaboration/innovation-flow/innovation.flow.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { ClassificationModule } from '@domain/common/classification/classification.module';
+import { LicenseModule } from '@domain/common/license/license.module';
 import { SpaceMoveRoomsModule } from '@domain/communication/space-move-rooms/space.move.rooms.module';
 import { VirtualActorModule } from '@domain/community/virtual-contributor/virtual.contributor.module';
 import { AccountHostModule } from '@domain/space/account.host/account.host.module';
@@ -31,6 +32,7 @@ import { ConversionService } from './conversion.service';
     AccountHostModule,
     RoleSetModule,
     AuthorizationPolicyModule,
+    LicenseModule,
     InputCreatorModule,
     NamingModule,
     PlatformModule,

--- a/src/services/api/conversion/conversion.resolver.mutations.spec.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.spec.ts
@@ -2,9 +2,11 @@ import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { CalloutTransferService } from '@domain/collaboration/callout-transfer/callout.transfer.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { LicenseService } from '@domain/common/license/license.service';
 import { VirtualContributorService } from '@domain/community/virtual-contributor/virtual.contributor.service';
 import { SpaceService } from '@domain/space/space/space.service';
 import { SpaceAuthorizationService } from '@domain/space/space/space.service.authorization';
+import { SpaceLicenseService } from '@domain/space/space/space.service.license';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
@@ -34,6 +36,8 @@ describe('ConversionResolverMutations', () => {
     getVirtualContributorByIdOrFail: Mock;
   };
   let _calloutTransferService: { transferCallout: Mock };
+  let spaceLicenseService: { applyLicensePolicy: Mock };
+  let licenseService: { saveAll: Mock };
 
   const actorContext = { actorID: 'actor-1', credentials: [] } as any;
 
@@ -54,6 +58,8 @@ describe('ConversionResolverMutations', () => {
     authorizationPolicyService = module.get(AuthorizationPolicyService) as any;
     virtualContributorService = module.get(VirtualContributorService) as any;
     _calloutTransferService = module.get(CalloutTransferService) as any;
+    spaceLicenseService = module.get(SpaceLicenseService) as any;
+    licenseService = module.get(LicenseService) as any;
   });
 
   it('should be defined', () => {
@@ -86,6 +92,35 @@ describe('ConversionResolverMutations', () => {
         conversionService.convertSpaceL1ToSpaceL0OrFail
       ).toHaveBeenCalledWith({ spaceL1ID: 'space-l1' });
       expect(result).toBe(convertedSpace);
+    });
+
+    it('reconciles the Free license entitlements after promotion', async () => {
+      authorizationService.grantAccessOrFail.mockReturnValue(undefined);
+      const convertedSpace = { id: 'space-l0' };
+      conversionService.convertSpaceL1ToSpaceL0OrFail.mockResolvedValue(
+        convertedSpace
+      );
+      spaceService.save.mockResolvedValue(convertedSpace);
+      spaceAuthorizationService.applyAuthorizationPolicy.mockResolvedValue([]);
+      authorizationPolicyService.saveAll.mockResolvedValue(undefined);
+      const updatedLicenses = [{ id: 'license-1' }];
+      spaceLicenseService.applyLicensePolicy.mockResolvedValue(updatedLicenses);
+      licenseService.saveAll.mockResolvedValue(undefined);
+      spaceService.getSpaceOrFail.mockResolvedValue(convertedSpace);
+
+      await resolver.convertSpaceL1ToSpaceL0(actorContext, {
+        spaceL1ID: 'space-l1',
+      });
+
+      expect(spaceLicenseService.applyLicensePolicy).toHaveBeenCalledWith(
+        'space-l0'
+      );
+      expect(licenseService.saveAll).toHaveBeenCalledWith(updatedLicenses);
+      expect(
+        spaceLicenseService.applyLicensePolicy.mock.invocationCallOrder[0]
+      ).toBeGreaterThan(
+        authorizationPolicyService.saveAll.mock.invocationCallOrder[0]
+      );
     });
   });
 

--- a/src/services/api/conversion/conversion.resolver.mutations.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.ts
@@ -12,12 +12,14 @@ import { AuthorizationService } from '@core/authorization/authorization.service'
 import { CalloutTransferService } from '@domain/collaboration/callout-transfer/callout.transfer.service';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { LicenseService } from '@domain/common/license/license.service';
 import { IVirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.interface';
 import { VirtualContributorService } from '@domain/community/virtual-contributor/virtual.contributor.service';
 import { VirtualContributorAuthorizationService } from '@domain/community/virtual-contributor/virtual.contributor.service.authorization';
 import { ISpace } from '@domain/space/space/space.interface';
 import { SpaceService } from '@domain/space/space/space.service';
 import { SpaceAuthorizationService } from '@domain/space/space/space.service.authorization';
+import { SpaceLicenseService } from '@domain/space/space/space.service.license';
 import { Inject, LoggerService } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { AiServerAdapter } from '@services/adapters/ai-server-adapter/ai.server.adapter';
@@ -47,6 +49,8 @@ export class ConversionResolverMutations {
     private virtualContributorAuthorizationService: VirtualContributorAuthorizationService,
     private calloutTransferService: CalloutTransferService,
     private aiServerAdapter: AiServerAdapter,
+    private spaceLicenseService: SpaceLicenseService,
+    private licenseService: LicenseService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
   ) {
@@ -80,6 +84,11 @@ export class ConversionResolverMutations {
     const updatedAuthorizations =
       await this.spaceAuthorizationService.applyAuthorizationPolicy(space.id);
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
+
+    const updatedLicenses = await this.spaceLicenseService.applyLicensePolicy(
+      space.id
+    );
+    await this.licenseService.saveAll(updatedLicenses);
 
     return this.spaceService.getSpaceOrFail(space.id);
   }

--- a/src/services/api/conversion/conversion.service.spec.ts
+++ b/src/services/api/conversion/conversion.service.spec.ts
@@ -1,8 +1,10 @@
+import { AccountType } from '@common/enums/account.type';
 import {
   EntityNotInitializedException,
   ValidationException,
 } from '@common/exceptions';
 import { RoleSetService } from '@domain/access/role-set/role.set.service';
+import { AccountHostService } from '@domain/space/account.host/account.host.service';
 import { SpaceService } from '@domain/space/space/space.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { NamingService } from '@services/infrastructure/naming/naming.service';
@@ -16,6 +18,7 @@ describe('ConversionService', () => {
   let spaceService: Record<string, Mock>;
   let _roleSetService: Record<string, Mock>;
   let _namingService: Record<string, Mock>;
+  let accountHostService: Record<string, Mock>;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -33,6 +36,10 @@ describe('ConversionService', () => {
       Mock
     >;
     _namingService = module.get(NamingService) as unknown as Record<
+      string,
+      Mock
+    >;
+    accountHostService = module.get(AccountHostService) as unknown as Record<
       string,
       Mock
     >;
@@ -82,6 +89,98 @@ describe('ConversionService', () => {
       await expect(
         service.convertSpaceL1ToSpaceL0OrFail({ spaceL1ID: 'space-l1' })
       ).rejects.toThrow(EntityNotInitializedException);
+    });
+
+    it('assigns a fresh Free license to the promoted L0 (no inheritance from parent)', async () => {
+      const parentLicenseId = 'parent-license-id';
+      const freshLicense = { id: 'fresh-license-id' };
+      const spaceL1 = {
+        id: 'space-l1',
+        nameID: 'l1-name',
+        levelZeroSpaceID: 'space-l0',
+        community: { roleSet: { id: 'roleset-l1' } },
+        collaboration: { innovationFlow: { id: 'flow-l1', states: [] } },
+        storageAggregator: { id: 'sa-l1', parentStorageAggregator: undefined },
+        subspaces: [],
+        parentSpace: { id: 'space-l0' },
+      };
+      const spaceL0Orig = {
+        id: 'space-l0',
+        license: { id: parentLicenseId },
+        account: {
+          id: 'account-1',
+          accountType: AccountType.USER,
+          storageAggregator: { id: 'sa-account' },
+        },
+        subspaces: [{ id: 'space-l1' }],
+      };
+
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(spaceL1 as never)
+        .mockResolvedValueOnce(spaceL0Orig as never);
+      vi.mocked(spaceService.createLicenseForSpaceL0).mockReturnValue(
+        freshLicense as never
+      );
+      vi.mocked(
+        spaceService.createTemplatesManagerForSpaceL0
+      ).mockResolvedValue({} as never);
+      vi.mocked(spaceService.save).mockImplementation(
+        async (s: unknown) => s as never
+      );
+
+      vi.mocked(_roleSetService.getUsersWithRole).mockResolvedValue([]);
+      vi.mocked(
+        _namingService.getReservedNameIDsLevelZeroSpaces
+      ).mockResolvedValue([]);
+      vi.mocked(
+        _namingService.createNameIdAvoidingReservedNameIDs
+      ).mockReturnValue('promoted-name');
+
+      const platformService = (
+        service as unknown as { platformService: Record<string, Mock> }
+      ).platformService;
+      const templatesManagerService = (
+        service as unknown as { templatesManagerService: Record<string, Mock> }
+      ).templatesManagerService;
+      const templateService = (
+        service as unknown as { templateService: Record<string, Mock> }
+      ).templateService;
+      const inputCreatorService = (
+        service as unknown as { inputCreatorService: Record<string, Mock> }
+      ).inputCreatorService;
+      const innovationFlowService = (
+        service as unknown as { innovationFlowService: Record<string, Mock> }
+      ).innovationFlowService;
+
+      vi.mocked(platformService.getTemplatesManagerOrFail).mockResolvedValue({
+        id: 'platform-tm',
+      } as never);
+      vi.mocked(
+        templatesManagerService.getTemplateFromTemplateDefault
+      ).mockResolvedValue({ id: 'template-l0' } as never);
+      vi.mocked(templateService.getTemplateOrFail).mockResolvedValue({
+        contentSpace: {
+          collaboration: { innovationFlow: { states: [] } },
+        },
+      } as never);
+      vi.mocked(
+        inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState
+      ).mockReturnValue([]);
+      vi.mocked(
+        innovationFlowService.updateInnovationFlowStates
+      ).mockImplementation(async (flow: unknown) => flow as never);
+
+      const result = await service.convertSpaceL1ToSpaceL0OrFail({
+        spaceL1ID: 'space-l1',
+      });
+
+      expect(spaceService.createLicenseForSpaceL0).toHaveBeenCalledTimes(1);
+      expect(result.license).toBe(freshLicense);
+      expect(result.license?.id).not.toBe(parentLicenseId);
+      expect(accountHostService.assignLicensePlansToSpace).toHaveBeenCalledWith(
+        'space-l1',
+        AccountType.USER
+      );
     });
 
     it('should throw EntityNotInitializedException when L0 space is missing account', async () => {


### PR DESCRIPTION
## Summary
- Wire `spaceLicenseService.applyLicensePolicy` + `licenseService.saveAll` into `convertSpaceL1ToSpaceL0` resolver so the fresh `License` entity created during promotion has its entitlements reconciled. Without this step the License row existed but every entitlement (including `SPACE_FREE`) stayed `enabled:false`, matching the symptom in #5289.
- Wire `LicenseModule` into `ConversionModule` and inject `SpaceLicenseService` / `LicenseService` into `ConversionResolverMutations`.
- Add unit coverage: happy-path service test asserts the promoted L0 receives a fresh `License` (id ≠ parent's) and `assignLicensePlansToSpace` is called with the account type; resolver test asserts the reconciler runs *after* the auth policy save so entitlements actually flip.

Closes #6022. Bug #5289 stays open per epic alkem-io/alkemio#1846 — manual verification required before closing.

## Test plan
- [x] `npx vitest run src/services/api/conversion/` — 40/40 green
- [x] `pnpm lint` (Biome) clean
- [ ] Manual smoke on dev: promote an L1 → query `space.license.entitlements` → confirm `SPACE_FREE.enabled = true` and `space-license-free` credential present on actor row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Space conversion now applies license policies after authorization recalculation, persisting updated licenses and assigning fresh licenses when promoting an L1 to L0.
* **Tests**
  * Added tests verifying license creation, policy application order, and persistence during space conversion, plus assertions that license plans are assigned to the promoted space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->