### PR TITLE
feat(forum): expose platform-wide mentionableContributors on Forum (#9742)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2647,6 +2647,10 @@ type Forum {
   discussions(queryData: DiscussionsInput): [Discussion!]
   """The ID of the entity"""
   id: UUID!
+  """
+  Capped list of Contributors (Users, Virtual Contributors, …) that may be @mentioned in the platform Forum. The Forum is platform-wide, so all platform Contributors of the requested types are returned. Use `filter` for typeahead search and `types` to restrict which Contributor kinds are returned.
+  """
+  mentionableContributors(filter: ContributorFilterInput, limit: Int, types: [ActorType!]): [ActorFull!]!
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
 }

--- a/src/platform/forum/forum.module.ts
+++ b/src/platform/forum/forum.module.ts
@@ -1,4 +1,5 @@
 import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { ActorLookupModule } from '@domain/actor/actor-lookup/actor.lookup.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { RoomModule } from '@domain/communication/room/room.module';
 import { Module } from '@nestjs/common';
@@ -20,6 +21,7 @@ import { ForumAuthorizationService } from './forum.service.authorization';
 @Module({
   imports: [
     AuthorizationModule,
+    ActorLookupModule,
     NotificationAdapterModule,
     AuthorizationPolicyModule,
     DiscussionModule,

--- a/src/platform/forum/forum.resolver.fields.spec.ts
+++ b/src/platform/forum/forum.resolver.fields.spec.ts
@@ -1,0 +1,73 @@
+import { ActorType } from '@common/enums/actor.type';
+import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { ForumResolverFields } from './forum.resolver.fields';
+
+describe('ForumResolverFields', () => {
+  let resolver: ForumResolverFields;
+  let actorLookupService: ActorLookupService;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ForumResolverFields, MockWinstonProvider],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    resolver = module.get(ForumResolverFields);
+    actorLookupService = module.get(ActorLookupService);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('mentionableContributors', () => {
+    it('queries the all-platform scope and forwards filter / limit / types', async () => {
+      const results = [
+        { id: 'a-1', type: ActorType.USER },
+        { id: 'a-2', type: ActorType.VIRTUAL_CONTRIBUTOR },
+      ] as any;
+      vi.mocked(
+        actorLookupService.findMentionableContributors
+      ).mockResolvedValue(results);
+
+      const result = await resolver.mentionableContributors(
+        { displayName: 'jo' },
+        50,
+        [ActorType.USER]
+      );
+
+      expect(
+        actorLookupService.findMentionableContributors
+      ).toHaveBeenCalledWith(
+        { allPlatform: true },
+        [ActorType.USER],
+        { displayName: 'jo' },
+        50
+      );
+      expect(result).toBe(results);
+    });
+
+    it('forwards undefined filter / limit / types when omitted by the caller', async () => {
+      vi.mocked(
+        actorLookupService.findMentionableContributors
+      ).mockResolvedValue([]);
+
+      await resolver.mentionableContributors();
+
+      expect(
+        actorLookupService.findMentionableContributors
+      ).toHaveBeenCalledWith(
+        { allPlatform: true },
+        undefined,
+        undefined,
+        undefined
+      );
+    });
+  });
+});

--- a/src/platform/forum/forum.resolver.fields.ts
+++ b/src/platform/forum/forum.resolver.fields.ts
@@ -1,8 +1,12 @@
 import { AuthorizationPrivilege } from '@common/enums';
+import { ActorType } from '@common/enums/actor.type';
 import { GraphqlGuard } from '@core/authorization';
+import { ContributorFilterInput } from '@core/filtering/input-types';
+import { IActorFull } from '@domain/actor/actor/actor.interface';
+import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { UUID } from '@domain/common/scalars';
 import { UseGuards } from '@nestjs/common';
-import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, Int, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import {
   AuthorizationActorHasPrivilege,
   Profiling,
@@ -14,7 +18,10 @@ import { ForumService } from './forum.service';
 
 @Resolver(() => IForum)
 export class ForumResolverFields {
-  constructor(private forumService: ForumService) {}
+  constructor(
+    private forumService: ForumService,
+    private actorLookupService: ActorLookupService
+  ) {}
 
   @AuthorizationActorHasPrivilege(AuthorizationPrivilege.READ)
   @UseGuards(GraphqlGuard)
@@ -53,5 +60,30 @@ export class ForumResolverFields {
     discussionID: string
   ): Promise<IDiscussion> {
     return await this.forumService.getDiscussionOrFail(forum, discussionID);
+  }
+
+  @AuthorizationActorHasPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
+  @ResolveField('mentionableContributors', () => [IActorFull], {
+    nullable: false,
+    description:
+      'Capped list of Contributors (Users, Virtual Contributors, …) that may be ' +
+      '@mentioned in the platform Forum. The Forum is platform-wide, so all ' +
+      'platform Contributors of the requested types are returned. Use `filter` ' +
+      'for typeahead search and `types` to restrict which Contributor kinds are ' +
+      'returned.',
+  })
+  async mentionableContributors(
+    @Args('filter', { nullable: true }) filter?: ContributorFilterInput,
+    @Args('limit', { type: () => Int, nullable: true }) limit?: number,
+    @Args('types', { type: () => [ActorType], nullable: true })
+    types?: ActorType[]
+  ): Promise<IActorFull[]> {
+    return this.actorLookupService.findMentionableContributors(
+      { allPlatform: true },
+      types,
+      filter,
+      limit
+    );
   }
 }


### PR DESCRIPTION
## Problem

@mention in Forum discussions never lists any users — reproducible on both the old (MUI) and new (CRD) design.

**Root cause:** the only `mentionableContributors` field lived on `Space`, resolving a visibility-aware scope from a `spaceID`. The platform Forum has no Space context, so the client could not supply a `spaceID` and the field could never resolve a list. See alkem-io/client-web#9742.

## Change

Add a `Forum.mentionableContributors(filter, limit, types)` resolver field that reuses the existing `{ allPlatform: true }` scope already supported by `ActorLookupService.findMentionableContributors` (the same scope a public L0 root space yields). Since the Forum is platform-wide, it returns all platform Contributors of the requested types.

- `forum.resolver.fields.ts` — new resolver field, guarded by `READ` like `discussions`.
- `forum.module.ts` — import `ActorLookupModule`.
- `forum.resolver.fields.spec.ts` — unit tests (allPlatform scope + arg forwarding).
- `schema.graphql` — regenerated (field only, +4 lines).

## Testing

- `vitest run src/platform/forum/forum.resolver.fields.spec.ts` — 3 passing.
- `tsc --noEmit` — clean.

Paired with the client-web PR on branch `client-9742`.

Closes #9742

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a mentionable contributors feature that allows users to discover and reference platform contributors within forum discussions with filtering options and customizable result limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/server/pull/6101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->