### PR TITLE
chore(azure-decommission): drop Azure devcontainer extension (US6)

### DIFF
--- a/.devcontainer/devcontainer-minimal.json
+++ b/.devcontainer/devcontainer-minimal.json
@@ -13,7 +13,6 @@
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "ms-azuretools.vscode-docker",
         "eamodio.gitlens",
         "firsttris.vscode-jest-runner",
         "GraphQL.vscode-graphql",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "ms-azuretools.vscode-docker",
         "eamodio.gitlens",
         "firsttris.vscode-jest-runner",
         "GraphQL.vscode-graphql",


### PR DESCRIPTION
## Summary

Part of the **zero-Azure decommission** — `workspace#003-azure-decommission`, **US6** (cosmetic scrub, no runtime impact).

- Remove `"ms-azuretools.vscode-docker"` from `.devcontainer/devcontainer.json` and `.devcontainer/devcontainer-minimal.json`.

This PR does **not** affect the GraphQL schema — the Schema Contract checklist below is N/A.

## Schema Contract Checklist (Feature 002)

- [x] N/A — devcontainer config only; no `schema.graphql` change.

## Other Notes

- Both devcontainer files remain valid JSON.
- **T048 (`.scripts/migrations/alkemio_dump.psql`) is intentionally NOT in this PR.** That 5.1 GB dump is **gitignored / untracked** — its embedded `AZURE_OPENAI_*` credential is never committed, so there is nothing to remove from the repo. Final disposition (delete the local fixture, or scrub + scope-exempt) is a repo-owner decision.
- The `azure/*` GitHub Actions in `build-deploy-k8s-*-hetzner.yml` are **documented exemptions** (also tracked in server spec `037-self-hosted-runners`) — untouched.
- **US5** (legacy `AZURE_*` LLM env pass-through to `libra-flow`) is gated on the VC migration — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
