### PR TITLE
fix: update resetLicenseOnAccounts mutation to return boolean and adjust account retrieval

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3878,7 +3878,7 @@ type Mutation {
   """Resets the interaction with the VC by recreating the room."""
   resetConversationVc(input: ConversationVcResetInput!): Conversation!
   """Reset all license plans on Accounts"""
-  resetLicenseOnAccounts: Space!
+  resetLicenseOnAccounts: Boolean!
   """Revoke a credential from an Actor."""
   revokeCredentialFromActor(actorID: UUID!, credentialType: CredentialType!, resourceID: UUID): Boolean!
   """Removes an authorization credential from an Organization."""

--- a/src/platform-admin/licensing/admin.licensing.resolver.mutations.ts
+++ b/src/platform-admin/licensing/admin.licensing.resolver.mutations.ts
@@ -204,13 +204,13 @@ export class AdminLicensingResolverMutations {
     return this.spaceService.getSpaceOrFail(space.id);
   }
 
-  @Mutation(() => ISpace, {
+  @Mutation(() => Boolean, {
     description: 'Reset all license plans on Accounts',
   })
   @Profiling.api
   async resetLicenseOnAccounts(
     @CurrentActor() actorContext: ActorContext
-  ): Promise<void> {
+  ): Promise<boolean> {
     const licensing =
       await this.licensingFrameworkService.getDefaultLicensingOrFail();
 
@@ -227,5 +227,6 @@ export class AdminLicensingResolverMutations {
         await this.accountLicenseService.applyLicensePolicy(account.id);
       await this.licenseService.saveAll(updatedLicenses);
     }
+    return true;
   }
 }

--- a/src/platform-admin/licensing/admin.licensing.service.ts
+++ b/src/platform-admin/licensing/admin.licensing.service.ts
@@ -1,6 +1,7 @@
 import { LicensingCredentialBasedPlanType } from '@common/enums/licensing.credential.based.plan.type';
 import { LogContext } from '@common/enums/logging.context';
 import { ValidationException } from '@common/exceptions';
+import { Account } from '@domain/space/account/account.entity';
 import { IAccount } from '@domain/space/account/account.interface';
 import { AccountLookupService } from '@domain/space/account.lookup/account.lookup.service';
 import { ISpace } from '@domain/space/space/space.interface';
@@ -180,7 +181,7 @@ export class AdminLicensingService {
   }
 
   public async getAllAccounts(): Promise<IAccount[]> {
-    return this.entityManager.find(IAccount, {
+    return this.entityManager.find(Account, {
       relations: {
         license: true,
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * License reset mutation now returns a Boolean success value, providing explicit confirmation of completion for clients.
  * Improved licensing data access to use concrete account entities, strengthening query correctness and type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->