### PR TITLE
chore: remove local build configuration for oidc-service in docker-co…

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -246,12 +246,6 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_oidc_service
-    # Local build of the sibling oidc-service repo so in-flight fixes
-    # (e.g. pre-consent claim attachment) run instead of the pinned Hub image.
-    # Override OIDC_SERVICE_REPO_PATH if your sibling clone lives elsewhere.
-    build:
-      context: ${OIDC_SERVICE_REPO_PATH:-../oidc-service}
-      dockerfile: Dockerfile
     image: alkemio/oidc-service:v0.8.0
     depends_on:
       - hydra


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OIDC service deployment to use a pre-built container image (v0.8.0) instead of building from local source code. This streamlines the deployment process while maintaining existing container configuration and networking setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->