### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -3621,12 +3621,40 @@ type Library {
   """The Innovation Packs in the platform Innovation Library."""
   innovationPacks(queryData: InnovationPacksInput): [InnovationPack!]!
   """
+  Paginated Innovation Packs in the platform Innovation Library (newest first).
+  """
+  innovationPacksPaginated(
+    """A pivot cursor after which items are selected"""
+    after: UUID
+    """A pivot cursor before which items are selected"""
+    before: UUID
+    """Amount of items after the cursor"""
+    first: Int
+    """Amount of items before the cursor"""
+    last: Int
+  ): PaginatedInnovationPacks!
+  """
   The Templates in the Innovation Library, together with information about the InnovationPack.
   """
   templates(
     """Only return Templates of particular TemplateTypes"""
     filter: LibraryTemplatesFilterInput
   ): [TemplateResult!]!
+  """
+  Paginated Templates in the Innovation Library, each with the InnovationPack that contributes it (newest first).
+  """
+  templatesPaginated(
+    """A pivot cursor after which items are selected"""
+    after: UUID
+    """A pivot cursor before which items are selected"""
+    before: UUID
+    """Only return Templates of particular TemplateTypes"""
+    filter: LibraryTemplatesFilterInput
+    """Amount of items after the cursor"""
+    first: Int
+    """Amount of items before the cursor"""
+    last: Int
+  ): PaginatedLibraryTemplateResults!
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
   """The VirtualContributors listed on this platform"""
@@ -5150,6 +5178,18 @@ type PageInfo {
 type PaginatedInAppNotifications {
   inAppNotifications: [InAppNotification!]!
   pageInfo: PageInfo!
+  total: Float!
+}
+
+type PaginatedInnovationPacks {
+  innovationPacks: [InnovationPack!]!
+  pageInfo: PageInfo!
+  total: Float!
+}
+
+type PaginatedLibraryTemplateResults {
+  pageInfo: PageInfo!
+  templateResults: [TemplateResult!]!
   total: Float!
 }
 


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size:   295374 bytes
Snapshot md5: 4964216a6f41cdda725b769ed2fc7c0b

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pagination controls for browsing innovation packs in the library
  * Added pagination controls for browsing library templates
  * Improved navigation through large collections with cursor-based pagination support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->