### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -2186,11 +2186,19 @@ input CreateInnovationFlowStateInput {
 type CreateInnovationFlowStateSettingsData {
   """The flag to set."""
   allowNewCallouts: Boolean!
+  """
+  Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted.
+  """
+  visible: Boolean
 }
 
 input CreateInnovationFlowStateSettingsInput {
   """The flag to set."""
   allowNewCallouts: Boolean!
+  """
+  Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted.
+  """
+  visible: Boolean
 }
 
 input CreateInnovationHubOnAccountInput {
@@ -3424,6 +3432,10 @@ type InnovationFlowState {
 type InnovationFlowStateSettings {
   """Whether new callouts can be added to this State."""
   allowNewCallouts: Boolean!
+  """
+  Whether this State/phase is shown in the member-facing navigation. Default true. UI-affordance only: it does NOT gate access to the phase content.
+  """
+  visible: Boolean!
 }
 
 type InnovationHub {
@@ -6471,14 +6483,20 @@ type RoleSet {
 }
 
 type RoleSetInvitationResult {
+  """
+  The existing open application that blocks this invitation, when the result type is ALREADY_HAS_OPEN_APPLICATION.
+  """
+  application: Application
   invitation: Invitation
   platformInvitation: PlatformInvitation
   type: RoleSetInvitationResultType!
 }
 
 enum RoleSetInvitationResultType {
+  ALREADY_HAS_OPEN_APPLICATION
   ALREADY_INVITED_TO_PLATFORM_AND_ROLE_SET
   ALREADY_INVITED_TO_ROLE_SET
+  ALREADY_MEMBER_OF_ROLE_SET
   INVITATION_TO_PARENT_NOT_AUTHORIZED
   INVITED_TO_PLATFORM_AND_ROLE_SET
   INVITED_TO_ROLE_SET
@@ -7905,8 +7923,14 @@ input UpdateInnovationFlowStateInput {
 }
 
 input UpdateInnovationFlowStateSettingsInput {
-  """The flag to set."""
-  allowNewCallouts: Boolean!
+  """
+  Optional. Sets whether new callouts can be added to this State; omission leaves the stored value unchanged.
+  """
+  allowNewCallouts: Boolean
+  """
+  Optional. Sets whether the phase is shown in member-facing navigation; omission leaves the stored value unchanged.
+  """
+  visible: Boolean
 }
 
 input UpdateInnovationFlowStatesSortOrderInput {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size:   296738 bytes
Snapshot md5: 19fe0e13a88deff4efe874730d3a8dd6

This PR was generated by the schema-baseline workflow.