### PR TITLE
resotre docs + fix quickstart-services for mac around notifications platform

### DIFF
--- a/.claude/commands/restore-dbs.md
+++ b/.claude/commands/restore-dbs.md
@@ -42,10 +42,13 @@ Required variables:
 > nothing. Follow the robust flow in [`docs/DatabaseRestore.md`](../../docs/DatabaseRestore.md) /
 > the [`restore-dbs` skill](../skills/restore-dbs.md): preflight → quiesce → restore → verify.
 
-1. Preflight — credentials present AND have the DB-name vars (stale `.env` is the #1 silent-failure cause):
+1. Preflight — credentials present AND all DB-name vars set (stale `.env` is the #1 silent-failure cause):
 ```bash
-test -f .scripts/backups/.env && grep -q POSTGRES_ALKEMIO_DB .scripts/backups/.env \
-  && echo "env OK" || echo "ERROR: copy .scripts/backups/.env.sample → .env and fill AWS keys + POSTGRES_*_DB"
+test -f .scripts/backups/.env \
+  && grep -q POSTGRES_ALKEMIO_DB .scripts/backups/.env \
+  && grep -q POSTGRES_SYNAPSE_DB .scripts/backups/.env \
+  && grep -q POSTGRES_KRATOS_DB .scripts/backups/.env \
+  && echo "env OK" || echo "ERROR: copy .scripts/backups/.env.sample → .env and fill AWS keys + POSTGRES_{ALKEMIO,SYNAPSE,KRATOS}_DB"
 ```
 
 2. Quiesce — bring the stack down to postgres-only so no service blocks `DROP DATABASE`:

--- a/.claude/commands/restore-dbs.md
+++ b/.claude/commands/restore-dbs.md
@@ -38,15 +38,35 @@ Required variables:
 
 ## Execution
 
-1. First verify credentials exist:
+> ⚠️ Do **not** just run the script and report its output — it can report success while loading
+> nothing. Follow the robust flow in [`docs/DatabaseRestore.md`](../../docs/DatabaseRestore.md) /
+> the [`restore-dbs` skill](../skills/restore-dbs.md): preflight → quiesce → restore → verify.
+
+1. Preflight — credentials present AND have the DB-name vars (stale `.env` is the #1 silent-failure cause):
 ```bash
-test -f .scripts/backups/.env && echo "Credentials file exists" || echo "ERROR: Missing .scripts/backups/.env - copy from .env.sample and configure"
+test -f .scripts/backups/.env && grep -q POSTGRES_ALKEMIO_DB .scripts/backups/.env \
+  && echo "env OK" || echo "ERROR: copy .scripts/backups/.env.sample → .env and fill AWS keys + POSTGRES_*_DB"
 ```
 
-2. If credentials exist, run the restore script. Parse arguments from `$ARGUMENTS` (environment, restart_services, non_interactive, restore_kratos):
+2. Quiesce — bring the stack down to postgres-only so no service blocks `DROP DATABASE`:
 ```bash
-cd .scripts/backups && bash restore_latest_backup_set.sh <environment> [restart_services] [non_interactive] [restore_kratos]
+docker compose -f quickstart-services.yml --env-file .env.docker stop
+docker compose -f quickstart-services.yml --env-file .env.docker up -d postgres
 ```
+
+3. Run the restore (parse `$ARGUMENTS`: environment, restart_services, non_interactive, restore_kratos). Pass `false` for restart so you bring the stack up yourself after:
+```bash
+cd .scripts/backups && bash restore_latest_backup_set.sh <environment> false [non_interactive] [restore_kratos]
+cd ../.. && docker compose -f quickstart-services.yml --env-file .env.docker up -d
+```
+
+4. **Verify** (mandatory — DB sizes should be hundreds of MB, not ~20–30 MB):
+```bash
+docker exec alkemio_dev_postgres psql -U synapse -d postgres -tAc \
+  "select datname, pg_size_pretty(pg_database_size(datname)) from pg_database where datname in ('alkemio','synapse');"
+docker ps --filter name=alkemio_dev_synapse --format '{{.Status}}'   # must be healthy, not Restarting
+```
+If synapse crash-loops with `not native to <name>`, fix `server_name` to match the data domain — see the runbook.
 
 **Default behavior:**
 - Restores `alkemio` and `synapse` databases

--- a/.claude/skills/restore-dbs.md
+++ b/.claude/skills/restore-dbs.md
@@ -1,125 +1,98 @@
 # Database Restoration
 
-When asked to restore databases or work with backup data from environments (prod, dev, acc, sandbox), follow this guide.
+Restore a real environment's data (prod/dev/**acc**/sandbox) into the local Docker
+`alkemio_dev_postgres` container — Alkemio + Synapse, optionally Kratos.
 
-## Overview
+Full runbook + troubleshooting: [`docs/DatabaseRestore.md`](../../docs/DatabaseRestore.md).
+Invoke this when asked to "restore the acc db", "get acc data locally", etc.
 
-The restore system downloads PostgreSQL backups from Scaleway S3 and restores them to the local Docker PostgreSQL container (`alkemio_dev_postgres`).
+## Critical: this restore silently fails in two ways — always run the robust flow + verify
 
-**Databases available:**
-- `alkemio` - Main application database
-- `synapse` - Matrix/Synapse communication database
-- `kratos` - Ory Kratos identity database (optional, usually not restored)
+A naive `bash restore_latest_backup_set.sh acc` can report success while loading **nothing**.
+Two traps (both cost real debugging time on 2026-06-02):
 
-## Prerequisites
+1. **Stale `.env`** missing `POSTGRES_*_DB` → target db name is empty → `DROP DATABASE ;` errors
+   under `set -e` → restore aborts, stale seed data left behind.
+2. **Live connections** — stack services reconnect faster than the script's terminate→drop, so
+   `DROP DATABASE` fails. Restore must run with the stack **down to postgres-only**.
 
-### 1. Credentials File
+So do NOT just run the script and report its output. Follow the procedure below and **verify by
+DB size** at the end.
 
-Ensure `.scripts/backups/.env` exists:
+## Procedure (default target: acc)
 
-```bash
-# Check if credentials exist
-test -f .scripts/backups/.env && echo "OK" || echo "Missing - needs setup"
-```
-
-If missing, create from sample:
-```bash
-cp .scripts/backups/.env.sample .scripts/backups/.env
-```
-
-Required variables:
-- `AWS_ACCESS_KEY_ID` - Scaleway S3 access key
-- `AWS_SECRET_ACCESS_KEY` - Scaleway S3 secret key
-- `POSTGRES_USER` - PostgreSQL user (typically "synapse")
-- `POSTGRES_PASSWORD` - PostgreSQL password
-- `POSTGRES_ALKEMIO_DB` - Alkemio database name
-- `POSTGRES_KRATOS_DB` - Kratos database name
-- `POSTGRES_SYNAPSE_DB` - Synapse database name
-
-### 2. Docker Services
-
-The PostgreSQL container must be running:
-```bash
-docker ps | grep alkemio_dev_postgres
-```
-
-If not running:
-```bash
-pnpm run start:services
-```
-
-## Restoration Commands
-
-### Restore Full Set (Recommended)
-
-Restores alkemio + synapse (kratos optional):
+### 1. Preflight
 
 ```bash
-cd .scripts/backups && bash restore_latest_backup_set.sh <environment> [restart_services] [non_interactive] [restore_kratos]
+# .env present AND has the DB-name vars (re-copy from sample if missing — stale .env is the #1 silent-failure cause)
+test -f .scripts/backups/.env && grep -q POSTGRES_ALKEMIO_DB .scripts/backups/.env \
+  && echo "env OK" || echo "FIX: cp .scripts/backups/.env.sample .scripts/backups/.env and fill AWS keys"
+docker ps --filter name=alkemio_dev_postgres --format '{{.Names}}' | grep -q . || echo "start postgres first"
 ```
+If `.env` is missing entirely, copy from `.env.sample` and ask the user for the AWS keys.
 
-**Arguments:**
-| Arg | Values | Default | Description |
-|-----|--------|---------|-------------|
-| environment | prod/dev/acc/sandbox | prod | Source environment |
-| restart_services | true/false | true | Restart services after |
-| non_interactive | true/false | true | Skip confirmation prompts |
-| restore_kratos | true/false | false | Include kratos database |
-
-**Examples:**
-```bash
-# Restore prod, restart services
-bash restore_latest_backup_set.sh prod
-
-# Restore dev, no restart
-bash restore_latest_backup_set.sh dev false
-
-# Restore acc with kratos
-bash restore_latest_backup_set.sh acc true true true
-```
-
-### Restore Single Database
-
-For restoring just one database:
+### 2. Quiesce — stack down to postgres-only (prevents the DROP-DATABASE connection race)
 
 ```bash
-cd .scripts/backups && bash restore_latest_backup.sh <database> <environment> [non_interactive]
+docker compose -f quickstart-services.yml --env-file .env.docker stop
+docker compose -f quickstart-services.yml --env-file .env.docker up -d postgres
 ```
 
-**Examples:**
+### 3. Restore (no auto-restart). Use a 10-min timeout — downloads are ~0.8–1.3 GB.
+
 ```bash
-bash restore_latest_backup.sh alkemio prod true
-bash restore_latest_backup.sh synapse dev true
-bash restore_latest_backup.sh kratos acc true
+cd .scripts/backups && bash restore_latest_backup_set.sh <env> false
+```
+- `<env>` = `acc` (default ask), `dev`, `sandbox`, `prod`.
+- Add `true true true` (`restart non_interactive restore_kratos`) only if kratos is needed; default skips it.
+- This also sets synapse `server_name` per env in `homeserver.yaml` + `.env.docker`.
+
+### 4. Bring the full stack back up
+
+```bash
+cd ../.. && docker compose -f quickstart-services.yml --env-file .env.docker up -d
 ```
 
-## Environment Mapping
+### 5. VERIFY (mandatory — this is what catches the silent failure)
 
-| Environment | S3 Bucket | Region | Matrix Server |
-|-------------|-----------|--------|---------------|
+```bash
+# Sizes: acc ≈ hundreds of MB. ~20–30 MB = restore did NOT take → investigate before reporting success.
+docker exec alkemio_dev_postgres psql -U synapse -d postgres -tAc \
+  "select datname, pg_size_pretty(pg_database_size(datname)) from pg_database where datname in ('alkemio','synapse');"
+docker exec alkemio_dev_postgres psql -U synapse -d alkemio -tAc \
+  "select (select count(*) from \"user\") users, (select count(*) from space) spaces;"
+# Synapse must be healthy and free of domain errors:
+docker ps --filter name=alkemio_dev_synapse --format '{{.Status}}'
+docker logs --since 60s alkemio_dev_synapse 2>&1 | grep -i "not native" && echo "server_name MISMATCH" || echo "server_name OK"
+```
+Reference (acc 2026-06-02): alkemio ≈ 620 MB / 402 users / 1543 spaces; synapse ≈ 868 MB / 732 users / 10336 rooms.
+
+## If synapse crash-loops (`Found users in database not native to <name>`)
+
+`server_name` must match the restored data's user domain (acc=`matrix-acc.alkem.io`,
+dev=`matrix-dev.alkem.io`, prod=`matrix.alkem.io`, seed=`alkemio.matrix.host`). Check the actual
+domain and fix:
+```bash
+docker exec alkemio_dev_postgres psql -U synapse -d synapse -tAc "select distinct split_part(name,':',2) from users limit 5;"
+# Set server_name to match in .build/synapse/homeserver.yaml + SYNAPSE_SERVER_NAME/SYNAPSE_HOMESERVER_NAME in .env.docker, then:
+docker compose -f quickstart-services.yml --env-file .env.docker up -d --force-recreate synapse matrix-adapter
+```
+
+## Apple Silicon note
+
+`quickstart-services.yml` must keep `platform: linux/amd64` on the `notification` service (only
+amd64-only image in the stack); without it `pnpm run start:services` aborts with
+`no matching manifest for linux/arm64/v8`.
+
+## Environment → bucket
+
+| Env | Bucket | Region | server_name |
+|-----|--------|--------|-------------|
 | prod | alkemio-s3-backups-prod-paris | fr-par | matrix.alkem.io |
-| dev | alkemio-s3-backups-dev | nl-ams | matrix-dev.alkem.io |
-| acc | alkemio-s3-backups-dev | nl-ams | matrix-acc.alkem.io |
-| sandbox | alkemio-s3-backups-dev | nl-ams | matrix-sandbox.alkem.io |
+| dev / acc / sandbox | alkemio-s3-backups-dev | nl-ams | matrix-{dev,acc,sandbox}.alkem.io |
 
-## Troubleshooting
+## Single-DB restore
 
-### AWS CLI Issues
-The script auto-installs AWS CLI v2 if missing. If authentication fails:
 ```bash
-aws configure list  # Check current config
-cat ~/.aws/credentials  # Verify credentials
-```
-
-### Database Connection Errors
-Ensure container is running and healthy:
-```bash
-docker exec alkemio_dev_postgres pg_isready -U synapse
-```
-
-### Backup Not Found
-List available backups:
-```bash
-source .scripts/backups/.env
-aws s3 ls s3://alkemio-s3-backups-prod-paris/storage/postgres/backups/alkemio/
+cd .scripts/backups && bash restore_latest_backup.sh <alkemio|synapse|kratos> <env> true
 ```

--- a/.claude/skills/restore-dbs.md
+++ b/.claude/skills/restore-dbs.md
@@ -25,8 +25,11 @@ DB size** at the end.
 
 ```bash
 # .env present AND has the DB-name vars (re-copy from sample if missing — stale .env is the #1 silent-failure cause)
-test -f .scripts/backups/.env && grep -q POSTGRES_ALKEMIO_DB .scripts/backups/.env \
-  && echo "env OK" || echo "FIX: cp .scripts/backups/.env.sample .scripts/backups/.env and fill AWS keys"
+test -f .scripts/backups/.env \
+  && grep -q POSTGRES_ALKEMIO_DB .scripts/backups/.env \
+  && grep -q POSTGRES_SYNAPSE_DB .scripts/backups/.env \
+  && grep -q POSTGRES_KRATOS_DB .scripts/backups/.env \
+  && echo "env OK" || echo "FIX: cp .scripts/backups/.env.sample .scripts/backups/.env and fill AWS keys + POSTGRES_{ALKEMIO,SYNAPSE,KRATOS}_DB"
 docker ps --filter name=alkemio_dev_postgres --format '{{.Names}}' | grep -q . || echo "start postgres first"
 ```
 If `.env` is missing entirely, copy from `.env.sample` and ask the user for the AWS keys.
@@ -44,7 +47,7 @@ docker compose -f quickstart-services.yml --env-file .env.docker up -d postgres
 cd .scripts/backups && bash restore_latest_backup_set.sh <env> false
 ```
 - `<env>` = `acc` (default ask), `dev`, `sandbox`, `prod`.
-- Add `true true true` (`restart non_interactive restore_kratos`) only if kratos is needed; default skips it.
+- Add `false true true` (`restart_services non_interactive restore_kratos`) only if kratos is needed — keep restart `false` so you bring the stack up yourself in step 4; default skips kratos.
 - This also sets synapse `server_name` per env in `homeserver.yaml` + `.env.docker`.
 
 ### 4. Bring the full stack back up

--- a/.scripts/backups/README.md
+++ b/.scripts/backups/README.md
@@ -3,13 +3,13 @@
 > 📘 **Full runbook (recommended):** [`docs/DatabaseRestore.md`](../../docs/DatabaseRestore.md) —
 > single-command + manual steps, verification, and troubleshooting for the silent-failure traps
 > below. Or just ask Claude: *"restore the acc db"*.
-
+>
 > ⚠️ **Two silent-failure traps** (the script can report success while loading nothing):
 > 1. A stale `.env` missing `POSTGRES_*_DB` → empty target name → restore aborts. Re-copy from `.env.sample`.
 > 2. `DROP DATABASE` fails if stack services are connected → restore with the stack **down to
 >    postgres-only** (`docker compose -f quickstart-services.yml --env-file .env.docker stop && ... up -d postgres`).
 >
-> **Always verify by DB size afterwards** (acc ≈ hundreds of MB; ~20–30 MB means it didn't take):
+> **Always verify by DB size afterward** (acc ≈ hundreds of MB; ~20–30 MB means it didn't take):
 > ```bash
 > docker exec alkemio_dev_postgres psql -U synapse -d postgres -tAc \
 >   "select datname, pg_size_pretty(pg_database_size(datname)) from pg_database where datname in ('alkemio','synapse');"
@@ -28,7 +28,7 @@
 Run `./restore_latest_backup_set.sh`. You can optionally pass an argument for the environment `dev | acc | sandbox | prod`. If no argument is passed, `prod` is selected.
 The script will:
 - Validate prerequisites
-- Invoke `restore_latest_backup.sh` script for `alkemio`, `kratos`, and `synapse` databases
+- Invoke `restore_latest_backup.sh` for `alkemio` and `synapse` by default. `kratos` is restored **only** when the 4th argument `restore_kratos=true` (default `false`)
 - Update `.env.docker` file with the correct `homeserver` env variables for the specific environment
 - Update `homeserver.yaml` with the correct server domain
 - Restart the docker-compose (`quickstart-services`) with `pnpm run start:services`

--- a/.scripts/backups/README.md
+++ b/.scripts/backups/README.md
@@ -1,8 +1,24 @@
 # How to use these scripts?
 
+> 📘 **Full runbook (recommended):** [`docs/DatabaseRestore.md`](../../docs/DatabaseRestore.md) —
+> single-command + manual steps, verification, and troubleshooting for the silent-failure traps
+> below. Or just ask Claude: *"restore the acc db"*.
+
+> ⚠️ **Two silent-failure traps** (the script can report success while loading nothing):
+> 1. A stale `.env` missing `POSTGRES_*_DB` → empty target name → restore aborts. Re-copy from `.env.sample`.
+> 2. `DROP DATABASE` fails if stack services are connected → restore with the stack **down to
+>    postgres-only** (`docker compose -f quickstart-services.yml --env-file .env.docker stop && ... up -d postgres`).
+>
+> **Always verify by DB size afterwards** (acc ≈ hundreds of MB; ~20–30 MB means it didn't take):
+> ```bash
+> docker exec alkemio_dev_postgres psql -U synapse -d postgres -tAc \
+>   "select datname, pg_size_pretty(pg_database_size(datname)) from pg_database where datname in ('alkemio','synapse');"
+> ```
+
 ## Prerequisites
 
-- Create `.env` file in the `backups` folder. Copy the .env.sample and fill in the missing values
+- Create `.env` file in the `backups` folder. Copy the .env.sample and fill in the missing values.
+  **Keep all `POSTGRES_*_DB` vars** — the script derives the target DB name from them.
 - The `postgres` container needs to be running from `quickstart-services`, or started with `pnpm run start:services`
 
 ## The following scripts are added

--- a/docs/DatabaseRestore.md
+++ b/docs/DatabaseRestore.md
@@ -1,0 +1,167 @@
+# Restoring an environment database locally (acc / dev / sandbox / prod)
+
+This runbook restores a real environment's PostgreSQL data (Alkemio + Synapse, optionally
+Kratos) from the Scaleway S3 backups into your local Docker `alkemio_dev_postgres` container.
+
+Two ways to do it:
+
+- **Ask Claude** (single command): *"restore the acc db"* → runs the [`restore-dbs`](../.claude/skills/restore-dbs.md)
+  skill, which performs the robust flow below and verifies the result.
+- **Manually**: follow [Manual procedure](#manual-procedure).
+
+> Most-common target is **acc**. Substitute `dev` / `sandbox` / `prod` as needed.
+
+---
+
+## TL;DR
+
+```bash
+# 1. Credentials present? (copy from sample and fill AWS keys if missing)
+test -f .scripts/backups/.env || cp .scripts/backups/.env.sample .scripts/backups/.env
+
+# 2. Restore acc (alkemio + synapse). Run with the stack DOWN to postgres-only — see why below.
+cd .scripts/backups && bash restore_latest_backup_set.sh acc
+
+# 3. Verify it actually loaded (sizes should be hundreds of MB, not tens)
+docker exec alkemio_dev_postgres psql -U synapse -d postgres -tAc \
+  "select datname, pg_size_pretty(pg_database_size(datname)) from pg_database where datname in ('alkemio','synapse');"
+```
+
+If a restore "succeeds" but the DB is only ~20–30 MB, it **silently failed** — see
+[Troubleshooting](#troubleshooting).
+
+---
+
+## Prerequisites
+
+1. **Credentials file** `.scripts/backups/.env` — copy from `.env.sample` and fill the AWS keys:
+
+   ```bash
+   cp .scripts/backups/.env.sample .scripts/backups/.env
+   ```
+
+   Required variables (the sample already lists them all — **do not delete any**):
+
+   | Variable | Value |
+   |----------|-------|
+   | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Scaleway S3 keys |
+   | `POSTGRES_USER` / `POSTGRES_PASSWORD` | `synapse` / (local pw) |
+   | `POSTGRES_ALKEMIO_DB` | `alkemio` |
+   | `POSTGRES_SYNAPSE_DB` | `synapse` |
+   | `POSTGRES_KRATOS_DB` | `kratos` |
+
+   > ⚠️ **If your `.env` predates 2026-06 it may be missing `POSTGRES_*_DB`.** The restore
+   > script derives the target DB name from these; if they're empty the restore runs
+   > `DROP DATABASE IF EXISTS ;` (empty name), errors under `set -e`, and **aborts without
+   > touching your data** — leaving stale seed data behind. Re-copy from `.env.sample`.
+
+2. **Postgres running:** `docker ps | grep alkemio_dev_postgres` (else `pnpm run start:services`).
+
+3. **Apple Silicon only:** `quickstart-services.yml` pins `platform: linux/amd64` on the
+   `notification` service — it's the one stack image published amd64-only (no arm64 manifest),
+   and without the pin `pnpm run start:services` aborts the whole `up`. Keep that line.
+
+---
+
+## Manual procedure
+
+The packaged `restore_latest_backup_set.sh acc` works **only if nothing is connected to the
+target DB when it runs `DROP DATABASE`** (see [Troubleshooting](#troubleshooting)). The reliable
+sequence is: restore against postgres-only, then bring the stack up.
+
+```bash
+cd /path/to/server
+
+# 1. Bring the stack down to postgres-only so no service holds a DB connection
+docker compose -f quickstart-services.yml --env-file .env.docker stop
+docker compose -f quickstart-services.yml --env-file .env.docker up -d postgres
+
+# 2. Restore (downloads latest acc dumps from S3, drops+creates+loads)
+cd .scripts/backups && bash restore_latest_backup_set.sh acc false   # false = don't auto-restart
+
+# 3. Make synapse server_name match the restored data (see note below), then bring everything up
+cd ../..
+docker compose -f quickstart-services.yml --env-file .env.docker up -d
+```
+
+### Synapse `server_name` must match the restored data
+
+Synapse refuses to start if its configured `server_name` doesn't match the user domain in its
+DB (`Found users in database not native to <name>`). The domain differs by source:
+
+| Data source | User domain / `server_name` |
+|-------------|------------------------------|
+| Local **seed** | `alkemio.matrix.host` |
+| **acc** backup | `matrix-acc.alkem.io` |
+| **dev** backup | `matrix-dev.alkem.io` |
+| **prod** backup | `matrix.alkem.io` |
+
+`restore_latest_backup_set.sh` sets this automatically per environment (in
+`.build/synapse/homeserver.yaml` + `SYNAPSE_SERVER_NAME` / `SYNAPSE_HOMESERVER_NAME` in
+`.env.docker`). If synapse crash-loops, confirm the config matches the actual data:
+
+```bash
+# What domain does the restored data actually use?
+docker exec alkemio_dev_postgres psql -U synapse -d synapse -tAc \
+  "select distinct split_part(name,':',2) from users limit 5;"
+# Then set server_name to match in homeserver.yaml + .env.docker and recreate:
+docker compose -f quickstart-services.yml --env-file .env.docker up -d --force-recreate synapse matrix-adapter
+```
+
+---
+
+## Verification (always do this)
+
+A restore can report success while having loaded nothing. Confirm:
+
+```bash
+# DB sizes — acc is hundreds of MB; ~20–30 MB means the restore did NOT take
+docker exec alkemio_dev_postgres psql -U synapse -d postgres -tAc \
+  "select datname, pg_size_pretty(pg_database_size(datname)) from pg_database where datname in ('alkemio','synapse');"
+
+# Row sanity (acc ≈ hundreds of users / thousands of spaces / thousands of rooms)
+docker exec alkemio_dev_postgres psql -U synapse -d alkemio -tAc \
+  "select (select count(*) from \"user\") users, (select count(*) from space) spaces;"
+docker exec alkemio_dev_postgres psql -U synapse -d synapse -tAc \
+  "select (select count(*) from users) users, (select count(*) from rooms) rooms;"
+
+# Synapse healthy + no domain errors
+docker ps --filter name=alkemio_dev_synapse --format '{{.Status}}'
+docker logs --since 60s alkemio_dev_synapse 2>&1 | grep -i "not native" || echo "server_name OK"
+```
+
+Reference (acc, 2026-06-02 backup): alkemio ≈ 620 MB / 402 users / 1543 spaces;
+synapse ≈ 868 MB / 732 users / 10336 rooms.
+
+---
+
+## Environment → bucket mapping
+
+| Env | S3 bucket | Region | Matrix `server_name` |
+|-----|-----------|--------|----------------------|
+| prod | `alkemio-s3-backups-prod-paris` | `fr-par` | `matrix.alkem.io` |
+| dev | `alkemio-s3-backups-dev` | `nl-ams` | `matrix-dev.alkem.io` |
+| acc | `alkemio-s3-backups-dev` | `nl-ams` | `matrix-acc.alkem.io` |
+| sandbox | `alkemio-s3-backups-dev` | `nl-ams` | `matrix-sandbox.alkem.io` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Restore "completes" but DB is ~20–30 MB / data unchanged | `.env` missing `POSTGRES_*_DB` → empty db name → `DROP DATABASE ;` errors under `set -e` and aborts | Re-copy `.env` from `.env.sample`; ensure `POSTGRES_ALKEMIO_DB`/`SYNAPSE_DB`/`KRATOS_DB` are set |
+| `DROP DATABASE ... is being accessed by other users` / restore aborts | Stack services (authorization-evaluation, file-service, oidc-service → alkemio; synapse → synapse) reconnect faster than the script's terminate→drop | Restore with stack **down to postgres-only** (see Manual procedure), then `up -d` |
+| Synapse crash-loops: `Found users in database not native to <name>` | `server_name` ≠ the user domain in the restored data | Set `server_name` to match the data's domain (see [table](#synapse-server_name-must-match-the-restored-data)), recreate synapse + matrix-adapter |
+| matrix-adapter logs 400/403 with old-domain user IDs | Adapter started before `SYNAPSE_SERVER_NAME` was corrected | `up -d --force-recreate matrix-adapter` |
+| `pnpm run start:services` fails: `no matching manifest for linux/arm64/v8` (notification) | amd64-only image on Apple Silicon | Keep `platform: linux/amd64` on the `notification` service in `quickstart-services.yml` |
+| `No backup files found` | Wrong env/bucket or AWS auth | `source .scripts/backups/.env && aws s3 ls s3://<bucket>/storage/postgres/backups/<env>/alkemio/` |
+
+---
+
+## Related
+
+- Skill (agent path): [`.claude/skills/restore-dbs.md`](../.claude/skills/restore-dbs.md)
+- Slash command: `/restore-dbs <env>`
+- Scripts + low-level reference: [`.scripts/backups/README.md`](../.scripts/backups/README.md)
+- Full local wipe + re-seed (NOT environment data): `/reset-db`

--- a/docs/DatabaseRestore.md
+++ b/docs/DatabaseRestore.md
@@ -94,6 +94,7 @@ DB (`Found users in database not native to <name>`). The domain differs by sourc
 | Local **seed** | `alkemio.matrix.host` |
 | **acc** backup | `matrix-acc.alkem.io` |
 | **dev** backup | `matrix-dev.alkem.io` |
+| **sandbox** backup | `matrix-sandbox.alkem.io` |
 | **prod** backup | `matrix.alkem.io` |
 
 `restore_latest_backup_set.sh` sets this automatically per environment (in
@@ -150,7 +151,7 @@ synapse ≈ 868 MB / 732 users / 10336 rooms.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Restore "completes" but DB is ~20–30 MB / data unchanged | `.env` missing `POSTGRES_*_DB` → empty db name → `DROP DATABASE ;` errors under `set -e` and aborts | Re-copy `.env` from `.env.sample`; ensure `POSTGRES_ALKEMIO_DB`/`SYNAPSE_DB`/`KRATOS_DB` are set |
+| Restore "completes" but DB is ~20–30 MB / data unchanged | `.env` missing `POSTGRES_*_DB` → empty db name → `DROP DATABASE ;` errors under `set -e` and aborts | Re-copy `.env` from `.env.sample`; ensure `POSTGRES_ALKEMIO_DB` / `POSTGRES_SYNAPSE_DB` / `POSTGRES_KRATOS_DB` are set |
 | `DROP DATABASE ... is being accessed by other users` / restore aborts | Stack services (authorization-evaluation, file-service, oidc-service → alkemio; synapse → synapse) reconnect faster than the script's terminate→drop | Restore with stack **down to postgres-only** (see Manual procedure), then `up -d` |
 | Synapse crash-loops: `Found users in database not native to <name>` | `server_name` ≠ the user domain in the restored data | Set `server_name` to match the data's domain (see [table](#synapse-server_name-must-match-the-restored-data)), recreate synapse + matrix-adapter |
 | matrix-adapter logs 400/403 with old-domain user IDs | Adapter started before `SYNAPSE_SERVER_NAME` was corrected | `up -d --force-recreate matrix-adapter` |

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -377,6 +377,8 @@ services:
     container_name: alkemio_dev_notifications
     hostname: notifications
     image: alkemio/notifications:v0.35.0
+    # notifications publishes amd64-only images; run under emulation on arm64 (Apple Silicon)
+    platform: linux/amd64
     depends_on:
       rabbitmq:
         condition: service_healthy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Database Restoration runbook with a clear preflight → quiesce → restore → verify workflow, mandatory verification checks, and environment→backup mappings.
  * Added guidance for Synapse server_name troubleshooting, Apple Silicon image notes, and updated restore examples (default restores Alkemio & Synapse; Kratos optional).

* **Bug Fixes**
  * Improved notification service compatibility on Apple Silicon (amd64 emulation guidance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->