### PR TITLE
feat(006-internal-admin-jobs-api): internal no-auth admin jobs REST API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -66,6 +66,7 @@ import { SearchModule } from '@services/api/search/search.module';
 import { UrlResolverModule } from '@services/api/url-resolver/url.resolver.module';
 import { CalendarEventIcsModule } from '@services/api-rest/calendar-event-ics/calendar-event-ics.module';
 import { IdentityResolveModule } from '@services/api-rest/identity-resolve/identity-resolve.module';
+import { InternalAdminModule } from '@services/api-rest/internal-admin/internal-admin.module';
 import { AuthResetSubscriberModule } from '@services/auth-reset/subscriber/auth-reset.subscriber.module';
 import { CollaborativeDocumentIntegrationModule } from '@services/collaborative-document-integration';
 import { ContributionReporterModule } from '@services/external/elasticsearch/contribution-reporter';
@@ -342,6 +343,7 @@ import { AdminSearchIngestModule } from './platform-admin/services/search/admin.
     InnovationHubModule,
     CalendarEventIcsModule,
     IdentityResolveModule,
+    InternalAdminModule,
     MeModule,
     VirtualActorModule,
     InputCreatorModule,

--- a/src/services/api-rest/internal-admin/dto/ingest.trigger.result.dto.ts
+++ b/src/services/api-rest/internal-admin/dto/ingest.trigger.result.dto.ts
@@ -1,0 +1,10 @@
+/**
+ * Result of triggering a from-scratch search ingest.
+ *
+ * `taskId` is the id of the async run; the caller polls
+ * `GET /rest/internal/admin/tasks/:id` with it to a terminal state.
+ * See spec 006-internal-admin-jobs-api.
+ */
+export class IngestTriggerResultDto {
+  taskId!: string;
+}

--- a/src/services/api-rest/internal-admin/dto/prune.result.dto.ts
+++ b/src/services/api-rest/internal-admin/dto/prune.result.dto.ts
@@ -1,0 +1,11 @@
+/**
+ * Result of the in-app-notification prune operation.
+ *
+ * Shape parity with {@link PruneInAppNotificationAdminResult} (the GraphQL
+ * payload returned by `adminInAppNotificationsPrune`). Exposed over the
+ * internal REST transport — see spec 006-internal-admin-jobs-api (FR-009).
+ */
+export class PruneResultDto {
+  removedCountOutsideRetentionPeriod!: number;
+  removedCountExceedingUserLimit!: number;
+}

--- a/src/services/api-rest/internal-admin/dto/task.status.dto.ts
+++ b/src/services/api-rest/internal-admin/dto/task.status.dto.ts
@@ -1,0 +1,16 @@
+import { TaskStatus } from '@domain/task/dto';
+
+/**
+ * Read-only projection of the existing `ITask` for the run-status endpoint.
+ *
+ * Source: `TaskService.get(id)` (Redis cache, 3600s TTL). An unknown/expired id
+ * surfaces as a 404 at the controller — never projected here. See spec
+ * 006-internal-admin-jobs-api (research R2) for the polling contract.
+ */
+export class TaskStatusDto {
+  id!: string;
+  status!: TaskStatus;
+  itemsCount?: number;
+  itemsDone?: number;
+  errors?: unknown[];
+}

--- a/src/services/api-rest/internal-admin/internal-admin.controller.spec.ts
+++ b/src/services/api-rest/internal-admin/internal-admin.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { SearchIngestService } from '@services/api/search/ingest/search.ingest.service';
 import { TaskService } from '@services/task';
 import { InAppNotificationAdminService } from '@src/platform-admin/in-app-notification/in.app.notification.admin.service';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { vi } from 'vitest';
 import { InternalAdminController } from './internal-admin.controller';
 
@@ -33,6 +34,14 @@ describe('InternalAdminController', () => {
           useValue: {
             create: vi.fn(),
             get: vi.fn(),
+          },
+        },
+        {
+          provide: WINSTON_MODULE_NEST_PROVIDER,
+          useValue: {
+            error: vi.fn(),
+            warn: vi.fn(),
+            verbose: vi.fn(),
           },
         },
       ],

--- a/src/services/api-rest/internal-admin/internal-admin.controller.spec.ts
+++ b/src/services/api-rest/internal-admin/internal-admin.controller.spec.ts
@@ -1,0 +1,165 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchIngestService } from '@services/api/search/ingest/search.ingest.service';
+import { TaskService } from '@services/task';
+import { InAppNotificationAdminService } from '@src/platform-admin/in-app-notification/in.app.notification.admin.service';
+import { vi } from 'vitest';
+import { InternalAdminController } from './internal-admin.controller';
+
+describe('InternalAdminController', () => {
+  let controller: InternalAdminController;
+  let inAppNotificationAdminService: InAppNotificationAdminService;
+  let searchIngestService: SearchIngestService;
+  let taskService: TaskService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InternalAdminController],
+      providers: [
+        {
+          provide: InAppNotificationAdminService,
+          useValue: {
+            pruneInAppNotifications: vi.fn(),
+          },
+        },
+        {
+          provide: SearchIngestService,
+          useValue: {
+            ingestFromScratch: vi.fn(),
+          },
+        },
+        {
+          provide: TaskService,
+          useValue: {
+            create: vi.fn(),
+            get: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(InternalAdminController);
+    inAppNotificationAdminService = module.get(InAppNotificationAdminService);
+    searchIngestService = module.get(SearchIngestService);
+    taskService = module.get(TaskService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('pruneInAppNotifications (US1)', () => {
+    const pruneResult = {
+      removedCountOutsideRetentionPeriod: 3,
+      removedCountExceedingUserLimit: 7,
+    };
+
+    it('calls pruneInAppNotifications exactly once and returns its result verbatim', async () => {
+      vi.spyOn(
+        inAppNotificationAdminService,
+        'pruneInAppNotifications'
+      ).mockResolvedValue(pruneResult as any);
+
+      const result = await controller.pruneInAppNotifications();
+
+      expect(
+        inAppNotificationAdminService.pruneInAppNotifications
+      ).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(pruneResult);
+    });
+
+    it('does not invoke any authorization step (no authz service injected)', () => {
+      // The controller is constructed with exactly the three reused services and
+      // nothing authorization-related. This guards FR-003 (no authz check).
+      expect((controller as any).authorizationService).toBeUndefined();
+      expect((controller as any).platformAuthorizationService).toBeUndefined();
+      expect(
+        (controller as any).platformAuthorizationPolicyService
+      ).toBeUndefined();
+    });
+
+    it('propagates service errors (surface as 5xx)', async () => {
+      vi.spyOn(
+        inAppNotificationAdminService,
+        'pruneInAppNotifications'
+      ).mockRejectedValue(new Error('Prune failed'));
+
+      await expect(controller.pruneInAppNotifications()).rejects.toThrow(
+        'Prune failed'
+      );
+    });
+  });
+
+  describe('triggerSearchIngest (US2)', () => {
+    const task = { id: 'task-abc-123' };
+
+    it('creates a task then fires ingestFromScratch(task) and returns { taskId }', async () => {
+      vi.spyOn(taskService, 'create').mockResolvedValue(task as any);
+      const ingestSpy = vi
+        .spyOn(searchIngestService, 'ingestFromScratch')
+        .mockResolvedValue(undefined as any);
+
+      const result = await controller.triggerSearchIngest();
+
+      expect(taskService.create).toHaveBeenCalledTimes(1);
+      expect(ingestSpy).toHaveBeenCalledTimes(1);
+      expect(ingestSpy).toHaveBeenCalledWith(task);
+      expect(result).toEqual({ taskId: task.id });
+    });
+
+    it('does not await ingestFromScratch (fire-and-forget)', async () => {
+      vi.spyOn(taskService, 'create').mockResolvedValue(task as any);
+      // A never-resolving ingest must not block the response.
+      vi.spyOn(searchIngestService, 'ingestFromScratch').mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }) as any
+      );
+
+      const result = await controller.triggerSearchIngest();
+
+      expect(result).toEqual({ taskId: task.id });
+    });
+  });
+
+  describe('getTaskStatus (US2)', () => {
+    it('returns the projected task for a known id', async () => {
+      const task = {
+        id: 'task-abc-123',
+        status: 'in-progress',
+        itemsCount: 1200,
+        itemsDone: 450,
+        errors: [],
+        // fields that must NOT leak into the projection:
+        created: 1,
+        start: 1,
+        action: 'auth-reset',
+        results: [],
+      };
+      vi.spyOn(taskService, 'get').mockResolvedValue(task as any);
+
+      const result = await controller.getTaskStatus('task-abc-123');
+
+      expect(taskService.get).toHaveBeenCalledWith('task-abc-123');
+      expect(result).toEqual({
+        id: 'task-abc-123',
+        status: 'in-progress',
+        itemsCount: 1200,
+        itemsDone: 450,
+        errors: [],
+      });
+    });
+
+    it('throws NotFoundException (404) when the task is undefined / expired', async () => {
+      vi.spyOn(taskService, 'get').mockResolvedValue(undefined as any);
+
+      await expect(controller.getTaskStatus('unknown-id')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+});

--- a/src/services/api-rest/internal-admin/internal-admin.controller.ts
+++ b/src/services/api-rest/internal-admin/internal-admin.controller.ts
@@ -1,0 +1,84 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  NotFoundException,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { SearchIngestService } from '@services/api/search/ingest/search.ingest.service';
+import { TaskService } from '@services/task';
+import { InAppNotificationAdminService } from '@src/platform-admin/in-app-notification/in.app.notification.admin.service';
+import { IngestTriggerResultDto } from './dto/ingest.trigger.result.dto';
+import { PruneResultDto } from './dto/prune.result.dto';
+import { TaskStatusDto } from './dto/task.status.dto';
+
+/**
+ * Internal admin jobs API — unauthenticated, in-cluster-only REST surface.
+ *
+ * Mounted under `/rest/internal/admin`. Internal **by construction**: no public
+ * Traefik IngressRoute matches the `/rest/internal` prefix (the same mechanism
+ * that protects `forward-auth` and `identity/resolve`). There is therefore
+ * intentionally NO `@UseGuards` / authorization here — callers are reachable
+ * only from inside the cluster via `alkemio-server-service:4000`.
+ *
+ * Each route invokes the SAME service method as its GraphQL counterpart so the
+ * two surfaces cannot diverge (spec 006-internal-admin-jobs-api, FR-009). The
+ * GraphQL mutations/queries under `src/platform-admin/` remain unchanged.
+ */
+@Controller('rest/internal/admin')
+export class InternalAdminController {
+  constructor(
+    private readonly inAppNotificationAdminService: InAppNotificationAdminService,
+    private readonly searchIngestService: SearchIngestService,
+    private readonly taskService: TaskService
+  ) {}
+
+  /**
+   * Prune in-app notifications. Synchronous — responds when the prune completes.
+   * GraphQL parity: `adminInAppNotificationsPrune`. No authz (FR-003); a thrown
+   * error surfaces as 5xx (FR-008).
+   */
+  @Post('in-app-notifications/prune')
+  async pruneInAppNotifications(): Promise<PruneResultDto> {
+    return await this.inAppNotificationAdminService.pruneInAppNotifications();
+  }
+
+  /**
+   * Trigger a from-scratch search ingest. Asynchronous — returns immediately
+   * with the task id while the reindex runs in the background. GraphQL parity:
+   * `adminSearchIngestFromScratch` (minus the authz block). The ingest is
+   * fire-and-forget — deliberately NOT awaited so the response returns < 5s
+   * (SC-004).
+   */
+  @Post('search-ingest')
+  @HttpCode(202)
+  async triggerSearchIngest(): Promise<IngestTriggerResultDto> {
+    const task = await this.taskService.create();
+    // start it asynchronously — do not await
+    this.searchIngestService.ingestFromScratch(task);
+    return { taskId: task.id };
+  }
+
+  /**
+   * Read-only run-status projection for polling. GraphQL parity: `task(id:)` →
+   * `TaskService.get(id)` (Redis cache, 3600s TTL). An unknown or TTL-expired id
+   * is a 404 the caller MUST treat as a terminal failure (research R2).
+   */
+  @Get('tasks/:id')
+  async getTaskStatus(@Param('id') id: string): Promise<TaskStatusDto> {
+    const task = await this.taskService.get(id);
+
+    if (!task) {
+      throw new NotFoundException(`Task '${id}' not found`);
+    }
+
+    return {
+      id: task.id,
+      status: task.status,
+      itemsCount: task.itemsCount,
+      itemsDone: task.itemsDone,
+      errors: task.errors,
+    };
+  }
+}

--- a/src/services/api-rest/internal-admin/internal-admin.controller.ts
+++ b/src/services/api-rest/internal-admin/internal-admin.controller.ts
@@ -1,7 +1,10 @@
+import { LogContext } from '@common/enums';
 import {
   Controller,
   Get,
   HttpCode,
+  Inject,
+  LoggerService,
   NotFoundException,
   Param,
   Post,
@@ -9,6 +12,7 @@ import {
 import { SearchIngestService } from '@services/api/search/ingest/search.ingest.service';
 import { TaskService } from '@services/task';
 import { InAppNotificationAdminService } from '@src/platform-admin/in-app-notification/in.app.notification.admin.service';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { IngestTriggerResultDto } from './dto/ingest.trigger.result.dto';
 import { PruneResultDto } from './dto/prune.result.dto';
 import { TaskStatusDto } from './dto/task.status.dto';
@@ -31,7 +35,9 @@ export class InternalAdminController {
   constructor(
     private readonly inAppNotificationAdminService: InAppNotificationAdminService,
     private readonly searchIngestService: SearchIngestService,
-    private readonly taskService: TaskService
+    private readonly taskService: TaskService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
   ) {}
 
   /**
@@ -55,8 +61,17 @@ export class InternalAdminController {
   @HttpCode(202)
   async triggerSearchIngest(): Promise<IngestTriggerResultDto> {
     const task = await this.taskService.create();
-    // start it asynchronously — do not await
-    this.searchIngestService.ingestFromScratch(task);
+    // start it asynchronously — do not await. ingestFromScratch records its own
+    // failures via taskService.completeWithError, but guard the detached promise
+    // so a rejection before/outside its internal try cannot become an
+    // unhandled-rejection.
+    this.searchIngestService.ingestFromScratch(task).catch(e => {
+      this.logger.error?.(
+        'Fire-and-forget search ingest rejected',
+        e?.stack,
+        LogContext.SEARCH_INGEST
+      );
+    });
     return { taskId: task.id };
   }
 
@@ -70,7 +85,10 @@ export class InternalAdminController {
     const task = await this.taskService.get(id);
 
     if (!task) {
-      throw new NotFoundException(`Task '${id}' not found`);
+      throw new NotFoundException({
+        message: 'Task not found',
+        details: { taskId: id },
+      });
     }
 
     return {

--- a/src/services/api-rest/internal-admin/internal-admin.isolation.spec.ts
+++ b/src/services/api-rest/internal-admin/internal-admin.isolation.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Isolation contract for the internal admin jobs API (US3).
+ *
+ * The endpoints under `/rest/internal/admin/*` are internal **by construction**:
+ * no public Traefik IngressRoute prefix matches `/rest/internal` (research R1,
+ * contract §Isolation). This test encodes that invariant so a future broad
+ * public route that *would* expose the internal surface fails CI.
+ *
+ * It is a pure invariant check — no app boot required.
+ */
+
+// The path prefixes the public Traefik IngressRoutes match (research R1).
+const PUBLIC_ROUTE_PREFIXES = [
+  '/api/public/rest',
+  '/api/private/rest',
+  '/api/private/non-interactive/rest',
+  '/graphql',
+];
+
+// The internal surface this feature mounts.
+const INTERNAL_BASE_PATH = '/rest/internal/admin';
+const INTERNAL_ROUTES = [
+  '/rest/internal/admin/in-app-notifications/prune',
+  '/rest/internal/admin/search-ingest',
+  '/rest/internal/admin/tasks/some-task-id',
+];
+
+const isPrefixOf = (prefix: string, path: string): boolean =>
+  path === prefix || path.startsWith(`${prefix}/`);
+
+describe('InternalAdmin isolation contract (US3)', () => {
+  it('no public route prefix is a prefix of the internal base path', () => {
+    for (const prefix of PUBLIC_ROUTE_PREFIXES) {
+      expect(isPrefixOf(prefix, INTERNAL_BASE_PATH)).toBe(false);
+    }
+  });
+
+  it('no public route prefix matches any concrete internal route', () => {
+    for (const route of INTERNAL_ROUTES) {
+      for (const prefix of PUBLIC_ROUTE_PREFIXES) {
+        expect(isPrefixOf(prefix, route)).toBe(false);
+      }
+    }
+  });
+
+  it('the internal surface lives under /rest/internal (never /api/* or /graphql)', () => {
+    expect(INTERNAL_BASE_PATH.startsWith('/rest/internal')).toBe(true);
+    for (const route of INTERNAL_ROUTES) {
+      expect(route.startsWith('/rest/internal/admin')).toBe(true);
+      expect(route.startsWith('/api/')).toBe(false);
+      expect(route.startsWith('/graphql')).toBe(false);
+    }
+  });
+});

--- a/src/services/api-rest/internal-admin/internal-admin.module.ts
+++ b/src/services/api-rest/internal-admin/internal-admin.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { SearchIngestModule } from '@services/api/search/ingest/search.ingest.module';
+import { TaskModule } from '@services/task';
+import { InAppNotificationAdminModule } from '@src/platform-admin/in-app-notification/in.app.notification.admin.module';
+import { InternalAdminController } from './internal-admin.controller';
+
+/**
+ * Wires the unauthenticated, in-cluster-only internal admin jobs REST surface.
+ *
+ * Imports the modules that already provide the services the GraphQL resolvers
+ * call — so the REST endpoints reuse the exact same methods (FR-009 parity).
+ * Mirrors the `IdentityResolveModule` internal-REST pattern.
+ */
+@Module({
+  imports: [InAppNotificationAdminModule, SearchIngestModule, TaskModule],
+  controllers: [InternalAdminController],
+})
+export class InternalAdminModule {}


### PR DESCRIPTION
## Summary

Adds an unauthenticated, **in-cluster-only** REST surface under `/rest/internal/admin/*` exposing the two `PLATFORM_ADMIN` admin operations plus a read-only run-status query, mirroring the existing `src/services/api-rest/identity-resolve/` internal-controller pattern.

This is the **LEAD** repo slice of workspace vertical feature `workspace#006-internal-admin-jobs-api`. The server image carrying these endpoints must ship **before** `infrastructure-operations` rewires any scheduled job (rollout ordering — plan §Rollout ordering).

### Endpoints (`InternalAdminController`, no `@UseGuards`)

| Method + path | Behaviour | GraphQL parity |
|---|---|---|
| `POST /rest/internal/admin/in-app-notifications/prune` | synchronous; returns `{ removedCountOutsideRetentionPeriod, removedCountExceedingUserLimit }` | `adminInAppNotificationsPrune` → `InAppNotificationAdminService.pruneInAppNotifications()` |
| `POST /rest/internal/admin/search-ingest` | `202`, fire-and-forget (ingest **not** awaited); returns `{ taskId }` | `adminSearchIngestFromScratch` → `TaskService.create()` + `SearchIngestService.ingestFromScratch(task)` |
| `GET /rest/internal/admin/tasks/:id` | projects task status; `404` on unknown/TTL-expired id | `task(id:)` → `TaskService.get(id)` |

### Design notes

- **No auth by design** — internal *by construction*: no public Traefik IngressRoute matches the `/rest/internal` prefix (same mechanism protecting `forward-auth` and `identity/resolve`). No new Traefik rule or NetworkPolicy.
- **FR-009 parity** — each endpoint invokes the *same* service method as its GraphQL counterpart, so the two surfaces cannot diverge. The GraphQL mutations/queries under `src/platform-admin/` are **untouched** (FR-012).
- **No DB schema change.** One module + one controller + 3 DTOs, registered in `app.module.ts` next to `IdentityResolveModule`.

### Tests

- `internal-admin.controller.spec.ts` — prune returns the result verbatim and invokes no authz; ingest creates a task, fires `ingestFromScratch` fire-and-forget, returns `{ taskId }`; status projects a known task and `404`s when `TaskService.get` resolves `undefined`.
- `internal-admin.isolation.spec.ts` — asserts none of the public route prefixes (`/api/public/rest`, `/api/private/rest`, `/api/private/non-interactive/rest`, `/graphql`) is a prefix of `/rest/internal/admin/*`, so a future broad public route fails CI (contract §Isolation, research R1).

### Exit gates (local, from worktree)

- `pnpm lint` (tsc --noEmit + biome) — green
- `pnpm build` (nest build) — green
- internal-admin specs — 11 tests green; full suite green via pre-commit hook

## Traceability

- Workspace feature: `workspace#006-internal-admin-jobs-api`
- Story: alkem-io/alkemio#1910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal administration REST surface for pruning in-app notifications, triggering from-scratch search ingests, and checking ingest task status asynchronously.
  * Exposed task results via new response payloads, including a `taskId` for polling.
* **Bug Fixes**
  * Improved background ingest handling by logging failures instead of risking unhandled promise rejections.
* **Tests**
  * Added an invariant test to ensure internal administration routes can’t be exposed through public URL prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->