### PR TITLE
fix(test): eliminate flaky validation.pipe spec

### DIFF
--- a/src/common/pipes/validation.pipe.spec.ts
+++ b/src/common/pipes/validation.pipe.spec.ts
@@ -1,23 +1,32 @@
-import { plainToInstance } from 'class-transformer';
 import { vi } from 'vitest';
-import { ValidationPipe } from './validation.pipe';
+import type { ValidationPipe as ValidationPipeType } from './validation.pipe';
 
-// Mock the BaseHandler as a proper class constructor
+const { plainToInstanceMock, baseHandlerHandleMock } = vi.hoisted(() => ({
+  plainToInstanceMock: vi
+    .fn()
+    .mockImplementation((_cls: any, value: any) => value),
+  baseHandlerHandleMock: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('class-transformer', () => ({
+  plainToInstance: plainToInstanceMock,
+}));
+
 vi.mock('@core/validation/handlers/base/base.handler', () => ({
   BaseHandler: class MockBaseHandler {
-    handle = vi.fn().mockResolvedValue([]);
+    handle = baseHandlerHandleMock;
   },
 }));
 
-// Mock class-transformer
-vi.mock('class-transformer', () => ({
-  plainToInstance: vi.fn().mockImplementation((_cls: any, value: any) => value),
-}));
-
 describe('ValidationPipe', () => {
-  let pipe: ValidationPipe;
+  let pipe: ValidationPipeType;
 
-  beforeEach(() => {
+  beforeAll(async () => {
+    // isolate: false in vitest.config shares the module cache across spec files.
+    // Reset + dynamic import guarantees validation.pipe re-evaluates with the
+    // class-transformer mock bound, regardless of prior spec load order.
+    vi.resetModules();
+    const { ValidationPipe } = await import('./validation.pipe');
     pipe = new ValidationPipe();
   });
 
@@ -97,14 +106,10 @@ describe('ValidationPipe', () => {
       const value = { field: 'data' };
       await pipe.transform(value, { type: 'body', metatype: MyDto });
 
-      expect(plainToInstance).toHaveBeenCalledWith(MyDto, value);
+      expect(plainToInstanceMock).toHaveBeenCalledWith(MyDto, value);
     });
 
     it('should delegate to BaseHandler for validation', async () => {
-      const { BaseHandler } = await import(
-        '@core/validation/handlers/base/base.handler'
-      );
-
       class AnotherDto {
         id!: string;
       }
@@ -112,8 +117,7 @@ describe('ValidationPipe', () => {
       const value = { id: '123' };
       await pipe.transform(value, { type: 'body', metatype: AnotherDto });
 
-      // Verify BaseHandler was instantiated
-      expect(BaseHandler).toBeDefined();
+      expect(baseHandlerHandleMock).toHaveBeenCalledWith(value, AnotherDto);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `src/common/pipes/validation.pipe.spec.ts > should call plainToInstance for custom metatypes` has failed in **at least 4 CI runs in the last 7 days** (#6037 ×2, #6030, #6010), always at line 100 with `Number of calls: 0`.
- Root cause: `vitest.config.ts` sets `isolate: false` for memory efficiency, so the Vite SSR module cache is shared across spec files in the same worker thread. When any earlier spec causes one of the 75 source files that import `class-transformer` to load, `validation.pipe.ts` evaluates with the **real** `plainToInstance` reference captured. The later `vi.mock('class-transformer', factory)` cannot retroactively rebind that import, and the assertion sees 0 calls. Pass/fail depends on file-execution order chosen by the thread pool — classic order-dependent flake.
- Fix: hoist the mock function with `vi.hoisted` so the spec keeps a stable ref, then `vi.resetModules()` + dynamic `import('./validation.pipe')` inside `beforeAll`. This guarantees the SUT re-evaluates with mocks bound regardless of prior load order. Same treatment applied to the `BaseHandler.handle` mock so the previously trivial `should delegate to BaseHandler` assertion now actually verifies the call.

## Test plan
- [x] `pnpm vitest run src/common/pipes/validation.pipe.spec.ts` — passes
- [x] `pnpm vitest run` (full suite) — 581/581 files pass, ran 3× in a row clean
- [x] Pre-commit hook (biome + tsc + full vitest) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with refactored mock setup and assertions for validation handling.

---

**Note:** This release includes internal testing improvements with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->