### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -4472,7 +4472,7 @@ type Mutation {
   """Resets the interaction with the VC by recreating the room."""
   resetConversationVc(input: ConversationVcResetInput!): Conversation!
   """Reset all license plans on Accounts"""
-  resetLicenseOnAccounts: Space!
+  resetLicenseOnAccounts: Boolean!
   """Revoke a credential from an Actor."""
   revokeCredentialFromActor(actorID: UUID!, credentialType: CredentialType!, resourceID: UUID): Boolean!
   """Removes an authorization credential from an Organization."""
@@ -7914,19 +7914,19 @@ input UpdateSpaceSettingsCollaborationInput {
   """
   Flag to control if events from Subspaces are visible on this Space calendar as well.
   """
-  allowEventsFromSubspaces: Boolean!
+  allowEventsFromSubspaces: Boolean
   """Flag to control if guest users can contribute to this Space."""
-  allowGuestContributions: Boolean!
+  allowGuestContributions: Boolean
   """Flag to control if members can create callouts."""
-  allowMembersToCreateCallouts: Boolean!
+  allowMembersToCreateCallouts: Boolean
   """Flag to control if members can create subspaces."""
-  allowMembersToCreateSubspaces: Boolean!
+  allowMembersToCreateSubspaces: Boolean
   """Flag to control if members can create video calls in this Space."""
-  allowMembersToVideoCall: Boolean!
+  allowMembersToVideoCall: Boolean
   """
   Flag to control if ability to contribute is inherited from parent Space.
   """
-  inheritMembershipRights: Boolean!
+  inheritMembershipRights: Boolean
 }
 
 input UpdateSpaceSettingsEntityInput {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size:   280285 bytes
Snapshot md5: bf3010862a0c9183d093d34b7c66ddb3

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated API schema to modify the license reset operation response format for improved consistency.
  * Made collaboration settings optional for improved flexibility when updating space configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->