### PR TITLE
feat: implement activity log management on transfers

### DIFF
--- a/src/domain/collaboration/callout-transfer/callout.transfer.module.ts
+++ b/src/domain/collaboration/callout-transfer/callout.transfer.module.ts
@@ -5,6 +5,7 @@ import { ProfileModule } from '@domain/common/profile/profile.module';
 import { TagsetModule } from '@domain/common/tagset/tagset.module';
 import { StorageBucketModule } from '@domain/storage/storage-bucket/storage.bucket.module';
 import { Module } from '@nestjs/common';
+import { ActivityModule } from '@platform/activity/activity.module';
 import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
 import { StorageAggregatorResolverModule } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.module';
 import { UrlGeneratorModule } from '@services/infrastructure/url-generator';
@@ -26,6 +27,7 @@ import { CalloutTransferService } from './callout.transfer.service';
     TagsetModule,
     EntityResolverModule,
     UrlGeneratorModule,
+    ActivityModule,
   ],
   providers: [CalloutTransferService, CalloutTransferResolverMutations],
   exports: [CalloutTransferService],

--- a/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
+++ b/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
@@ -222,6 +222,7 @@ describe('CalloutTransferService', () => {
       const callout = {
         id: 'callout-1',
         nameID: 'callout',
+        calloutsSet: { id: 'src-cs' },
       } as any;
 
       vi.mocked(
@@ -245,6 +246,7 @@ describe('CalloutTransferService', () => {
       const callout = {
         id: 'callout-1',
         nameID: 'callout',
+        calloutsSet: { id: 'src-cs' },
       } as any;
 
       vi.mocked(
@@ -413,6 +415,7 @@ describe('CalloutTransferService', () => {
       const callout = {
         id: 'callout-1',
         nameID: 'callout',
+        calloutsSet: { id: 'src-cs' },
       } as any;
 
       vi.mocked(
@@ -439,6 +442,80 @@ describe('CalloutTransferService', () => {
 
       vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
         tagsetTemplates: [],
+      } as any);
+
+      await expect(
+        service.transferCallout(callout, targetCalloutsSet)
+      ).rejects.toThrow(RelationshipNotFoundException);
+    });
+
+    it('should resolve sourceCalloutsSetID from persistence when not on the input entity', async () => {
+      // Caller iterates a CalloutsSet's callouts; TypeORM does not back-populate
+      // the inverse calloutsSet on each child, so it arrives undefined.
+      const callout = {
+        id: 'callout-1',
+        nameID: 'callout',
+      } as any;
+
+      vi.mocked(
+        storageAggregatorResolverService.getStorageAggregatorForCalloutsSet
+      ).mockResolvedValue(storageAggregator);
+      vi.mocked(calloutService.save).mockResolvedValue(callout);
+
+      vi.mocked(calloutService.getCalloutOrFail)
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          calloutsSet: { id: 'resolved-src-cs' },
+        } as any) // fallback resolve
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: { profile: { storageBucket: { id: 'sb-1' } } },
+          contributions: [],
+        } as any) // updateStorageAggregator
+        .mockResolvedValueOnce(calloutForUrlCaches as any) // revokeUrlCaches
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: {
+            profile: {
+              tagsets: [
+                { id: 'ts-1', name: TagsetReservedName.DEFAULT, tags: [] },
+              ],
+            },
+          },
+        } as any) // updateTagsetsFromTemplates
+        .mockResolvedValueOnce(calloutForClassification as any) // updateClassificationFromTemplates
+        .mockResolvedValueOnce(callout); // final return
+
+      vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
+        tagsetTemplates: [],
+      } as any);
+      vi.mocked(
+        profileService.convertTagsetTemplatesToCreateTagsetInput
+      ).mockReturnValue([]);
+
+      vi.mocked(entityManager.findOne)
+        .mockResolvedValueOnce({ id: 'collab-source' } as any)
+        .mockResolvedValueOnce({ id: 'collab-target' } as any);
+
+      await service.transferCallout(callout, targetCalloutsSet);
+
+      // Activity move should fire using the resolved source calloutsSet id
+      expect(activityService.moveActivitiesForCallout).toHaveBeenCalledWith(
+        'callout-1',
+        'collab-source',
+        'collab-target'
+      );
+    });
+
+    it('should throw RelationshipNotFoundException when source calloutsSet cannot be resolved', async () => {
+      const callout = {
+        id: 'callout-1',
+        nameID: 'callout',
+      } as any;
+
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValueOnce({
+        id: 'callout-1',
+        calloutsSet: undefined,
       } as any);
 
       await expect(

--- a/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
+++ b/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
@@ -8,11 +8,13 @@ import { ProfileService } from '@domain/common/profile/profile.service';
 import { TagsetService } from '@domain/common/tagset/tagset.service';
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ActivityService } from '@platform/activity/activity.service';
 import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
 import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { EntityManager } from 'typeorm';
 import { CalloutService } from '../callout/callout.service';
 import { CalloutsSetService } from '../callouts-set/callouts.set.service';
 import { CalloutTransferService } from './callout.transfer.service';
@@ -27,6 +29,8 @@ describe('CalloutTransferService', () => {
   let storageAggregatorResolverService: StorageAggregatorResolverService;
   let _classificationService: ClassificationService;
   let _urlGeneratorCacheService: UrlGeneratorCacheService;
+  let activityService: ActivityService;
+  let entityManager: EntityManager;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -52,6 +56,8 @@ describe('CalloutTransferService', () => {
     );
     _classificationService = module.get(ClassificationService);
     _urlGeneratorCacheService = module.get(UrlGeneratorCacheService);
+    activityService = module.get(ActivityService);
+    entityManager = module.get(EntityManager);
   });
 
   describe('transferCallout', () => {
@@ -299,6 +305,108 @@ describe('CalloutTransferService', () => {
       // Should create new tagset from template
       expect(tagsetService.createTagsetWithName).toHaveBeenCalled();
       expect(tagsetService.save).toHaveBeenCalled();
+    });
+
+    it('should re-stamp activity rows from source collaboration to target collaboration', async () => {
+      const callout = {
+        id: 'callout-1',
+        nameID: 'callout',
+        calloutsSet: { id: 'source-cs' },
+      } as any;
+
+      vi.mocked(
+        storageAggregatorResolverService.getStorageAggregatorForCalloutsSet
+      ).mockResolvedValue(storageAggregator);
+      vi.mocked(calloutService.save).mockResolvedValue(callout);
+
+      vi.mocked(calloutService.getCalloutOrFail)
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: { profile: { storageBucket: { id: 'sb-1' } } },
+          contributions: [],
+        } as any) // updateStorageAggregator
+        .mockResolvedValueOnce(calloutForUrlCaches as any) // revokeUrlCaches
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: {
+            profile: {
+              tagsets: [
+                { id: 'ts-1', name: TagsetReservedName.DEFAULT, tags: [] },
+              ],
+            },
+          },
+        } as any) // updateTagsetsFromTemplates
+        .mockResolvedValueOnce(calloutForClassification as any) // updateClassificationFromTemplates
+        .mockResolvedValueOnce(callout); // final return
+
+      vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
+        tagsetTemplates: [],
+      } as any);
+      vi.mocked(
+        profileService.convertTagsetTemplatesToCreateTagsetInput
+      ).mockReturnValue([]);
+
+      // entityManager.findOne returns the source/target collaboration ids in
+      // the order the service awaits them via Promise.all.
+      vi.mocked(entityManager.findOne)
+        .mockResolvedValueOnce({ id: 'collab-source' } as any)
+        .mockResolvedValueOnce({ id: 'collab-target' } as any);
+
+      await service.transferCallout(callout, targetCalloutsSet);
+
+      expect(activityService.moveActivitiesForCallout).toHaveBeenCalledWith(
+        'callout-1',
+        'collab-source',
+        'collab-target'
+      );
+    });
+
+    it('should skip activity move when source calloutsSet has no associated collaboration', async () => {
+      const callout = {
+        id: 'callout-1',
+        nameID: 'callout',
+        calloutsSet: { id: 'template-cs' },
+      } as any;
+
+      vi.mocked(
+        storageAggregatorResolverService.getStorageAggregatorForCalloutsSet
+      ).mockResolvedValue(storageAggregator);
+      vi.mocked(calloutService.save).mockResolvedValue(callout);
+
+      vi.mocked(calloutService.getCalloutOrFail)
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: { profile: { storageBucket: { id: 'sb-1' } } },
+          contributions: [],
+        } as any)
+        .mockResolvedValueOnce(calloutForUrlCaches as any)
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: {
+            profile: {
+              tagsets: [
+                { id: 'ts-1', name: TagsetReservedName.DEFAULT, tags: [] },
+              ],
+            },
+          },
+        } as any)
+        .mockResolvedValueOnce(calloutForClassification as any)
+        .mockResolvedValueOnce(callout);
+
+      vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
+        tagsetTemplates: [],
+      } as any);
+      vi.mocked(
+        profileService.convertTagsetTemplatesToCreateTagsetInput
+      ).mockReturnValue([]);
+
+      vi.mocked(entityManager.findOne)
+        .mockResolvedValueOnce(null) // source collab missing
+        .mockResolvedValueOnce({ id: 'collab-target' } as any);
+
+      await service.transferCallout(callout, targetCalloutsSet);
+
+      expect(activityService.moveActivitiesForCallout).not.toHaveBeenCalled();
     });
 
     it('should throw RelationshipNotFoundException when profile has no tagsets', async () => {

--- a/src/domain/collaboration/callout-transfer/callout.transfer.service.ts
+++ b/src/domain/collaboration/callout-transfer/callout.transfer.service.ts
@@ -49,9 +49,9 @@ export class CalloutTransferService {
       callout.nameID
     );
 
-    // Capture source collab id BEFORE swapping the calloutsSet so we can
-    // re-stamp activity rows after the move.
-    const sourceCalloutsSetID = callout.calloutsSet?.id;
+    // Capture source calloutsSet id BEFORE swapping so we can re-stamp
+    // activity rows after the move.
+    const sourceCalloutsSetID = await this.resolveSourceCalloutsSetID(callout);
 
     // Update all the storage aggregators
     const storageAggregator =
@@ -95,14 +95,33 @@ export class CalloutTransferService {
     return await this.calloutService.getCalloutOrFail(updatedCallout.id);
   }
 
+  // Callers may pass a partial entity without calloutsSet hydrated (e.g. when
+  // iterating a CalloutsSet's callouts — TypeORM does not back-populate the
+  // inverse side), so fall back to a DB lookup and fail fast if still missing.
+  private async resolveSourceCalloutsSetID(callout: ICallout): Promise<string> {
+    if (callout.calloutsSet?.id) {
+      return callout.calloutsSet.id;
+    }
+    const persisted = await this.calloutService.getCalloutOrFail(callout.id, {
+      loadEagerRelations: false,
+      relations: { calloutsSet: true },
+      select: { id: true, calloutsSet: { id: true } },
+    });
+    if (!persisted.calloutsSet?.id) {
+      throw new RelationshipNotFoundException(
+        'Cannot resolve source CalloutsSet for callout transfer',
+        LogContext.COLLABORATION,
+        { calloutId: callout.id }
+      );
+    }
+    return persisted.calloutsSet.id;
+  }
+
   private async moveActivityLogForCallout(
     calloutID: string,
-    sourceCalloutsSetID: string | undefined,
+    sourceCalloutsSetID: string,
     targetCalloutsSetID: string
   ): Promise<void> {
-    if (!sourceCalloutsSetID) {
-      return;
-    }
     const [sourceCollab, targetCollab] = await Promise.all([
       this.entityManager.findOne(Collaboration, {
         loadEagerRelations: false,

--- a/src/domain/collaboration/callout-transfer/callout.transfer.service.ts
+++ b/src/domain/collaboration/callout-transfer/callout.transfer.service.ts
@@ -4,6 +4,7 @@ import {
   EntityNotInitializedException,
   RelationshipNotFoundException,
 } from '@common/exceptions';
+import { Collaboration } from '@domain/collaboration/collaboration/collaboration.entity';
 import { ClassificationService } from '@domain/common/classification/classification.service';
 import { ProfileService } from '@domain/common/profile/profile.service';
 import { TagsetService } from '@domain/common/tagset/tagset.service';
@@ -12,8 +13,11 @@ import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.a
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { StorageBucketService } from '@domain/storage/storage-bucket/storage.bucket.service';
 import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { ActivityService } from '@platform/activity/activity.service';
 import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
 import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
+import { EntityManager } from 'typeorm';
 import { ICallout } from '../callout/callout.interface';
 import { CalloutService } from '../callout/callout.service';
 import { ICalloutsSet } from '../callouts-set/callouts.set.interface';
@@ -29,7 +33,10 @@ export class CalloutTransferService {
     private readonly profileService: ProfileService,
     private readonly tagsetService: TagsetService,
     private readonly storageAggregatorResolverService: StorageAggregatorResolverService,
-    private readonly urlGeneratorCacheService: UrlGeneratorCacheService
+    private readonly urlGeneratorCacheService: UrlGeneratorCacheService,
+    private readonly activityService: ActivityService,
+    @InjectEntityManager('default')
+    private readonly entityManager: EntityManager
   ) {}
 
   public async transferCallout(
@@ -41,6 +48,10 @@ export class CalloutTransferService {
       targetCalloutsSet.id,
       callout.nameID
     );
+
+    // Capture source collab id BEFORE swapping the calloutsSet so we can
+    // re-stamp activity rows after the move.
+    const sourceCalloutsSetID = callout.calloutsSet?.id;
 
     // Update all the storage aggregators
     const storageAggregator =
@@ -73,7 +84,45 @@ export class CalloutTransferService {
       tagsetTemplateSet.tagsetTemplates
     );
 
+    // Re-stamp activity log rows so they follow the callout. Skipped if either
+    // calloutsSet has no associated collaboration (e.g. template scope).
+    await this.moveActivityLogForCallout(
+      updatedCallout.id,
+      sourceCalloutsSetID,
+      targetCalloutsSet.id
+    );
+
     return await this.calloutService.getCalloutOrFail(updatedCallout.id);
+  }
+
+  private async moveActivityLogForCallout(
+    calloutID: string,
+    sourceCalloutsSetID: string | undefined,
+    targetCalloutsSetID: string
+  ): Promise<void> {
+    if (!sourceCalloutsSetID) {
+      return;
+    }
+    const [sourceCollab, targetCollab] = await Promise.all([
+      this.entityManager.findOne(Collaboration, {
+        loadEagerRelations: false,
+        where: { calloutsSet: { id: sourceCalloutsSetID } },
+        select: { id: true },
+      }),
+      this.entityManager.findOne(Collaboration, {
+        loadEagerRelations: false,
+        where: { calloutsSet: { id: targetCalloutsSetID } },
+        select: { id: true },
+      }),
+    ]);
+    if (!sourceCollab || !targetCollab) {
+      return;
+    }
+    await this.activityService.moveActivitiesForCallout(
+      calloutID,
+      sourceCollab.id,
+      targetCollab.id
+    );
   }
 
   private async updateStorageAggregator(

--- a/src/platform/activity/activity.service.spec.ts
+++ b/src/platform/activity/activity.service.spec.ts
@@ -486,6 +486,89 @@ describe('ActivityService', () => {
     });
   });
 
+  describe('moveActivitiesForCallout', () => {
+    const buildUpdateQb = () => {
+      const qb: any = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        setParameters: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue(undefined),
+      };
+      return qb;
+    };
+
+    it('should issue a single bulk UPDATE matching resource and parent ids', async () => {
+      const qb = buildUpdateQb();
+      activityRepository.createQueryBuilder!.mockReturnValue(qb);
+
+      await service.moveActivitiesForCallout(
+        'callout-1',
+        'collab-old',
+        'collab-new'
+      );
+
+      expect(qb.update).toHaveBeenCalledWith(Activity);
+      expect(qb.where).toHaveBeenCalledWith(
+        '"resourceID" = :calloutID OR "parentID" = :calloutID'
+      );
+      expect(qb.setParameters).toHaveBeenCalledWith({
+        calloutID: 'callout-1',
+        oldCollaborationID: 'collab-old',
+        newCollaborationID: 'collab-new',
+      });
+      expect(qb.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('should rewrite parentID via CASE only when it equals the old collaboration id', async () => {
+      const qb = buildUpdateQb();
+      activityRepository.createQueryBuilder!.mockReturnValue(qb);
+
+      await service.moveActivitiesForCallout(
+        'callout-1',
+        'collab-old',
+        'collab-new'
+      );
+
+      const setArg = qb.set.mock.calls[0][0];
+      expect(setArg.collaborationID).toBe('collab-new');
+      expect(typeof setArg.parentID).toBe('function');
+      expect(setArg.parentID()).toContain(
+        'CASE WHEN "parentID" = :oldCollaborationID THEN :newCollaborationID ELSE "parentID" END'
+      );
+    });
+
+    it('should be a no-op when source and destination collaborations match', async () => {
+      await service.moveActivitiesForCallout('callout-1', 'same', 'same');
+
+      expect(activityRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeSubspaceCreatedActivityForResource', () => {
+    it('should issue a single bulk DELETE filtered by resourceID and SUBSPACE_CREATED type', async () => {
+      const qb: any = {
+        delete: vi.fn().mockReturnThis(),
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue(undefined),
+      };
+      activityRepository.createQueryBuilder!.mockReturnValue(qb);
+
+      await service.removeSubspaceCreatedActivityForResource('space-l1');
+
+      expect(qb.from).toHaveBeenCalledWith(Activity);
+      expect(qb.where).toHaveBeenCalledWith(
+        '"resourceID" = :resourceID AND "type" = :type',
+        {
+          resourceID: 'space-l1',
+          type: ActivityEventType.SUBSPACE_CREATED,
+        }
+      );
+      expect(qb.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getLatestActivitiesPerSpaceMembership', () => {
     it('should query activities for collaboration IDs from membership info', async () => {
       const qb = {

--- a/src/platform/activity/activity.service.ts
+++ b/src/platform/activity/activity.service.ts
@@ -69,6 +69,55 @@ export class ActivityService {
     return await this.save(activity);
   }
 
+  // Re-stamps every Activity row that references the given callout (either as
+  // the resource itself or as the parent of a contribution-level event) onto
+  // the destination collaboration. Top-level callout events store the
+  // collaborationID in `parentID` (CALLOUT_PUBLISHED, DISCUSSION_COMMENT) and
+  // are rewritten too; per-contribution events store the calloutID in
+  // `parentID` and are left intact via the CASE expression.
+  async moveActivitiesForCallout(
+    calloutID: string,
+    oldCollaborationID: string,
+    newCollaborationID: string
+  ): Promise<void> {
+    if (oldCollaborationID === newCollaborationID) {
+      return;
+    }
+    await this.activityRepository
+      .createQueryBuilder()
+      .update(Activity)
+      .set({
+        collaborationID: newCollaborationID,
+        parentID: () =>
+          'CASE WHEN "parentID" = :oldCollaborationID THEN :newCollaborationID ELSE "parentID" END',
+      })
+      .where('"resourceID" = :calloutID OR "parentID" = :calloutID')
+      .setParameters({
+        calloutID,
+        oldCollaborationID,
+        newCollaborationID,
+      })
+      .execute();
+  }
+
+  // Removes the SUBSPACE_CREATED entry that points at a space which has been
+  // promoted/moved out of its source parent. The row is the only stale entry
+  // — the moved space's own collaboration carries its activity history with
+  // it because collaborationID is preserved.
+  async removeSubspaceCreatedActivityForResource(
+    resourceID: string
+  ): Promise<void> {
+    await this.activityRepository
+      .createQueryBuilder()
+      .delete()
+      .from(Activity)
+      .where('"resourceID" = :resourceID AND "type" = :type', {
+        resourceID,
+        type: ActivityEventType.SUBSPACE_CREATED,
+      })
+      .execute();
+  }
+
   async getActivityForCollaborations(
     collaborationIDs: string[],
     options?: {

--- a/src/services/api/conversion/conversion.module.ts
+++ b/src/services/api/conversion/conversion.module.ts
@@ -14,6 +14,7 @@ import { SpaceLookupModule } from '@domain/space/space.lookup/space.lookup.modul
 import { TemplateModule } from '@domain/template/template/template.module';
 import { TemplatesManagerModule } from '@domain/template/templates-manager/templates.manager.module';
 import { Module } from '@nestjs/common';
+import { ActivityModule } from '@platform/activity/activity.module';
 import { PlatformModule } from '@platform/platform/platform.module';
 import { AiServerAdapterModule } from '@services/adapters/ai-server-adapter/ai.server.adapter.module';
 import { NotificationAdapterModule } from '@services/adapters/notification-adapter/notification.adapter.module';
@@ -48,6 +49,7 @@ import { ConversionService } from './conversion.service';
     AiServerAdapterModule,
     NotificationAdapterModule,
     EntityResolverModule,
+    ActivityModule,
   ],
   providers: [ConversionService, ConversionResolverMutations],
   exports: [ConversionService, ConversionResolverMutations],

--- a/src/services/api/conversion/conversion.service.move.spec.ts
+++ b/src/services/api/conversion/conversion.service.move.spec.ts
@@ -8,6 +8,7 @@ import { CalloutsSetService } from '@domain/collaboration/callouts-set/callouts.
 import { SpaceService } from '@domain/space/space/space.service';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ActivityService } from '@platform/activity/activity.service';
 import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
@@ -23,6 +24,7 @@ describe('ConversionService — Cross-L0 Moves', () => {
   let entityManager: Record<string, Mock>;
   let spaceLookupService: Record<string, Mock>;
   let calloutsSetService: Record<string, Mock>;
+  let activityService: Record<string, Mock>;
 
   // Reusable mock chain for EntityManager.createQueryBuilder()
   const mockQueryBuilder = () => {
@@ -129,6 +131,10 @@ describe('ConversionService — Cross-L0 Moves', () => {
       Mock
     >;
     calloutsSetService = module.get(CalloutsSetService) as unknown as Record<
+      string,
+      Mock
+    >;
+    activityService = module.get(ActivityService) as unknown as Record<
       string,
       Mock
     >;
@@ -342,6 +348,22 @@ describe('ConversionService — Cross-L0 Moves', () => {
         roleSetService.removePendingInvitationsAndApplications
       ).toHaveBeenCalledWith(['roleset-l1', 'roleset-child-l2-a']);
     });
+
+    it('should drop the stale SUBSPACE_CREATED activity entry on the source parent', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL1())
+        .mockResolvedValueOnce(makeTargetL0());
+      setupHappyPathMocks();
+
+      await service.moveSpaceL1ToSpaceL0OrFail({
+        spaceL1ID: 'source-l1',
+        targetSpaceL0ID: 'target-l0',
+      });
+
+      expect(
+        activityService.removeSubspaceCreatedActivityForResource
+      ).toHaveBeenCalledWith('source-l1');
+    });
   });
 
   // ── moveSpaceL1ToSpaceL2OrFail ──────────────────────────────────
@@ -512,6 +534,23 @@ describe('ConversionService — Cross-L0 Moves', () => {
       expect(
         roleSetService.removePendingInvitationsAndApplications
       ).toHaveBeenCalledWith('roleset-l1');
+    });
+
+    it('should drop the stale SUBSPACE_CREATED activity entry on the source parent', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL1())
+        .mockResolvedValueOnce(makeTargetL1())
+        .mockResolvedValueOnce(makeTargetL0());
+      setupHappyPathMocks();
+
+      await service.moveSpaceL1ToSpaceL2OrFail({
+        spaceL1ID: 'source-l1',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      expect(
+        activityService.removeSubspaceCreatedActivityForResource
+      ).toHaveBeenCalledWith('source-l1');
     });
   });
 

--- a/src/services/api/conversion/conversion.service.spec.ts
+++ b/src/services/api/conversion/conversion.service.spec.ts
@@ -11,6 +11,7 @@ import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.serv
 import { TemplateService } from '@domain/template/template/template.service';
 import { TemplatesManagerService } from '@domain/template/templates-manager/templates.manager.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ActivityService } from '@platform/activity/activity.service';
 import { PlatformService } from '@platform/platform/platform.service';
 import { NamingService } from '@services/infrastructure/naming/naming.service';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
@@ -31,6 +32,7 @@ describe('ConversionService', () => {
   let templateService: Record<string, Mock>;
   let inputCreatorService: Record<string, Mock>;
   let innovationFlowService: Record<string, Mock>;
+  let activityService: Record<string, Mock>;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -77,6 +79,10 @@ describe('ConversionService', () => {
     innovationFlowService = module.get(
       InnovationFlowService
     ) as unknown as Record<string, Mock>;
+    activityService = module.get(ActivityService) as unknown as Record<
+      string,
+      Mock
+    >;
   });
 
   // Stubs every roleSetService accessor used by getSpaceCommunityRoles so
@@ -335,6 +341,39 @@ describe('ConversionService', () => {
       expect(
         roleSetService.removePendingInvitationsAndApplications
       ).toHaveBeenCalledWith('roleset-l1');
+    });
+
+    it('should drop the stale SUBSPACE_CREATED activity entry on the source L0', async () => {
+      const roleSetL1 = { id: 'roleset-l1' };
+      const spaceL1 = {
+        id: 'space-l1',
+        levelZeroSpaceID: 'l0-a',
+        community: { roleSet: roleSetL1 },
+        storageAggregator: { id: 'sa-l1' },
+      };
+      const parentL1 = {
+        id: 'parent-l1',
+        levelZeroSpaceID: 'l0-a',
+        storageAggregator: { id: 'sa-parent-l1' },
+        community: { roleSet: { id: 'roleset-parent-l1' } },
+      };
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(spaceL1)
+        .mockResolvedValueOnce(parentL1);
+      stubEmptyCommunityRoles();
+      vi.mocked(
+        roleSetService.setParentRoleSetAndCredentials
+      ).mockResolvedValue(roleSetL1);
+      vi.mocked(spaceService.save).mockImplementation(async (s: unknown) => s);
+
+      await service.convertSpaceL1ToSpaceL2OrFail({
+        spaceL1ID: 'space-l1',
+        parentSpaceL1ID: 'parent-l1',
+      });
+
+      expect(
+        activityService.removeSubspaceCreatedActivityForResource
+      ).toHaveBeenCalledWith('space-l1');
     });
   });
 

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -29,6 +29,7 @@ import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.a
 import { TemplateService } from '@domain/template/template/template.service';
 import { TemplatesManagerService } from '@domain/template/templates-manager/templates.manager.service';
 import { Inject, LoggerService } from '@nestjs/common';
+import { ActivityService } from '@platform/activity/activity.service';
 import { PlatformService } from '@platform/platform/platform.service';
 import { NotificationInputCommunityInvitation } from '@services/adapters/notification-adapter/dto/space/notification.dto.input.space.community.invitation';
 import { NotificationUserAdapter } from '@services/adapters/notification-adapter/notification.user.adapter';
@@ -62,6 +63,7 @@ export class ConversionService {
     private communityResolverService: CommunityResolverService,
     private roleSetAuthorizationService: RoleSetAuthorizationService,
     private authorizationPolicyService: AuthorizationPolicyService,
+    private activityService: ActivityService,
     private readonly entityManager: EntityManager,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
@@ -234,6 +236,12 @@ export class ConversionService {
         roleSetL1
       );
     }
+
+    // Drop the now-stale SUBSPACE_CREATED entry on the source L0's activity
+    // log — the moved space is no longer a subspace of that L0.
+    await this.activityService.removeSubspaceCreatedActivityForResource(
+      spaceL1.id
+    );
 
     return spaceL1;
   }
@@ -703,6 +711,12 @@ export class ConversionService {
       targetL0.account.accountType
     );
 
+    // Drop the now-stale SUBSPACE_CREATED entry on the source L0's activity
+    // log — the moved space lives under a different L0 now.
+    await this.activityService.removeSubspaceCreatedActivityForResource(
+      savedSpace.id
+    );
+
     return { space: savedSpace, removedActorIds: uniqueRemovedActorIds };
   }
 
@@ -858,6 +872,12 @@ export class ConversionService {
     await this.accountHostService.assignLicensePlansToSpace(
       savedSpace.id,
       targetL0.account.accountType
+    );
+
+    // Drop the now-stale SUBSPACE_CREATED entry on the source parent's
+    // activity log — the moved space is no longer a subspace under it.
+    await this.activityService.removeSubspaceCreatedActivityForResource(
+      savedSpace.id
     );
 
     return { space: savedSpace, removedActorIds };

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -487,6 +487,13 @@ export class ConversionService {
         userAdmin.id
       );
     }
+
+    // Drop the now-stale SUBSPACE_CREATED entry on the source L0's activity
+    // log — the demoted space is no longer a direct subspace of that L0.
+    await this.activityService.removeSubspaceCreatedActivityForResource(
+      spaceL1.id
+    );
+
     return spaceL1;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity logs are re-stamped/moved when callouts are transferred between collaborations.
  * Stale "subspace created" activity entries are removed during space conversions/moves to keep activity history accurate.

* **Tests**
  * Added coverage for activity movement during callout transfers.
  * Added coverage for activity cleanup during space conversion and move operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->