### PR TITLE
Update the designVersion for all users to 2 - the new UI

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -6478,7 +6478,7 @@ type UserSettings {
   """The date at which the entity was created."""
   createdDate: DateTime!
   """
-  The design version this User has selected (1 = legacy design generation; 2 = current default design generation; 3+ reserved for future generations).
+  The design version this User has selected (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).
   """
   designVersion: Int!
   """The home space settings for this User."""
@@ -9088,7 +9088,7 @@ input UpdateUserSettingsEntityInput {
   """Settings related to this users Communication preferences."""
   communication: UpdateUserSettingsCommunicationInput
   """
-  Update the user's design version. Any integer accepted (1 = legacy design generation; 2 = current default design generation; 3+ reserved for future generations).
+  Update the user's design version. Any integer accepted (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).
   """
   designVersion: Int
   """Settings related to Home Space."""

--- a/specs/096-user-design-version/contracts/graphql.md
+++ b/specs/096-user-design-version/contracts/graphql.md
@@ -27,7 +27,7 @@ type UserSettings {
 type UserSettings {
   authorization: Authorization
   communication: UserSettingsCommunication!
-  "The design version this User has selected (1 = legacy design generation; 2 = current default design generation; 3+ reserved for future generations)."
+  "The design version this User has selected (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations)."
   designVersion: Int!
   homeSpace: UserSettingsHomeSpace!
   id: UUID!
@@ -58,7 +58,7 @@ input UpdateUserSettingsEntityInput {
 ```graphql
 input UpdateUserSettingsEntityInput {
   communication: UpdateUserSettingsCommunicationInput
-  "Update the user's design version. Any integer accepted (1 = legacy design generation; 2 = current default design generation; 3+ reserved for future generations)."
+  "Update the user's design version. Any integer accepted (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations)."
   designVersion: Int
   homeSpace: UpdateUserSettingsHomeSpaceInput
   notification: UpdateUserSettingsNotificationInput
@@ -88,7 +88,7 @@ input CreateUserSettingsInput {
 ```graphql
 input CreateUserSettingsInput {
   communication: CreateUserSettingsCommunicationInput
-  "Initial design version for this User. Defaults to 2 (the current default design generation) when omitted. Pass 1 to opt into the legacy design."
+  "Initial design version for this User. Defaults to 2 (the current default design generation) when omitted. Pass 1 to opt into the legacy design (deprecated; scheduled for removal)."
   designVersion: Int
   homeSpace: CreateUserSettingsHomeSpaceInput
   notification: CreateUserSettingsNotificationInput

--- a/specs/096-user-design-version/data-model.md
+++ b/specs/096-user-design-version/data-model.md
@@ -12,7 +12,7 @@
 
 | Property | Type | DB Column | DB Type | Nullable | Default | Notes |
 | -------- | ---- | --------- | ------- | -------- | ------- | ----- |
-| `designVersion` | `number` | `designVersion` | `int` | `NOT NULL` | `2` *(was `1` in Phase 1; flipped 2026-05-26)* | UI design generation for the user. `1` = legacy design generation; `2` = current default design generation; `3+` reserved for future generations. |
+| `designVersion` | `number` | `designVersion` | `int` | `NOT NULL` | `2` *(was `1` in Phase 1; flipped 2026-05-26)* | UI design generation for the user. `1` = legacy design generation (deprecated, scheduled for removal); `2` = current default design generation; `3+` reserved for future generations. Phase 3 (2026-06-17) flipped every persisted `1` row to `2` via `UPDATE`; `1` remains a valid but deprecated value pending full retirement. |
 
 **TypeORM decorator**:
 
@@ -30,7 +30,7 @@ designVersion!: number;
 ```ts
 @Field(() => Int, {
   nullable: false,
-  description: 'The design version this User has selected (1 = legacy design generation; 2 = current default design generation; 3+ reserved for future generations).',
+  description: 'The design version this User has selected (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).',
 })
 designVersion!: number;
 ```
@@ -43,7 +43,7 @@ Non-null on output because the column is `NOT NULL` with a default — every row
 | ---- | ------ | ----------------- |
 | Value must be an integer | FR-004, FR-005 | `class-validator` `@IsInt()` on the create + update DTO fields. Non-integers (string, decimal, boolean) rejected with a 400-class validation error before reaching the domain. |
 | No min/max bound | FR-004 | No `@Min` / `@Max` decorators. Negative integers, zero, and arbitrarily large positive integers are all accepted. |
-| Default = 2 | FR-002, FR-003 | DB column default + explicit seeding in `UserService.getDefaultUserSettings()`. Belt-and-braces — either layer alone would be sufficient. Phase 2 (2026-05-26) flipped the value from `1` to `2` via column-default DDL only; existing rows were preserved. |
+| Default = 2 | FR-002, FR-003 | DB column default + explicit seeding in `UserService.getDefaultUserSettings()`. Belt-and-braces — either layer alone would be sufficient. Phase 2 (2026-05-26) flipped the value from `1` to `2` via column-default DDL only; existing rows were preserved. Phase 3 (2026-06-17) ran a one-shot `UPDATE` to drain the remaining `designVersion = 1` rows onto `2`; non-`1` rows preserved verbatim. |
 | Required on output | FR-008 | GraphQL field is `nullable: false`. |
 | Optional on input | inherent to partial-update semantics | GraphQL field is `nullable: true` on both create and update inputs; omitting it leaves the existing value alone. |
 
@@ -97,10 +97,28 @@ ALTER TABLE "user_settings"
 
 **Critical invariant**: column-default DDL only. **No `UPDATE` statements anywhere.** Existing rows preserve whatever `designVersion` they have at the time of migration; only future inserts that omit the column are affected (they pick up `2`).
 
+### Phase 3 (2026-06-17) — `1781800000000-BackfillUserSettingsDesignVersionLegacyToCurrentDefault.ts`
+
+**Up**:
+
+```sql
+UPDATE "user_settings"
+  SET "designVersion" = 2
+  WHERE "designVersion" = 1;
+```
+
+**Down**: intentional no-op. Rationale below.
+
+**Scope**: only rows currently holding the legacy value `1`. Rows holding any other integer (`0`, `-1`, `5`, `7`, …) are preserved verbatim — FR-004 still applies; this is the legacy-to-current-default flip, not a clamp. The column default is **not** changed (Phase 2 already set it to `2`).
+
+**Why no symmetric down()**: a flip of `2 → 1` would not selectively restore the pre-migration distribution — we do not track which rows previously held `1`, and after Phase 3 the legitimate-`2` and back-filled-`2` rows are indistinguishable. Operators who must revert should restore a pre-migration database backup.
+
 **Behavioral notes**:
 
-- Both migrations are idempotent in the standard TypeORM sense (the migration registry tracks `up` execution) and reversible via `migration:revert`.
+- All three migrations are idempotent in the standard TypeORM sense (the migration registry tracks `up` execution).
+- Phase 1 and Phase 2 are reversible via `migration:revert`; Phase 3 is not (the down() is a documented no-op).
 - Run the standard migration validation harness on the Phase 2 migration: `.scripts/migrations/run_validate_migration.sh`. CSV diff for `user_settings` should be **identical row content**; only schema-metadata diff should be `column_default 1 → 2`.
+- Phase 3 validation: the CSV diff for `user_settings` should show every row that previously held `1` now holding `2`; no other column changes; no row count change. Rows that previously held a non-`1` integer are preserved verbatim.
 
 ## Default Seeding (Service Layer)
 
@@ -132,9 +150,9 @@ The block sits at the top level of the function alongside the existing `if (upda
 
 | Surface | Compatibility |
 | ------- | ------------- |
-| `UserSettings` GraphQL output | Strictly additive — new non-null field. Clients that don't query it are unaffected; clients that do query it always get a value (`2` for new rows after Phase 2; pre-Phase-2 rows retain whatever was persisted). |
-| `UpdateUserSettingsEntityInput` | Strictly additive — new optional field. Existing callers continue to work unchanged. |
-| `CreateUserSettingsInput` | Strictly additive — new optional field. The internal `getDefaultUserSettings()` is the only producer, and it is updated in lockstep. |
-| Database | Strictly additive — Phase 1 added `NOT NULL DEFAULT 1` column; Phase 2 flipped the column default to `2` via `ALTER COLUMN ... SET DEFAULT 2`. No data loss, no existing row updated. Reversible via the down migrations. |
+| `UserSettings` GraphQL output | Strictly additive — new non-null field. Clients that don't query it are unaffected; clients that do query it always get a value (`2` for new rows after Phase 2; pre-Phase-2 rows retained whatever was persisted until Phase 3 flipped all `1` rows to `2`). |
+| `UpdateUserSettingsEntityInput` | Strictly additive — new optional field. Existing callers continue to work unchanged. Description updated in Phase 3 (2026-06-17) to flag `1` as deprecated and scheduled for removal. |
+| `CreateUserSettingsInput` | Strictly additive — new optional field. The internal `getDefaultUserSettings()` is the only producer, and it is updated in lockstep. Description updated in Phase 3 (2026-06-17) to flag `1` as deprecated and scheduled for removal. |
+| Database | Phase 1 added `NOT NULL DEFAULT 1` column; Phase 2 flipped the column default to `2` via `ALTER COLUMN ... SET DEFAULT 2`; Phase 3 ran a one-shot `UPDATE` to flip all persisted `1` rows to `2` (non-`1` rows preserved verbatim). Phase 1 + Phase 2 are reversible via the down migrations; Phase 3 down() is a documented no-op (revert path is restore-from-backup). After Phase 3, no rows persist with `designVersion = 1` unless a user has explicitly opted back in via `updateUserSettings` since the backfill ran. The legacy value is on a decommission path; a future migration/PR will narrow the validator and drop the `1` value entirely (separate effort, breaking schema change). |
 | Authorization | Unchanged. |
 | Events | Unchanged (no new events). |

--- a/specs/096-user-design-version/quickstart.md
+++ b/specs/096-user-design-version/quickstart.md
@@ -34,13 +34,13 @@ This guide walks through verifying the feature end-to-end against a local Alkemi
 
 This validates **FR-002, FR-003, FR-008** and Story 1 acceptance for new users in the Phase-2 release.
 
-## Story 1 (continued) — Existing user keeps their current value *(Phase 2 invariant)*
+## Story 1 (continued) — Existing user after Phase 3 backfill
 
-1. Log in as a user that existed **before** the Phase-2 migration ran (any account from `restore-dbs` or a long-lived dev account that was on the column-default `1` from Phase 1, or a user that previously opted into `2` or any other integer).
+1. Log in as a user that existed **before** the Phase-3 migration ran.
 2. Run the same query as above.
-3. **Expected**: `me.user.settings.designVersion` returns **whatever value was persisted before the migration**. Phase-1 default-applied users still see `1`; Phase-1 opt-ins to `2` still see `2`; any other integer set via `updateUserSettings` is preserved verbatim. The Phase-2 migration is column-default DDL only — **no row was updated**.
+3. **Expected**: `me.user.settings.designVersion === 2`. Phase 3 ran `UPDATE "user_settings" SET "designVersion" = 2 WHERE "designVersion" = 1`, so every legacy-`1` row was flipped onto the current default. Rows that pre-Phase-3 held any other integer (`0`, `-1`, `5`, `7`, …) are still preserved verbatim — Phase 3 is a legacy-to-current-default flip, not a clamp.
 
-This validates the Phase-2 preserved-choice invariant (Session 2026-05-26 clarification) and supersedes the Phase-1 reading that the existing-user value is `1`. FR-009 itself still holds for the Phase-1 release window.
+This supersedes the Phase-2 preserved-choice reading for rows that held `1`. Phase-1 and Phase-2 narratives elsewhere in the spec remain accurate historical records of those releases.
 
 ## Phase 2 preserved-choice check (operator)
 
@@ -59,6 +59,35 @@ docker exec alkemio_dev_postgres psql -U synapse -d alkemio \
 ```
 
 Expected after Phase-2 migration: `2`.
+
+## Phase 3 backfill check (operator)
+
+Before running the Phase-3 migration, snapshot the row distribution:
+
+```bash
+docker exec alkemio_dev_postgres psql -U synapse -d alkemio \
+  -c 'SELECT "designVersion", COUNT(*) FROM user_settings GROUP BY "designVersion" ORDER BY "designVersion";'
+```
+
+Apply: `pnpm run migration:run`
+
+Re-query the distribution. Expected:
+
+- The `1`-bucket reports `0` rows.
+- The `2`-bucket count equals the pre-migration `(count at 1) + (count at 2)`.
+- All other buckets (`0`, `-1`, `5`, `7`, … if any existed) are unchanged.
+- Total row count is unchanged.
+
+Confirm the column default is still `2` (Phase 2 invariant — Phase 3 does not touch schema):
+
+```bash
+docker exec alkemio_dev_postgres psql -U synapse -d alkemio \
+  -c "SELECT column_default FROM information_schema.columns WHERE table_name='user_settings' AND column_name='designVersion';"
+```
+
+Expected: `2`.
+
+The Phase-3 `down()` is intentionally a no-op (we do not track which rows previously held `1`); `pnpm run migration:revert` reports the migration as reverted but leaves the row distribution unchanged. Operators who must restore the pre-Phase-3 distribution should restore a pre-migration database backup.
 
 ## Story 2 — Switch design version
 
@@ -153,7 +182,7 @@ To roll back during local testing:
 pnpm run migration:revert
 ```
 
-The most recent down migration (`FlipUserSettingsDesignVersionDefaultToNew`) resets the column default to `1`; reverting further drops the column entirely. Re-running `migration:run` re-creates it (default `1` from Phase 1) and then flips the default to `2` (Phase 2). Existing rows are not touched by either direction.
+The most recent down migration (`BackfillUserSettingsDesignVersionLegacyToCurrentDefault`) is a documented no-op — row distribution is left as-is. Reverting further: `FlipUserSettingsDesignVersionDefaultToNew` resets the column default to `1`; one more revert drops the column entirely. Re-running `migration:run` re-creates the column (default `1` from Phase 1), flips the default to `2` (Phase 2), and then re-applies the Phase-3 backfill (zero rows if already drained). Phase 1/2 down migrations leave existing rows untouched; Phase 3's no-op down() means a true revert of the backfill requires restoring a pre-migration database backup.
 
 ## Test plan summary
 

--- a/specs/096-user-design-version/spec.md
+++ b/specs/096-user-design-version/spec.md
@@ -19,6 +19,10 @@
 
 - Q: When should the default flip to `2`? → A: Now. The column default moves from `1` to `2` via a new migration. New users are created with `2`; **existing user rows are not modified** — they retain whatever value they currently have (whether default-applied `1`, explicit `1`, explicit `2`, or any other integer per FR-004). The `1` value remains valid and is rebranded as the legacy design generation; users can opt back to `1` (or any integer) via `updateUserSettings`. Phase 1 history (FR-002/003/009, SC-001/002, Story 1) is left intact as the historical record of the 2026-05-13 release.
 
+### Session 2026-06-17
+
+- Q: What about existing users still holding `designVersion = 1`? → A: Flip them to `2` now via a one-shot backfill migration (`UPDATE "user_settings" SET "designVersion" = 2 WHERE "designVersion" = 1`). The legacy generation (`1`) is on an imminent decommission path; the DTO descriptions are updated to flag it as deprecated. Users can still opt back into `1` via `updateUserSettings` until the deprecation completes — FR-004 still applies — but the persisted distribution is normalised onto the current default `2`. Rows holding any other integer (`0`, `-1`, `5`, `7`, …) are preserved verbatim. New inserts continue to default to `2` (unchanged from Phase 2). Full retirement of the `1` value (validator narrowing, breaking schema change, constant removal) is a separate, later PR. Phase 1 and Phase 2 wording elsewhere in this document is left intact as the historical record.
+
 ## User Scenarios & Testing _(mandatory)_
 
 ### User Story 1 - Every user has a recorded design version, defaulting to 1 (Priority: P1)
@@ -114,3 +118,4 @@ Whenever the client retrieves a user (e.g., the currently authenticated user) it
 - Existing user records get the default value (`1`) on first read after deployment, via either a column default or a backfill — the choice is left to the implementation plan, but the outward behavior must be that every user appears to have design version `1` until they change it.
 - The "new design" maps conceptually to `2` and is opt-in until a subsequent release flips the column default. The server does not enforce or assume the conceptual mapping; it is documentation only.
 - Phase 2 (2026-05-26) flipped the column default from `1` to `2` for new inserts only — no UPDATE was issued, so the existing user-row distribution is preserved. Phase 1 wording elsewhere in this document is left as the historical record of the 2026-05-13 release.
+- Phase 3 (2026-06-17) ran a one-shot `UPDATE "user_settings" SET "designVersion" = 2 WHERE "designVersion" = 1` that drained the legacy distribution, leaving non-`1` rows untouched. The legacy value `1` remains acceptable on the API (FR-004) but is flagged as deprecated in the DTO descriptions pending full retirement in a later PR.

--- a/specs/096-user-design-version/tasks.md
+++ b/specs/096-user-design-version/tasks.md
@@ -211,6 +211,19 @@ Product decision per [`spec.md` → Clarifications → Session 2026-05-26](./spe
 - **Phase 1 narrative left intact.** FR-002/003/009, SC-001/002, User Story 1 in `spec.md` describe what shipped on 2026-05-13 and remain accurate as historical record; phase-2 behavior is captured in the Session 2026-05-26 clarification and the Assumptions addendum.
 - **Verification**: `SELECT "designVersion", COUNT(*) FROM user_settings GROUP BY "designVersion"` before/after the migration must show identical distribution; the column default afterwards must report `2`. The `run_validate_migration.sh` CSV diff for `user_settings` should show identical row content with only `column_default 1 → 2` in the schema-metadata diff.
 
+### 2026-06-17 — Phase 3: legacy backfill — all `designVersion = 1` rows flipped to `2`
+
+Product decision per [`spec.md` → Clarifications → Session 2026-06-17](./spec.md#session-2026-06-17). The legacy generation is on an imminent decommission path; Phase 3 drains the persisted `1` distribution while leaving the API still permissive (FR-004) so users can opt back in until the deprecation lands.
+
+- **New migration** `src/migrations/1781800000000-BackfillUserSettingsDesignVersionLegacyToCurrentDefault.ts` does `UPDATE "user_settings" SET "designVersion" = 2 WHERE "designVersion" = 1`. Narrow `WHERE` so rows holding any other integer (`0`, `-1`, `5`, `7`, …) are preserved verbatim — FR-004 still applies; this is the legacy-to-current-default flip, not a clamp.
+- **Column default unchanged.** Phase 2 already set the column default to `2`; Phase 3 only touches data, never schema.
+- **No-op `down()`.** A symmetric `2 → 1` flip would clobber legitimately-on-`2` rows (which after Phase 3 is every user); we do not track which rows previously held `1`, so a correct revert isn't possible from DDL alone. Documented in the migration body. Revert path: restore a pre-migration database backup.
+- **DTO + interface descriptions updated** to flag `1` as "legacy design generation, deprecated and scheduled for removal" (`user.settings.dto.create.ts`, `user.settings.dto.update.ts`, `user.settings.interface.ts`). `schema.graphql` regenerated — only description-string changes on `CreateUserSettingsInput.designVersion`, `UpdateUserSettingsEntityInput.designVersion`, and `UserSettings.designVersion`. No additive, no breaking.
+- **No source-code changes** to constants/entity/service/spec/mock — Phase 2's rename + constant references are already future-proof. The constants file header gets a Phase 3 entry only.
+- **Phase 1 and Phase 2 narratives left intact.** They remain accurate historical records of what shipped on those dates; Phase 3 behavior is captured in the Session 2026-06-17 clarification and the Assumptions addendum.
+- **Verification**: `SELECT "designVersion", COUNT(*) FROM user_settings GROUP BY "designVersion"` immediately post-migration must report zero rows at `1`; the previous `1`-count must have moved into the `2`-bucket; non-`1` buckets unchanged. The `run_validate_migration.sh` CSV diff for `user_settings` should show every row that previously held `1` now holding `2`, no other column changes, no row count change.
+- **Out of scope (next PR, separate effort)**: full retirement of the `1` value — narrow the validator (`@Min(2)` or equivalent), remove `DESIGN_VERSION_LEGACY`, drop the legacy GraphQL description wording (breaking schema change requiring `BREAKING-APPROVED` from CODEOWNERS).
+
 ### Follow-up — Client coordination (next release)
 
 The legacy `alkemio-crd-enabled` LocalStorage flag (boolean) should be retired on the client side; its replacement is a LocalStorage entry that stores the integer value of `me.user.settings.designVersion`. The server is now the source of truth.

--- a/src/domain/community/user-settings/dto/user.settings.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.create.ts
@@ -43,7 +43,7 @@ export class CreateUserSettingsInput {
   @Field(() => Int, {
     nullable: true,
     description:
-      'Initial design version for this User. Defaults to 2 (the current default design generation) when omitted. Pass 1 to opt into the legacy design.',
+      'Initial design version for this User. Defaults to 2 (the current default design generation) when omitted. Pass 1 to opt into the legacy design (deprecated; scheduled for removal).',
   })
   @IsOptional()
   @IsInt()

--- a/src/domain/community/user-settings/dto/user.settings.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.update.ts
@@ -43,7 +43,7 @@ export class UpdateUserSettingsEntityInput {
   @Field(() => Int, {
     nullable: true,
     description:
-      "Update the user's design version. Any integer accepted (1 = legacy design generation; 2 = current default design generation; 3+ reserved for future generations).",
+      "Update the user's design version. Any integer accepted (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).",
   })
   @IsOptional()
   @IsInt()

--- a/src/domain/community/user-settings/user.settings.design.version.constants.ts
+++ b/src/domain/community/user-settings/user.settings.design.version.constants.ts
@@ -13,6 +13,11 @@
  * - Phase 2 (clarification 2026-05-26): the column default was flipped to `2`
  *   (now exported as `DESIGN_VERSION_CURRENT_DEFAULT`) via a column-default DDL
  *   migration with no row UPDATE — existing rows preserve whatever they had.
+ * - Phase 3 (clarification 2026-06-17): a one-shot backfill flipped every row
+ *   still holding `1` onto `2`. The API still accepts `1` (FR-004 stands) so
+ *   `DESIGN_VERSION_LEGACY` remains exported; it now names a value on an
+ *   imminent decommission path and a future PR will narrow the validator and
+ *   drop the constant.
  *
  * Client coordination: the legacy `alkemio-crd-enabled` LocalStorage flag (a
  * boolean) should be retired in favour of a key that stores the integer value

--- a/src/domain/community/user-settings/user.settings.interface.ts
+++ b/src/domain/community/user-settings/user.settings.interface.ts
@@ -34,7 +34,7 @@ export class IUserSettings extends IAuthorizable {
   @Field(() => Int, {
     nullable: false,
     description:
-      'The design version this User has selected (1 = legacy design generation; 2 = current default design generation; 3+ reserved for future generations).',
+      'The design version this User has selected (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).',
   })
   designVersion!: number;
 }

--- a/src/migrations/1781800000000-BackfillUserSettingsDesignVersionLegacyToCurrentDefault.ts
+++ b/src/migrations/1781800000000-BackfillUserSettingsDesignVersionLegacyToCurrentDefault.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BackfillUserSettingsDesignVersionLegacyToCurrentDefault1781800000000
+  implements MigrationInterface
+{
+  name = 'BackfillUserSettingsDesignVersionLegacyToCurrentDefault1781800000000';
+
+  // Phase 3 (2026-06-17) — one-shot backfill to flip all rows holding the
+  // legacy designVersion (1) onto the current default (2). The legacy
+  // generation is on an imminent decommission path; this normalises the
+  // persisted distribution while the API still permits opting back into 1
+  // (FR-004). New inserts continue to default to 2 — the column default was
+  // already set by migration 1779797470780 in Phase 2 and is not touched
+  // here.
+  //
+  // Scope: only rows currently holding the legacy value 1. Any other integer
+  // (0, -1, 5, 7, …) is preserved verbatim — FR-004 still applies; this is
+  // the legacy-to-current-default flip, not a clamp.
+  //
+  // Idempotent — re-applying affects zero rows once the legacy distribution
+  // has been drained.
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "user_settings" SET "designVersion" = 2 WHERE "designVersion" = 1`
+    );
+  }
+
+  // No automatic rollback. We do not track which rows previously held 1, so
+  // a symmetric down() that flipped 2 → 1 would clobber every user that was
+  // legitimately on 2 (which after this migration is every user). Operators
+  // who must revert should restore a pre-migration database backup.
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Intentional no-op. See note above.
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked legacy design version `1` as deprecated and scheduled for removal.
  * Clarified design version `2` as the current default.
  * Reserved design version `3+` for future use.

* **Chores**
  * Added automated migration to update existing users from legacy design version `1` to version `2`.
  * Updated field descriptions across specifications and interfaces to reflect deprecation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->