### PR TITLE
fix(schema): make deprecation-lifecycle test dates relative (de-bomb)

### DIFF
--- a/src/tools/schema/__tests__/lifecycle-window.spec.ts
+++ b/src/tools/schema/__tests__/lifecycle-window.spec.ts
@@ -37,6 +37,17 @@ function writeSchema(p: string, sdl: string) {
   writeFileSync(p, sdl.trim() + '\n');
 }
 
+/**
+ * Returns an ISO `YYYY-MM-DD` date `n` days from today (negative = past).
+ * All fixture dates are computed relative to `new Date()` so these tests are
+ * calendar-independent and never expire (no hardcoded "time-bomb" literals).
+ */
+const isoDaysFromNow = (n: number): string => {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0, 10);
+};
+
 describe('FR-005/011/012 deprecation lifecycle enforcement', () => {
   const tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'schema-lifecycle-'));
   const reportPath = path.join(tmpRoot, 'change-report.json');
@@ -69,9 +80,12 @@ describe('FR-005/011/012 deprecation lifecycle enforcement', () => {
   });
 
   it('classifies premature removal before removeAfter as PREMATURE_REMOVAL', () => {
-    // Prepare baseline with deprecated field (valid window)
-    const sinceDate = '2025-10-01';
-    const removeAfter = '2026-06-01'; // must be in the future relative to today
+    // Prepare baseline with deprecated field (valid window).
+    // removeAfter is comfortably in the FUTURE so removing the field now is
+    // genuinely premature; sinceDate is far enough in the past that the
+    // original deprecation window itself was valid (>= 90 days).
+    const sinceDate = isoDaysFromNow(-240);
+    const removeAfter = isoDaysFromNow(120); // future relative to today
     const deprecatedSchema = `type Query {
       hello: String @deprecated(reason: "REMOVE_AFTER=${removeAfter} | cleanup")
     }`;
@@ -116,8 +130,11 @@ describe('FR-005/011/012 deprecation lifecycle enforcement', () => {
   });
 
   it('classifies removal after removeAfter but <90 elapsed days as INFO', () => {
-    const sinceDate = '2025-09-15';
-    const removeAfter = '2025-10-01'; // already past test date but <90 days elapsed
+    // removeAfter is in the PAST (window met) and fewer than 90 days ago, while
+    // sinceDate is far enough back that the deprecation has been live >= 90 days
+    // — so retirement is valid and classified INFO ("retired after window").
+    const sinceDate = isoDaysFromNow(-150);
+    const removeAfter = isoDaysFromNow(-30); // past, but < 90 days ago
     const deprecatedSchema = `type Query { hello: String @deprecated(reason: "REMOVE_AFTER=${removeAfter} | cleanup") }`;
     const removalSchema = 'type Query { other: String }';
     const oldPath = path.join(tmpRoot, 'breaking-old.graphql');
@@ -157,8 +174,10 @@ describe('FR-005/011/012 deprecation lifecycle enforcement', () => {
   });
 
   it('classifies valid retirement (after removeAfter & >=90 days) as INFO', () => {
-    const sinceDate = '2025-05-01';
-    const removeAfter = '2025-08-15';
+    // Fully valid retirement: removeAfter well in the past AND the deprecation
+    // has been live for >= 90 days (window met + min-days met → INFO).
+    const sinceDate = isoDaysFromNow(-300);
+    const removeAfter = isoDaysFromNow(-200);
     const deprecatedSchema = `type Query { hello: String @deprecated(reason: "REMOVE_AFTER=${removeAfter} | cleanup") }`;
     const retirementSchema = 'type Query { other: String }';
     const oldPath = path.join(tmpRoot, 'retire-old.graphql');


### PR DESCRIPTION
## Problem — time-bomb test

`src/tools/schema/__tests__/lifecycle-window.spec.ts` hardcoded calendar dates that have since expired, making the deprecation-lifecycle classification tests **date-dependent** ("time bombs"). As of 2026-06-01 this caused CI failures (`1 failed | 6638 passed`):

- **"premature removal before removeAfter → PREMATURE_REMOVAL"** pinned `removeAfter = '2026-06-01'` with the comment *"must be in the future relative to today"* — but that date is now **today**, so removing the field is no longer premature and the case fails.
- **"removal after removeAfter but <90 elapsed days → INFO"** pinned `removeAfter = '2025-10-01'` (~243 days in the past) — a **latent** time-bomb waiting to drift.

## Fix

Every fixture date is now **computed relative to `new Date()`** via a small helper:

```ts
const isoDaysFromNow = (n: number): string => {
  const d = new Date();
  d.setDate(d.getDate() + n);
  return d.toISOString().slice(0, 10);
};
```

The cases are now calendar-independent and never expire. **Production classification logic** under `src/tools/schema/` and `src/schema-contract/` is **untouched** — only the test's fixture date setup changed. The 90-day window / premature logic was already correct; only the stale literals were the problem.

## Cases hardened

| Case | Before | After |
|---|---|---|
| premature removal → `PREMATURE_REMOVAL` | `removeAfter='2026-06-01'`, `sinceDate='2025-10-01'` | `removeAfter = today+120`, `sinceDate = today-240` (future → genuinely premature) |
| retirement <90d after removeAfter → `INFO` | `removeAfter='2025-10-01'`, `sinceDate='2025-09-15'` | `removeAfter = today-30`, `sinceDate = today-150` (window met, ≥90 days live) |
| valid retirement (≥90d) → `INFO` | `removeAfter='2025-08-15'`, `sinceDate='2025-05-01'` | `removeAfter = today-200`, `sinceDate = today-300` |

The "<90 days short-window" case (`today+25`) was already dynamic and is kept as-is.

## Verification

Targeted spec, run isolated:

```
✓ src/tools/schema/__tests__/lifecycle-window.spec.ts (4 tests)
  ✓ flags invalid short removal window on new deprecation (<90 days)
  ✓ classifies premature removal before removeAfter as PREMATURE_REMOVAL
  ✓ classifies removal after removeAfter but <90 elapsed days as INFO
  ✓ classifies valid retirement (after removeAfter & >=90 days) as INFO
Test Files  1 passed (1)
     Tests  4 passed (4)
```

Full suite also green: **6628 passed | 7 skipped | 0 failed**.

> ⚠️ This must also be cherry-picked into `release/60` — the same failure blocks Release 60 CI (server PR #6110 / workspace#005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test maintainability by updating test fixtures to use dynamically computed dates instead of hardcoded values, ensuring tests remain accurate across calendar changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->