### PR TITLE
fix(migrations): backfill missing storage_bucket on Space/Account profiles

### DIFF
--- a/src/migrations/1779062400000-BackfillSpaceAccountProfileBuckets.ts
+++ b/src/migrations/1779062400000-BackfillSpaceAccountProfileBuckets.ts
@@ -1,0 +1,103 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Repairs Space/Account profiles created by migration 1771000022000
+ * (MoveNameIdToActorAddSpaceAccountProfiles) which inserted minimal
+ * profile rows for pre-existing Spaces/Accounts but skipped creating
+ * the `storage_bucket` and `location` rows that
+ * `ProfileService.createProfile()` normally creates alongside.
+ *
+ * Affected rows are detectable as: `profile.type IN ('space','account')`
+ * AND `profile.storageBucketId IS NULL`. The parent storage_aggregator is
+ * resolved via the owning Space or Account, both of which extend Actor
+ * (CTI) so `actor.id = space.id = account.id`.
+ *
+ * Without this repair, `ProfileAuthorizationService.applyAuthorizationPolicy`
+ * fails its relation null-check (`!profile.storageBucket`) on auth-reset of
+ * the owning Space/Account, throwing `RelationshipNotFoundException`.
+ */
+export class BackfillSpaceAccountProfileBuckets1779062400000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      DECLARE
+        rec RECORD;
+        new_bucket_id uuid;
+        new_bucket_auth_id uuid;
+        new_location_id uuid;
+        default_mime_types TEXT := 'application/pdf,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet,text/csv,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text,application/rtf,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.oasis.opendocument.presentation,application/vnd.ms-powerpoint.presentation.macroEnabled.12,application/vnd.openxmlformats-officedocument.presentationml.slideshow,application/vnd.ms-powerpoint.slideshow.macroEnabled.12,application/vnd.openxmlformats-officedocument.presentationml.template,application/vnd.ms-powerpoint.template.macroEnabled.12,application/vnd.oasis.opendocument.graphics,image/bmp,image/jpg,image/jpeg,image/x-png,image/png,image/gif,image/webp,image/svg+xml,image/avif,image/heic,image/heif';
+        default_max_file_size INT := 15728640;
+        default_geo_location JSONB := '{"isValid": false}'::jsonb;
+        skipped_count INT := 0;
+      BEGIN
+        FOR rec IN
+          SELECT
+            p.id AS profile_id,
+            COALESCE(s."storageAggregatorId", acc."storageAggregatorId") AS aggregator_id
+          FROM profile p
+          INNER JOIN actor a ON a."profileId" = p.id
+          LEFT JOIN space s ON s.id = a.id AND a.type = 'space'
+          LEFT JOIN account acc ON acc.id = a.id AND a.type = 'account'
+          WHERE p.type IN ('space', 'account')
+            AND p."storageBucketId" IS NULL
+        LOOP
+          IF rec.aggregator_id IS NULL THEN
+            -- Owning Space/Account has no storage_aggregator either; cannot
+            -- create a bucket without one. Skip and let the operator triage.
+            skipped_count := skipped_count + 1;
+            RAISE NOTICE
+              'Skipping profile % — parent Space/Account has no storage_aggregator',
+              rec.profile_id;
+            CONTINUE;
+          END IF;
+
+          new_bucket_id := gen_random_uuid();
+          new_bucket_auth_id := gen_random_uuid();
+          new_location_id := gen_random_uuid();
+
+          INSERT INTO authorization_policy
+            (id, "createdDate", "updatedDate", version,
+             "credentialRules", "privilegeRules", type)
+          VALUES
+            (new_bucket_auth_id, NOW(), NOW(), 1,
+             '[]'::jsonb, '[]'::jsonb, 'storage-bucket');
+
+          INSERT INTO storage_bucket
+            (id, "createdDate", "updatedDate", version,
+             "allowedMimeTypes", "maxFileSize",
+             "authorizationId", "storageAggregatorId")
+          VALUES
+            (new_bucket_id, NOW(), NOW(), 1,
+             default_mime_types, default_max_file_size,
+             new_bucket_auth_id, rec.aggregator_id);
+
+          INSERT INTO location
+            (id, "createdDate", "updatedDate", version, "geoLocation")
+          VALUES
+            (new_location_id, NOW(), NOW(), 1, default_geo_location);
+
+          UPDATE profile
+          SET "storageBucketId" = new_bucket_id,
+              "locationId" = new_location_id
+          WHERE id = rec.profile_id;
+        END LOOP;
+
+        IF skipped_count > 0 THEN
+          RAISE NOTICE
+            '% profile(s) skipped: parent has no storage_aggregator. Manual review required.',
+            skipped_count;
+        END IF;
+      END $$;
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Data-repair migration with no safe automatic reversal: once the
+    // backfilled buckets are in use (documents uploaded, auth rules
+    // populated by reset), deleting them would lose work. If you need to
+    // undo a botched migration run, do so manually with full operator
+    // context.
+  }
+}

--- a/src/migrations/1779062400000-BackfillSpaceAccountProfileBuckets.ts
+++ b/src/migrations/1779062400000-BackfillSpaceAccountProfileBuckets.ts
@@ -35,6 +35,7 @@ export class BackfillSpaceAccountProfileBuckets1779062400000
         FOR rec IN
           SELECT
             p.id AS profile_id,
+            p."locationId" AS existing_location_id,
             COALESCE(s."storageAggregatorId", acc."storageAggregatorId") AS aggregator_id
           FROM profile p
           INNER JOIN actor a ON a."profileId" = p.id
@@ -55,7 +56,10 @@ export class BackfillSpaceAccountProfileBuckets1779062400000
 
           new_bucket_id := gen_random_uuid();
           new_bucket_auth_id := gen_random_uuid();
-          new_location_id := gen_random_uuid();
+          -- Preserve any existing location row; only synthesise one if the
+          -- profile has none. Avoids orphaning location rows for profiles
+          -- that lost only their storage_bucket.
+          new_location_id := rec.existing_location_id;
 
           INSERT INTO authorization_policy
             (id, "createdDate", "updatedDate", version,
@@ -73,10 +77,13 @@ export class BackfillSpaceAccountProfileBuckets1779062400000
              default_mime_types, default_max_file_size,
              new_bucket_auth_id, rec.aggregator_id);
 
-          INSERT INTO location
-            (id, "createdDate", "updatedDate", version, "geoLocation")
-          VALUES
-            (new_location_id, NOW(), NOW(), 1, default_geo_location);
+          IF new_location_id IS NULL THEN
+            new_location_id := gen_random_uuid();
+            INSERT INTO location
+              (id, "createdDate", "updatedDate", version, "geoLocation")
+            VALUES
+              (new_location_id, NOW(), NOW(), 1, default_geo_location);
+          END IF;
 
           UPDATE profile
           SET "storageBucketId" = new_bucket_id,
@@ -96,8 +103,18 @@ export class BackfillSpaceAccountProfileBuckets1779062400000
   public async down(_queryRunner: QueryRunner): Promise<void> {
     // Data-repair migration with no safe automatic reversal: once the
     // backfilled buckets are in use (documents uploaded, auth rules
-    // populated by reset), deleting them would lose work. If you need to
-    // undo a botched migration run, do so manually with full operator
-    // context.
+    // populated by reset), deleting them would lose work.
+    //
+    // For a manual rollback the operator must, in order:
+    //   1. Identify backfilled storage_bucket rows whose owning profile is
+    //      `type IN ('space','account')` and currently has the empty
+    //      `authorization_policy` shape this migration produced
+    //      (`credentialRules = '[]'` and `privilegeRules = '[]'`);
+    //      confirm no document rows reference them.
+    //   2. NULL out `profile.storageBucketId` (and, where this migration
+    //      also created a fresh location, `profile.locationId`) on those
+    //      profiles.
+    //   3. DELETE the storage_bucket rows, then the associated
+    //      authorization_policy rows, then the orphaned location rows.
   }
 }


### PR DESCRIPTION
## Summary
Backfills the `storage_bucket` (+ its `authorization_policy`) and `location` rows that should have been created alongside the Space/Account profiles inserted by migration `1771000022000` (`MoveNameIdToActorAddSpaceAccountProfiles`, from the Actor/NameableEntity refactor in commit `e182239bd`).

## Why
The original migration backfilled minimal `profile` rows for pre-existing Spaces and Accounts that did not yet have a profile, but it skipped the `storage_bucket` and `location` rows that `ProfileService.createProfile()` creates alongside in the normal code path. The gap was harmless until alkem-io/server#6062 wired `Space.profile` / `Account.profile` into the auth-reset cascade — that cascade walks `ProfileAuthorizationService.applyAuthorizationPolicy`, which has a strict relation null-check at `src/domain/common/profile/profile.service.authorization.ts:83`:

```
if (!profile.references || !profile.tagsets || !profile.authorization ||
    !profile.visuals || !profile.storageBucket) {
  throw new RelationshipNotFoundException(...);
}
```

`profile.storageBucket` is `null` for these orphan profiles, so the reset throws:

```
RelationshipNotFoundException: Unable to load Profile with entities at start of auth reset: 599846d5-ff88-427c-8b5c-62c7b8cf08c9
  at ProfileAuthorizationService.applyAuthorizationPolicy (.../profile.service.authorization.js:81:19)
  at SpaceAuthorizationService.propagateAuthorizationToChildEntities (.../space.service.authorization.js:266:39)
  at SpaceAuthorizationService.applyAuthorizationPolicy (.../space.service.authorization.js:162:37)
  at AccountAuthorizationService.applyAuthorizationPolicyForChildEntities (.../account.service.authorization.js:112:41)
  at AccountAuthorizationService.applyAuthorizationPolicy (.../account.service.authorization.js:87:44)
```

## What this migration creates per affected profile

Output is row-shape-identical to what `mgr.save(space|account)` cascades at original create time:

- new `authorization_policy` (type `storage-bucket`, empty rules — populated by the next auth-reset)
- new `storage_bucket` (default allowed mime types, `maxFileSize = 15728640`, attached to the owning Space/Account's `storageAggregatorId`)
- new `location` (`geoLocation = '{"isValid": false}'` — matches what `LocationService.createLocation()` produces without an address)
- `profile.storageBucketId` and `profile.locationId` linked

Constants are inlined (no imports from `src/common/enums`) per the project's migration policy — keeps history stable against future enum edits.

## Idempotency

The SELECT predicate excludes profiles that already have `storageBucketId IS NOT NULL`, so re-running the migration is a no-op once applied. Profiles whose parent Space/Account has no `storage_aggregator` at all (none exist on dev) are skipped with a `RAISE NOTICE`.

## Scope (dev cluster verified read-only)

| profile.type | total | backfilled by this migration | skipped |
|---|---|---|---|
| space | 286 | 27 | 0 |
| account | 54 | 20 | 0 |

## Down

No-op with a comment. Once backfilled buckets are in active use, deleting them would lose work; safer to leave irreversible.

## Related
- alkem-io/server#6062 — cascaded auth into Space.profile / Account.profile (introduces the visible failure)
- Original regression: commit `e182239bd` (PR-introducing migration `1771000022000`)

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test:ci:no:coverage` — 581 files / 6459 tests green
- [x] Dry-run SELECT against dev DB — matches expected 47 affected profiles, 0 unrecoverable
- [ ] After merge: run `pnpm migration:run` on dev; verify the 47 broken profiles now have buckets
- [ ] Run `auth:reset` on each affected Space/Account; verify the resets succeed (no more `Unable to load Profile with entities` errors)
- [ ] Confirm Storage admin tab loads on a previously affected Space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored missing storage bucket and location relationships for space and account profiles, creating required default entries so affected profiles have working file storage and location metadata.
  * Profiles lacking an owning storage aggregator are left untouched and recorded as skipped.

* **Chores**
  * Migration applied as a one-way data repair (no automatic rollback).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/server/pull/6069)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->