### PR TITLE
test: enhance tagset template update tests for fallback behavior

### DIFF
--- a/src/domain/common/classification/classification.service.spec.ts
+++ b/src/domain/common/classification/classification.service.spec.ts
@@ -1,3 +1,4 @@
+import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { TagsetType } from '@common/enums/tagset.type';
 import {
   EntityNotFoundException,
@@ -403,7 +404,7 @@ describe('ClassificationService', () => {
   });
 
   describe('updateTagsetTemplateOnSelectTagset', () => {
-    it('should update existing tagset with new template and default tags', async () => {
+    it('should fall back to default tags when template has no allowedValues', async () => {
       const existingTagset = { id: 'ts-1', name: 'category', tags: ['old'] };
       vi.spyOn(Classification, 'findOne').mockResolvedValue({
         id: 'cls-1',
@@ -425,6 +426,58 @@ describe('ClassificationService', () => {
 
       expect(existingTagset.tags).toEqual(['default-val']);
       expect(result).toBe(existingTagset);
+    });
+
+    it('should preserve current tag when present in target template allowedValues', async () => {
+      const existingTagset = {
+        id: 'ts-1',
+        name: TagsetReservedName.FLOW_STATE,
+        tags: ['EXPLORE'],
+      };
+      vi.spyOn(Classification, 'findOne').mockResolvedValue({
+        id: 'cls-1',
+        tagsets: [existingTagset],
+      } as any);
+      (tagsetService.getTagsetByName as Mock).mockReturnValue(existingTagset);
+      (tagsetService.save as Mock).mockResolvedValue(existingTagset as any);
+
+      const template = {
+        name: TagsetReservedName.FLOW_STATE,
+        type: TagsetType.SELECT_ONE,
+        allowedValues: ['EXPLORE', 'DEFINE', 'BRAINSTORM'],
+        defaultSelectedValue: 'DEFINE',
+      } as unknown as ITagsetTemplate;
+
+      await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+      expect(existingTagset.tags).toEqual(['EXPLORE']);
+      expect((existingTagset as any).tagsetTemplate).toBe(template);
+    });
+
+    it('should fall back to default when current tag absent from target template allowedValues', async () => {
+      const existingTagset = {
+        id: 'ts-1',
+        name: TagsetReservedName.FLOW_STATE,
+        tags: ['HOME'],
+      };
+      vi.spyOn(Classification, 'findOne').mockResolvedValue({
+        id: 'cls-1',
+        tagsets: [existingTagset],
+      } as any);
+      (tagsetService.getTagsetByName as Mock).mockReturnValue(existingTagset);
+      (tagsetService.save as Mock).mockResolvedValue(existingTagset as any);
+
+      const template = {
+        name: TagsetReservedName.FLOW_STATE,
+        type: TagsetType.SELECT_ONE,
+        allowedValues: ['EXPLORE', 'DEFINE', 'BRAINSTORM'],
+        defaultSelectedValue: 'EXPLORE',
+      } as unknown as ITagsetTemplate;
+
+      await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+      expect(existingTagset.tags).toEqual(['EXPLORE']);
+      expect((existingTagset as any).tagsetTemplate).toBe(template);
     });
 
     it('should create new tagset when template name not found in classification', async () => {


### PR DESCRIPTION
## Resolution

This issue is **already resolved in code** — fix shipped in PR #5959 (`Cross Space(L0) moves of Subspaces(L1)`, commit `ce42443c0`, merged 2026-04-08). What was missing was the regression test mandated by AC item 5; that has now been added.

### How it's resolved

The fall-back/preserve logic lives in `ClassificationService.updateTagsetTemplateOnSelectTagset` at `src/domain/common/classification/classification.service.ts:193-228`:

```ts
if (existingTagset) {
  existingTagset.tagsetTemplate = tagsetTemplate;
  // Preserve current value when it is still valid in the target template;
  // only fall back to the default when the current value is not allowed.
  const currentValue = existingTagset.tags?.[0];
  const isCurrentValueValid =
    currentValue != null &&
    tagsetTemplate.allowedValues?.includes(currentValue);
  existingTagset.tags = isCurrentValueValid ? [currentValue] : defaultTags;
  return await this.tagsetService.save(existingTagset);
}
```

All three flow-state-bearing entry points route through this function:

- **Cross-space callout transfer** — `src/domain/collaboration/callout-transfer/callout.transfer.service.ts:304`
- **L1↔L2 / L0 conversion** — `src/services/api/conversion/conversion.service.ts:879`
- **Innovation-flow template change** (alkem-io/client-web#9353 path) — `src/domain/collaboration/innovation-flow/innovation.flow.service.ts:330` via `tagset.service.ts:updateTagsetsSelectedValue` (sibling logic, same preserve-or-default semantic)

### Acceptance criteria

- [x] Cross-space transfer where source state name is absent in destination → callout assigned destination default state
- [x] Cross-space transfer where source state name is present in destination → callout keeps that state name (matches by name)
- [x] Same logic applies when a destination space's innovation flow was changed via template (verified against alkem-io/client-web#9353)
- [x] Transferred callout is visible in the destination after the move (classification tagset always carries a value in destination's `allowedValues`)
- [x] Regression test added so this does not slip again — see below
- [ ] Verified against alkem-io/server#4970 and alkem-io/client-web#9353 — left for manual end-to-end verification before closing those bugs (per epic alkem-io/alkemio#1846: "do not auto-close")

### What I did in this pass

Added regression tests in `src/domain/common/classification/classification.service.spec.ts` covering both branches of the preserve/fallback logic:

1. `should preserve current tag when present in target template allowedValues` — current `['EXPLORE']`, allowedValues `['EXPLORE','DEFINE','BRAINSTORM']`, default `'DEFINE'` → expects `['EXPLORE']`.
2. `should fall back to default when current tag absent from target template allowedValues` — current `['HOME']`, allowedValues `['EXPLORE','DEFINE','BRAINSTORM']`, default `'EXPLORE'` → expects `['EXPLORE']`.

Also renamed the pre-existing test (`should update existing tagset with new template and default tags`) to `should fall back to default tags when template has no allowedValues` so it correctly describes the path it exercises (template without `allowedValues` → `undefined?.includes(...)` is falsy → fallback). Without `allowedValues` the test only happened to pass by coincidence; the new tests are the ones that genuinely guard the regression.

`pnpm test -- src/domain/common/classification/classification.service.spec.ts` → 24 passed (was 22).

### Note

The pre-existing bugs alkem-io/server#4970 and alkem-io/client-web#9353 stay open until manually verified and closed, per the epic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite coverage for tagset template selection functionality.
  * Added comprehensive test cases validating tag handling when templates are updated.
  * Test scenarios now cover tag preservation within template allowed values, tag replacement with default values, and fallback behavior when templates provide no allowed values.
  * Verified that tagset template references are properly updated during template selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->