### PR TITLE
Switch permissions on Space's StorageBucket

### DIFF
--- a/specs/102-space-member-file-upload/contracts/authorization-contract.md
+++ b/specs/102-space-member-file-upload/contracts/authorization-contract.md
@@ -51,6 +51,8 @@ Given the Space's authorization has been (re)computed:
 
 - Unit: the Space authorization computation includes the member file-upload rule when
   the setting is ON and omits it when OFF (and the rule targets the correct actor
-  set and cascades to the shared storage).
+  set, is handed to the Space profile authorization step so it cascades to
+  `space.profile.storageBucket`, and is **not** placed on the About profile storage or
+  the storage aggregator's directStorage).
 - Manual/integration: a plain member in a setting-ON Space creates a callout with an
   image without a permission error; the same member in a setting-OFF Space is denied.

--- a/specs/102-space-member-file-upload/data-model.md
+++ b/specs/102-space-member-file-upload/data-model.md
@@ -19,19 +19,20 @@ and `schema-baseline.graphql` are unaffected.
 | **Space** | Owns the "members may create callouts" setting and its own shared storage location. | None |
 | **Space setting: members-may-create-callouts** | The single switch that gates both callout creation and (now) the matching file-upload capability. | None — read, not modified |
 | **Space member (actor credential set)** | The actors who, when the setting is on, may create callouts and upload their files. | None — referenced, not modified |
-| **Space shared storage location** | The Space-level storage that temporarily holds new callout content; the target of the file-upload capability. | None to its data; its computed authorization policy gains one credential rule |
+| **Space shared storage location** | The Space-level storage that temporarily holds new callout content — concretely the Space profile's storage bucket (`space.profile.storageBucket`); the target of the file-upload capability. | None to its data; its computed authorization policy gains one credential rule |
 | **Authorization policy (computed)** | The recomputed access rules for the shared storage. | Gains one **conditional, cascading** credential rule granting the file-upload capability to the eligible actor set |
 
 ## Authorization rule (the one added element)
 
 - **Subject**: the actor credential set permitted to create callouts in the Space
   (members, plus inherited parent-space members where applicable).
-- **Granted capability**: file-upload on the Space's shared storage location.
+- **Granted capability**: file-upload on the Space's shared storage location (the
+  Space profile's storage bucket, `space.profile.storageBucket`).
 - **Condition**: present only when the Space's "members may create callouts" setting
   is enabled; absent otherwise.
-- **Scope/propagation**: cascades from the Space's storage aggregator down to that
-  Space's shared storage bucket only; does not extend to other spaces or to unrelated
-  child entities.
+- **Scope/propagation**: cascades from the Space profile authorization down to that
+  Space profile's storage bucket only; does not extend to the About profile storage,
+  the storage aggregator's directStorage, other spaces, or unrelated child entities.
 - **Lifecycle**: created/removed solely by the authorization-reset computation for
   the owning Space; never written ad hoc.
 

--- a/specs/102-space-member-file-upload/plan.md
+++ b/specs/102-space-member-file-upload/plan.md
@@ -16,10 +16,12 @@ fails mid-way with a permission error.
 The technical approach is authorization-only: when the Space authorization policy is
 (re)computed, and only when the "members may create callouts" setting is enabled,
 grant the file-upload capability on the Space's shared storage to the same set of
-actors who may create callouts. This mirrors the existing pattern that grants the
-"create subspace" capability to members when "members may create subspaces" is
-enabled. No schema, migration, GraphQL contract, or storage-mechanism change is
-required.
+actors who may create callouts. The Space's shared storage is concretely the **Space
+profile's storage bucket** (`space.profile.storageBucket`), so the grant is injected
+via the Space profile authorization step and cascades to that bucket. This mirrors the
+existing pattern that grants the "create subspace" capability to members when "members
+may create subspaces" is enabled. No schema, migration, GraphQL contract, or
+storage-mechanism change is required.
 
 ## Technical Context
 
@@ -50,7 +52,7 @@ who may not create callouts. Effective only after the Space's authorization is
 recomputed.
 
 **Scale/Scope**: Affects every Space whose "members may create callouts" setting is
-enabled. Three source files plus a constant; one new unit-test assertion area.
+enabled. One source file plus a constant; one unit-test assertion area.
 
 ## Constitution Check
 
@@ -59,10 +61,10 @@ enabled. Three source files plus a constant; one new unit-test assertion area.
 - **1. Domain-Centric Design First** — PASS. The change lives in the domain
   authorization services (`src/domain/space/...` and `src/domain/storage/...`); no
   business logic is added to resolvers or controllers.
-- **2. Modular NestJS Boundaries** — PASS. No new modules; the storage-aggregator
-  authorization service gains an optional parameter consumed by the space
-  authorization service it already depends on. No new cross-module coupling or
-  circular dependency.
+- **2. Modular NestJS Boundaries** — PASS. No new modules and no service signature
+  changes; the gated rule is passed into the existing `credentialRulesFromParent`
+  argument of the profile authorization service the Space authorization service
+  already depends on. No new cross-module coupling or circular dependency.
 - **3. GraphQL Schema as Stable Contract** — PASS. No schema change. The
   `uploadFileOnStorageBucket` mutation and all types are untouched; only the
   computed authorization policy that the existing privilege check reads changes.
@@ -109,20 +111,19 @@ specs/102-space-member-file-upload/
 src/
 ├── common/constants/authorization/
 │   └── credential.rule.constants.ts          # add a named constant for the new rule
-├── domain/storage/storage-aggregator/
-│   └── storage.aggregator.service.authorization.ts   # accept + apply optional extra credential rules, cascading to directStorage
 └── domain/space/space/
-    ├── space.service.authorization.ts        # compute the gated member file-upload rule and pass it into the storage-aggregator cascade
-    └── space.service.authorization.spec.ts   # assert gating, scoping, and absence-when-off
+    ├── space.service.authorization.ts        # compute the gated member file-upload rule and pass it into the Space profile authorization cascade
+    └── space.service.authorization.spec.ts   # assert gating, scoping, target bucket, and absence-when-off
 ```
 
 **Structure Decision**: Single-project backend. The change is confined to the
-authorization computation in two domain authorization services plus one constants
-file. The Space authorization service (which already owns the Space settings and the
-member credential criteria, and already drives the storage-aggregator authorization
-cascade) is the correct owner of the gating decision; the storage-aggregator
-authorization service is the correct place to receive and apply the resulting rule so
-it cascades to the Space's shared storage bucket.
+authorization computation in the Space authorization service plus one constants file.
+The Space authorization service already owns the Space settings, the member credential
+criteria, and the call that drives the Space profile authorization cascade — so it is
+the correct owner of both the gating decision and the injection point. The rule is
+handed to the existing `credentialRulesFromParent` parameter of the profile
+authorization service and cascades to `space.profile.storageBucket`. No change to the
+storage-aggregator authorization service is required.
 
 ## Complexity Tracking
 

--- a/specs/102-space-member-file-upload/quickstart.md
+++ b/specs/102-space-member-file-upload/quickstart.md
@@ -6,6 +6,16 @@ In a Space configured to let members create callouts, members can now upload the
 files their callouts contain (e.g. a description image) without hitting a permission
 error. The capability is gated by that Space setting and scoped to that Space.
 
+The Space-level bucket that stages this content is the **Space profile's storage
+bucket** (`space.profile.storageBucket`). The grant lands there only — not on the
+storage aggregator's `directStorage`, and not on the About profile storage.
+
+> **Client note**: the `client-web` `SpaceStorageConfig` query currently uploads to
+> `space.about.profile.storageBucket`. Until that is repointed to
+> `space.profile.storageBucket`, the end-to-end create-callout flow will still target
+> the About bucket. This server change grants upload on the correct (Space profile)
+> bucket; the client fix is tracked separately.
+
 ## Prerequisites
 
 - Local stack running: `pnpm run start:services`, migrations applied
@@ -62,5 +72,6 @@ Run the affected authorization unit specs:
 
 ```bash
 pnpm test -- src/domain/space/space/space.service.authorization.spec.ts
+# Confirm the storage-aggregator revert is clean (no member grant on directStorage):
 pnpm test -- src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.spec.ts
 ```

--- a/specs/102-space-member-file-upload/research.md
+++ b/specs/102-space-member-file-upload/research.md
@@ -5,6 +5,28 @@ credential-based authorization computes write access to a Space's shared storage
 the analogous "members may create callouts/subspaces" capability is already granted,
 and where a gated grant should be injected so it is correctly scoped.
 
+## Which storage bucket is the Space's shared storage for callout creation
+
+- **Decision**: The Space-level bucket that stages new callout content is the **Space
+  profile's storage bucket**, reached via `space → profile → storageBucket`
+  (`space.profile.storageBucket`). The member file-upload grant targets *this* bucket
+  and no other.
+- **Rationale**: The Space profile's storage bucket is the Space's own document store.
+  It is the semantically correct "Space storage" for content that belongs to the Space
+  before a callout exists. Granting upload here keeps the capability tightly scoped to
+  one bucket the Space owns directly.
+- **Correction of an earlier assumption** *(this supersedes the first implementation)*:
+  - The first cut granted upload on the **storage aggregator's `directStorage`**
+    bucket (`space.storageAggregator.directStorage`). That bucket is **not** the
+    create-callout upload target for spaces — only the platform and account storage
+    configs use `directStorageBucket`. Grant removed.
+  - The client's `SpaceStorageConfig` query currently resolves the upload target to
+    the **About profile's** bucket (`space.about.profile.storageBucket`). That is the
+    *wrong* bucket — uploading Space-level callout content into the About (description)
+    storage makes no semantic sense. The server grant is therefore **not** placed on
+    the About profile; the client must be corrected to point at
+    `space.profile.storageBucket`. *(Client change tracked separately.)*
+
 ## How storage upload is authorized today
 
 - **Decision**: Keep the existing upload authorization check unchanged; widen *who
@@ -53,22 +75,27 @@ and where a gated grant should be injected so it is correctly scoped.
 ## Where and when to inject the grant (scoping)
 
 - **Decision**: Compute the gated rule in the **Space authorization service** (which
-  owns the Space settings and member criteria) and pass it into the **storage
-  aggregator authorization** step as an optional set of additional credential rules,
-  marked to cascade so it reaches the Space's shared storage bucket. Gate strictly on
-  the "members may create callouts" setting.
+  owns the Space settings and member criteria) and pass it as a cascading credential
+  rule into the **Space profile authorization** step
+  (`profileAuthorizationService.applyAuthorizationPolicy(space.profile.id, …, rules)`),
+  so it reaches `space.profile.storageBucket`. Gate strictly on the "members may
+  create callouts" setting.
 - **Rationale**: Each Space (including each subspace) computes its own authorization
-  from its own settings and owns its own shared storage, so injecting at this point
-  yields correct per-Space scoping (FR-005) with no leakage across spaces. The
-  storage-aggregator authorization reset only touches that Space's own shared storage
-  bucket, so the cascade stays scoped. The optional parameter is backward-compatible
-  with the other callers (platform, account, user, organization) which pass nothing.
+  from its own settings and owns its own profile storage, so injecting at this point
+  yields correct per-Space scoping (FR-005) with no leakage across spaces. The Space
+  profile authorization reset only touches that Space's own profile subtree, whose
+  only `FILE_UPLOAD`-relevant node is its storage bucket, so the cascade stays scoped
+  to exactly the target bucket. The `profileAuthorizationService` already accepts a
+  `credentialRulesFromParent` argument, so no service signature change is needed.
 - **Alternatives considered**:
+  - *Pass the rule into the storage-aggregator authorization step* (the first
+    implementation) — rejected: lands on `directStorage`, which the create-callout
+    flow does not use for spaces.
+  - *Pass the rule into the Space About authorization step* — rejected: lands on
+    `space.about.profile.storageBucket`, the About/description storage, which is not
+    the correct home for Space-level callout content.
   - *Append the rule to the Space's top-level policy with cascade* — rejected:
-    cascades everywhere in the Space subtree, not just the shared storage.
-  - *Add the rule inside the storage-aggregator service unconditionally* — rejected:
-    that service is shared by platform/account/user/organization and has no business
-    knowing about callout settings.
+    cascades everywhere in the Space subtree, not just the Space profile storage.
 
 ## Effectivity / rollout
 

--- a/specs/102-space-member-file-upload/spec.md
+++ b/specs/102-space-member-file-upload/spec.md
@@ -170,7 +170,9 @@ Space B members gain nothing. Repeat for a subspace relative to its parent.
   then relocated to the callout once it exists.
 - **Shared Space Storage Location**: The Space-level storage used as the temporary
   home for callout content during creation; write access to it is the permission
-  this feature adjusts.
+  this feature adjusts. Concretely this is the **Space's own profile storage bucket**
+  (`space.profile.storageBucket`) — not the Space About/description storage, and not
+  the storage aggregator's direct storage.
 
 ## Success Criteria *(mandatory)*
 
@@ -208,3 +210,8 @@ Space B members gain nothing. Repeat for a subspace relative to its parent.
   Space's configuration and is the correct set to receive the upload ability.
 - This feature concerns authorization only; it does not change how files are stored,
   scanned, or relocated.
+- The Space's shared storage location for staged callout content is the Space's own
+  profile storage bucket (`space.profile.storageBucket`). The client currently uploads
+  to the Space About profile's storage bucket instead; correcting the client to point
+  at the Space profile bucket is a separate, client-side change outside this server
+  feature's scope.

--- a/specs/102-space-member-file-upload/tasks.md
+++ b/specs/102-space-member-file-upload/tasks.md
@@ -42,15 +42,17 @@ Single-project backend. Source under `src/`, unit specs co-located as
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-**Purpose**: Make the Space-level storage authorization able to receive extra,
-parent-supplied credential rules and cascade them to the shared storage bucket. This
-is shared plumbing that the gating logic in Phase 3 depends on.
+**Purpose**: Confirm the injection point. The Space profile authorization step
+(`profileAuthorizationService.applyAuthorizationPolicy`) already accepts a
+`credentialRulesFromParent` argument that cascades to the profile's storage bucket, so
+no plumbing change is required — the gated rule from Phase 3 is passed straight into
+this existing parameter.
 
 **⚠️ CRITICAL**: User-story work cannot begin until this phase is complete.
 
-- [X] T002 Extend `StorageAggregatorAuthorizationService.applyAuthorizationPolicy` in `src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.ts`: add an optional third parameter `additionalCredentialRules: IAuthorizationPolicyRuleCredential[] = []`; after the existing anonymous/registered read rule is appended and before the `directStorage` bucket authorization is applied, append `additionalCredentialRules` to the storage aggregator authorization so cascading rules reach the bucket. Add the import for `IAuthorizationPolicyRuleCredential` from `@core/authorization/authorization.policy.rule.credential.interface`. Existing callers (platform/account/user/organization) pass nothing and are unaffected.
+- [X] T002 No code change. Verify that `ProfileAuthorizationService.applyAuthorizationPolicy(profileID, parentAuthorization, credentialRulesFromParent)` in `src/domain/common/profile/profile.service.authorization.ts` pushes `credentialRulesFromParent` onto the profile authorization and that the profile's `storageBucket` inherits cascading rules — i.e. a `cascade: true` rule passed here reaches `space.profile.storageBucket`. (No storage-aggregator change: the grant must NOT land on `directStorage`.)
 
-**Checkpoint**: Storage-aggregator authorization accepts and propagates parent-supplied rules; no behavior change yet.
+**Checkpoint**: Injection point confirmed; the Space profile authorization will carry the rule to the Space profile storage bucket.
 
 ---
 
@@ -65,12 +67,12 @@ with an embedded image — it succeeds and the image is attached (per
 
 ### Implementation for User Story 1
 
-- [X] T003 [US1] Add a private helper `getStorageMemberFileUploadRules(roleSet, spaceSettings)` in `src/domain/space/space/space.service.authorization.ts` that returns `[]` when `spaceSettings.collaboration.allowMembersToCreateCallouts` is false; otherwise builds a credential rule granting `[AuthorizationPrivilege.FILE_UPLOAD]` to the create-callout actor criteria (reuse the existing `getActorCriteria(roleSet, spaceSettings)` helper), sets `cascade = true`, names it with `CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD`, and returns it as a single-element array (return `[]` if the criteria set is empty). Import the new constant.
-- [X] T004 [US1] In `propagateAuthorizationToChildEntities` in `src/domain/space/space/space.service.authorization.ts`, compute the rules via the new helper (using `space.community.roleSet` and `space.settings`) and pass them as the new third argument to the `storageAggregatorAuthorizationService.applyAuthorizationPolicy(space.storageAggregator!, space.authorization!, …)` call.
+- [X] T003 [US1] Add a private helper `getStorageMemberFileUploadRules(roleSet, spaceSettings, spaceMembershipAllowed)` in `src/domain/space/space/space.service.authorization.ts` that returns `[]` when `!spaceMembershipAllowed` or `spaceSettings.collaboration.allowMembersToCreateCallouts` is false; otherwise builds a credential rule granting `[AuthorizationPrivilege.FILE_UPLOAD]` to the create-callout actor criteria (reuse the existing `getActorCriteria(roleSet, spaceSettings)` helper), sets `cascade = true`, names it with `CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD`, and returns it as a single-element array (return `[]` if the criteria set is empty). Import the new constant.
+- [X] T004 [US1] In `propagateAuthorizationToChildEntities` in `src/domain/space/space/space.service.authorization.ts`, compute the rules via the new helper (using `space.community.roleSet`, `space.settings`, `spaceMembershipAllowed`) and pass them as the third argument (`credentialRulesFromParent`) to the **Space profile** authorization call: `profileAuthorizationService.applyAuthorizationPolicy(space.profile!.id, space.authorization!, storageMemberFileUploadRules)`. Do NOT pass them to the storage-aggregator or the Space About authorization calls.
 
 ### Tests for User Story 1
 
-- [X] T005 [P] [US1] In `src/domain/space/space/space.service.authorization.spec.ts`, add a test asserting that when `allowMembersToCreateCallouts` is true, the computed Space storage authorization includes a `FILE_UPLOAD` credential rule named `CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD`.
+- [X] T005 [P] [US1] In `src/domain/space/space/space.service.authorization.spec.ts`, add a test asserting that when `allowMembersToCreateCallouts` is true, the rules passed to the **Space profile** authorization call include a `FILE_UPLOAD` credential rule named `CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD` (cascading), and a sibling test asserting the rule is **absent** from both the storage-aggregator call (no extra-rules argument) and the Space About authorization call.
 
 ### Verification for User Story 1
 
@@ -91,7 +93,7 @@ creation and upload to the Space's shared storage (per `quickstart.md` → "Veri
 
 ### Tests for User Story 2
 
-- [X] T007 [P] [US2] In `src/domain/space/space/space.service.authorization.spec.ts`, add a test asserting that when `allowMembersToCreateCallouts` is false, the computed Space storage authorization does NOT include the `CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD` rule.
+- [X] T007 [P] [US2] In `src/domain/space/space/space.service.authorization.spec.ts`, add tests asserting that when `allowMembersToCreateCallouts` is false — and, separately, when `spaceMembershipAllowed` is false (archived) — the Space profile authorization call receives no `CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD` rule.
 
 ### Verification for User Story 2
 
@@ -112,7 +114,7 @@ members may upload to Space A's shared storage; repeat for a parent/subspace pai
 
 ### Tests for User Story 3
 
-- [X] T009 [P] [US3] In `src/domain/space/space/space.service.authorization.spec.ts`, add a test asserting the granted rule targets the create-callout actor criteria (members, plus inherited parent-space members where `inheritMembershipRights` + public applies) and is marked to cascade — i.e. it matches the criteria returned by `getActorCriteria` and reaches the shared storage bucket.
+- [X] T009 [P] [US3] In `src/domain/space/space/space.service.authorization.spec.ts`, add a test asserting the rule passed to the Space profile authorization call targets the create-callout actor criteria (members, plus inherited parent-space members where `inheritMembershipRights` + public applies) and is marked to cascade — i.e. it matches the criteria returned by `getActorCriteria` and reaches `space.profile.storageBucket`.
 
 ### Verification for User Story 3
 
@@ -126,8 +128,8 @@ members may upload to Space A's shared storage; repeat for a parent/subspace pai
 
 **Purpose**: Quality gates and final validation.
 
-- [X] T011 [P] Run `pnpm lint` (tsc --noEmit + biome) and fix any issues in the three changed files.
-- [X] T012 [P] Run the affected unit specs: `pnpm test -- src/domain/space/space/space.service.authorization.spec.ts` and `pnpm test -- src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.spec.ts`.
+- [X] T011 [P] Run `pnpm lint` (tsc --noEmit + biome) and fix any issues in the changed files (`space.service.authorization.ts` + spec, and the reverted `storage.aggregator.service.authorization.ts`).
+- [X] T012 [P] Run the affected unit specs: `pnpm test -- src/domain/space/space/space.service.authorization.spec.ts` (and `src/domain/storage/storage-aggregator/` to confirm the storage-aggregator revert is clean).
 - [X] T013 Sanity-check that no schema change leaked: `pnpm run schema:print && pnpm run schema:sort` produce no diff to `schema.graphql`.
 - [X] T014 Run the `quickstart.md` regression check: confirm an admin can still create a callout with an embedded image exactly as before.
 
@@ -138,7 +140,7 @@ members may upload to Space A's shared storage; repeat for a parent/subspace pai
 ### Phase Dependencies
 
 - **Setup (Phase 1, T001)**: No dependencies — can start immediately.
-- **Foundational (Phase 2, T002)**: Depends on T001 (uses no constant itself, but precedes story work). BLOCKS all user stories.
+- **Foundational (Phase 2, T002)**: Verification-only (no code change); confirms the Space profile authorization injection point. Precedes story work.
 - **User Story 1 (Phase 3)**: Depends on T001 + T002. Implements the rule (T003 → T004); this also realizes the behavior asserted by US2 and US3.
 - **User Story 2 (Phase 4)** and **User Story 3 (Phase 5)**: Depend on the US1 implementation (T003–T004) existing, since they assert properties of the same rule. Their test/verification tasks are otherwise independent of each other.
 - **Polish (Phase 6)**: Depends on all desired stories being complete.
@@ -194,6 +196,13 @@ Task: "US3 manual scoping verification per quickstart.md"                       
   [P] for story traceability but touch one file — coordinate those edits.
 - This feature changes authorization computation only: no schema, migration, GraphQL
   contract, or storage-mechanism change (see `data-model.md`).
+- **Target bucket**: the grant lands on the Space profile's storage bucket
+  (`space.profile.storageBucket`) — NOT the storage aggregator's `directStorage`, and
+  NOT the About profile storage (`space.about.profile.storageBucket`).
+- **Client follow-up (separate repo)**: the client `SpaceStorageConfig` query
+  (`client-web`) currently resolves the create-callout upload target to
+  `space.about.profile.storageBucket`; it must be repointed to
+  `space.profile.storageBucket` for the end-to-end flow to use the granted bucket.
 - The new capability takes effect per Space at the next authorization reset
   (`quickstart.md` covers triggering it).
 - Commit after each logical group; keep migrations N/A (none here).

--- a/src/domain/space/space/space.service.authorization.spec.ts
+++ b/src/domain/space/space/space.service.authorization.spec.ts
@@ -850,11 +850,29 @@ describe('SpaceAuthorizationService', () => {
       );
     };
 
-    const getStorageAggregatorRulesArg = () =>
-      (storageAggregatorAuthorizationService.applyAuthorizationPolicy as any)
-        .mock.calls[0][2];
+    // The member FILE_UPLOAD grant is applied on the Space profile, so it
+    // cascades to the Space profile's own storage bucket
+    // (`space.profile.storageBucket`) — the Space-level location used to stage
+    // new callout content during creation.
+    const getSpaceProfileRulesArg = () =>
+      (profileAuthorizationService.applyAuthorizationPolicy as any).mock
+        .calls[0][2] ?? [];
 
-    it('[US1] grants FILE_UPLOAD to members on the space storage when allowMembersToCreateCallouts is true', async () => {
+    const getStorageAggregatorCall = () =>
+      (storageAggregatorAuthorizationService.applyAuthorizationPolicy as any)
+        .mock.calls[0];
+
+    const getSpaceAboutRulesArg = () =>
+      (spaceAboutAuthorizationService.applyAuthorizationPolicy as any).mock
+        .calls[0][2] ?? [];
+
+    const findFileUploadRule = (rules: any[]) =>
+      rules.find(
+        (rule: any) =>
+          rule.name === CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD
+      );
+
+    it('[US1] grants FILE_UPLOAD to members on the Space profile storage when allowMembersToCreateCallouts is true', async () => {
       const memberCriterias = [
         { type: AuthorizationCredential.SPACE_MEMBER, resourceID: 'space-1' },
       ];
@@ -873,14 +891,14 @@ describe('SpaceAuthorizationService', () => {
         []
       );
 
-      const storageCall = (
-        storageAggregatorAuthorizationService.applyAuthorizationPolicy as any
+      // Applied against the Space's own profile and authorization
+      const profileCall = (
+        profileAuthorizationService.applyAuthorizationPolicy as any
       ).mock.calls[0];
-      // Passed against the space's own storage aggregator and authorization
-      expect(storageCall[0]).toBe(space.storageAggregator);
-      expect(storageCall[1]).toBe(space.authorization);
+      expect(profileCall[0]).toBe(space.profile!.id);
+      expect(profileCall[1]).toBe(space.authorization);
 
-      const rulesArg = storageCall[2];
+      const rulesArg = profileCall[2];
       expect(rulesArg).toHaveLength(1);
       expect(rulesArg[0].name).toBe(
         CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD
@@ -888,11 +906,35 @@ describe('SpaceAuthorizationService', () => {
       expect(rulesArg[0].grantedPrivileges).toContain(
         AuthorizationPrivilege.FILE_UPLOAD
       );
-      // Must cascade to reach the directStorage bucket
+      // Must cascade to reach the Space profile's storage bucket
       expect(rulesArg[0].cascade).toBe(true);
     });
 
-    it('[US2] does NOT grant FILE_UPLOAD when allowMembersToCreateCallouts is false', async () => {
+    it('[US1] does NOT grant FILE_UPLOAD on the storage aggregator or the About profile', async () => {
+      // The grant must land only on the Space profile's storage bucket — never
+      // on the storage aggregator's directStorage nor the About profile storage.
+      const space = createMockSpace();
+      setupPropagateMocks();
+      (roleSetService.getCredentialsForRole as any).mockResolvedValue([
+        { type: AuthorizationCredential.SPACE_MEMBER, resourceID: 'space-1' },
+      ]);
+      (
+        roleSetService.getDirectParentCredentialForRole as any
+      ).mockResolvedValue(undefined);
+
+      await service.propagateAuthorizationToChildEntities(
+        space as any,
+        true,
+        []
+      );
+
+      // Storage aggregator is invoked with no extra credential rules argument
+      expect(getStorageAggregatorCall()[2]).toBeUndefined();
+      // About path carries only the read rule, no FILE_UPLOAD grant
+      expect(findFileUploadRule(getSpaceAboutRulesArg())).toBeUndefined();
+    });
+
+    it('[US2] does NOT grant FILE_UPLOAD on the Space profile when allowMembersToCreateCallouts is false', async () => {
       const offSettings = {
         ...defaultSettings,
         collaboration: {
@@ -915,8 +957,8 @@ describe('SpaceAuthorizationService', () => {
         []
       );
 
-      // No additional credential rules handed to the storage aggregator
-      expect(getStorageAggregatorRulesArg()).toEqual([]);
+      // No credential rules handed to the Space profile
+      expect(getSpaceProfileRulesArg()).toEqual([]);
     });
 
     it('[US2] does NOT grant FILE_UPLOAD when membership is not allowed (e.g. archived space) even if allowMembersToCreateCallouts is true', async () => {
@@ -938,7 +980,7 @@ describe('SpaceAuthorizationService', () => {
         []
       );
 
-      expect(getStorageAggregatorRulesArg()).toEqual([]);
+      expect(getSpaceProfileRulesArg()).toEqual([]);
     });
 
     it('[US3] targets create-callout actor criteria including inherited parent members and cascades', async () => {
@@ -967,7 +1009,7 @@ describe('SpaceAuthorizationService', () => {
         []
       );
 
-      const rulesArg = getStorageAggregatorRulesArg();
+      const rulesArg = getSpaceProfileRulesArg();
       expect(rulesArg).toHaveLength(1);
       expect(rulesArg[0].grantedPrivileges).toEqual([
         AuthorizationPrivilege.FILE_UPLOAD,

--- a/src/domain/space/space/space.service.authorization.ts
+++ b/src/domain/space/space/space.service.authorization.ts
@@ -469,11 +469,13 @@ export class SpaceAuthorizationService {
 
     // When members are allowed to create callouts they need to be able to
     // upload files to the Space-level storage bucket, as new callout content
-    // (e.g. description images) is uploaded there temporarily before the
-    // callout's own storage bucket exists. Grant FILE_UPLOAD to the same
-    // actors that may create callouts. Gated on spaceMembershipAllowed so that
-    // archived spaces (where membership capabilities are disabled) do not grant
-    // upload access on their storage bucket.
+    // (e.g. description images, attached References) is uploaded there
+    // temporarily before the callout's own storage bucket exists. That
+    // Space-level bucket is the Space profile's storage bucket
+    // (`space.profile.storageBucket`); the grant is applied on the Space
+    // profile authorization below so it reaches exactly that bucket. Gated on
+    // spaceMembershipAllowed so that archived spaces (where membership
+    // capabilities are disabled) do not grant upload access.
     const storageMemberFileUploadRules =
       await this.getStorageMemberFileUploadRules(
         space.community.roleSet,
@@ -486,8 +488,7 @@ export class SpaceAuthorizationService {
       () =>
         this.storageAggregatorAuthorizationService.applyAuthorizationPolicy(
           space.storageAggregator!,
-          space.authorization!,
-          storageMemberFileUploadRules
+          space.authorization!
         )
     );
     updatedAuthorizations.push(...storageAuthorizations);
@@ -558,13 +559,19 @@ export class SpaceAuthorizationService {
     );
     updatedAuthorizations.push(...aboutAuthorizations);
 
+    // Apply the member FILE_UPLOAD grant on the Space profile: the rule
+    // cascades to the Space profile's own storage bucket
+    // (`space.profile.storageBucket`), which is the Space-level location used to
+    // stage new callout content during creation. No grant is placed on the
+    // About profile or the storage aggregator's directStorage.
     const profileAuthorizations = await this.resilientCascade(
       'space.profile',
       ctx,
       () =>
         this.profileAuthorizationService.applyAuthorizationPolicy(
           space.profile!.id,
-          space.authorization!
+          space.authorization!,
+          storageMemberFileUploadRules
         )
     );
     updatedAuthorizations.push(...profileAuthorizations);
@@ -736,7 +743,7 @@ export class SpaceAuthorizationService {
       criteria,
       CREDENTIAL_RULE_SPACE_STORAGE_MEMBER_FILE_UPLOAD
     );
-    // Must cascade so the rule reaches the storage aggregator's directStorage bucket.
+    // Must cascade so the rule reaches the Space profile's storage bucket.
     fileUploadRule.cascade = true;
     return [fileUploadRule];
   }

--- a/src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.ts
+++ b/src/domain/storage/storage-aggregator/storage.aggregator.service.authorization.ts
@@ -1,6 +1,5 @@
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
-import { IAuthorizationPolicyRuleCredential } from '@core/authorization/authorization.policy.rule.credential.interface';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { Injectable } from '@nestjs/common';
@@ -18,8 +17,7 @@ export class StorageAggregatorAuthorizationService {
 
   async applyAuthorizationPolicy(
     storageAggregatorInput: IStorageAggregator,
-    parentAuthorization: IAuthorizationPolicy | undefined,
-    additionalCredentialRules: IAuthorizationPolicyRuleCredential[] = []
+    parentAuthorization: IAuthorizationPolicy | undefined
   ): Promise<IAuthorizationPolicy[]> {
     const storageAggregator =
       await this.storageAggregatorService.getStorageAggregatorOrFail(
@@ -55,16 +53,6 @@ export class StorageAggregatorAuthorizationService {
         storageAggregator.authorization,
         AuthorizationPrivilege.READ
       );
-    // Additional rules supplied by the parent entity (e.g. a Space granting
-    // members FILE_UPLOAD on its storage when members can create callouts).
-    // These must cascade to reach the directStorage bucket below.
-    if (additionalCredentialRules.length > 0) {
-      storageAggregator.authorization =
-        this.authorizationPolicyService.appendCredentialAuthorizationRules(
-          storageAggregator.authorization,
-          additionalCredentialRules
-        );
-    }
     updatedAuthorizations.push(storageAggregator.authorization);
 
     const bucketAuthorizations =


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected authorization rule cascade path for member file uploads to use Space profile storage bucket instead of storage aggregator, ensuring proper permission scoping.

* **Documentation**
  * Updated specifications and implementation notes to clarify that member file uploads for callouts target the Space profile's storage bucket exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->