### PR TITLE
fix(innovation-flow): reject comma-containing state names on edit paths

### DIFF
--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
@@ -323,6 +323,30 @@ describe('InnovationFlowService', () => {
       expect(result).toBe(updatedState);
     });
 
+    it('should throw ValidationException when renamed state name contains a comma', async () => {
+      const states = [
+        { id: 's-1', displayName: 'State A', sortOrder: 10 },
+        { id: 's-2', displayName: 'State B', sortOrder: 20 },
+      ];
+      const flow = {
+        id: 'flow-1',
+        states,
+        currentStateID: 's-1',
+        flowStatesTagsetTemplate: undefined,
+      } as any;
+
+      vi.mocked(repository.findOne).mockResolvedValue(flow);
+
+      await expect(
+        service.updateInnovationFlowState('flow-1', {
+          innovationFlowStateID: 's-1',
+          displayName: 'State,A',
+        } as any)
+      ).rejects.toThrow(ValidationException);
+      // Must reject before the state is ever updated/persisted
+      expect(innovationFlowStateService.update).not.toHaveBeenCalled();
+    });
+
     it('should throw EntityNotFoundException when state is not found in flow', async () => {
       const flow = {
         id: 'flow-1',
@@ -464,6 +488,24 @@ describe('InnovationFlowService', () => {
           displayName: 'X',
         } as any)
       ).rejects.toThrow(RelationshipNotFoundException);
+    });
+
+    it('should throw ValidationException when the new state name contains a comma', async () => {
+      const flow = {
+        id: 'flow-1',
+        states: [{ id: 's-1', sortOrder: 5 }],
+        settings: { maximumNumberOfStates: 10 },
+      } as any;
+
+      await expect(
+        service.createStateOnInnovationFlow(flow, {
+          displayName: 'New,State',
+        } as any)
+      ).rejects.toThrow(ValidationException);
+      // Must reject before the state is ever created/persisted
+      expect(
+        innovationFlowStateService.createInnovationFlowState
+      ).not.toHaveBeenCalled();
     });
 
     it('should throw ValidationException when maximum number of states is reached', async () => {
@@ -791,6 +833,26 @@ describe('InnovationFlowService', () => {
         tagsetTemplateService.updateTagsetTemplateDefinition
       ).toHaveBeenCalled();
       expect(tagsetService.updateTagsetsSelectedValue).toHaveBeenCalled();
+    });
+
+    it('should throw ValidationException when a new state name contains a comma', async () => {
+      const flow = {
+        id: 'flow-1',
+        states: [{ id: 's-old-1', displayName: 'Old A', sortOrder: 10 }],
+        currentStateID: 's-old-1',
+      } as any;
+
+      await expect(
+        service.updateInnovationFlowStates(flow, [
+          { displayName: 'New A', sortOrder: 5 },
+          { displayName: 'New,B', sortOrder: 10 },
+        ] as any)
+      ).rejects.toThrow(ValidationException);
+      // Must reject before any existing state is deleted or rebuilt
+      expect(innovationFlowStateService.delete).not.toHaveBeenCalled();
+      expect(
+        innovationFlowStateService.createInnovationFlowState
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -189,6 +189,9 @@ export class InnovationFlowService {
         }
       );
     }
+    // Reject comma-containing names on rename (commas are reserved separators)
+    this.validateStateDisplayNames([stateUpdatedData.displayName]);
+
     const renamedState =
       updatedState.displayName !== stateUpdatedData.displayName
         ? { old: updatedState.displayName, new: stateUpdatedData.displayName }
@@ -241,6 +244,10 @@ export class InnovationFlowService {
     innovationFlow: IInnovationFlow,
     newStates: CreateInnovationFlowStateInput[]
   ) {
+    // Reject comma-containing names before rebuilding the states
+    // (commas are reserved separators in the database)
+    this.validateStateDisplayNames(newStates.map(state => state.displayName));
+
     // Get the name of the currently selected as current state
     const selectedStateName = innovationFlow.currentStateID
       ? (await this.getCurrentState(innovationFlow.currentStateID))?.displayName
@@ -338,6 +345,10 @@ export class InnovationFlowService {
     innovationFlow: IInnovationFlow,
     stateData: CreateInnovationFlowStateInput
   ): Promise<IInnovationFlowState> {
+    // Reject comma-containing names before adding the state
+    // (commas are reserved separators in the database)
+    this.validateStateDisplayNames([stateData.displayName]);
+
     const maximumNumberOfStates = innovationFlow.settings.maximumNumberOfStates;
     if (!innovationFlow.states) {
       throw new RelationshipNotFoundException(
@@ -513,9 +524,22 @@ export class InnovationFlowService {
         LogContext.INNOVATION_FLOW
       );
     }
-    // Avoid commas in state names, because they are used to separate states in the database
-    // This validation is also performed on the client: domain/collaboration/InnovationFlow/InnovationFlowDragNDropEditor/InnovationFlowStateForm.tsx
-    // Keep them in sync consistently
+    this.validateStateDisplayNames(stateNames);
+  }
+
+  /**
+   * Rejects flow state display names that contain a comma.
+   *
+   * Commas are reserved as the separator for flow state names in the database,
+   * so any name containing one would corrupt that encoding. This must be
+   * enforced on every path that persists a state name — creation *and* every
+   * edit path (rebuild, add, rename) — otherwise invalid data can be saved on
+   * edit and only surface later (e.g. when saving a space as a template).
+   *
+   * This validation is also performed on the client: domain/collaboration/InnovationFlow/InnovationFlowDragNDropEditor/InnovationFlowStateForm.tsx
+   * Keep them in sync consistently.
+   */
+  public validateStateDisplayNames(stateNames: string[]) {
     if (stateNames.some(name => name.includes(','))) {
       throw new ValidationException(
         `Invalid characters found on flow state: ${stateNames}`,


### PR DESCRIPTION
Closes #6132

## Root cause

Commas are reserved as the separator for flow-state names in the database. The **create** path already rejects them (`validateInnovationFlowDefinition`, `innovation.flow.service.ts`), but the **edit** paths skipped that check entirely:

- `updateInnovationFlowStates` — rebuilds all states, no character validation
- `createStateOnInnovationFlow` — only checked the max-state count
- `updateInnovationFlowState` — renamed a single state with no validation

So a comma could be sneaked into a phase name after creation and persisted without complaint. It only surfaced later — when saving the space as a template the names are re-validated, producing a confusing `Invalid characters found on flow state` error pointing at data the system itself allowed.

## Fix

- Extracted the comma check from `validateInnovationFlowDefinition` into a small shared helper `validateStateDisplayNames(stateNames: string[])`.
- Applied it consistently on all three edit paths, **before** any state is deleted, created, or renamed — so invalid data can never be stored to begin with.
- `validateInnovationFlowDefinition` now delegates to the same helper, keeping behavior on the create path identical.

No GraphQL schema or DB migration changes; minimal, targeted, single-repo.

## Regression tests

Added to `innovation.flow.service.spec.ts`, one per edit path (rename, add, rebuild). Each asserts a `ValidationException` is thrown and that no persistence/mutation method is invoked. Verified the three tests fail on the unpatched source and pass with the fix.

## Gates

- Tests: full suite green (6666 passed), incl. 3 new regression tests
- Build: `pnpm build` clean
- Lint: `pnpm lint` (tsc --noEmit + biome) clean

## Notes

A matching client-side check already lives in `InnovationFlowStateForm.tsx`; the helper's doc comment points there to keep them in sync. This is the server-side enforcement that guarantees bad names can't be persisted regardless of client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side validation now rejects innovation flow state display names that contain commas when creating, renaming, or bulk-updating states.
* **Tests**
  * Added negative tests covering rejection of comma-containing state names to ensure validation prevents creation, update, or deletion/rebuild with invalid names.
* **Documentation**
  * Clarified validation behavior and the comma-reserved constraint in definition validation comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->