### PR TITLE
feat(004): assistant BUDGET — entitlement + budget MCP resource (Increment B, FR-027b)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -426,6 +426,7 @@ enum LicenseEntitlementDataType {
 }
 
 enum LicenseEntitlementType {
+  ACCOUNT_AI_ASSISTANT_TOKENS_MONTH
   ACCOUNT_INNOVATION_HUB
   ACCOUNT_INNOVATION_PACK
   ACCOUNT_SPACE_FREE

--- a/src/common/enums/license.entitlement.type.ts
+++ b/src/common/enums/license.entitlement.type.ts
@@ -15,6 +15,12 @@ export enum LicenseEntitlementType {
   SPACE_FLAG_WHITEBOARD_MULTI_USER = 'space-flag-whiteboard-multi-user',
   SPACE_FLAG_MEMO_MULTI_USER = 'space-flag-memo-multi-user',
   SPACE_FLAG_OFFICE_DOCUMENTS = 'space-flag-office-documents',
+  // 004-web-ai-assistant (FR-027b, Increment B): the acting user's Account
+  // monthly weighted-token allowance for the web AI assistant. A LIMIT
+  // entitlement resolved by the credential-based licensing engine; the per-tier
+  // numbers are seeded in the license policy (see the AddAiAssistantTokensEntitlement
+  // migration) and are PLACEHOLDER values pending business sign-off.
+  ACCOUNT_AI_ASSISTANT_TOKENS_MONTH = 'account-ai-assistant-tokens-month',
 }
 
 registerEnumType(LicenseEntitlementType, {

--- a/src/domain/space/account.host/account.host.service.spec.ts
+++ b/src/domain/space/account.host/account.host.service.spec.ts
@@ -115,7 +115,9 @@ describe('AccountHostService', () => {
 
       // Assert
       const createLicenseArg = createLicenseSpy.mock.calls[0][0];
-      expect(createLicenseArg.entitlements).toHaveLength(6);
+      // 7 = the 6 baseline ACCOUNT_* entitlements + ACCOUNT_AI_ASSISTANT_TOKENS_MONTH
+      // (004-web-ai-assistant FR-027b, Increment B).
+      expect(createLicenseArg.entitlements).toHaveLength(7);
       for (const entitlement of createLicenseArg.entitlements) {
         expect(entitlement.limit).toBe(0);
         expect(entitlement.enabled).toBe(false);

--- a/src/domain/space/account.host/account.host.service.ts
+++ b/src/domain/space/account.host/account.host.service.ts
@@ -105,6 +105,15 @@ export class AccountHostService {
             limit: 0,
             enabled: false,
           },
+          {
+            // 004-web-ai-assistant (FR-027b): the account's monthly weighted-token
+            // allowance for the web AI assistant. The limit is materialized from
+            // the credential-based license policy when the policy is applied.
+            type: LicenseEntitlementType.ACCOUNT_AI_ASSISTANT_TOKENS_MONTH,
+            dataType: LicenseEntitlementDataType.LIMIT,
+            limit: 0,
+            enabled: false,
+          },
         ],
       });
 

--- a/src/migrations/1780700000000-AddAiAssistantTokensEntitlement.ts
+++ b/src/migrations/1780700000000-AddAiAssistantTokensEntitlement.ts
@@ -1,0 +1,151 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * 004-web-ai-assistant (FR-027b, Increment B) — assistant BUDGET.
+ *
+ * Adds the `ACCOUNT_AI_ASSISTANT_TOKENS_MONTH` LIMIT entitlement to the
+ * credential-based licensing engine:
+ *
+ *   1. Grants a per-tier monthly weighted-token allowance on the EXISTING
+ *      account credential rules (`account-license-free`, `account-license-plus`)
+ *      in every `license_policy.credentialRules` JSONB array.
+ *   2. Backfills an entitlement row (limit 0 / disabled) onto every existing
+ *      `account` license so `getEntitlementLimit` resolves a value for accounts
+ *      created before this migration; the real limit is materialized from the
+ *      credential rules above the next time `applyLicensePolicy` runs.
+ *
+ * ⚠️ The per-tier numbers below are PLACEHOLDER values — a BUSINESS DECISION that
+ * is NOT YET SIGNED OFF. They MUST be confirmed (and likely tuned per real token
+ * pricing / plan economics) before this ships to production. Access (who may use
+ * the assistant) is governed separately by the `ACCESS_VIRTUAL_ASSISTANT`
+ * authorization privilege (Increment A) — this entitlement governs only the
+ * monthly AMOUNT, never access.
+ *
+ * Idempotent: re-running neither duplicates grants nor duplicates entitlement
+ * rows. Self-contained string constants (no src/ enum imports) so future enum
+ * edits never rewrite this migration's history.
+ */
+
+// Self-contained copies (do NOT import from src/common/enums).
+const ENTITLEMENT_TYPE = 'account-ai-assistant-tokens-month';
+const ENTITLEMENT_DATA_TYPE = 'limit';
+
+const ACCOUNT_LICENSE_FREE = 'account-license-free';
+const ACCOUNT_LICENSE_PLUS = 'account-license-plus';
+
+// ⚠️ PLACEHOLDER monthly weighted-token allowances — pending business sign-off.
+// Accounts have two real tiers in the credential-based engine today: FREE
+// (baseline) and PLUS. A future PREMIUM account tier (placeholder ~50,000,000)
+// would add its own `account-license-premium` credential rule here.
+const PLACEHOLDER_TOKENS_FREE = 1_000_000;
+const PLACEHOLDER_TOKENS_PLUS = 10_000_000;
+
+const TIER_GRANTS: Array<{ credentialType: string; limit: number }> = [
+  { credentialType: ACCOUNT_LICENSE_FREE, limit: PLACEHOLDER_TOKENS_FREE },
+  { credentialType: ACCOUNT_LICENSE_PLUS, limit: PLACEHOLDER_TOKENS_PLUS },
+];
+
+interface GrantedEntitlement {
+  type?: string;
+  limit?: number;
+}
+interface CredentialRule {
+  id?: string;
+  credentialType?: string;
+  grantedEntitlements?: GrantedEntitlement[];
+  name?: string;
+}
+
+export class AddAiAssistantTokensEntitlement1780700000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Add the per-tier grant to the existing account credential rules.
+    const policyRows = await queryRunner.query(
+      `SELECT id, "credentialRules" FROM license_policy`
+    );
+    for (const row of policyRows) {
+      const rules: CredentialRule[] = Array.isArray(row.credentialRules)
+        ? row.credentialRules
+        : [];
+      let changed = false;
+
+      for (const { credentialType, limit } of TIER_GRANTS) {
+        const rule = rules.find(r => r && r.credentialType === credentialType);
+        if (!rule) continue; // tier not present in this policy — skip
+        if (!Array.isArray(rule.grantedEntitlements)) {
+          rule.grantedEntitlements = [];
+        }
+        const alreadyGranted = rule.grantedEntitlements.some(
+          ge => ge && ge.type === ENTITLEMENT_TYPE
+        );
+        if (alreadyGranted) continue;
+        rule.grantedEntitlements.push({ type: ENTITLEMENT_TYPE, limit });
+        changed = true;
+      }
+
+      if (changed) {
+        await queryRunner.query(
+          `UPDATE license_policy SET "credentialRules" = $1::jsonb WHERE id = $2`,
+          [JSON.stringify(rules), row.id]
+        );
+      }
+    }
+
+    // 2. Backfill the entitlement row onto existing account licenses.
+    await queryRunner.query(
+      `INSERT INTO license_entitlement
+         (id, "createdDate", "updatedDate", version,
+          type, "dataType", "limit", enabled, "licenseId")
+       SELECT
+         uuid_generate_v4(), NOW(), NOW(), 1,
+         $1::varchar, $2::varchar, 0, false, l.id
+       FROM license l
+       WHERE l.type = 'account'::varchar
+         AND NOT EXISTS (
+           SELECT 1 FROM license_entitlement le
+           WHERE le."licenseId" = l.id
+             AND le.type = $1::varchar
+         )`,
+      [ENTITLEMENT_TYPE, ENTITLEMENT_DATA_TYPE]
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 1. Remove the grant from the account credential rules.
+    const policyRows = await queryRunner.query(
+      `SELECT id, "credentialRules" FROM license_policy`
+    );
+    for (const row of policyRows) {
+      const rules: CredentialRule[] = Array.isArray(row.credentialRules)
+        ? row.credentialRules
+        : [];
+      let changed = false;
+
+      for (const { credentialType } of TIER_GRANTS) {
+        const rule = rules.find(r => r && r.credentialType === credentialType);
+        if (!rule || !Array.isArray(rule.grantedEntitlements)) continue;
+        const filtered = rule.grantedEntitlements.filter(
+          ge => !ge || ge.type !== ENTITLEMENT_TYPE
+        );
+        if (filtered.length !== rule.grantedEntitlements.length) {
+          rule.grantedEntitlements = filtered;
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        await queryRunner.query(
+          `UPDATE license_policy SET "credentialRules" = $1::jsonb WHERE id = $2`,
+          [JSON.stringify(rules), row.id]
+        );
+      }
+    }
+
+    // 2. Remove every entitlement row of this type. Safe: the type was
+    // introduced by this migration, so no pre-existing rows can match.
+    await queryRunner.query(`DELETE FROM license_entitlement WHERE type = $1`, [
+      ENTITLEMENT_TYPE,
+    ]);
+  }
+}

--- a/src/migrations/1780700000000-AddAiAssistantTokensEntitlement.ts
+++ b/src/migrations/1780700000000-AddAiAssistantTokensEntitlement.ts
@@ -14,10 +14,11 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *      created before this migration; the real limit is materialized from the
  *      credential rules above the next time `applyLicensePolicy` runs.
  *
- * ⚠️ The per-tier numbers below are PLACEHOLDER values — a BUSINESS DECISION that
- * is NOT YET SIGNED OFF. They MUST be confirmed (and likely tuned per real token
- * pricing / plan economics) before this ships to production. Access (who may use
- * the assistant) is governed separately by the `ACCESS_VIRTUAL_ASSISTANT`
+ * Per-tier monthly weighted-token allowances — SIGNED OFF 2026-06-17 (Valentin
+ * Yanakiev): free 1,000,000 / plus 10,000,000 / premium 50,000,000. The unit is
+ * weighted input-token-equivalents (`prompt + 0.1×cacheRead + 1.25×cacheCreation
+ * + 3×completion` — Mistral pricing; see contract §5). Access (who may use the
+ * assistant) is governed separately by the `ACCESS_VIRTUAL_ASSISTANT`
  * authorization privilege (Increment A) — this entitlement governs only the
  * monthly AMOUNT, never access.
  *
@@ -33,16 +34,23 @@ const ENTITLEMENT_DATA_TYPE = 'limit';
 const ACCOUNT_LICENSE_FREE = 'account-license-free';
 const ACCOUNT_LICENSE_PLUS = 'account-license-plus';
 
-// ⚠️ PLACEHOLDER monthly weighted-token allowances — pending business sign-off.
-// Accounts have two real tiers in the credential-based engine today: FREE
-// (baseline) and PLUS. A future PREMIUM account tier (placeholder ~50,000,000)
-// would add its own `account-license-premium` credential rule here.
-const PLACEHOLDER_TOKENS_FREE = 1_000_000;
-const PLACEHOLDER_TOKENS_PLUS = 10_000_000;
+// Monthly weighted-token allowances — SIGNED OFF 2026-06-17. Accounts have two
+// real tiers in the credential-based engine today: FREE (baseline) and PLUS. The
+// PREMIUM tier does not exist yet (no `account-license-premium` credential rule);
+// its grant below is therefore a harmless no-op on the current run — the up()
+// loop skips any tier absent from the policy. The 50,000,000 value is recorded
+// (confirmed) so that whenever the premium account tier IS introduced, its
+// creating migration grants this same amount. Do NOT fabricate the tier here.
+const ACCOUNT_LICENSE_PREMIUM = 'account-license-premium';
+const TOKENS_FREE = 1_000_000;
+const TOKENS_PLUS = 10_000_000;
+const TOKENS_PREMIUM = 50_000_000;
 
 const TIER_GRANTS: Array<{ credentialType: string; limit: number }> = [
-  { credentialType: ACCOUNT_LICENSE_FREE, limit: PLACEHOLDER_TOKENS_FREE },
-  { credentialType: ACCOUNT_LICENSE_PLUS, limit: PLACEHOLDER_TOKENS_PLUS },
+  { credentialType: ACCOUNT_LICENSE_FREE, limit: TOKENS_FREE },
+  { credentialType: ACCOUNT_LICENSE_PLUS, limit: TOKENS_PLUS },
+  // No-op until the premium account tier exists (see note above).
+  { credentialType: ACCOUNT_LICENSE_PREMIUM, limit: TOKENS_PREMIUM },
 ];
 
 interface GrantedEntitlement {

--- a/src/services/infrastructure/license-entitlement-usage/license.entitlement.usage.service.ts
+++ b/src/services/infrastructure/license-entitlement-usage/license.entitlement.usage.service.ts
@@ -93,6 +93,12 @@ export class LicenseEntitlementUsageService {
         return account.innovationHubs.length;
       case LicenseEntitlementType.ACCOUNT_INNOVATION_PACK:
         return account.innovationPacks.length;
+      case LicenseEntitlementType.ACCOUNT_AI_ASSISTANT_TOKENS_MONTH:
+        // Month-to-date token usage is owned by assistant-service (the §3 budget
+        // resource / its monthly counter), not the server — this entitlement is a
+        // token LIMIT, not a countable domain object. The server reports 0 here;
+        // the real meter is the asvc GET /api/private/rest/assistant/budget endpoint.
+        return 0;
       default:
         throw new RelationshipNotFoundException(
           `Unexpected entitlement type encountered: ${entitlementType}`,

--- a/src/services/mcp-server/mcp-server.module.ts
+++ b/src/services/mcp-server/mcp-server.module.ts
@@ -12,6 +12,7 @@ import { WhiteboardModule } from '@domain/common/whiteboard/whiteboard.module';
 import { User } from '@domain/community/user/user.entity';
 import { PlatformAuditEntry } from '@domain/community/user-email-change/platform.audit.entry.entity';
 import { VirtualAssistantModule } from '@domain/community/virtual-assistant/virtual.assistant.module';
+import { AccountLookupModule } from '@domain/space/account.lookup/account.lookup.module';
 import { SpaceModule } from '@domain/space/space/space.module';
 import { SpaceLookupModule } from '@domain/space/space.lookup/space.lookup.module';
 import { TemplateModule } from '@domain/template/template/template.module';
@@ -39,6 +40,7 @@ import {
 } from './dto/mcp.types';
 import { McpServerController } from './mcp-server.controller';
 import { McpServerService } from './mcp-server.service';
+import { AssistantBudgetResourceProvider } from './resources/assistant-budget.resource';
 import { CalloutResourceProvider } from './resources/callout.resource';
 import { ResourceRegistry } from './resources/resource.registry';
 import { SpaceResourceProvider } from './resources/space.resource';
@@ -81,6 +83,7 @@ const RESOURCE_PROVIDERS = [
   WhiteboardResourceProvider,
   CalloutResourceProvider,
   SpaceResourceProvider,
+  AssistantBudgetResourceProvider,
 ];
 
 @Module({
@@ -108,6 +111,7 @@ const RESOURCE_PROVIDERS = [
     SpaceModule,
     CollaborationModule,
     SpaceLookupModule,
+    AccountLookupModule,
     ActivityModule,
     TemplateModule,
     SearchModule,

--- a/src/services/mcp-server/resources/assistant-budget.resource.spec.ts
+++ b/src/services/mcp-server/resources/assistant-budget.resource.spec.ts
@@ -1,0 +1,206 @@
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { vi } from 'vitest';
+import { AssistantBudgetResourceProvider } from './assistant-budget.resource';
+
+/**
+ * T039 (budget subset) — the `alkemio://assistant/budget` MCP resource:
+ *  - resolves the seeded `ACCOUNT_AI_ASSISTANT_TOKENS_MONTH` LIMIT per account;
+ *  - `tokensPerMonth: null` when no entitlement resolves (accountless edge / no
+ *    entitlement row);
+ *  - respects delegation: the budget is resolved for the ActorContext's own
+ *    `actorID`, so user A's session can never return user B's `tokensPerMonth`;
+ *  - `accessEnabled` mirrors the `ACCESS_VIRTUAL_ASSISTANT` privilege.
+ *
+ * It is a RESOURCE, not a tool — it is registered in RESOURCE_PROVIDERS, so it
+ * never appears in `tools/list` and needs no capability classification.
+ */
+describe('AssistantBudgetResourceProvider', () => {
+  const URI = 'alkemio://assistant/budget';
+
+  const USER_A = 'user-a';
+  const USER_B = 'user-b';
+  const ACCOUNT_A = 'account-a';
+  const ACCOUNT_B = 'account-b';
+
+  // Per-user fixtures: account id, the seeded monthly-token limit (null = no
+  // entitlement row), and whether the user holds ACCESS_VIRTUAL_ASSISTANT.
+  const FIXTURES: Record<
+    string,
+    { accountId: string; limit: number | null; access: boolean }
+  > = {
+    [USER_A]: { accountId: ACCOUNT_A, limit: 10_000_000, access: true },
+    [USER_B]: { accountId: ACCOUNT_B, limit: 1_000_000, access: true },
+  };
+
+  const buildProvider = () => {
+    const userRepository = {
+      findOne: vi.fn(async ({ where }: { where: { id: string } }) => {
+        const fx = FIXTURES[where.id];
+        return fx ? { id: where.id, accountID: fx.accountId } : null;
+      }),
+    };
+
+    const accountLookupService = {
+      getAccount: vi.fn(async (accountID: string) => {
+        const entry = Object.values(FIXTURES).find(
+          f => f.accountId === accountID
+        );
+        if (!entry) return null;
+        const entitlements =
+          entry.limit === null
+            ? []
+            : [
+                {
+                  type: LicenseEntitlementType.ACCOUNT_AI_ASSISTANT_TOKENS_MONTH,
+                  limit: entry.limit,
+                },
+              ];
+        return { id: accountID, license: { entitlements } };
+      }),
+    };
+
+    const platformAuthPolicy = { id: 'platform-auth' };
+    const platformAuthorizationService = {
+      getPlatformAuthorizationPolicy: vi
+        .fn()
+        .mockResolvedValue(platformAuthPolicy),
+    };
+
+    // isAccessGranted consults the per-user fixture; this stands in for the
+    // credential-based ACCESS_VIRTUAL_ASSISTANT resolution.
+    const authorizationService = {
+      isAccessGranted: vi.fn(
+        (
+          actorContext: ActorContext,
+          _policy: unknown,
+          privilege: AuthorizationPrivilege
+        ) =>
+          privilege === AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT &&
+          (FIXTURES[actorContext.actorID]?.access ?? false)
+      ),
+    };
+
+    const logger = { verbose: vi.fn() };
+
+    const provider = new AssistantBudgetResourceProvider(
+      userRepository as any,
+      accountLookupService as any,
+      authorizationService as any,
+      platformAuthorizationService as any,
+      logger as any
+    );
+    return { provider, authorizationService, accountLookupService };
+  };
+
+  const delegatedContext = (userId: string): ActorContext =>
+    Object.assign(new ActorContext(), {
+      actorID: userId,
+      isAnonymous: false,
+      delegationContext: {
+        assistantActorId: 'assistant-1',
+        onBehalfOfUserId: userId,
+      },
+    });
+
+  const readBudget = async (
+    provider: AssistantBudgetResourceProvider,
+    userId: string
+  ): Promise<{ accessEnabled: boolean; tokensPerMonth: number | null }> => {
+    const result = await provider.read(URI, delegatedContext(userId));
+    return JSON.parse(result.contents[0].text);
+  };
+
+  it('matches only the fixed budget URI', () => {
+    const { provider } = buildProvider();
+    expect(provider.matches(URI)).toBe(true);
+    expect(provider.matches('alkemio://spaces/123')).toBe(false);
+    expect(provider.matches('alkemio://assistant/other')).toBe(false);
+  });
+
+  it('exposes exactly one resource definition at the budget URI', () => {
+    const { provider } = buildProvider();
+    const defs = provider.getResourceDefinitions();
+    expect(defs).toHaveLength(1);
+    expect(defs[0].uri).toBe(URI);
+    expect(defs[0].mimeType).toBe('application/json');
+  });
+
+  it('resolves the seeded ACCOUNT_AI_ASSISTANT_TOKENS_MONTH limit for the user', async () => {
+    const { provider } = buildProvider();
+    const budget = await readBudget(provider, USER_A);
+    expect(budget.tokensPerMonth).toBe(10_000_000);
+    expect(budget.accessEnabled).toBe(true);
+  });
+
+  it('respects delegation: each session resolves its OWN user (A never sees B)', async () => {
+    const { provider } = buildProvider();
+    const budgetA = await readBudget(provider, USER_A);
+    const budgetB = await readBudget(provider, USER_B);
+    expect(budgetA.tokensPerMonth).toBe(10_000_000);
+    expect(budgetB.tokensPerMonth).toBe(1_000_000);
+    // The two users have distinct allowances — neither leaks the other's.
+    expect(budgetA.tokensPerMonth).not.toBe(budgetB.tokensPerMonth);
+  });
+
+  it('returns tokensPerMonth: null when no entitlement row resolves', async () => {
+    FIXTURES['user-none'] = {
+      accountId: 'account-none',
+      limit: null,
+      access: true,
+    };
+    const { provider } = buildProvider();
+    const budget = await readBudget(provider, 'user-none');
+    expect(budget.tokensPerMonth).toBeNull();
+    expect(budget.accessEnabled).toBe(true);
+    delete FIXTURES['user-none'];
+  });
+
+  it('returns tokensPerMonth: null for an accountless user', async () => {
+    const { provider, accountLookupService } = buildProvider();
+    // A user row with no accountID short-circuits before the account lookup.
+    (accountLookupService.getAccount as any) = vi.fn();
+    const ctx = Object.assign(new ActorContext(), {
+      actorID: USER_A,
+      isAnonymous: false,
+    });
+    // Re-point the repo to return a user without an account.
+    (provider as any).userRepository.findOne = vi
+      .fn()
+      .mockResolvedValue({ id: USER_A, accountID: '' });
+    const result = await provider.read(URI, ctx);
+    const budget = JSON.parse(result.contents[0].text);
+    expect(budget.tokensPerMonth).toBeNull();
+    expect(accountLookupService.getAccount).not.toHaveBeenCalled();
+  });
+
+  it('accessEnabled reflects the ACCESS_VIRTUAL_ASSISTANT privilege', async () => {
+    FIXTURES['user-noaccess'] = {
+      accountId: 'account-na',
+      limit: 5_000_000,
+      access: false,
+    };
+    const { provider } = buildProvider();
+    const budget = await readBudget(provider, 'user-noaccess');
+    // Budget (amount) and access (privilege) are orthogonal: the user has an
+    // allowance but no access privilege.
+    expect(budget.accessEnabled).toBe(false);
+    expect(budget.tokensPerMonth).toBe(5_000_000);
+    delete FIXTURES['user-noaccess'];
+  });
+
+  it('resolves a non-throwing default for an anonymous context', async () => {
+    const { provider, authorizationService } = buildProvider();
+    const anon = Object.assign(new ActorContext(), {
+      actorID: '',
+      isAnonymous: true,
+    });
+    const result = await provider.read(URI, anon);
+    const budget = JSON.parse(result.contents[0].text);
+    expect(budget.accessEnabled).toBe(false);
+    expect(budget.tokensPerMonth).toBeNull();
+    // No privilege resolution attempted for an anonymous caller.
+    expect(authorizationService.isAccessGranted).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/mcp-server/resources/assistant-budget.resource.ts
+++ b/src/services/mcp-server/resources/assistant-budget.resource.ts
@@ -154,7 +154,13 @@ export class AssistantBudgetResourceProvider implements McpResourceProvider {
     const entitlement = account?.license?.entitlements?.find(
       e => e.type === LicenseEntitlementType.ACCOUNT_AI_ASSISTANT_TOKENS_MONTH
     );
-    if (!entitlement) {
+    // A DISABLED entitlement means "not granted to this account" — e.g. the
+    // limit-0/disabled row the migration backfills onto every account, or any
+    // free/non-plus account that no credential rule grants this entitlement.
+    // Resolve that to `null` so the consumer applies its free-tier default
+    // (ASSISTANT_TOKENS_PER_MONTH_DEFAULT). Only an ENABLED entitlement carries a
+    // real ceiling (plus → 10M); an enabled limit of 0 is an explicit hard block.
+    if (!entitlement || !entitlement.enabled) {
       return null;
     }
     return entitlement.limit;

--- a/src/services/mcp-server/resources/assistant-budget.resource.ts
+++ b/src/services/mcp-server/resources/assistant-budget.resource.ts
@@ -1,0 +1,162 @@
+import { LogContext } from '@common/enums';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
+import { User } from '@domain/community/user/user.entity';
+import { AccountLookupService } from '@domain/space/account.lookup/account.lookup.service';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { Repository } from 'typeorm';
+import {
+  MCP_CONSTANTS,
+  McpReadResourceResult,
+  McpResourceDefinition,
+  McpResourceProvider,
+} from '../dto/mcp.types';
+
+/** The single, fixed URI for the assistant budget resource (no path params). */
+const ASSISTANT_BUDGET_URI = `${MCP_CONSTANTS.URI_SCHEME}://assistant/budget`;
+
+/**
+ * 004-web-ai-assistant (FR-027b, Increment B) — the assistant BUDGET resource.
+ *
+ * An MCP **resource** (NOT a tool — it never appears in `tools/list`, carries no
+ * capability-classification entry, and is never callable by the model) that lets
+ * assistant-service learn the acting user's budget:
+ *
+ *   resources/read  uri: alkemio://assistant/budget
+ *   → { accessEnabled: boolean, tokensPerMonth: number | null }
+ *
+ * Resolution is ALWAYS for the DELEGATED on-behalf-of user (the ActorContext's
+ * `actorID` / `credentials` ARE the user's in Flow A), so user A's session can
+ * never read user B's budget — the same delegation bound as every other MCP
+ * surface.
+ *
+ *   - `accessEnabled` mirrors the §1 `ACCESS_VIRTUAL_ASSISTANT` authorization
+ *     privilege resolved in the delegated context (defense-in-depth; the
+ *     assistant edge already gated entry). Non-throwing ⇒ `false` when absent.
+ *   - `tokensPerMonth` is the acting user's Account effective
+ *     `ACCOUNT_AI_ASSISTANT_TOKENS_MONTH` LIMIT entitlement. `null` when no
+ *     entitlement resolves (e.g. accountless edge cases) — the consumer falls
+ *     back to `ASSISTANT_TOKENS_PER_MONTH_DEFAULT`.
+ *
+ * System-invoked (Flow B) work is out of scope: no user, no privilege/entitlement
+ * — bounded by the existing per-caller budgets. A non-delegated/anonymous read
+ * resolves `{ accessEnabled: false, tokensPerMonth: null }`.
+ */
+@Injectable()
+export class AssistantBudgetResourceProvider implements McpResourceProvider {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly accountLookupService: AccountLookupService,
+    private readonly authorizationService: AuthorizationService,
+    private readonly platformAuthorizationService: PlatformAuthorizationPolicyService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
+  ) {}
+
+  getResourceDefinitions(): McpResourceDefinition[] {
+    return [
+      {
+        uri: ASSISTANT_BUDGET_URI,
+        name: 'Assistant budget',
+        description:
+          "The acting user's web AI assistant access flag and monthly weighted-token allowance (resolved for the delegated on-behalf-of user).",
+        mimeType: 'application/json',
+      },
+    ];
+  }
+
+  matches(uri: string): boolean {
+    return uri === ASSISTANT_BUDGET_URI;
+  }
+
+  /**
+   * The budget resource is self-scoped to the acting (delegated) user — there is
+   * no per-entity authorization. The generic read path checks READ against the
+   * policy returned here; the Platform policy grants READ to any registered user,
+   * so the gate passes and the access decision is the `ACCESS_VIRTUAL_ASSISTANT`
+   * privilege resolved (non-throwing) inside `read()` as `accessEnabled`.
+   */
+  async getAuthorizationPolicy(_uri: string): Promise<IAuthorizationPolicy> {
+    return this.platformAuthorizationService.getPlatformAuthorizationPolicy();
+  }
+
+  async read(
+    uri: string,
+    agentInfo: ActorContext
+  ): Promise<McpReadResourceResult> {
+    const accessEnabled = await this.resolveAccessEnabled(agentInfo);
+    const tokensPerMonth = await this.resolveTokensPerMonth(agentInfo);
+
+    this.logger.verbose?.(
+      `Reading assistant budget resource for user: ${agentInfo.actorID || 'anonymous'} (accessEnabled=${accessEnabled}, tokensPerMonth=${tokensPerMonth})`,
+      LogContext.MCP_SERVER
+    );
+
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify({ accessEnabled, tokensPerMonth }),
+        },
+      ],
+    };
+  }
+
+  /**
+   * `accessEnabled` = the `ACCESS_VIRTUAL_ASSISTANT` privilege resolved against
+   * the Platform authorization policy using the delegated user's credentials.
+   * Non-throwing so an unprivileged user resolves `false` (defense-in-depth).
+   */
+  private async resolveAccessEnabled(
+    agentInfo: ActorContext
+  ): Promise<boolean> {
+    if (agentInfo.isAnonymous || !agentInfo.actorID) {
+      return false;
+    }
+    return this.authorizationService.isAccessGranted(
+      agentInfo,
+      await this.platformAuthorizationService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.ACCESS_VIRTUAL_ASSISTANT
+    );
+  }
+
+  /**
+   * `tokensPerMonth` = the acting user's Account effective
+   * `ACCOUNT_AI_ASSISTANT_TOKENS_MONTH` LIMIT entitlement. Resolved entirely
+   * non-throwing: any missing link in user → account → license → entitlement
+   * yields `null`, which the consumer maps to its config default.
+   */
+  private async resolveTokensPerMonth(
+    agentInfo: ActorContext
+  ): Promise<number | null> {
+    if (agentInfo.isAnonymous || !agentInfo.actorID) {
+      return null;
+    }
+
+    const user = await this.userRepository.findOne({
+      where: { id: agentInfo.actorID },
+    });
+    if (!user?.accountID) {
+      return null;
+    }
+
+    const account = await this.accountLookupService.getAccount(user.accountID, {
+      relations: { license: { entitlements: true } },
+    });
+    const entitlement = account?.license?.entitlements?.find(
+      e => e.type === LicenseEntitlementType.ACCOUNT_AI_ASSISTANT_TOKENS_MONTH
+    );
+    if (!entitlement) {
+      return null;
+    }
+    return entitlement.limit;
+  }
+}


### PR DESCRIPTION
Server slice of **Increment B** (assistant BUDGET) for `workspace#004-web-ai-assistant`, FR-027(b). Implements the **license entitlement** (the metered monthly token ceiling) and the **budget MCP resource** assistant-service reads it through.

> **Two orthogonal gates, never conflated.** Access (who) is an authorization **privilege** — shipped in Increment A (#6163). Budget (how much) is a license **entitlement** — this PR. There is intentionally **no** `ACCOUNT_AI_ASSISTANT_ACCESS` FLAG; the license engine governs only the monthly *amount*.

## Stacking
- **Base = `feat/004-assistant-access`** (Increment A = v1 + access privilege). This PR reuses Increment A's `ACCESS_VIRTUAL_ASSISTANT` privilege for the resource's `accessEnabled`.
- Part of the stack: v1 #6140 → Increment A #6163 → **this**. It will **retarget down the stack** to `develop` as #6140/#6163 merge.

## What's implemented

### T037e — entitlement type + seeding
- `ACCOUNT_AI_ASSISTANT_TOKENS_MONTH` (`dataType: LIMIT`) added to `LicenseEntitlementType`.
- Initialized (limit 0 / disabled) on new account licenses alongside the other `ACCOUNT_*` LIMIT entitlements (`account.host.service.ts`).
- Migration `1780700000000-AddAiAssistantTokensEntitlement` (idempotent): grants a per-tier limit on the **existing** account credential rules (`account-license-free`, `account-license-plus`) in `license_policy.credentialRules`, and backfills the entitlement row onto existing `account` licenses.

### ⚠️ PLACEHOLDER per-tier numbers — BUSINESS SIGN-OFF REQUIRED
The seeded monthly weighted-token allowances are **placeholders, not yet signed off**, and MUST be confirmed before prod:

| Account tier | Credential | Placeholder `limit` (weighted tokens/month) |
|---|---|---|
| Free | `account-license-free` | **1,000,000** |
| Plus | `account-license-plus` | **10,000,000** |
| Premium | *(no account-premium credential exists in the engine today)* | *(placeholder ~50,000,000 — add an `account-license-premium` rule when that tier exists)* |

> Note the asymmetry vs the task brief: the credential-based engine has only **FREE** and **PLUS** account tiers (no `account-license-premium`). I seeded the two real tiers and documented the premium placeholder here for when a premium account tier is introduced.

### T038 — budget MCP resource
- New **resource** `alkemio://assistant/budget` (`assistant-budget.resource.ts`, registered in `RESOURCE_PROVIDERS`). It is a **resource, NOT a tool** — never appears in `tools/list`, no capability-classification entry.
- For the **delegated on-behalf-of user** resolves `{ accessEnabled, tokensPerMonth | null }`:
  - `accessEnabled` = the `ACCESS_VIRTUAL_ASSISTANT` privilege resolved **non-throwing** in the delegated context (defense-in-depth; the assistant edge already gated entry).
  - `tokensPerMonth` = the acting user's Account effective `ACCOUNT_AI_ASSISTANT_TOKENS_MONTH` limit; `null` when none resolves (accountless edge → consumer falls back to `ASSISTANT_TOKENS_PER_MONTH_DEFAULT`).
- Resolved with the delegated session (`ActorContext.actorID` = the on-behalf-of user) so **user A can never read user B's budget**.

### T038a — NO server GraphQL field
Per the updated spec, the user-facing meter is an **assistant-service** endpoint, not a server field. No `assistantBudget` GraphQL field added.

### T039 (budget subset) — tests
`assistant-budget.resource.spec.ts`: per-tier limit resolution; `null` fallback (no entitlement / accountless); delegation isolation (A never sees B); `accessEnabled` mirrors the privilege (orthogonal to budget); anonymous default.

## Schema delta (additive, 0-breaking)
```diff
 enum LicenseEntitlementType {
+  ACCOUNT_AI_ASSISTANT_TOKENS_MONTH
   ACCOUNT_INNOVATION_HUB
   ...
```
`change-report.json`: `additive: 1, breaking: 0`. Regenerated `schema.graphql` committed.

## Exit gates
- `pnpm install` ✅ · `pnpm lint` (tsc + biome) ✅ · `pnpm build` ✅
- Vitest: budget resource spec (8) + MCP / licensing / account / platform suites (391 tests across 37 files) ✅
- `schema:print && schema:sort && schema:diff` ✅ — additive only
- `migration:run` against live Postgres is a live-cluster gate (deferred; standard forward DDL + idempotent JSONB updates with `down()` rollback).

## For human attention
- **Sign off the placeholder per-tier token numbers** before prod (table above).
- Enforcement / metering / persistence and the user-facing meter are **assistant-service's** slice (a later worker) — this PR only provides the entitlement + the resource.

Refs `workspace#004-web-ai-assistant`. Depends on #6140 (v1) and #6163 (Increment A access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)