### PR TITLE
fix: cascade auth to Space and Account profiles

### DIFF
--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -12,7 +12,6 @@ import {
 import { EntityNotFoundException } from '@common/exceptions/entity.not.found.exception';
 import { ICollaboraDocument } from '@domain/collaboration/collabora-document/collabora.document.interface';
 import { CollaboraDocumentService } from '@domain/collaboration/collabora-document/collabora.document.service';
-import { CreateCollaboraDocumentInput } from '@domain/collaboration/collabora-document/dto/collabora.document.dto.create';
 import { CreateLinkInput } from '@domain/collaboration/link/dto/link.dto.create';
 import { LinkService } from '@domain/collaboration/link/link.service';
 import { IPoll } from '@domain/collaboration/poll/poll.interface';

--- a/src/domain/space/account/account.service.authorization.spec.ts
+++ b/src/domain/space/account/account.service.authorization.spec.ts
@@ -153,6 +153,15 @@ describe('AccountAuthorizationService', () => {
         service.applyAuthorizationPolicy(mockAccount)
       ).rejects.toThrow(RelationshipNotFoundException);
     });
+
+    it('should throw when profile is missing', async () => {
+      const mockAccount = createMockAccount({ profile: undefined } as any);
+      (accountService.getAccountOrFail as any).mockResolvedValue(mockAccount);
+
+      await expect(
+        service.applyAuthorizationPolicy(mockAccount)
+      ).rejects.toThrow(RelationshipNotFoundException);
+    });
   });
 
   describe('applyAuthorizationPolicyForChildEntities', () => {
@@ -212,6 +221,14 @@ describe('AccountAuthorizationService', () => {
       ).rejects.toThrow(RelationshipNotFoundException);
     });
 
+    it('should throw when profile is missing', async () => {
+      const mockAccount = createMockAccount({ profile: undefined } as any);
+
+      await expect(
+        service.applyAuthorizationPolicyForChildEntities(mockAccount)
+      ).rejects.toThrow(RelationshipNotFoundException);
+    });
+
     it('should process spaces, VCs, IPs, hubs, license, and storage aggregator', async () => {
       const mockAccount = createMockAccount({
         spaces: [{ id: 'space-1', nameID: 'space-name' }],
@@ -265,6 +282,9 @@ describe('AccountAuthorizationService', () => {
       expect(
         innovationHubAuthorizationService.applyAuthorizationPolicy
       ).toHaveBeenCalled();
+      expect(
+        profileAuthorizationService.applyAuthorizationPolicy
+      ).toHaveBeenCalledWith('account-profile-1', mockAccount.authorization);
     });
 
     it('should return empty authorizations when account has no child entities', async () => {

--- a/src/domain/space/account/account.service.authorization.spec.ts
+++ b/src/domain/space/account/account.service.authorization.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@common/exceptions';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { LicenseAuthorizationService } from '@domain/common/license/license.service.authorization';
+import { ProfileAuthorizationService } from '@domain/common/profile/profile.service.authorization';
 import { VirtualContributorAuthorizationService } from '@domain/community/virtual-contributor/virtual.contributor.service.authorization';
 import { InnovationHubAuthorizationService } from '@domain/innovation-hub/innovation.hub.service.authorization';
 import { StorageAggregatorAuthorizationService } from '@domain/storage/storage-aggregator/storage.aggregator.service.authorization';
@@ -28,6 +29,7 @@ describe('AccountAuthorizationService', () => {
   let storageAggregatorAuthorizationService: StorageAggregatorAuthorizationService;
   let innovationHubAuthorizationService: InnovationHubAuthorizationService;
   let licenseAuthorizationService: LicenseAuthorizationService;
+  let profileAuthorizationService: ProfileAuthorizationService;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -58,6 +60,11 @@ describe('AccountAuthorizationService', () => {
       InnovationHubAuthorizationService
     );
     licenseAuthorizationService = module.get(LicenseAuthorizationService);
+    profileAuthorizationService = module.get(ProfileAuthorizationService);
+
+    (
+      profileAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
   });
 
   it('should be defined', () => {
@@ -78,6 +85,7 @@ describe('AccountAuthorizationService', () => {
       innovationHubs: [],
       storageAggregator: { id: 'storage-1' },
       license: { id: 'license-1' },
+      profile: { id: 'account-profile-1' },
       ...overrides,
     }) as any;
 

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -75,8 +75,9 @@ export class AccountAuthorizationService {
     );
     if (!account.storageAggregator || !account.license || !account.profile) {
       throw new RelationshipNotFoundException(
-        `Unable to load Account with entities at start of auth reset: ${account.id} `,
-        LogContext.ACCOUNT
+        'Unable to load Account with entities at start of auth reset',
+        LogContext.ACCOUNT,
+        { accountID: account.id }
       );
     }
     const updatedAuthorizations: IAuthorizationPolicy[] = [];
@@ -149,8 +150,9 @@ export class AccountAuthorizationService {
       !account.profile
     ) {
       throw new RelationshipNotFoundException(
-        `Unable to load Account with entities at start of auth reset: ${account.id} `,
-        LogContext.ACCOUNT
+        'Unable to load Account with entities at start of auth reset',
+        LogContext.ACCOUNT,
+        { accountID: account.id }
       );
     }
     const updatedAuthorizations: IAuthorizationPolicy[] = [];

--- a/src/domain/space/account/account.service.authorization.ts
+++ b/src/domain/space/account/account.service.authorization.ts
@@ -24,6 +24,7 @@ import { ICredentialDefinition } from '@domain/actor/credential/credential.defin
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { LicenseAuthorizationService } from '@domain/common/license/license.service.authorization';
+import { ProfileAuthorizationService } from '@domain/common/profile/profile.service.authorization';
 import { VirtualContributorAuthorizationService } from '@domain/community/virtual-contributor/virtual.contributor.service.authorization';
 import { InnovationHubAuthorizationService } from '@domain/innovation-hub/innovation.hub.service.authorization';
 import { StorageAggregatorAuthorizationService } from '@domain/storage/storage-aggregator/storage.aggregator.service.authorization';
@@ -47,6 +48,7 @@ export class AccountAuthorizationService {
     private innovationHubAuthorizationService: InnovationHubAuthorizationService,
     private accountService: AccountService,
     private licenseAuthorizationService: LicenseAuthorizationService,
+    private profileAuthorizationService: ProfileAuthorizationService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
@@ -59,6 +61,7 @@ export class AccountAuthorizationService {
         loadEagerRelations: false,
         relations: {
           authorization: true,
+          profile: true,
           spaces: {
             templatesManager: true,
           },
@@ -70,7 +73,7 @@ export class AccountAuthorizationService {
         },
       }
     );
-    if (!account.storageAggregator || !account.license) {
+    if (!account.storageAggregator || !account.license || !account.profile) {
       throw new RelationshipNotFoundException(
         `Unable to load Account with entities at start of auth reset: ${account.id} `,
         LogContext.ACCOUNT
@@ -142,7 +145,8 @@ export class AccountAuthorizationService {
       !account.innovationPacks ||
       !account.storageAggregator ||
       !account.innovationHubs ||
-      !account.license
+      !account.license ||
+      !account.profile
     ) {
       throw new RelationshipNotFoundException(
         `Unable to load Account with entities at start of auth reset: ${account.id} `,
@@ -174,6 +178,13 @@ export class AccountAuthorizationService {
         account.authorization
       );
     updatedAuthorizations.push(...storageAggregatorAuthorizations);
+
+    const profileAuthorizations =
+      await this.profileAuthorizationService.applyAuthorizationPolicy(
+        account.profile.id,
+        account.authorization
+      );
+    updatedAuthorizations.push(...profileAuthorizations);
 
     for (const vc of account.virtualContributors) {
       const updatedVcAuthorizations =

--- a/src/domain/space/space/space.service.authorization.spec.ts
+++ b/src/domain/space/space/space.service.authorization.spec.ts
@@ -167,6 +167,17 @@ describe('SpaceAuthorizationService', () => {
       );
     });
 
+    it('should throw when space.profile is missing', async () => {
+      const mockSpace = createMockSpace({ profile: undefined });
+      (spaceLookupService.getSpaceOrFail as any).mockResolvedValue(
+        mockSpace as any
+      );
+
+      await expect(service.applyAuthorizationPolicy('space-1')).rejects.toThrow(
+        RelationshipNotFoundException
+      );
+    });
+
     it('should successfully apply auth policy for L0 ACTIVE public space', async () => {
       const mockSpace = createMockSpace();
       (spaceLookupService.getSpaceOrFail as any).mockResolvedValue(
@@ -245,6 +256,9 @@ describe('SpaceAuthorizationService', () => {
       expect(
         templatesManagerAuthorizationService.applyAuthorizationPolicy
       ).toHaveBeenCalled();
+      expect(
+        profileAuthorizationService.applyAuthorizationPolicy
+      ).toHaveBeenCalledWith('space-profile-1', mockSpace.authorization);
     });
 
     it('should apply auth policy for ARCHIVED space without membership', async () => {

--- a/src/domain/space/space/space.service.authorization.spec.ts
+++ b/src/domain/space/space/space.service.authorization.spec.ts
@@ -15,6 +15,7 @@ import { RoleSetService } from '@domain/access/role-set/role.set.service';
 import { CollaborationAuthorizationService } from '@domain/collaboration/collaboration/collaboration.service.authorization';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { LicenseAuthorizationService } from '@domain/common/license/license.service.authorization';
+import { ProfileAuthorizationService } from '@domain/common/profile/profile.service.authorization';
 import { CommunityAuthorizationService } from '@domain/community/community/community.service.authorization';
 import { StorageAggregatorAuthorizationService } from '@domain/storage/storage-aggregator/storage.aggregator.service.authorization';
 import { TemplatesManagerAuthorizationService } from '@domain/template/templates-manager/templates.manager.service.authorization';
@@ -34,6 +35,7 @@ describe('SpaceAuthorizationService', () => {
   let collaborationAuthorizationService: CollaborationAuthorizationService;
   let storageAggregatorAuthorizationService: StorageAggregatorAuthorizationService;
   let spaceAboutAuthorizationService: SpaceAboutAuthorizationService;
+  let profileAuthorizationService: ProfileAuthorizationService;
   let licenseAuthorizationService: LicenseAuthorizationService;
   let templatesManagerAuthorizationService: TemplatesManagerAuthorizationService;
   let platformRolesAccessService: PlatformRolesAccessService;
@@ -80,6 +82,7 @@ describe('SpaceAuthorizationService', () => {
       id: 'about-1',
       profile: { id: 'profile-1' },
     },
+    profile: { id: 'space-profile-1' },
     storageAggregator: { id: 'storage-1' },
     templatesManager: { id: 'templates-1' },
     subspaces: [],
@@ -117,11 +120,16 @@ describe('SpaceAuthorizationService', () => {
       StorageAggregatorAuthorizationService
     );
     spaceAboutAuthorizationService = module.get(SpaceAboutAuthorizationService);
+    profileAuthorizationService = module.get(ProfileAuthorizationService);
     licenseAuthorizationService = module.get(LicenseAuthorizationService);
     templatesManagerAuthorizationService = module.get(
       TemplatesManagerAuthorizationService
     );
     platformRolesAccessService = module.get(PlatformRolesAccessService);
+
+    (
+      profileAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
   });
 
   it('should be defined', () => {

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -29,6 +29,7 @@ import { CollaborationAuthorizationService } from '@domain/collaboration/collabo
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { LicenseAuthorizationService } from '@domain/common/license/license.service.authorization';
+import { ProfileAuthorizationService } from '@domain/common/profile/profile.service.authorization';
 import { CommunityAuthorizationService } from '@domain/community/community/community.service.authorization';
 import { StorageAggregatorAuthorizationService } from '@domain/storage/storage-aggregator/storage.aggregator.service.authorization';
 import { TemplatesManagerAuthorizationService } from '@domain/template/templates-manager/templates.manager.service.authorization';
@@ -50,6 +51,7 @@ export class SpaceAuthorizationService {
     private communityAuthorizationService: CommunityAuthorizationService,
     private collaborationAuthorizationService: CollaborationAuthorizationService,
     private spaceAboutAuthorizationService: SpaceAboutAuthorizationService,
+    private profileAuthorizationService: ProfileAuthorizationService,
     private templatesManagerAuthorizationService: TemplatesManagerAuthorizationService,
     private spaceLookupService: SpaceLookupService,
     private licenseAuthorizationService: LicenseAuthorizationService,
@@ -80,6 +82,7 @@ export class SpaceAuthorizationService {
         about: {
           profile: true,
         },
+        profile: true,
         storageAggregator: {
           authorization: true,
           directStorage: { authorization: true },
@@ -94,6 +97,7 @@ export class SpaceAuthorizationService {
       !space.authorization ||
       !space.community ||
       !space.community.roleSet ||
+      !space.profile ||
       !space.subspaces ||
       !space.license
     ) {
@@ -392,6 +396,7 @@ export class SpaceAuthorizationService {
       !space.community.roleSet ||
       !space.about ||
       !space.about.profile ||
+      !space.profile ||
       !space.storageAggregator ||
       !space.license
     ) {
@@ -472,6 +477,13 @@ export class SpaceAuthorizationService {
         [credentialRuleReadOnAbout]
       );
     updatedAuthorizations.push(...aboutAuthorizations);
+
+    const profileAuthorizations =
+      await this.profileAuthorizationService.applyAuthorizationPolicy(
+        space.profile.id,
+        space.authorization
+      );
+    updatedAuthorizations.push(...profileAuthorizations);
 
     return updatedAuthorizations;
   }

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -102,8 +102,9 @@ export class SpaceAuthorizationService {
       !space.license
     ) {
       throw new RelationshipNotFoundException(
-        `Unable to load Space with entities at start of auth reset: ${space.id} `,
-        LogContext.SPACES
+        'Unable to load Space with entities at start of auth reset',
+        LogContext.SPACES,
+        { spaceID: space.id }
       );
     }
 
@@ -401,8 +402,9 @@ export class SpaceAuthorizationService {
       !space.license
     ) {
       throw new RelationshipNotFoundException(
-        `Unable to load entities on auth reset for space base ${space.id} `,
-        LogContext.SPACES
+        'Unable to load entities on auth reset for space base',
+        LogContext.SPACES,
+        { spaceID: space.id }
       );
     }
 

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -69,13 +69,7 @@ import { SpaceFilterService } from '@services/infrastructure/space-filter/space.
 import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
 import { keyBy } from 'lodash';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import {
-  EntityManager,
-  FindManyOptions,
-  FindOneOptions,
-  In,
-  Repository,
-} from 'typeorm';
+import { FindManyOptions, FindOneOptions, In, Repository } from 'typeorm';
 import { IAccount } from '../account/account.interface';
 import { ISpaceAbout } from '../space.about/space.about.interface';
 import { SpaceAboutService } from '../space.about/space.about.service';


### PR DESCRIPTION
## Summary
- Wires `space.service.authorization.ts` and `account.service.authorization.ts` to load `entity.profile` and cascade auth via `profileAuthorizationService.applyAuthorizationPolicy`, which in turn cascades to `profile.storageBucket`.
- Repairs the broken storage-bucket auth policies that surface as alkem-io/client-web#9636 ("AuthorizationPolicy without credential rules provided" on the Storage tab).
- Also removes two pre-existing unused imports flagged by biome.

## Linked issue
Fixes alkem-io/client-web#9636

## Root cause
Commit `e182239bd` (PR introducing the Actor/NameableEntity refactor) added `space.profile = createProfile(ProfileType.SPACE, …)` and `account.profile = createProfile(ProfileType.ACCOUNT, …)` but did not touch any `*.authorization.ts` files. As a result, every Space/Account created after that commit had a profile (and underlying storage bucket) whose authorization policy was never reset, leaving `credentialRules = []`. When the Storage tab's field-resolver tried `grantAccessOrFail(actor, bucket.authorization, READ)`, the empty rules tripped `AuthorizationInvalidPolicyException`.

Pre-existing entities (User, Organization, VirtualContributor) already had auth-cascade to their own `profile`, so they were unaffected.

## Scope of broken data on acceptance (read-only verification)
- 92 broken Space.profile storage buckets (89 live + 3 orphan)
- 78 broken Account.profile storage buckets (all live)
- All created **after** 2026-02-24, matching the regression commit date.
- Other broken bucket types in the DB (callout-framing, contribution-link, etc.) pre-date `e182239bd` and are unrelated noise — not addressed here.

## Recovery
Running an auth-reset on each affected Space/Account through the existing tooling will repopulate the empty `credentialRules`. No data migration required.

## Test plan
- [x] `pnpm lint` clean (no new warnings; removed two pre-existing ones)
- [x] `pnpm test -- src/domain/space/space/space.service.authorization.spec.ts src/domain/space/account/account.service.authorization.spec.ts` — all green
- [x] Full suite (581 files, 6453 tests) green
- [ ] After deploy: run auth-reset on affected Spaces/Accounts in acceptance and confirm Storage tab loads
- [ ] Verify no new `AuthorizationPolicy without credential rules provided` errors in client-web Storage tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authorization policy enforcement to include profile validation and authorization for accounts and spaces, ensuring proper access control across these entities.

* **Tests**
  * Expanded test coverage for profile authorization scenarios and missing profile handling.

* **Chores**
  * Removed unused imports and reformatted code imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/server/pull/6062)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->