### PR TITLE
feat(004): assistant ACCESS authorization privilege (Increment A, FR-027)

### DIFF
--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -207,6 +207,20 @@ http:
           - X-Alkemio-Actor-Id
         trustForwardHeader: true
 
+    # 004-web-ai-assistant (FR-027): the assistant edge's forwardAuth. Same
+    # identity resolution as alkemio-resolve, but the endpoint ALSO enforces the
+    # ACCESS_VIRTUAL_ASSISTANT privilege: it returns 403 (which traefik
+    # propagates) when the acting user lacks access, refusing the request BEFORE
+    # assistant-service is reached. Only the browser assistant edge uses this;
+    # the system path (/internal/invoke) does not traverse it, so it stays
+    # exempt.
+    alkemio-resolve-assistant:
+      forwardAuth:
+        address: 'http://host.docker.internal:4000/rest/internal/assistant-forward-auth'
+        authResponseHeaders:
+          - X-Alkemio-Actor-Id
+        trustForwardHeader: true
+
   routers:
     oidc-public:
       rule: 'PathPrefix(`/oidc`)'
@@ -331,8 +345,10 @@ http:
 
     # 004-web-ai-assistant: browser /api/private/rest/assistant/* → strip full
     # prefix → assistant-service on the host. Identity-at-gateway (OIDC):
-    # client X-Alkemio-* headers are zeroed, then alkemio-resolve forwardAuth
-    # resolves the alkemio_session cookie (or Hydra bearer) and injects
+    # client X-Alkemio-* headers are zeroed, then alkemio-resolve-assistant
+    # forwardAuth resolves the alkemio_session cookie (or Hydra bearer) AND
+    # enforces the ACCESS_VIRTUAL_ASSISTANT privilege (403 before
+    # assistant-service is reached for users without access), injecting
     # X-Alkemio-Actor-Id — the only identity assistant-service accepts.
     # more specific than 'api-private-rest'
     assistant-service:
@@ -340,7 +356,7 @@ http:
       service: 'assistant-service'
       middlewares:
         - strip-client-alkemio-headers
-        - alkemio-resolve
+        - alkemio-resolve-assistant
         - strip-api-private-rest-assistant
       entryPoints:
         - 'web'

--- a/schema.graphql
+++ b/schema.graphql
@@ -102,6 +102,7 @@ enum AuthenticationType {
 
 enum AuthorizationCredential {
   ACCOUNT_ADMIN
+  ASSISTANT_ACCESS
   BETA_TESTER
   GLOBAL_ADMIN
   GLOBAL_ANONYMOUS
@@ -195,6 +196,7 @@ enum AuthorizationPolicyType {
 
 enum AuthorizationPrivilege {
   ACCESS_INTERACTIVE_GUIDANCE
+  ACCESS_VIRTUAL_ASSISTANT
   ACCOUNT_LICENSE_MANAGE
   AUTHORIZATION_RESET
   COMMUNITY_ASSIGN_VC_FROM_ACCOUNT
@@ -346,6 +348,7 @@ enum ConversationEventType {
 enum CredentialType {
   ACCOUNT_ADMIN
   ACCOUNT_LICENSE_PLUS
+  ASSISTANT_ACCESS
   BETA_TESTER
   GLOBAL_ADMIN
   GLOBAL_ANONYMOUS
@@ -715,6 +718,7 @@ enum RoleName {
   LEAD
   MEMBER
   OWNER
+  PLATFORM_ASSISTANT_ACCESS
   PLATFORM_BETA_TESTER
   PLATFORM_VC_CAMPAIGN
   REGISTERED
@@ -4493,6 +4497,10 @@ type Platform {
   templatesManager: TemplatesManager
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
+  """
+  Whether the current user may use the web AI assistant (the ACCESS_VIRTUAL_ASSISTANT privilege, 004-web-ai-assistant). client-web reads this to gate every assistant UI cue.
+  """
+  virtualAssistantAccess: Boolean!
   """The mappings of well-known Virtual Contributors to their UUIDs."""
   wellKnownVirtualContributors: PlatformWellKnownVirtualContributors!
 }

--- a/src/common/constants/authorization/credential.rule.types.constants.ts
+++ b/src/common/constants/authorization/credential.rule.types.constants.ts
@@ -92,6 +92,8 @@ export const CREDENTIAL_RULE_PLATFORM_CREATE_INNOVATION_PACK =
   'credentialRuleTypes-platformCreateInnovationPack';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE =
   'credentialRuleTypes-platformAccessGuidance';
+export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_VIRTUAL_ASSISTANT =
+  'credentialRuleTypes-platformAccessVirtualAssistant';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_DASHBOARD =
   'credentialRuleTypes-platformAccessDashboard';
 export const CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER =

--- a/src/common/enums/authorization.credential.ts
+++ b/src/common/enums/authorization.credential.ts
@@ -32,6 +32,7 @@ export enum AuthorizationCredential {
   // Roles to allow easier management of users
   BETA_TESTER = 'beta-tester',
   VC_CAMPAIGN = 'vc-campaign',
+  ASSISTANT_ACCESS = 'assistant-access', // grants ACCESS_VIRTUAL_ASSISTANT (004-web-ai-assistant, FR-027)
 }
 
 registerEnumType(AuthorizationCredential, {

--- a/src/common/enums/authorization.privilege.ts
+++ b/src/common/enums/authorization.privilege.ts
@@ -44,6 +44,7 @@ export enum AuthorizationPrivilege {
   MOVE_POST = 'move-post',
   MOVE_CONTRIBUTION = 'move-contribution',
   ACCESS_INTERACTIVE_GUIDANCE = 'access-interactive-guidance',
+  ACCESS_VIRTUAL_ASSISTANT = 'access-virtual-assistant', // may the user use the web AI assistant (004-web-ai-assistant, FR-027)
   UPDATE_CONTENT = 'update-content',
   RECEIVE_NOTIFICATIONS = 'receive-notifications',
   RECEIVE_NOTIFICATIONS_ADMIN = 'receive-notifications-admin',

--- a/src/common/enums/role.name.ts
+++ b/src/common/enums/role.name.ts
@@ -15,6 +15,7 @@ export enum RoleName {
   GLOBAL_SUPPORT_MANAGER = 'global-support-manager',
   PLATFORM_BETA_TESTER = 'platform-beta-tester',
   PLATFORM_VC_CAMPAIGN = 'platform-vc-campaign',
+  PLATFORM_ASSISTANT_ACCESS = 'platform-assistant-access',
   REGISTERED = 'registered',
   GUEST = 'guest',
   ANONYMOUS = 'anonymous',

--- a/src/core/auth/oidc/assistant-forward-auth.controller.spec.ts
+++ b/src/core/auth/oidc/assistant-forward-auth.controller.spec.ts
@@ -1,0 +1,128 @@
+import { AuthorizationPrivilege } from '@common/enums';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import type { Request, Response } from 'express';
+import { type Mocked, vi } from 'vitest';
+import { AssistantForwardAuthController } from './assistant-forward-auth.controller';
+import { ANONYMOUS_ACTOR_ID, HEADER_ACTOR_ID } from './constants';
+import {
+  ForwardAuthResolverService,
+  SessionStoreUnavailableError,
+} from './forward-auth.resolver.service';
+
+/**
+ * 004-web-ai-assistant (FR-027, T037d): the assistant-edge privilege gate.
+ * Verifies a request whose acting user lacks ACCESS_VIRTUAL_ASSISTANT is
+ * refused (403) before assistant-service is reached, while a privileged user
+ * is admitted (200 + actor header).
+ */
+describe('AssistantForwardAuthController', () => {
+  let controller: AssistantForwardAuthController;
+  let resolver: Mocked<ForwardAuthResolverService>;
+  let authorizationService: Mocked<AuthorizationService>;
+
+  const buildRes = () => {
+    const res = {
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      end: vi.fn(),
+    };
+    return res as unknown as Response & {
+      setHeader: ReturnType<typeof vi.fn>;
+      status: ReturnType<typeof vi.fn>;
+      end: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  const actorWith = (actorID: string, isAnonymous = false): ActorContext => {
+    const ctx = new ActorContext();
+    ctx.actorID = actorID;
+    ctx.isAnonymous = isAnonymous;
+    return ctx;
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AssistantForwardAuthController,
+        {
+          provide: ForwardAuthResolverService,
+          useValue: { resolveActorContext: vi.fn() },
+        },
+        {
+          provide: AuthorizationService,
+          useValue: { isAccessGranted: vi.fn() },
+        },
+        {
+          provide: PlatformAuthorizationPolicyService,
+          useValue: {
+            getPlatformAuthorizationPolicy: vi
+              .fn()
+              .mockResolvedValue({ id: 'platform-auth' }),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(AssistantForwardAuthController);
+    resolver = module.get(ForwardAuthResolverService);
+    authorizationService = module.get(AuthorizationService);
+  });
+
+  it('admits a privileged user: 200 + stamps the actor header', async () => {
+    resolver.resolveActorContext.mockResolvedValue(actorWith('user-1'));
+    authorizationService.isAccessGranted.mockReturnValue(true);
+    const res = buildRes();
+
+    await controller.resolve(undefined, {} as Request, res);
+
+    expect(authorizationService.isAccessGranted).toHaveBeenCalledWith(
+      expect.objectContaining({ actorID: 'user-1' }),
+      { id: 'platform-auth' },
+      AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(HEADER_ACTOR_ID, 'user-1');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('refuses an unprivileged user with 403 before assistant-service', async () => {
+    resolver.resolveActorContext.mockResolvedValue(actorWith('user-2'));
+    authorizationService.isAccessGranted.mockReturnValue(false);
+    const res = buildRes();
+
+    await controller.resolve(undefined, {} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    // Must NOT stamp the actor header on refusal (request never proceeds).
+    expect(res.setHeader).not.toHaveBeenCalledWith(
+      HEADER_ACTOR_ID,
+      expect.anything()
+    );
+  });
+
+  it('refuses an anonymous caller (never holds the privilege) with 403', async () => {
+    resolver.resolveActorContext.mockResolvedValue(
+      actorWith(ANONYMOUS_ACTOR_ID, true)
+    );
+    authorizationService.isAccessGranted.mockReturnValue(false);
+    const res = buildRes();
+
+    await controller.resolve(undefined, {} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 503 when the BFF session store is unavailable', async () => {
+    resolver.resolveActorContext.mockRejectedValue(
+      new SessionStoreUnavailableError()
+    );
+    const res = buildRes();
+
+    await controller.resolve(undefined, {} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(authorizationService.isAccessGranted).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/auth/oidc/assistant-forward-auth.controller.ts
+++ b/src/core/auth/oidc/assistant-forward-auth.controller.ts
@@ -1,0 +1,91 @@
+import { AuthorizationPrivilege } from '@common/enums';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { Controller, Get, Query, Req, Res } from '@nestjs/common';
+import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import type { Request, Response } from 'express';
+import { ANONYMOUS_ACTOR_ID, HEADER_ACTOR_ID } from './constants';
+import {
+  ForwardAuthResolverService,
+  SessionStoreUnavailableError,
+} from './forward-auth.resolver.service';
+
+/**
+ * 004-web-ai-assistant (FR-027, T037d): the server-side **assistant edge**
+ * forwardAuth decision endpoint.
+ *
+ * Mounted under `/rest/internal/*` (same as the universal forwardAuth endpoint)
+ * so it is unreachable from the public internet — only the Traefik
+ * `alkemio-resolve-assistant` ForwardAuth middleware reaches it. The Traefik
+ * router for `/api/private/rest/assistant` points its ForwardAuth here instead
+ * of the universal `/rest/internal/forward-auth`.
+ *
+ * Unlike the universal endpoint (which ALWAYS returns 200), this one is the
+ * PRIMARY access gate for the web AI assistant:
+ *   - Resolves the acting ActorContext from the SAME identity sources (cookie /
+ *     Hydra bearer / non-interactive-login bearer / guest) via the universal
+ *     controller's `resolveActorContext`.
+ *   - If the resolved actor holds `ACCESS_VIRTUAL_ASSISTANT` on the Platform
+ *     authorization policy → 200 + stamps `X-Alkemio-Actor-Id`, so the request
+ *     proceeds to assistant-service.
+ *   - Otherwise → **403** (`permission_denied`) BEFORE assistant-service is
+ *     reached. An anonymous caller never holds the privilege, so it is refused
+ *     too.
+ *
+ * Flow B (`/internal/invoke`, system-invoked) does NOT traverse this browser
+ * edge / the `alkemio-resolve-assistant` middleware, so it is exempt by
+ * construction — there is no user and no privilege gate on that path.
+ */
+@Controller('rest/internal')
+export class AssistantForwardAuthController {
+  constructor(
+    private readonly forwardAuthResolverService: ForwardAuthResolverService,
+    private readonly authorizationService: AuthorizationService,
+    private readonly platformAuthorizationService: PlatformAuthorizationPolicyService
+  ) {}
+
+  @Get('assistant-forward-auth')
+  async resolve(
+    @Query('guestName') guestNameRaw: string | undefined,
+    @Req() req: Request,
+    @Res() res: Response
+  ): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store');
+
+    const guestName =
+      typeof guestNameRaw === 'string' ? guestNameRaw : undefined;
+
+    let actorContext;
+    try {
+      actorContext = await this.forwardAuthResolverService.resolveActorContext(
+        req,
+        guestName
+      );
+    } catch (err) {
+      if (err instanceof SessionStoreUnavailableError) {
+        res.status(503).end();
+        return;
+      }
+      throw err;
+    }
+
+    const hasAccess = this.authorizationService.isAccessGranted(
+      actorContext,
+      await this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT
+    );
+
+    if (!hasAccess) {
+      // Primary access gate: refuse before assistant-service is reached.
+      res.status(403).end();
+      return;
+    }
+
+    res.setHeader(
+      HEADER_ACTOR_ID,
+      actorContext.actorID && actorContext.actorID.length > 0
+        ? actorContext.actorID
+        : ANONYMOUS_ACTOR_ID
+    );
+    res.status(200).end();
+  }
+}

--- a/src/core/auth/oidc/forward-auth.controller.ts
+++ b/src/core/auth/oidc/forward-auth.controller.ts
@@ -1,14 +1,10 @@
-import { NonInteractiveLoginStrategy } from '@core/auth/non-interactive-login/non-interactive-login.strategy';
-import { AuthenticationService } from '@core/authentication/authentication.service';
-import { Controller, Get, Inject, Query, Req, Res } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { AlkemioConfig } from '@src/types';
-import { randomUUID } from 'crypto';
+import { Controller, Get, Query, Req, Res } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { ANONYMOUS_ACTOR_ID, HEADER_ACTOR_ID } from './constants';
-import type { SessionStoreHandle } from './session-store.redis';
-import { SESSION_STORE_HANDLE } from './strategies/cookie-session.errors';
-import { HydraBearerValidator } from './strategies/hydra-bearer.validator';
+import {
+  ForwardAuthResolverService,
+  SessionStoreUnavailableError,
+} from './forward-auth.resolver.service';
 
 /**
   Traefik ForwardAuth decision endpoint. Single source-of-truth for
@@ -22,12 +18,9 @@ import { HydraBearerValidator } from './strategies/hydra-bearer.validator';
 
   Identity sources tried in order:
     1. session cookie               — browsers/SPA (BFF Redis-backed session).
-                                      Cookie name comes from
-                                      `identity.authentication.providers.oidc.cookie.name`
-                                      (env-suffixed per environment: `alkemio_session`,
-                                      `alkemio_session_sandbox`, …).
     2. `Authorization: Bearer <jwt>` — API/M2M (Hydra-issued, JWKS-validated)
     3. `?guestName=` query param    — anonymous guest with display name
+  …all resolved by the shared `ForwardAuthResolverService`.
 
   Semantics: ALWAYS returns 200 AND ALWAYS stamps `X-Alkemio-Actor-Id`.
   Authenticated users get their canonical actor id; guests get the synthetic
@@ -47,21 +40,9 @@ import { HydraBearerValidator } from './strategies/hydra-bearer.validator';
  */
 @Controller('rest/internal')
 export class ForwardAuthController {
-  private readonly sessionCookieName: string;
-
   constructor(
-    private readonly authenticationService: AuthenticationService,
-    @Inject(SESSION_STORE_HANDLE)
-    private readonly sessionStore: SessionStoreHandle,
-    private readonly hydraBearerValidator: HydraBearerValidator,
-    private readonly nonInteractiveLoginStrategy: NonInteractiveLoginStrategy,
-    configService: ConfigService<AlkemioConfig, true>
-  ) {
-    this.sessionCookieName = configService.get(
-      'identity.authentication.providers.oidc.cookie.name',
-      { infer: true }
-    );
-  }
+    private readonly forwardAuthResolverService: ForwardAuthResolverService
+  ) {}
 
   @Get('forward-auth')
   async resolve(
@@ -74,90 +55,21 @@ export class ForwardAuthController {
     const guestName =
       typeof guestNameRaw === 'string' ? guestNameRaw : undefined;
 
-    // 1. Cookie path — browsers/SPA. Bare sid post express-session signature
-    //    verification (matches Redis key suffix). Only honour it when the
-    //    request actually carried the session cookie — express-session
-    //    auto-generates a sid for every request, so without this guard the
-    //    endpoint would attempt a BFF Redis lookup for unauthenticated traffic.
-    //    The cookie name is per-env
-    const sid = req.cookies?.[this.sessionCookieName]
-      ? typeof req.sessionID === 'string' && req.sessionID.length > 0
-        ? req.sessionID
-        : undefined
-      : undefined;
-
-    let cookiePayload = null;
-    if (sid) {
-      try {
-        cookiePayload = await this.sessionStore.get(sid);
-      } catch {
+    let ctx;
+    try {
+      ctx = await this.forwardAuthResolverService.resolveActorContext(
+        req,
+        guestName
+      );
+    } catch (err) {
+      if (err instanceof SessionStoreUnavailableError) {
         // Store unreachable — surface 503 so Traefik returns the same to caller.
         res.status(503).end();
         return;
       }
+      throw err;
     }
 
-    if (cookiePayload) {
-      const ctx =
-        await this.authenticationService.getActorContextFromBffPayload(
-          cookiePayload,
-          guestName
-        );
-      res.setHeader(
-        HEADER_ACTOR_ID,
-        ctx.actorID && ctx.actorID.length > 0 ? ctx.actorID : ANONYMOUS_ACTOR_ID
-      );
-      res.status(200).end();
-      return;
-    }
-
-    // 2. Bearer path — API/M2M. JWKS-validated Hydra access token (RS256).
-    //    Validator throws BearerValidationError on any failure; forwardAuth
-    //    semantics require us to swallow that and fall through to anonymous
-    //    rather than 401 the caller.
-    const auth = req.headers['authorization'];
-    if (typeof auth === 'string') {
-      const correlationId = randomUUID();
-      try {
-        const result =
-          await this.hydraBearerValidator.validateAuthorizationHeader(
-            auth,
-            correlationId,
-            correlationId
-          );
-        if (result.actorContext.actorID) {
-          res.setHeader(HEADER_ACTOR_ID, result.actorContext.actorID);
-        }
-        res.status(200).end();
-        return;
-      } catch {
-        // Bearer invalid as Hydra RS256 → try the HS256 non-interactive-login
-        // path below before giving up.
-      }
-
-      // 2b. Non-interactive-login bearer path — HS256 self-signed tokens
-      //     minted by `/api/auth/non-interactive-login`. Mirrors the GraphQL
-      //     Passport chain (Hydra → non-interactive-login fall-through) so
-      //     forwardAuth-protected REST routes (file-service,
-      //     collaborative-document) accept the same test bearers GraphQL does.
-      //     Strategy.validate returns null when the feature is disabled or the
-      //     token is not an HS256 non-interactive-login JWT, so this is inert
-      //     in production.
-      const niCtx = await this.nonInteractiveLoginStrategy.validate(req);
-      if (niCtx?.actorID) {
-        res.setHeader(HEADER_ACTOR_ID, niCtx.actorID);
-        res.status(200).end();
-        return;
-      }
-    }
-
-    // 3. Guest/anonymous fall-through. getActorContextFromBffPayload(null,
-    //    guestName) reproduces the prior behaviour: guest with display name
-    //    if provided, anonymous otherwise.
-    const ctx = await this.authenticationService.getActorContextFromBffPayload(
-      null,
-      guestName
-    );
     // Always stamp the actor header. Authenticated/guest contexts carry their
     // own actorID; anonymous contexts get the nil-UUID sentinel that
     // auth-evaluation-service recognises as GLOBAL_ANONYMOUS. Downstream

--- a/src/core/auth/oidc/forward-auth.resolver.service.ts
+++ b/src/core/auth/oidc/forward-auth.resolver.service.ts
@@ -1,0 +1,133 @@
+import { ActorContext } from '@core/actor-context/actor.context';
+import { NonInteractiveLoginStrategy } from '@core/auth/non-interactive-login/non-interactive-login.strategy';
+import { AuthenticationService } from '@core/authentication/authentication.service';
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AlkemioConfig } from '@src/types';
+import { randomUUID } from 'crypto';
+import type { Request } from 'express';
+import type { SessionStoreHandle } from './session-store.redis';
+import { SESSION_STORE_HANDLE } from './strategies/cookie-session.errors';
+import { HydraBearerValidator } from './strategies/hydra-bearer.validator';
+
+/**
+ * Sentinel thrown by {@link ForwardAuthResolverService.resolveActorContext}
+ * when the BFF session store is unreachable — callers translate this into a
+ * 503 so Traefik propagates it.
+ */
+export class SessionStoreUnavailableError extends Error {}
+
+/**
+ * Shared identity resolution for the Traefik forwardAuth decision endpoints.
+ * Tries the same identity sources used across the platform — cookie (BFF
+ * session) → Hydra RS256 bearer → non-interactive-login HS256 bearer → guest /
+ * anonymous — and returns the resolved {@link ActorContext} (with credentials,
+ * usable for authorization decisions).
+ *
+ * Used by both the universal `/rest/internal/forward-auth` endpoint (which
+ * always 200s and stamps the actor header) and the assistant edge
+ * `/rest/internal/assistant-forward-auth` endpoint (which additionally gates on
+ * the `ACCESS_VIRTUAL_ASSISTANT` privilege). Extracting it here keeps the two
+ * routes byte-identical in how they resolve "who is this request".
+ */
+@Injectable()
+export class ForwardAuthResolverService {
+  private readonly sessionCookieName: string;
+
+  constructor(
+    private readonly authenticationService: AuthenticationService,
+    @Inject(SESSION_STORE_HANDLE)
+    private readonly sessionStore: SessionStoreHandle,
+    private readonly hydraBearerValidator: HydraBearerValidator,
+    private readonly nonInteractiveLoginStrategy: NonInteractiveLoginStrategy,
+    configService: ConfigService<AlkemioConfig, true>
+  ) {
+    this.sessionCookieName = configService.get(
+      'identity.authentication.providers.oidc.cookie.name',
+      { infer: true }
+    );
+  }
+
+  /**
+   * Resolves the acting ActorContext from a request. Throws
+   * {@link SessionStoreUnavailableError} when the BFF session store is
+   * unreachable; never throws for an absent/invalid credential (falls through
+   * to guest/anonymous, matching forwardAuth semantics).
+   */
+  public async resolveActorContext(
+    req: Request,
+    guestName?: string
+  ): Promise<ActorContext> {
+    // 1. Cookie path — browsers/SPA. Bare sid post express-session signature
+    //    verification (matches Redis key suffix). Only honour it when the
+    //    request actually carried the session cookie — express-session
+    //    auto-generates a sid for every request, so without this guard the
+    //    endpoint would attempt a BFF Redis lookup for unauthenticated traffic.
+    //    The cookie name is per-env.
+    const sid = req.cookies?.[this.sessionCookieName]
+      ? typeof req.sessionID === 'string' && req.sessionID.length > 0
+        ? req.sessionID
+        : undefined
+      : undefined;
+
+    let cookiePayload = null;
+    if (sid) {
+      try {
+        cookiePayload = await this.sessionStore.get(sid);
+      } catch {
+        throw new SessionStoreUnavailableError();
+      }
+    }
+
+    if (cookiePayload) {
+      return this.authenticationService.getActorContextFromBffPayload(
+        cookiePayload,
+        guestName
+      );
+    }
+
+    // 2. Bearer path — API/M2M. JWKS-validated Hydra access token (RS256).
+    //    Validator throws BearerValidationError on any failure; forwardAuth
+    //    semantics require us to swallow that and fall through to anonymous
+    //    rather than 401 the caller.
+    const auth = req.headers['authorization'];
+    if (typeof auth === 'string') {
+      const correlationId = randomUUID();
+      try {
+        const result =
+          await this.hydraBearerValidator.validateAuthorizationHeader(
+            auth,
+            correlationId,
+            correlationId
+          );
+        if (result.actorContext.actorID) {
+          return result.actorContext;
+        }
+      } catch {
+        // Bearer invalid as Hydra RS256 → try the HS256 non-interactive-login
+        // path below before giving up.
+      }
+
+      // 2b. Non-interactive-login bearer path — HS256 self-signed tokens
+      //     minted by `/api/auth/non-interactive-login`. Mirrors the GraphQL
+      //     Passport chain (Hydra → non-interactive-login fall-through) so
+      //     forwardAuth-protected REST routes (file-service,
+      //     collaborative-document) accept the same test bearers GraphQL does.
+      //     Strategy.validate returns null when the feature is disabled or the
+      //     token is not an HS256 non-interactive-login JWT, so this is inert
+      //     in production.
+      const niCtx = await this.nonInteractiveLoginStrategy.validate(req);
+      if (niCtx?.actorID) {
+        return niCtx;
+      }
+    }
+
+    // 3. Guest/anonymous fall-through. getActorContextFromBffPayload(null,
+    //    guestName) reproduces the prior behaviour: guest with display name if
+    //    provided, anonymous otherwise.
+    return this.authenticationService.getActorContextFromBffPayload(
+      null,
+      guestName
+    );
+  }
+}

--- a/src/core/auth/oidc/oidc.module.ts
+++ b/src/core/auth/oidc/oidc.module.ts
@@ -1,15 +1,19 @@
 import { ActorContextModule } from '@core/actor-context/actor.context.module';
 import { NonInteractiveLoginModule } from '@core/auth/non-interactive-login/non-interactive-login.module';
 import { AuthenticationModule } from '@core/authentication/authentication.module';
+import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { Logger, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_FILTER } from '@nestjs/core';
 import { PassportModule } from '@nestjs/passport';
+import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
 import { AlkemioConfig } from '@src/types';
 import Redis from 'ioredis';
 import { createRemoteJWKSet } from 'jose';
+import { AssistantForwardAuthController } from './assistant-forward-auth.controller';
 import { parseBearerAudAllowList } from './bearer-aud-allow-list';
 import { ForwardAuthController } from './forward-auth.controller';
+import { ForwardAuthResolverService } from './forward-auth.resolver.service';
 import { OidcController } from './oidc.controller';
 import { OidcService } from './oidc.service';
 import { buildSessionStore } from './session-store.redis';
@@ -31,10 +35,17 @@ import {
     AuthenticationModule,
     ActorContextModule,
     NonInteractiveLoginModule,
+    AuthorizationModule,
+    PlatformAuthorizationPolicyModule,
   ],
-  controllers: [OidcController, ForwardAuthController],
+  controllers: [
+    OidcController,
+    ForwardAuthController,
+    AssistantForwardAuthController,
+  ],
   providers: [
     OidcService,
+    ForwardAuthResolverService,
     {
       provide: SESSION_STORE_HANDLE,
       inject: [ConfigService],

--- a/src/domain/access/platform-roles-access/platform.roles.access.service.spec.ts
+++ b/src/domain/access/platform-roles-access/platform.roles.access.service.spec.ts
@@ -133,6 +133,10 @@ describe('PlatformRolesAccessService', () => {
         ],
         [RoleName.PLATFORM_BETA_TESTER, AuthorizationCredential.BETA_TESTER],
         [RoleName.PLATFORM_VC_CAMPAIGN, AuthorizationCredential.VC_CAMPAIGN],
+        [
+          RoleName.PLATFORM_ASSISTANT_ACCESS,
+          AuthorizationCredential.ASSISTANT_ACCESS,
+        ],
         [RoleName.REGISTERED, AuthorizationCredential.GLOBAL_REGISTERED],
         [RoleName.GUEST, AuthorizationCredential.GLOBAL_GUEST],
         [RoleName.ANONYMOUS, AuthorizationCredential.GLOBAL_ANONYMOUS],

--- a/src/domain/access/platform-roles-access/platform.roles.access.service.ts
+++ b/src/domain/access/platform-roles-access/platform.roles.access.service.ts
@@ -101,6 +101,8 @@ export class PlatformRolesAccessService {
         return AuthorizationCredential.BETA_TESTER;
       case RoleName.PLATFORM_VC_CAMPAIGN:
         return AuthorizationCredential.VC_CAMPAIGN;
+      case RoleName.PLATFORM_ASSISTANT_ACCESS:
+        return AuthorizationCredential.ASSISTANT_ACCESS;
       case RoleName.REGISTERED:
         return AuthorizationCredential.GLOBAL_REGISTERED;
       case RoleName.GUEST:

--- a/src/migrations/1764590884533-seed.ts
+++ b/src/migrations/1764590884533-seed.ts
@@ -395,6 +395,11 @@ export class Seed1764590884533 implements MigrationInterface {
         userPolicy: { minimum: 0, maximum: -1 },
       },
       {
+        name: 'platform-assistant-access',
+        credential: { type: 'assistant-access', resourceID: '' },
+        userPolicy: { minimum: 0, maximum: -1 },
+      },
+      {
         name: 'global-community-reader',
         credential: { type: 'global-community-reader', resourceID: '' },
         userPolicy: { minimum: 0, maximum: -1 },

--- a/src/migrations/1780600000000-PlatformAssistantAccessRole.ts
+++ b/src/migrations/1780600000000-PlatformAssistantAccessRole.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+/**
+ * 004-web-ai-assistant (FR-027): registers the `platform-assistant-access`
+ * entry role on the existing platform RoleSet so the EXISTING
+ * `assignPlatformRoleToUser` / `removePlatformRoleFromUser` mutations can grant
+ * / revoke the `assistant-access` credential per user (same family as
+ * `platform-beta-tester` / `platform-vc-campaign`). Holders of that credential
+ * — together with platform admins — are granted ACCESS_VIRTUAL_ASSISTANT by the
+ * credential rule in platform.service.authorization.ts (applied on
+ * authorization-policy reset; no data migration for the rule itself).
+ *
+ * Fresh bootstraps seed this role via the seed migration's createPlatformRoles;
+ * this migration covers already-bootstrapped databases. Idempotent: it inserts
+ * only when the role is absent from the platform RoleSet.
+ */
+export class PlatformAssistantAccessRole1780600000000
+  implements MigrationInterface
+{
+  name = 'PlatformAssistantAccessRole1780600000000';
+
+  private readonly roleName = 'platform-assistant-access';
+  private readonly credential = { type: 'assistant-access', resourceID: '' };
+  private readonly userPolicy = { minimum: 0, maximum: -1 };
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Resolve the platform RoleSet id (the platform row carries roleSetId).
+    const platformRows: { roleSetId: string | null }[] =
+      await queryRunner.query(`SELECT "roleSetId" FROM "platform" LIMIT 1`);
+    const roleSetId = platformRows?.[0]?.roleSetId;
+    if (!roleSetId) {
+      // No platform RoleSet (e.g. a not-yet-bootstrapped DB) — nothing to do;
+      // the seed migration will create the role on bootstrap.
+      return;
+    }
+
+    // Idempotency: skip when the role already exists on this RoleSet.
+    const existing: { count: string }[] = await queryRunner.query(
+      `SELECT COUNT(*) as count FROM "role" WHERE "roleSetId" = $1 AND name = $2`,
+      [roleSetId, this.roleName]
+    );
+    if (Number(existing?.[0]?.count ?? 0) > 0) {
+      return;
+    }
+
+    await queryRunner.query(
+      `INSERT INTO "role" (id, "createdDate", "updatedDate", version, "roleSetId", name, credential, "parentCredentials", "requiresEntryRole", "requiresSameRoleInParentRoleSet", "userPolicy", "organizationPolicy", "virtualContributorPolicy")
+       VALUES ($1, NOW(), NOW(), 1, $2, $3, $4, '[]', false, false, $5, '{"minimum": 0, "maximum": 0}', '{"minimum": 0, "maximum": 0}')`,
+      [
+        randomUUID(),
+        roleSetId,
+        this.roleName,
+        JSON.stringify(this.credential),
+        JSON.stringify(this.userPolicy),
+      ]
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const platformRows: { roleSetId: string | null }[] =
+      await queryRunner.query(`SELECT "roleSetId" FROM "platform" LIMIT 1`);
+    const roleSetId = platformRows?.[0]?.roleSetId;
+    if (!roleSetId) {
+      return;
+    }
+    await queryRunner.query(
+      `DELETE FROM "role" WHERE "roleSetId" = $1 AND name = $2`,
+      [roleSetId, this.roleName]
+    );
+  }
+}

--- a/src/platform/platform/platform.resolver.fields.ts
+++ b/src/platform/platform/platform.resolver.fields.ts
@@ -143,4 +143,21 @@ export class PlatformResolverFields {
     const stored = platform.wellKnownVirtualContributors;
     return { mappings: stored?.mappings ?? [] };
   }
+
+  @ResolveField('virtualAssistantAccess', () => Boolean, {
+    nullable: false,
+    description:
+      'Whether the current user may use the web AI assistant (the ACCESS_VIRTUAL_ASSISTANT privilege, 004-web-ai-assistant). client-web reads this to gate every assistant UI cue.',
+  })
+  async virtualAssistantAccess(
+    @CurrentActor() actorContext: ActorContext
+  ): Promise<boolean> {
+    // Non-throwing read so an unprivileged user resolves `false` (and the
+    // client hides the assistant) rather than receiving an authorization error.
+    return this.authorizationService.isAccessGranted(
+      actorContext,
+      await this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT
+    );
+  }
 }

--- a/src/platform/platform/platform.service.authorization.spec.ts
+++ b/src/platform/platform/platform.service.authorization.spec.ts
@@ -1,3 +1,5 @@
+import { AuthorizationCredential } from '@common/enums/authorization.credential';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { RoleSetType } from '@common/enums/role.set.type';
 import { RelationshipNotFoundException } from '@common/exceptions/relationship.not.found.exception';
 import { RoleSetAuthorizationService } from '@domain/access/role-set/role.set.service.authorization';
@@ -20,6 +22,7 @@ describe('PlatformAuthorizationService', () => {
   let service: PlatformAuthorizationService;
   let platformService: Mocked<PlatformService>;
   let messagingAuthorizationService: Mocked<MessagingAuthorizationService>;
+  let authorizationPolicyService: Mocked<AuthorizationPolicyService>;
 
   const mockPlatform: IPlatform = {
     id: 'platform-1',
@@ -50,7 +53,10 @@ describe('PlatformAuthorizationService', () => {
       createCredentialRuleUsingTypesOnly: vi.fn(() => ({
         cascade: false,
       })),
-      createCredentialRule: vi.fn(() => ({
+      createCredentialRule: vi.fn((grantedPrivileges, criterias, name) => ({
+        grantedPrivileges,
+        criterias,
+        name,
         cascade: false,
       })),
     };
@@ -142,6 +148,7 @@ describe('PlatformAuthorizationService', () => {
     );
     platformService = module.get(PlatformService);
     messagingAuthorizationService = module.get(MessagingAuthorizationService);
+    authorizationPolicyService = module.get(AuthorizationPolicyService);
   });
 
   it('should be defined', () => {
@@ -207,6 +214,38 @@ describe('PlatformAuthorizationService', () => {
       ).toHaveBeenCalled();
       expect(result).toBeDefined();
       expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  // 004-web-ai-assistant (FR-027): the ACCESS_VIRTUAL_ASSISTANT credential rule.
+  describe('ACCESS_VIRTUAL_ASSISTANT credential rule', () => {
+    it('grants ACCESS_VIRTUAL_ASSISTANT to GLOBAL_ADMIN OR ASSISTANT_ACCESS, never GLOBAL_REGISTERED', async () => {
+      platformService.getPlatformOrFail.mockResolvedValue(mockPlatform);
+      messagingAuthorizationService.applyAuthorizationPolicy.mockResolvedValue(
+        []
+      );
+
+      await service.applyAuthorizationPolicy();
+
+      const assistantRuleCall =
+        authorizationPolicyService.createCredentialRule.mock.calls.find(call =>
+          (call[0] as AuthorizationPrivilege[]).includes(
+            AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT
+          )
+        );
+
+      expect(assistantRuleCall).toBeDefined();
+      const criteriaTypes = (
+        assistantRuleCall![1] as { type: AuthorizationCredential }[]
+      ).map(c => c.type);
+
+      // Anchored to platform admin + the admin-assignable access credential.
+      expect(criteriaTypes).toContain(AuthorizationCredential.GLOBAL_ADMIN);
+      expect(criteriaTypes).toContain(AuthorizationCredential.ASSISTANT_ACCESS);
+      // Out of the box NOT every registered user.
+      expect(criteriaTypes).not.toContain(
+        AuthorizationCredential.GLOBAL_REGISTERED
+      );
     });
   });
 });

--- a/src/platform/platform/platform.service.authorization.ts
+++ b/src/platform/platform/platform.service.authorization.ts
@@ -1,6 +1,7 @@
 import {
   CREDENTIAL_RULE_PLATFORM_CREATE_ORGANIZATION,
   CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_GUIDANCE,
+  CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_VIRTUAL_ASSISTANT,
   CREDENTIAL_RULE_TYPES_PLATFORM_ADMINS,
   CREDENTIAL_RULE_TYPES_PLATFORM_AUTH_RESET,
   CREDENTIAL_RULE_TYPES_PLATFORM_FILE_UPLOAD_ANY_USER,
@@ -164,6 +165,10 @@ export class PlatformAuthorizationService {
       await this.createCredentialRuleInteractiveGuidance();
     credentialRules.push(credentialRuleInteractiveGuidance);
 
+    const credentialRuleVirtualAssistantAccess =
+      this.createCredentialRuleVirtualAssistantAccess();
+    credentialRules.push(credentialRuleVirtualAssistantAccess);
+
     return this.authorizationPolicyService.appendCredentialAuthorizationRules(
       authorization,
       credentialRules
@@ -215,6 +220,29 @@ export class PlatformAuthorizationService {
     userChatGuidanceAccessPrivilegeRule.cascade = false;
 
     return userChatGuidanceAccessPrivilegeRule;
+  }
+
+  /**
+   * 004-web-ai-assistant (FR-027): grant ACCESS_VIRTUAL_ASSISTANT to platform
+   * admins OR holders of the admin-assignable ASSISTANT_ACCESS credential
+   * (the PLATFORM_ASSISTANT_ACCESS role). Anchored to GLOBAL_ADMIN — NOT
+   * GLOBAL_REGISTERED — so out of the box only platform admins may use the
+   * web AI assistant. Mirrors createCredentialRuleInteractiveGuidance, but the
+   * criteria are the two access-bearing credentials (OR semantics).
+   */
+  private createCredentialRuleVirtualAssistantAccess(): IAuthorizationPolicyRuleCredential {
+    const virtualAssistantAccessRule =
+      this.authorizationPolicyService.createCredentialRule(
+        [AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT],
+        [
+          { type: AuthorizationCredential.GLOBAL_ADMIN, resourceID: '' },
+          { type: AuthorizationCredential.ASSISTANT_ACCESS, resourceID: '' },
+        ],
+        CREDENTIAL_RULE_TYPES_PLATFORM_ACCESS_VIRTUAL_ASSISTANT
+      );
+    virtualAssistantAccessRule.cascade = false;
+
+    return virtualAssistantAccessRule;
   }
 
   private createPlatformCredentialRules(): IAuthorizationPolicyRuleCredential[] {


### PR DESCRIPTION
## Increment A — assistant access (authorization privilege) · `workspace#004-web-ai-assistant`

Server slice of **Increment A** (FR-027(a)). **Access (who may use the web AI assistant) is an authorization PRIVILEGE**, granted exactly like `ACCESS_INTERACTIVE_GUIDANCE`. The orthogonal budget/entitlement half (FR-027(b)/FR-028 — `ACCOUNT_AI_ASSISTANT_TOKENS_MONTH`, the budget MCP resource, `assistantBudget`) is **Increment B**, a later PR — not in scope here.

Contract: `specs/004-web-ai-assistant/contracts/assistant-access-and-budget.md` §1.

### Stacking
- **Base = `feat/004-web-ai-assistant`** (stacked on the v1 server PR #6140 — the `virtual-assistant` actor + MCP host + assistant edge). The diff here is **only Increment A**.
- Retarget this PR to `develop` after #6140 merges.

### What landed (task-by-task)
- **T037a — enums.** `AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT`, `AuthorizationCredential.ASSISTANT_ACCESS = 'assistant-access'`, `RoleName.PLATFORM_ASSISTANT_ACCESS = 'platform-assistant-access'`.
- **T037b — credential rule + Platform field.** `platform.service.authorization.ts` grants `ACCESS_VIRTUAL_ASSISTANT` to **`GLOBAL_ADMIN` OR `ASSISTANT_ACCESS`** — anchored to `GLOBAL_ADMIN`, never `GLOBAL_REGISTERED` (out of the box only platform admins). Surfaced as the gated boolean `Platform.virtualAssistantAccess`, read **non-throwing** so an unprivileged user resolves `false` (client hides every assistant cue) rather than erroring.
- **T037c — role registration.** `platform-assistant-access` registered as a platform `RoleSet` entry role (`getCredentialForRole` mapping + bootstrap seed + idempotent migration `1780600000000-PlatformAssistantAccessRole` for already-bootstrapped DBs). Managed by the **existing** `assignPlatformRoleToUser` / `removePlatformRoleFromUser` mutations — **no new mutation**. It falls through to the default `GRANT_GLOBAL_ADMINS` gate and is **not** license-coupled (unlike beta-tester/vc-campaign, which auto-grant `ACCOUNT_LICENSE_PLUS`).
- **T037d — assistant-edge privilege gate.** New dedicated forwardAuth endpoint `/rest/internal/assistant-forward-auth` resolves identity via the shared `ForwardAuthResolverService` (extracted from `ForwardAuthController`, byte-identical resolution) and **refuses with 403 (`permission_denied`) BEFORE assistant-service** when the acting user lacks `ACCESS_VIRTUAL_ASSISTANT`. Traefik assistant router retargeted from `alkemio-resolve` to a new `alkemio-resolve-assistant` middleware. **Flow B (`/internal/invoke`, system-invoked) does not traverse this edge — exempt by construction.**
- **T039 (access subset) — tests.** GLOBAL_ADMIN + ASSISTANT_ACCESS holders get the privilege, GLOBAL_REGISTERED does not; the role maps to its credential; the edge gate admits the privileged, refuses the unprivileged/anonymous (403), and 503s on session-store loss.

### Schema delta (additive, **0 breaking** — for the client codegen that follows)
- `+ Platform.virtualAssistantAccess: Boolean!`
- `+ AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT`
- `+ AuthorizationCredential.ASSISTANT_ACCESS`
- `+ CredentialType.ASSISTANT_ACCESS`
- `+ RoleName.PLATFORM_ASSISTANT_ACCESS`

### Exit gates
- `pnpm install` ✓ · `pnpm lint` (tsc --noEmit + biome) ✓ · `pnpm build` ✓
- `vitest` ✓ — full suite green (6858 passed / 7 skipped); the 3 changed specs green in isolation (23 tests)
- `schema:print && schema:sort && schema:diff` ✓ — **5 additive, 0 breaking**; regenerated `schema.graphql` committed

### Needs human attention
- **Bootstrap/auth-reset seeding**: the credential rule applies on authorization-policy reset (code, no data migration). The RoleSet role is seeded for fresh bootstraps and via the idempotent migration for existing DBs. `migration:run` against a live Postgres was not executed here (standard forward DDL) — verify a fresh bootstrap/auth-reset grants `ACCESS_VIRTUAL_ASSISTANT` to platform admins and `ASSISTANT_ACCESS` holders only.
- **Edge gate is a forwardAuth endpoint, not an app controller** — see the Traefik `alkemio-resolve-assistant` change; prod/acc Traefik manifests (infra-ops) must mirror it for the gate to take effect outside local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)