### PR TITLE
fix(auth): surface passkeys as an authentication method

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -86,6 +86,7 @@ enum AuthenticationType {
   GITHUB
   LINKEDIN
   MICROSOFT
+  PASSKEY
   UNKNOWN
 }
 

--- a/src/common/enums/authentication.type.ts
+++ b/src/common/enums/authentication.type.ts
@@ -6,6 +6,7 @@ export enum AuthenticationType {
   GITHUB = 'github',
   CLEVERBASE = 'cleverbase',
   EMAIL = 'email',
+  PASSKEY = 'passkey',
   UNKNOWN = 'unknown',
 }
 

--- a/src/services/infrastructure/kratos/kratos.service.spec.ts
+++ b/src/services/infrastructure/kratos/kratos.service.spec.ts
@@ -151,6 +151,52 @@ describe('KratosService', () => {
       expect(result).toHaveLength(3);
     });
 
+    it('should return PASSKEY when identity has passkey credentials', () => {
+      const identity = {
+        credentials: {
+          passkey: { type: 'passkey', identifiers: ['UBs4UpEGrcXkdiXg'] },
+        },
+      } as unknown as Identity;
+
+      const result = service.mapAuthenticationType(identity);
+      expect(result).toEqual([AuthenticationType.PASSKEY]);
+    });
+
+    it('should return PASSKEY for legacy webauthn credentials', () => {
+      const identity = {
+        credentials: {
+          webauthn: { type: 'webauthn', identifiers: ['legacy-key'] },
+        },
+      } as unknown as Identity;
+
+      const result = service.mapAuthenticationType(identity);
+      expect(result).toEqual([AuthenticationType.PASSKEY]);
+    });
+
+    it('should include PASSKEY alongside oidc and password (issue #9773 follow-up)', () => {
+      // Real acc identity ev.dimitrovv@gmail.com: cleverbase + linkedin oidc,
+      // a password, AND a passkey — all four must be reported.
+      const identity = {
+        credentials: {
+          oidc: {
+            identifiers: [
+              'cleverbase:1572006587f483f6c1',
+              'linkedin:9NMK-3ClHo',
+            ],
+          },
+          password: { type: 'password' },
+          passkey: { type: 'passkey', identifiers: ['TQ6uViIgcdoMpYzh'] },
+        },
+      } as unknown as Identity;
+
+      const result = service.mapAuthenticationType(identity);
+      expect(result).toContain(AuthenticationType.CLEVERBASE);
+      expect(result).toContain(AuthenticationType.LINKEDIN);
+      expect(result).toContain(AuthenticationType.EMAIL);
+      expect(result).toContain(AuthenticationType.PASSKEY);
+      expect(result).toHaveLength(4);
+    });
+
     it('should de-duplicate when multiple identifiers share a provider', () => {
       const identity = {
         credentials: {

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -218,6 +218,8 @@ export class KratosService {
    *   - `github`    -> `AuthenticationType.GITHUB`
    *   - `cleverbase` -> `AuthenticationType.CLEVERBASE`
    * - If the identity has password credentials, it adds `AuthenticationType.EMAIL`.
+   * - If the identity has passkey (or legacy webauthn) credentials, it adds
+   *   `AuthenticationType.PASSKEY`.
    * - If none of the above conditions are met, it adds `AuthenticationType.UNKNOWN`.
    */
   public mapAuthenticationType(identity: Identity): AuthenticationType[] {
@@ -247,6 +249,13 @@ export class KratosService {
 
     if (identity.credentials.password) {
       authTypes.add(AuthenticationType.EMAIL);
+    }
+
+    // Passkeys are a separate Kratos credential type (`passkey`, with `webauthn`
+    // as the legacy key) — not OIDC and not password — so they must be detected
+    // explicitly or they never surface as an authentication method.
+    if (identity.credentials.passkey || identity.credentials.webauthn) {
+      authTypes.add(AuthenticationType.PASSKEY);
     }
 
     return authTypes.size ? [...authTypes] : [AuthenticationType.UNKNOWN];


### PR DESCRIPTION
## Problem

Passkeys are not added / visible in `me.user.authentication.methods`.

This is the same bug class as the OIDC under-reporting in alkem-io/client-web#9773 — `KratosService.mapAuthenticationType()` only inspected the `oidc` and `password` credential types, so Kratos `passkey` credentials (legacy key: `webauthn`) were never reported.

> Note: the OIDC half of that bug (multi-provider + `CLEVERBASE`) already landed on `release/60` separately, so this PR is **passkeys-only** against the current base.

## Evidence (acceptance, Kratos v26.2.0, admin API)

6 identities have `credentials.passkey`. The standout is `ev.dimitrovv@gmail.com`, which carries **cleverbase + linkedin (oidc) + password + passkey** — all four should be reported, but the passkey was dropped.

## Fix

- Detect `passkey` (and legacy `webauthn`) credentials → new `AuthenticationType.PASSKEY`.
- Add `PASSKEY` to the GraphQL `AuthenticationType` enum (additive, non-breaking); `schema.graphql` regenerated.

```ts
if (identity.credentials.passkey || identity.credentials.webauthn) {
  authTypes.add(AuthenticationType.PASSKEY);
}
```

## Tests

`kratos.service.spec.ts` (63 pass): passkey-only, legacy webauthn, and the full `ev.dimitrovv` shape (`cleverbase + linkedin + password + passkey` → 4 methods). `tsc --noEmit` and `biome check` clean.

## Notes / follow-ups

- The pre-commit full-suite run includes a **pre-existing, date-dependent** failure in `src/tools/schema/__tests__/lifecycle-window.spec.ts` that also fails on the untouched `release/60` base — unrelated to this change.
- `client-web` needs a label/icon for the new `PASSKEY` enum value once this schema ships (and `CLEVERBASE`, from the already-merged OIDC fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)