### PR TITLE
fix: contributors-rule cascade + drop dead UserInfo type aliases

### DIFF
--- a/src/domain/collaboration/collaboration/collaboration.service.authorization.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.authorization.ts
@@ -289,6 +289,7 @@ export class CollaborationAuthorizationService {
         contributors,
         CREDENTIAL_RULE_COLLABORATION_CONTRIBUTORS
       );
+    contributorsRule.cascade = true;
     newRules.push(contributorsRule);
 
     return this.authorizationPolicyService.appendCredentialAuthorizationRules(

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -109,17 +109,9 @@ export class CollaborativeDocumentIntegrationService {
   }
 
   public async who(data: WhoInputData): Promise<string> {
-    const actorContext = await this.authenticationService.getActorContext(
-      data.auth
-    );
+    const authCtx = await this.authenticationService.getActorContext(data.auth);
 
-    // Anonymous callers must not get an actor identifier back — the
-    // RPC reply is forwarded to the collaborative-document client.
-    if (actorContext.isAnonymous) {
-      return '';
-    }
-
-    return actorContext.actorID;
+    return authCtx.actorID;
   }
 
   public async save({

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -109,9 +109,17 @@ export class CollaborativeDocumentIntegrationService {
   }
 
   public async who(data: WhoInputData): Promise<string> {
-    const authCtx = await this.authenticationService.getActorContext(data.auth);
+    const actorContext = await this.authenticationService.getActorContext(
+      data.auth
+    );
 
-    return authCtx.actorID;
+    // Anonymous callers must not get an actor identifier back — the
+    // RPC reply is forwarded to the collaborative-document client.
+    if (actorContext.isAnonymous) {
+      return '';
+    }
+
+    return actorContext.actorID;
   }
 
   public async save({

--- a/src/services/collaborative-document-integration/types/index.ts
+++ b/src/services/collaborative-document-integration/types/index.ts
@@ -1,4 +1,3 @@
 export * from './error.codes';
 export * from './event.pattern.enum';
 export * from './message.pattern.enum';
-export * from './user.info';

--- a/src/services/collaborative-document-integration/types/user.info.ts
+++ b/src/services/collaborative-document-integration/types/user.info.ts
@@ -1,4 +1,4 @@
 export type UserInfo = {
   id: string;
-  email: string;
+  guestName?: string;
 };

--- a/src/services/collaborative-document-integration/types/user.info.ts
+++ b/src/services/collaborative-document-integration/types/user.info.ts
@@ -1,4 +1,0 @@
-export type UserInfo = {
-  id: string;
-  guestName?: string;
-};

--- a/src/services/whiteboard-integration/types/index.ts
+++ b/src/services/whiteboard-integration/types/index.ts
@@ -1,4 +1,3 @@
 export * from './event.pattern';
 
 export * from './message.pattern';
-export * from './user.info';

--- a/src/services/whiteboard-integration/types/user.info.ts
+++ b/src/services/whiteboard-integration/types/user.info.ts
@@ -1,4 +1,4 @@
 export type UserInfo = {
   id: string;
-  email: string;
+  guestName?: string;
 };

--- a/src/services/whiteboard-integration/types/user.info.ts
+++ b/src/services/whiteboard-integration/types/user.info.ts
@@ -1,4 +1,0 @@
-export type UserInfo = {
-  id: string;
-  guestName?: string;
-};


### PR DESCRIPTION
Two small follow-ups to PR #5888 (which already shipped the big contribution-reporter restructure). The original PR for these changes was #5894, but it got stale (March 2026) and ~70% of it has since been independently merged via #5888. This PR carries forward the bits #5888 did not subsume that still hold up under scrutiny.

## Changes

### 1. `collaboration.service.authorization.ts` — contributors rule cascades

The siblings (`adminsRule`, line 254) already cascade. `contributorsRule` was the lone exception, so the contribute privilege wasn't flowing to child entities of a Collaboration. One-line fix.

```diff
   const contributorsRule =
     this.authorizationPolicyService.createCredentialRule(
       [AuthorizationPrivilege.CONTRIBUTE],
       contributors,
       CREDENTIAL_RULE_COLLABORATION_CONTRIBUTORS
     );
+  contributorsRule.cascade = true;
   newRules.push(contributorsRule);
```

### 2. Delete both dead `UserInfo` type aliases

PR #5894's original scope was to remove the `email` field from `whiteboard-integration/types/user.info.ts`. Audit showed:

- An identical `UserInfo` type was also declared in `collaborative-document-integration/types/user.info.ts`.
- Both types are re-exported via their package's `types/index.ts` barrel.
- **Neither type is imported anywhere** in `src/` or `test/` (verified by `grep -rn 'UserInfo\b' src/ test/`).
- The only barrel consumer downstream (`save.output.data.ts` pulling `SaveErrorCodes`) is unaffected.

Renaming a field on dead code doesn't do anything useful — the call site that supposedly leaks email doesn't exist. So both type files + their barrel `export * from './user.info'` lines are deleted outright. If a future integration revives this concept, it should design the type fresh against current privacy norms.

## Dropped from scope

PR #5894 also patched `CollaborativeDocumentIntegrationService.who()` to early-return `''` when the caller is anonymous. Tracing the actual behaviour:

- `ActorContext.actorID` defaults to `''` (class-field default).
- `ActorContextService.createAnonymous()` sets `credentials` + `isAnonymous = true` but does **not** touch `actorID`.
- So `authCtx.actorID` is already `''` for any anonymous caller today.

The `if (isAnonymous) return ''` branch would only fire in a case where the existing code already returns the same value. Zero runtime effect — pretend-protection that suggests a fix was needed when nothing was actually leaking. Dropped.

## Closes / replaces

- Replaces stale PR #5894 by @valeksiev (March 2026). The other content of #5894 is already on develop via #5888.
- #5894 has been closed with a pointer to this one.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Affected vitest specs pass (`collaboration.service.authorization.spec.ts`, etc.) — 105 tests green