### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -6471,14 +6471,20 @@ type RoleSet {
 }
 
 type RoleSetInvitationResult {
+  """
+  The existing open application that blocks this invitation, when the result type is ALREADY_HAS_OPEN_APPLICATION.
+  """
+  application: Application
   invitation: Invitation
   platformInvitation: PlatformInvitation
   type: RoleSetInvitationResultType!
 }
 
 enum RoleSetInvitationResultType {
+  ALREADY_HAS_OPEN_APPLICATION
   ALREADY_INVITED_TO_PLATFORM_AND_ROLE_SET
   ALREADY_INVITED_TO_ROLE_SET
+  ALREADY_MEMBER_OF_ROLE_SET
   INVITATION_TO_PARENT_NOT_AUTHORIZED
   INVITED_TO_PLATFORM_AND_ROLE_SET
   INVITED_TO_ROLE_SET


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size:   296053 bytes
Snapshot md5: fe73ce9f82504bce73988a5e3c91a230

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role set invitation results now include application reference information and expanded status indicators for pending applications and existing role set members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->