### PR TITLE
feat: additional tabs on L0 spaces (#6177)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/103-persist-phase-visibility"
+  "feature_directory": "specs/104-l0-additional-tabs"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,8 @@ Key rules:
 - N/A (test-infrastructure work; no schema, no migrations) (100-fix-flaky-tests)
 - TypeScript 5.3 on Node.js 22 LTS (Volta-pinned 22.21.1) + NestJS 10, `@nestjs/graphql` (code-first), TypeORM 0.3 (custom fork `pkg.pr.new/antst/typeorm`), Apollo Server 4, GraphQL 16, class-validator / class-transformer (story/6138-persist-phase-tab-visibility)
 - PostgreSQL 17.5 — existing `innovation_flow_state.settings` JSONB column. **No DDL**; data backfill only. (story/6138-persist-phase-tab-visibility)
+- TypeScript 5.3 on Node.js 22 LTS (Volta-pinned 22.21.1) + NestJS 10, TypeORM 0.3 (custom fork `pkg.pr.new/antst/typeorm`), Apollo Server 4, GraphQL 16, class-validator / class-transformer, Winston (story/6177-adding-additional-tabs-in-l0-space)
+- PostgreSQL 17.5 — existing `innovation_flow.settings` (`json` column) carrying `minimumNumberOfStates` / `maximumNumberOfStates`. No DDL; data backfill only (raise max 4→8 on L0 flows). Join path for the migration: `space.level = 0` → `space.collaborationId` → `collaboration.innovationFlowId` → `innovation_flow.settings`. (story/6177-adding-additional-tabs-in-l0-space)
 
 ## Recent Changes
 - 028-migrate-biome-linting: Migrated from ESLint + Prettier to Biome for linting and formatting

--- a/specs/104-l0-additional-tabs/checklists/requirements.md
+++ b/specs/104-l0-additional-tabs/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Requirements Quality Checklist: Adding additional tabs in L0 space
+
+**Purpose**: Validate that the specification for L0 additional-tabs support is complete, unambiguous, and ready for planning.
+**Created**: 2026-06-22
+**Feature**: [spec.md](../spec.md)
+
+## Requirement Completeness
+
+- [X] CHK001 Every functional requirement (FR-001..FR-014) maps to at least one user story or acceptance scenario.
+- [X] CHK002 The loosened L0 maximum value is explicitly stated and justified (matches subspace max of 8).
+- [X] CHK003 The preserved L0 minimum (4) is explicitly stated with rationale (fixed phases floor).
+- [X] CHK004 Behavior for the at-maximum add and at-minimum delete boundaries is specified.
+- [X] CHK005 Template-application behavior for L0 (preserve first 4, append extras, reject on overflow) is specified.
+- [X] CHK006 Data migration for pre-existing L0 spaces is addressed (FR-014).
+
+## Requirement Clarity
+
+- [X] CHK007 "Fixed phases" is defined precisely (first 4 by sort order; undeletable via min floor; not replaced by template apply).
+- [X] CHK008 No remaining `[NEEDS CLARIFICATION]` markers in the spec after clarify loop.
+- [X] CHK009 Each FR is independently testable and uses MUST/MAY consistently.
+- [X] CHK010 GraphQL contract impact is stated (reuse existing mutations; note any schema regen need).
+
+## Regression Safety
+
+- [X] CHK011 Subspace (L1/L2) behavior is explicitly required to remain unchanged (FR-011, SC-005).
+- [X] CHK012 Authorization parity with existing mutations is required (FR-012).
+- [X] CHK013 Flow-state tagset-template synchronization is required to remain correct on add/delete.
+
+## Success Criteria Quality
+
+- [X] CHK014 Success criteria are measurable and technology-agnostic (SC-001..SC-006).
+- [X] CHK015 A success criterion ties the feature to the repo's exit gates (SC-006).
+
+## Notes
+
+- All items verified during the clarify loop. The spec resolves the open decisions (max value, migration, fixed-phase semantics, template-overflow handling) in the Clarifications section appended by `/speckit-clarify`.

--- a/specs/104-l0-additional-tabs/contracts/graphql.md
+++ b/specs/104-l0-additional-tabs/contracts/graphql.md
@@ -1,0 +1,33 @@
+# GraphQL Contract Notes: Adding additional tabs in L0 space
+
+**Feature**: 104-l0-additional-tabs | **Date**: 2026-06-22
+
+## Summary
+
+**No schema change.** This feature reuses the existing InnovationFlow mutations unchanged. The only differences are (a) the persisted bound values on L0 InnovationFlows and (b) internal service logic in the template applier. The `pnpm run schema:diff` gate MUST report zero diff (FR-013).
+
+## Reused mutations (unchanged contract)
+
+### `createStateOnInnovationFlow(innovationFlowData: CreateInnovationFlowStateOnInnovationFlowInput!): InnovationFlowState!`
+- Adds a tab to an InnovationFlow. Already enforces `maximumNumberOfStates` generically.
+- **Behavioral change (not contract change)**: for L0 flows the effective max is now 8 (was 4), so adds beyond the 4th now succeed up to 8.
+- Authorization: existing UPDATE privilege on the InnovationFlow / Collaboration. Unchanged.
+
+### `deleteStateOnInnovationFlow(deleteData: DeleteStateOnInnovationFlowInput!): InnovationFlowState!`
+- Removes a tab. Already enforces `minimumNumberOfStates` generically.
+- **Behavioral guarantee**: for L0 the min stays 4, so deletes below 4 remain rejected. Callout reassignment from the deleted state is unchanged.
+
+### `updateCollaborationFromSpaceTemplate(updateData: UpdateCollaborationFromSpaceTemplateInput!): Collaboration!`
+- Applies a Space Template to a Collaboration.
+- **Behavioral change (not contract change)**: when the target Collaboration belongs to an L0 Space, the first 4 fixed states are preserved (not replaced); template states are appended up to the L0 max; an apply that would exceed the L0 max is rejected with a `ValidationException`. Subspace behavior is unchanged.
+
+## Field reads (unchanged)
+
+- `InnovationFlow.settings.minimumNumberOfStates` / `.maximumNumberOfStates` continue to be exposed as today; clients (client-web#9857) read them to gate the add/delete UI. The L0 values they read change from 4/4 to 4/8.
+
+## Verification
+
+```bash
+pnpm run schema:print && pnpm run schema:sort && pnpm run schema:diff
+# Expected: no diff (change-report.json shows zero changes)
+```

--- a/specs/104-l0-additional-tabs/data-model.md
+++ b/specs/104-l0-additional-tabs/data-model.md
@@ -1,0 +1,83 @@
+# Phase 1 Data Model: Adding additional tabs in L0 space
+
+**Feature**: 104-l0-additional-tabs | **Date**: 2026-06-22
+
+No DDL changes. This feature changes persisted *values* and internal logic only. Below are the entities involved and the invariants that govern them.
+
+## Entities
+
+### Space
+- `level: SpaceLevel` (`int` column; `L0 = 0`, `L1 = 1`, `L2 = 2`). Drives the bounds applied at creation.
+- `collaborationId: uuid` (`@OneToOne` → Collaboration). Used to resolve a Collaboration's owning Space (and thus its level) in the template-applier.
+- `levelZeroSpaceID: uuid`. Unchanged; not modified by this feature.
+
+### Collaboration
+- `innovationFlowId: uuid` (`@OneToOne` → InnovationFlow). Join link for the migration and for level resolution.
+- `isTemplate: boolean`. Template collaborations are not `space` rows, so they are excluded from the L0 migration and from L0 preservation.
+
+### InnovationFlow
+- `states: InnovationFlowState[]` (`@OneToMany`). The tabs.
+- `currentStateID: uuid`. Must remain pointing at a live state after add/delete.
+- `settings: jsonb` → `IInnovationFlowSettings`. **The only value changed by this feature.**
+- `flowStatesTagsetTemplate`. Canonical allowed-values list; kept in sync by existing add/update/delete paths.
+
+### InnovationFlowState
+- `displayName`, `description?`, `sortOrder`, `settings` (incl. `visible` from #6138). The first `L0_FIXED_INNOVATION_FLOW_STATES` (4) by `sortOrder` are the L0 "fixed phases".
+
+### InnovationFlowSettings (the value object inside `InnovationFlow.settings`)
+- `minimumNumberOfStates: number`
+- `maximumNumberOfStates: number`
+
+## Bounds matrix (after this feature)
+
+| Space level | minimumNumberOfStates | maximumNumberOfStates | Change |
+|-------------|-----------------------|-----------------------|--------|
+| L0 (root)   | 4 (unchanged)         | **8** (was 4)         | max raised; fixed-phase floor preserved |
+| L1 / L2     | 1 (unchanged)         | 8 (unchanged)         | none (regression guard) |
+
+Source of truth: `innovation.flow.constants.ts`
+- `L0_MIN_INNOVATION_FLOW_STATES = 4`
+- `L0_MAX_INNOVATION_FLOW_STATES = 8`
+- `L0_FIXED_INNOVATION_FLOW_STATES = 4`
+- `SUBSPACE_MIN_INNOVATION_FLOW_STATES = 1`
+- `SUBSPACE_MAX_INNOVATION_FLOW_STATES = 8`
+
+## Invariants
+
+- **INV-1**: For an L0 InnovationFlow, `4 <= states.length <= 8` at all times after creation.
+- **INV-2**: An L0 InnovationFlow always retains its first 4 fixed states (by leading sort order); they are never deleted (count floor) nor replaced/reordered by template apply.
+- **INV-3**: `currentStateID` always references one of `states` after any add/delete/apply.
+- **INV-4**: `flowStatesTagsetTemplate.allowedValues` equals the set of live state `displayName`s after any mutation.
+- **INV-5**: Subspace (L1/L2) bounds and behavior are unchanged.
+
+## Migration: BackfillL0InnovationFlowMaxStates
+
+**Column type**: `innovation_flow.settings` is **`jsonb`** in the live DB (baseline created it as `json`; migration `1767883714610-convertJsonToJsonb` converted it to `jsonb`, alongside `innovation_flow_state.settings`). So the backfill uses `jsonb_set` directly — no `::jsonb` casting — matching the `BackfillInnovationFlowStateVisible` precedent which ran `jsonb_set` on the same-typed `innovation_flow_state.settings`.
+
+**Transformation (up)**: For every `innovation_flow` whose owning `space.level = 0` and whose current `settings->>'maximumNumberOfStates' = '4'`, set `maximumNumberOfStates = 8`. `minimumNumberOfStates` untouched (stays 4).
+
+```sql
+UPDATE innovation_flow AS f
+SET settings = jsonb_set(f.settings, '{maximumNumberOfStates}', '8'::jsonb, true)
+FROM collaboration AS c
+JOIN space AS s ON s."collaborationId" = c.id
+WHERE c."innovationFlowId" = f.id
+  AND s.level = 0
+  AND (f.settings ->> 'maximumNumberOfStates') = '4';
+```
+
+**Idempotency**: The `= '4'` guard makes re-runs no-ops and protects any admin-set value.
+
+**Reversibility (down)**: Reverse only rows currently at 8 for L0 flows back to 4 (best-effort; an L0 flow legitimately at 8 by admin action after deploy is indistinguishable, so `down` is documented as a rollback of the backfill default, not a perfect inverse).
+
+```sql
+UPDATE innovation_flow AS f
+SET settings = jsonb_set(f.settings, '{maximumNumberOfStates}', '4'::jsonb, true)
+FROM collaboration AS c
+JOIN space AS s ON s."collaborationId" = c.id
+WHERE c."innovationFlowId" = f.id
+  AND s.level = 0
+  AND (f.settings ->> 'maximumNumberOfStates') = '8';
+```
+
+**Rollback note**: Reverting after admins have added 5–8 tabs to L0 spaces will leave those spaces holding more states than the restored max of 4 (the `down` only lowers the *bound*, not the data). This is acceptable for a backward rollback because the add-guard simply prevents *new* adds; existing states remain valid. Documented inline in the migration.

--- a/specs/104-l0-additional-tabs/plan.md
+++ b/specs/104-l0-additional-tabs/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Adding additional tabs in L0 space
+
+**Branch**: `story/6177-adding-additional-tabs-in-l0-space` | **Date**: 2026-06-22 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/104-l0-additional-tabs/spec.md`
+
+## Summary
+
+Loosen the L0 (root space) InnovationFlow tab/state bounds so admins can add tabs beyond the fixed 4 — raising the L0 `maximumNumberOfStates` from 4 to 8 (the existing subspace maximum) while keeping `minimumNumberOfStates` at 4 so the first 4 phases stay fixed. The existing `createStateOnInnovationFlow` / `deleteStateOnInnovationFlow` mutations already enforce bounds generically, so they need no signature change — only the bounds they read change. Three code touch-points: (1) L0 creation in `space.service.ts` stops pinning max=4; (2) the Space-Template applier preserves the first 4 fixed states on L0 instead of replacing all; (3) an idempotent migration backfills `maximumNumberOfStates = 8` onto existing L0 spaces. Bound values become named constants to remove the scattered magic numbers. No GraphQL schema change expected.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3 on Node.js 22 LTS (Volta-pinned 22.21.1)
+
+**Primary Dependencies**: NestJS 10, TypeORM 0.3 (custom fork `pkg.pr.new/antst/typeorm`), Apollo Server 4, GraphQL 16, class-validator / class-transformer, Winston
+
+**Storage**: PostgreSQL 17.5 — existing `innovation_flow.settings` (`jsonb` column; converted from `json` by migration `1767883714610-convertJsonToJsonb`) carrying `minimumNumberOfStates` / `maximumNumberOfStates`. No DDL; data backfill only (raise max 4→8 on L0 flows). Join path for the migration: `space.level = 0` → `space.collaborationId` → `collaboration.innovationFlowId` → `innovation_flow.settings`.
+
+**Testing**: Vitest 4.x — unit specs (`*.spec.ts`) alongside the service/resolver. Risk-based; reuse the existing `innovation.flow.service.spec.ts` and `template.applier.service.spec.ts` patterns (defaultMockerFactory, vi.mocked).
+
+**Target Platform**: Linux server (NestJS GraphQL backend, `/graphql`).
+
+**Project Type**: web-service (single backend project).
+
+**Performance Goals**: N/A — request-scoped mutations on a single InnovationFlow; no new hot paths. The migration is a single bulk UPDATE bounded by the number of L0 spaces (small).
+
+**Constraints**: Must not regress L1/L2 behavior; must keep the flow-state tagset template in sync; must not change the GraphQL contract (verified by `schema:diff`); migration must be idempotent and reversible.
+
+**Scale/Scope**: ~3k TS files repo; this change is ~3 production touch-points + 1 migration + constants + tests. Within the "Full SDD" band because it carries a migration and a data-shape-affecting behavioral change.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **1. Domain-Centric Design First** — PASS. All logic stays in domain services (`innovation-flow`, `space`, `template-applier`). No business rules added to resolvers; the resolver continues to delegate.
+- **2. Modular NestJS Boundaries** — PASS. Touches existing modules only; no new module, no circular dependency. Bound constants live in the innovation-flow domain (pure values).
+- **3. GraphQL Schema as Stable Contract** — PASS. No field/type changes; the existing mutations are reused. `schema:print` + `schema:diff` gate confirms zero diff (FR-013). No deprecations.
+- **4. Explicit Data & Event Flow** — PASS. Mutations keep validation → authorization → domain operation → persistence ordering; no direct repository calls added to resolvers. The applier preservation logic stays in the service layer.
+- **5. Observability & Operational Readiness** — PASS. Reuses existing structured exceptions (`ValidationException` with `LogContext`). Migration logs via TypeORM's runner. No orphaned metrics.
+- **6. Code Quality with Pragmatic Testing** — PASS. Add focused unit tests for: L0 add beyond 4, L0 delete floor, L0 template-apply preservation, subspace regression. Skip trivial pass-through coverage.
+- **7. API Consistency & Evolution Discipline** — PASS. No naming changes; reuses imperative mutation names. No shared enum/scalar changes.
+- **8. Secure-by-Design Integration** — PASS. Authorization checks unchanged and still enforced before mutation (FR-012). No new external integration.
+- **9. Container & Deployment Determinism** — PASS. No env-var reads outside config bootstrap; bound values are code constants.
+- **10. Simplicity & Incremental Hardening** — PASS. Chose the minimal approach: no new immutable-flag column (Clarification Q2); reuse existing bounds + apply-preservation. No speculative infra.
+
+No violations → Complexity Tracking table left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/104-l0-additional-tabs/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (GraphQL contract notes)
+├── checklists/
+│   └── requirements.md  # From /speckit-specify
+├── spec.md
+└── tasks.md             # /speckit-tasks output (created next step)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── domain/
+│   ├── collaboration/
+│   │   ├── innovation-flow/
+│   │   │   ├── innovation.flow.constants.ts          # NEW: L0/subspace bound constants
+│   │   │   ├── innovation.flow.service.ts            # CHANGE: updateInnovationFlowStatesFromTemplate + isLevelZeroInnovationFlow
+│   │   │   └── innovation.flow.service.spec.ts       # add L0 add/delete + template-preserve tests
+│   │   └── innovation-flow-settings/
+│   │       └── innovation.flow.settings.interface.ts # (min/max fields — unchanged)
+│   ├── space/
+│   │   └── space/
+│   │       └── space.service.ts                      # CHANGE: L0 max 4→8 (use constants)
+│   └── template/
+│       └── template-applier/
+│           ├── template.applier.service.ts           # CHANGE: call ...FromTemplate (L0 preserve)
+│           └── template.applier.service.spec.ts       # update mocks to new method name
+└── migrations/
+    └── <ts>-BackfillL0InnovationFlowMaxStates.ts      # NEW: backfill max=8 on L0 flows
+```
+
+**Structure Decision**: Single backend project (Option 1). All changes land in the existing `src/domain/collaboration/innovation-flow`, `src/domain/space/space`, `src/domain/template/template-applier`, and `src/migrations` directories. A new constants file (`innovation.flow.constants.ts`) gives FR-010 its single source of truth, consumed by `space.service.ts` (creation bounds) and the applier (overflow guard).
+
+## Phase 0 — Research
+
+See [research.md](./research.md). Key resolved unknowns: exact constraint locations (`space.service.ts:1284-1285` for L0, `:1373-1374` for subspaces; `innovation.flow.service.ts:352/359` add-guard, `:385/392` delete-guard), the wholesale-replacement behavior of `updateInnovationFlowStates` (the reason L0 template-apply needs special handling), the migration join path, and the backfill migration precedent.
+
+## Phase 1 — Design
+
+- **[data-model.md](./data-model.md)** — entities touched (InnovationFlow, InnovationFlowState, InnovationFlowSettings, Space), the bounds invariants, and the migration's data transformation.
+- **[contracts/](./contracts/)** — GraphQL contract notes confirming the reused mutations and the expected zero schema diff.
+- **[quickstart.md](./quickstart.md)** — how to validate the feature locally (create L0 space, add a 5th tab, attempt delete to floor, apply a template).
+
+## Phase 2 — Tasks
+
+Generated by `/speckit-tasks` into [tasks.md](./tasks.md). Not produced by this plan step.
+
+## Complexity Tracking
+
+> No constitution violations — table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/104-l0-additional-tabs/quickstart.md
+++ b/specs/104-l0-additional-tabs/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: Adding additional tabs in L0 space
+
+**Feature**: 104-l0-additional-tabs | **Date**: 2026-06-22
+
+## Prerequisites
+
+```bash
+pnpm install
+pnpm run start:services      # PostgreSQL 17.5, RabbitMQ, Redis, Ory
+pnpm run migration:run       # applies the L0 max-states backfill among others
+pnpm start:dev               # GraphQL at /graphql, playground at /graphiql
+```
+
+## Validate the behavior
+
+1. **Create / pick an L0 space.** A fresh L0 space starts with its 4 fixed phases. Read its InnovationFlow settings — `minimumNumberOfStates` should be `4` and `maximumNumberOfStates` should now be `8`.
+
+2. **Add a 5th tab (US1).** Run `createStateOnInnovationFlow` against the L0 space's InnovationFlow:
+   ```graphql
+   mutation {
+     createStateOnInnovationFlow(innovationFlowData: {
+       innovationFlowID: "<L0_FLOW_ID>",
+       displayName: "Extra Phase"
+     }) { id displayName sortOrder }
+   }
+   ```
+   Expect success; the flow now has 5 states, the new one last by sort order.
+
+3. **Reach the max (US1 scenario 2).** Keep adding until 8 states exist, then add once more — expect a `ValidationException` citing the maximum of 8; no 9th state created.
+
+4. **Try to delete below the floor (US2).** On an L0 space with exactly 4 states, run `deleteStateOnInnovationFlow` — expect a `ValidationException` citing the minimum of 4. On an L0 space with 5 states, delete the added tab — expect success back to 4; any callouts on the deleted state move to a remaining state.
+
+5. **Apply a Space Template (US3).** Apply a template whose InnovationFlow defines extra phases via `updateCollaborationFromSpaceTemplate` against the L0 space's collaboration:
+   - Expect the 4 fixed phases preserved (same names, leading order) and template extras appended up to 8.
+   - Apply a template that would exceed 8 — expect atomic rejection, space unchanged.
+
+6. **Regression — subspace (US1 scenario 3, FR-011).** Repeat add/delete/apply on an L1 subspace — behavior must be identical to before this feature (min 1, max 8).
+
+## Run the gates
+
+```bash
+pnpm test:ci:no:coverage     # unit/integration
+pnpm build                   # production build
+pnpm lint                    # tsc --noEmit + biome check
+pnpm run schema:print && pnpm run schema:sort && pnpm run schema:diff   # expect zero diff
+```

--- a/specs/104-l0-additional-tabs/research.md
+++ b/specs/104-l0-additional-tabs/research.md
@@ -1,0 +1,66 @@
+# Phase 0 Research: Adding additional tabs in L0 space
+
+**Feature**: 104-l0-additional-tabs | **Date**: 2026-06-22
+
+## R1. Where the L0 "4 tabs" constraint is enforced
+
+**Decision**: The 4/4 pin lives in exactly one creation site; the runtime add/delete guards are generic.
+
+- `src/domain/space/space/space.service.ts` `createRootSpaceAndSubspaces()` lines **1284-1285** set `minimumNumberOfStates = 4` and `maximumNumberOfStates = 4` for L0 at creation. Line **1278** also rejects templates with fewer than 4 states.
+- `src/domain/space/space/space.service.ts` `createSubspace()` lines **1373-1374** set `maximumNumberOfStates = 8`, `minimumNumberOfStates = 1` for L1/L2.
+- `src/domain/collaboration/innovation-flow/innovation.flow.service.ts`:
+  - `createStateOnInnovationFlow()` line **352** reads `settings.maximumNumberOfStates`; line **359** rejects when `states.length >= max`.
+  - `deleteStateOnInnovationFlow()` line **385** reads `settings.minimumNumberOfStates`; line **392** rejects when `states.length <= min`.
+  - `validateInnovationFlowDefinition()` lines **494-528** validate a full state set against min/max.
+
+**Rationale**: Because the add/delete guards are already generic over the persisted bounds, raising the L0 maximum at creation (and backfilling existing rows) is sufficient to let admins add tabs — no mutation logic change. **Alternatives rejected**: special-casing the mutations by space level (more branching, more regression surface) — unnecessary given the bounds-driven design.
+
+## R2. Why template application needs special handling for L0
+
+**Decision**: The Space-Template applier replaces *all* states, so for L0 it must instead preserve the first 4 fixed states and append only the additional template states.
+
+- `src/domain/template/template-applier/template.applier.service.ts` `updateCollaborationFromTemplateContentSpace()` lines **125-134** call `innovationFlowService.updateInnovationFlowStates(targetFlow, newStatesInput)`.
+- `updateInnovationFlowStates()` (`innovation.flow.service.ts` lines **243-298**) **deletes every existing state** (lines 256-260) then recreates from the input — a wholesale replacement. For an L0 space this would wipe the 4 fixed phases, violating FR-008.
+
+**Rationale**: To honor "without overriding the fixed phases (the first 4)" the applier must, when the target is L0, build the new state set as `[first 4 existing fixed states] + [template states that are not duplicates], capped at the L0 max`, and reject if the result would exceed the L0 max (Clarification Q4 → FR-009). The applier resolver (`template.applier.resolver.mutations.ts`) already loads the target collaboration with its `innovationFlow.states`; the service can resolve the owning Space's `level` to branch L0 vs subspace.
+
+**Alternatives rejected**: (a) Leaving the wholesale replacement and relying on the template always containing the 4 fixed phases first — fragile, depends on template authorship. (b) A new immutable per-state flag — rejected in Clarification Q2 for simplicity.
+
+## R3. Resolving the target Space level from a Collaboration
+
+**Decision**: Query the `space` row by `collaborationId` to read `level` (mirrors the existing private helper pattern `getCollaborationByInnovationFlowId` in `innovation.flow.service.ts:760`).
+
+**Rationale**: TemplateContentSpaces (templates) are not rows in the `space` table, so a missing `space` row means the target is a template/non-space collaboration → no L0 preservation needed (behaves as today). A found row with `level = 0` triggers preservation.
+
+## R4. Migration join path & precedent
+
+**Decision**: Backfill `maximumNumberOfStates = 8` on `innovation_flow.settings` for L0 spaces only, leaving `minimumNumberOfStates` at 4.
+
+- Join: `space (level = 0)` → `space."collaborationId"` → `collaboration."innovationFlowId"` → `innovation_flow.settings`.
+- Column type is **`jsonb`** in the live DB. The baseline created it as `json`, but migration `1767883714610-convertJsonToJsonb` converted `innovation_flow.settings` (and `innovation_flow_state.settings`) to `jsonb`. So the backfill uses `jsonb_set(settings, '{maximumNumberOfStates}', '8'::jsonb, true)` directly — no `::jsonb` casting needed.
+- Precedent: `src/migrations/1780500000000-BackfillInnovationFlowStateVisible.ts` — idempotent JSONB backfill with a reversible `down()`.
+
+**Idempotency**: Only update rows where the current `maximumNumberOfStates` is `4` (the old L0 pin), so re-running is a no-op and any admin-customized value is never clobbered. **Reversibility**: `down()` sets it back to 4 for L0 flows currently at 8 (best-effort; documented inline).
+
+**Rationale**: Without the backfill, existing L0 spaces remain pinned at 4 and cannot gain tabs (FR-014). Filtering by `space.level = 0` naturally excludes templates and subspaces.
+
+## R5. Constants location (FR-010)
+
+**Decision**: Add `src/domain/collaboration/innovation-flow/innovation.flow.constants.ts` exporting:
+`L0_MIN_INNOVATION_FLOW_STATES = 4`, `L0_MAX_INNOVATION_FLOW_STATES = 8`, `SUBSPACE_MIN_INNOVATION_FLOW_STATES = 1`, `SUBSPACE_MAX_INNOVATION_FLOW_STATES = 8`, and a derived `L0_FIXED_INNOVATION_FLOW_STATES = 4` (the fixed-phase count == the L0 minimum).
+
+**Rationale**: Removes the four magic numbers in `space.service.ts` and gives the applier overflow guard and the migration a single referenced source. Lives in the innovation-flow domain because the bounds are an InnovationFlow concept; consumed by `space.service.ts` and the applier via path alias `@domain/...`.
+
+**Alternatives rejected**: putting constants in `space` domain — the bounds semantically belong to InnovationFlow; placing them there avoids a space→innovation-flow value dependency inversion.
+
+## R6. Schema-contract impact
+
+**Decision**: No schema change expected. The change is purely in persisted setting values + internal service logic; no GraphQL type/field/mutation is added or altered.
+
+**Verification**: `pnpm run schema:print && pnpm run schema:sort && pnpm run schema:diff` must report zero diff before PR (FR-013). If a diff appears, it indicates an unintended contract change to investigate.
+
+## R7. Test strategy & precedent
+
+**Decision**: Unit tests in `innovation.flow.service.spec.ts` (add-beyond-4, delete-floor against L0 bounds) and `template.applier.service.spec.ts` (L0 preservation, overflow rejection, subspace regression). Use the existing Vitest mocking infra (`defaultMockerFactory`, `repositoryProviderMockFactory`, `vi.mocked`).
+
+**Rationale**: Constitution Principle 6 — risk-based. The bound-guard behavior and the applier-preservation branch carry real regression risk and are the testable invariants; trivial getters are skipped.

--- a/specs/104-l0-additional-tabs/spec.md
+++ b/specs/104-l0-additional-tabs/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Adding additional tabs in L0 space
+
+**Feature Branch**: `story/6177-adding-additional-tabs-in-l0-space`
+
+**Created**: 2026-06-22
+
+**Status**: Draft
+
+**Input**: User description: "Adding additional tabs in L0 space — As a user, I want to be able to add more tabs to the fixed 4 Space L0 ones. Rework the L0 constraints for amount of tabs to be similar to L1 and L2. Revise the existing mutation for adding flow state to L0 space and fix/extend. Revise the template logic for creating/applying space templates to work with the latest changes without regressions and without overriding the fixed phases for L0 space (the first 4)."
+
+**Story**: [alkem-io/server#6177](https://github.com/alkem-io/server/issues/6177)
+
+**Epic**: [alkem-io/alkemio#1930 "Additional Tabs Support in L0 spaces"](https://github.com/alkem-io/alkemio/issues/1930)
+
+**Sibling (frontend) story**: client-web#9857
+
+## Background *(non-normative context)*
+
+In Alkemio, a **Space** exists at one of three levels: L0 (root space of an account), L1 (subspace), L2 (sub-subspace). Each Space's Collaboration owns an **InnovationFlow** whose **states** render as the navigation **tabs** of the Space. The number of states an InnovationFlow may hold is bounded by two settings persisted on the flow: `minimumNumberOfStates` and `maximumNumberOfStates`.
+
+Today these bounds are set at Space creation time and differ by level:
+
+- **L0**: `minimumNumberOfStates = 4`, `maximumNumberOfStates = 4` (a fixed, immutable set of exactly 4 tabs).
+- **L1 / L2 (subspaces)**: `minimumNumberOfStates = 1`, `maximumNumberOfStates = 8` (flexible).
+
+Because L0 is pinned to 4/4, a user cannot add a 5th tab to an L0 space: the add-state mutation rejects it, and applying a Space Template either fails the bound check or would replace the 4 fixed tabs entirely. This feature loosens the L0 upper bound so users can **add** tabs beyond the first 4, while keeping the first 4 phases **fixed** (they cannot be removed, and template application must not overwrite them).
+
+## Clarifications
+
+### Session 2026-06-22 (iteration 1)
+
+All ambiguities below were surfaced across the SpecKit taxonomy (Scope & Boundaries, Domain & Data Model, Interaction & State, Non-Functional, Edge Cases, Integration). In YOLO mode each is resolved by decision, with rationale, and encoded into the requirements above.
+
+- **Q1 (Scope / Domain): What numeric maximum should L0 spaces allow?**
+  **A:** 8 — the same maximum subspaces (L1/L2) already use. Rationale: the story says "similar to L1 and L2"; reusing the existing subspace bound avoids inventing a new value and keeps the frontend's tab handling uniform. Encoded in FR-001, SC-002. The two bound values (min 4 for L0, max 8 shared) become named constants (FR-010).
+
+- **Q2 (Domain / Data Model): Does "fixed first 4 phases" require a new per-state immutable flag, or is the minimum-of-4 floor sufficient?**
+  **A:** No new flag. "Fixed" is enforced by (a) keeping `minimumNumberOfStates = 4` on L0 so the count can never drop below 4, and (b) the template-apply path preserving the first 4 states by leading sort order rather than replacing them. Rationale: Principle 10 (Simplicity) — avoid speculative schema additions; the floor + apply-preservation fully satisfies the story's "without overriding the fixed phases (the first 4)". Encoded in FR-002, FR-008. (Note: deletion of a *specific* one of the first 4 while above the floor is out of scope for this story — the frontend slice client-web#9857 governs which tabs are deletable in the UI; the server guarantees only the count floor and template preservation.)
+
+- **Q3 (Data Model / Migration): Do existing L0 spaces (persisted with max=4) automatically gain the loosened maximum?**
+  **A:** Yes, via an idempotent data migration that sets `maximumNumberOfStates = 8` on the `innovation_flow.settings` of every L0 space (`space.level = 0` → `collaboration` → `innovation_flow`), leaving `minimumNumberOfStates` untouched (stays 4). Rationale: without backfill, only newly created L0 spaces could add tabs, contradicting "I want to be able to add more tabs" for the existing fleet. Template content spaces are excluded because they are not rows in the `space` table. Encoded in FR-014. Follows the existing backfill pattern (`1780500000000-BackfillInnovationFlowStateVisible`).
+
+- **Q4 (Interaction / Edge Case): When applying a Space Template would push an L0 space beyond its maximum, reject or silently truncate?**
+  **A:** Reject atomically, leaving the target unchanged. Rationale: silent truncation loses user-intended template content unpredictably; an explicit validation error is the least-surprising, testable behavior and matches how add-state already rejects at the max. Encoded in FR-009, US3 scenario 2.
+
+- **Q5 (Integration / Contract): Does the GraphQL schema change?**
+  **A:** No new mutations or input fields are required. `createStateOnInnovationFlow` and `deleteStateOnInnovationFlow` already exist and are generic over the bounds; only the *bounds* (set at L0 creation and backfilled) change, plus internal template-apply logic. The schema is therefore expected to be unchanged; `pnpm run schema:print && schema:diff` is run as a gate to confirm zero diff. Encoded in FR-013 and the GraphQL/Contract assumption.
+
+- **Q6 (Interaction / State): How does the template-apply path know a target is L0 so it can preserve the first 4?**
+  **A:** The applier resolves the target Space (and its `level`) for the collaboration being updated; for `level === L0` it preserves the existing first-4 states (by sort order) and appends only the template's *additional* states up to the L0 maximum, instead of the wholesale `updateInnovationFlowStates` replacement used for subspaces. Subspace behavior is untouched (FR-011). Encoded in FR-008.
+
+No `[NEEDS CLARIFICATION]` markers remain in this spec.
+
+### Session 2026-06-22 (iteration 2)
+
+Re-scan across all taxonomy categories produced **zero new ambiguities**. The decisions from iteration 1 are internally consistent, every FR is testable, and no requirement depends on an unresolved choice. Clarify loop terminates.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Add a tab beyond the fixed 4 on an L0 space (Priority: P1)
+
+As a Space administrator of an L0 (root) space, I want to add a new tab in addition to the 4 fixed ones, so the space can host more phases of work — the same flexibility subspaces already have.
+
+**Why this priority**: This is the core, must-have scope of the epic. Without it the feature delivers no value. It is the minimal viable slice — once an admin can add a 5th tab to an L0 space, the feature is demonstrable.
+
+**Independent Test**: Create an L0 space (which starts with 4 states), call the add-state mutation against its InnovationFlow, and confirm a 5th state is created and persisted with the correct sort order and a valid current-state pointer.
+
+**Acceptance Scenarios**:
+
+1. **Given** an L0 space whose InnovationFlow has the 4 fixed states, **When** an authorized admin adds a new state via the create-state mutation, **Then** the InnovationFlow has 5 states, the new state appears last in sort order, and the flow-state tagset template lists all 5 names.
+2. **Given** an L0 space whose InnovationFlow already holds the maximum allowed number of states, **When** an admin attempts to add one more, **Then** the mutation is rejected with a validation error stating the maximum, and no state is created.
+3. **Given** an L1 or L2 subspace, **When** an admin adds a tab, **Then** behavior is unchanged from today (regression guard).
+
+---
+
+### User Story 2 - Keep the first 4 L0 phases fixed and undeletable (Priority: P1)
+
+As a platform operator, I want the original 4 L0 phases to remain fixed — a user may add tabs but must never delete the space below 4 states — so existing L0 spaces keep their canonical phase structure.
+
+**Why this priority**: AC#1 of the story ("Rework the L0 constraints … similar to L1 and L2") must not regress the guarantee that L0 always has at least its 4 fixed phases. If deletion below 4 were allowed, existing data assumptions and the frontend's fixed-tab handling would break. Equal priority to US1 because the loosened upper bound is only safe if the lower bound holds.
+
+**Independent Test**: Against an L0 space with exactly 4 states, attempt to delete a state and confirm rejection; against an L0 space with 5 states, delete the 5th and confirm it succeeds down to but not below 4.
+
+**Acceptance Scenarios**:
+
+1. **Given** an L0 space with exactly 4 states, **When** an admin attempts to delete any state, **Then** the deletion is rejected with a validation error citing the minimum of 4.
+2. **Given** an L0 space with 5 states, **When** an admin deletes one added tab, **Then** the space returns to 4 states and the deletion succeeds; callouts assigned to the deleted state are moved to a remaining valid state.
+3. **Given** an L0 space, **When** the minimum bound is read, **Then** it equals 4 (unchanged from today).
+
+---
+
+### User Story 3 - Apply a Space Template to an L0 space without overwriting the fixed phases (Priority: P2)
+
+As a Space administrator, I want to apply a Space Template to my L0 space and have it add the template's extra phases/callouts without replacing or reordering the 4 fixed L0 phases, so templates compose with the fixed structure instead of fighting it.
+
+**Why this priority**: AC#3 of the story. It is essential for a regression-free rollout but depends on US1/US2 being in place first; templates are applied less frequently than the basic add-tab action, so it is P2 rather than P1.
+
+**Independent Test**: Apply a Space Template (whose InnovationFlow has its own states) to an L0 space and confirm the first 4 fixed phases are preserved in identity and order, while any additional template states are appended up to the L0 maximum.
+
+**Acceptance Scenarios**:
+
+1. **Given** an L0 space with its 4 fixed phases and a Space Template whose InnovationFlow defines additional phases, **When** the template is applied, **Then** the 4 fixed phases remain (same names, same leading order) and the template's additional phases are appended without exceeding the L0 maximum.
+2. **Given** a Space Template whose InnovationFlow would push the L0 space beyond its maximum number of states, **When** the template is applied, **Then** the apply is rejected (per the resolved clarification) with a clear validation error and the target space is left unchanged.
+3. **Given** creation of a new L0 space from a template, **When** the space is created, **Then** it starts with exactly the 4 fixed phases (creation-time behavior unchanged) and the loosened maximum is in effect so tabs can be added afterward.
+
+---
+
+### Edge Cases
+
+- **At-maximum add**: Adding a state when the flow is already at `maximumNumberOfStates` must be rejected with the existing max-states validation error; the loosened L0 maximum must be a single source of truth shared with the validation path.
+- **Delete to the floor**: Deleting a state when at exactly 4 (the L0 minimum) must be rejected; callout reassignment must not run for a rejected delete.
+- **Template with fewer than 4 states**: Creating an L0 space from a template whose InnovationFlow has fewer than 4 states must still be rejected at creation time (existing guard preserved).
+- **Template apply that exceeds the L0 maximum**: Resolved in Clarifications — reject atomically rather than silently truncate.
+- **Sort order / current state pointer**: After adding or removing a tab, the current-state pointer must remain valid and sort order monotonic.
+- **Existing L0 spaces created before this change**: They were persisted with `maximumNumberOfStates = 4`. Whether they automatically gain the loosened maximum is resolved in Clarifications (data backfill decision).
+- **Flow-state tagset template**: Adding/removing a tab must keep the InnovationFlow's flow-state tagset template's allowed values in sync with the live states.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow an L0 (root) space's InnovationFlow to hold more than 4 states, raising its `maximumNumberOfStates` to match the subspace allowance (8) rather than being pinned to 4.
+- **FR-002**: The system MUST keep the L0 InnovationFlow `minimumNumberOfStates` at 4, so an L0 space can never be reduced below its 4 fixed phases.
+- **FR-003**: When a new L0 space is created, the system MUST initialize it with exactly the 4 fixed phases (creation behavior unchanged) while persisting the loosened maximum so additional tabs can be added afterward.
+- **FR-004**: The create-state (add-tab) mutation MUST succeed for an authorized actor on an L0 space whose current state count is below the L0 maximum, appending the new state with a correct sort order and keeping the flow-state tagset template in sync.
+- **FR-005**: The create-state mutation MUST reject an add when the L0 InnovationFlow is already at its maximum number of states, returning the existing max-states validation error and persisting no state.
+- **FR-006**: The delete-state mutation MUST reject any deletion that would take an L0 InnovationFlow below 4 states, returning the existing min-states validation error.
+- **FR-007**: The delete-state mutation MUST succeed for added tabs above the floor, reassigning callouts from the deleted state to a remaining valid state, exactly as it does today for subspaces.
+- **FR-008**: Applying a Space Template to an existing L0 space MUST preserve the 4 fixed phases (identity and leading order) and MUST NOT replace or reorder them; the template's additional phases MAY be appended subject to the L0 maximum.
+- **FR-009**: Applying a Space Template to an L0 space whose resulting state count would exceed the L0 maximum MUST be rejected atomically, leaving the target space unchanged (per Clarification).
+- **FR-010**: The L0 minimum/maximum bounds MUST be defined as named constants (single source of truth) rather than scattered magic numbers, so the add/delete validation paths and the creation path agree.
+- **FR-011**: Subspace (L1/L2) behavior for adding, deleting, and template application MUST remain unchanged (no regressions).
+- **FR-012**: All new and changed mutations MUST enforce the existing authorization checks before mutating, and MUST validate inputs at the DTO layer.
+- **FR-013**: Changes to the GraphQL surface (if any) MUST regenerate the committed schema artifact; if no schema change is required, the spec MUST note that the existing mutations are reused unchanged.
+- **FR-014**: Existing L0 spaces persisted with `maximumNumberOfStates = 4` MUST be migrated to the loosened maximum so their administrators can add tabs (per Clarification on backfill).
+
+### Key Entities *(include if feature involves data)*
+
+- **Space**: The collaboration container at a given `level` (L0/L1/L2). Owns a Collaboration which owns the InnovationFlow. Level drives the state-count bounds applied at creation.
+- **InnovationFlow**: Holds an ordered set of states (the tabs), a `currentStateID`, a flow-state tagset template (the canonical list of state names), and a `settings` JSONB carrying `minimumNumberOfStates` and `maximumNumberOfStates`.
+- **InnovationFlowState**: A single tab/phase — `displayName`, optional `description`, `sortOrder`, optional per-state settings. The first 4 on an L0 space are the "fixed phases".
+- **InnovationFlowSettings**: The bounds object (`minimumNumberOfStates`, `maximumNumberOfStates`) persisted in the InnovationFlow `settings` JSONB column.
+- **Space Template / TemplateContentSpace**: A reusable Collaboration shape (InnovationFlow states + callouts) that can be applied to a Space or used to seed a new one.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An authorized admin can add at least one tab beyond the fixed 4 on an L0 space, and the new tab persists and is returned by subsequent queries.
+- **SC-002**: An L0 space can hold up to the same maximum number of tabs as a subspace (8); the (4+1)th through 8th adds all succeed and the 9th is rejected.
+- **SC-003**: 100% of attempts to delete an L0 space below 4 states are rejected; the space never persists fewer than 4 states.
+- **SC-004**: Applying any Space Template to an L0 space preserves the 4 fixed phases by name and leading order in 100% of cases, with zero instances of the fixed phases being replaced or reordered.
+- **SC-005**: No regression in subspace (L1/L2) add/delete/template behavior, verified by the existing and added tests passing.
+- **SC-006**: The repo's full local exit gates (test suite, production build, lint/format/typecheck) pass clean on the branch before PR.
+
+## Assumptions
+
+- The maximum number of tabs an L0 space may hold equals the existing subspace maximum (8). This mirrors "similar to L1 and L2" from the story and avoids introducing a new bound value. (Confirmed in Clarifications.)
+- The 4 fixed L0 phases are exactly the first 4 states by sort order at creation; "fixed" means they cannot be deleted (the minimum-of-4 floor) and template application must not replace/reorder them. No separate per-state immutable flag is introduced unless required (resolved in Clarifications).
+- Authorization for adding/deleting tabs on L0 spaces uses the same privilege already required for the create-state / delete-state mutations on subspaces; no new privilege is introduced.
+- The frontend slice (client-web#9857) consumes the existing mutations; this server slice keeps the GraphQL mutation contract stable, reusing `createStateOnInnovationFlow` and `deleteStateOnInnovationFlow`.
+- Existing L0 spaces require a data migration to raise their persisted maximum from 4 to 8; the minimum stays 4 (resolved in Clarifications).
+- The flow-state tagset template is kept in sync by the existing add/update/delete paths; no new sync mechanism is introduced.

--- a/specs/104-l0-additional-tabs/tasks.md
+++ b/specs/104-l0-additional-tabs/tasks.md
@@ -1,0 +1,129 @@
+---
+description: "Task list for 104-l0-additional-tabs"
+---
+
+# Tasks: Adding additional tabs in L0 space
+
+**Input**: Design documents from `/specs/104-l0-additional-tabs/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/graphql.md, quickstart.md
+
+**Tests**: Included — the spec requires regression safety (SC-005) and the constitution mandates risk-based unit tests for the bound guards and the applier branch.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Absolute-from-repo-root paths are given.
+
+## Path Conventions
+
+Single backend project — `src/` at repo root. All paths below are repo-root-relative.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Single source of truth for the bound values (FR-010).
+
+- [X] T001 Create `src/domain/collaboration/innovation-flow/innovation.flow.constants.ts` exporting `L0_MIN_INNOVATION_FLOW_STATES = 4`, `L0_MAX_INNOVATION_FLOW_STATES = 8`, `L0_FIXED_INNOVATION_FLOW_STATES = 4`, `SUBSPACE_MIN_INNOVATION_FLOW_STATES = 1`, `SUBSPACE_MAX_INNOVATION_FLOW_STATES = 8`. Add a file-level doc comment tying the values to FR-001/FR-002/FR-010.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Wire the constants into the creation path so new spaces get the right bounds. Blocks every user story because it establishes the L0 bounds the runtime guards read.
+
+- [X] T002 [US1] In `src/domain/space/space/space.service.ts` `createRootSpaceAndSubspaces()` (lines ~1284-1285), replace the literal `minimumNumberOfStates = 4` / `maximumNumberOfStates = 4` with `L0_MIN_INNOVATION_FLOW_STATES` / `L0_MAX_INNOVATION_FLOW_STATES`. Also replace the `< 4` literal in the at-least-4 guard (line ~1278) with `L0_FIXED_INNOVATION_FLOW_STATES`. Import from `@domain/collaboration/innovation-flow/innovation.flow.constants`.
+- [X] T003 [US1] In the same file `createSubspace()` (lines ~1373-1374), replace the subspace `maximumNumberOfStates = 8` / `minimumNumberOfStates = 1` literals with `SUBSPACE_MAX_INNOVATION_FLOW_STATES` / `SUBSPACE_MIN_INNOVATION_FLOW_STATES` (no behavior change — removes the remaining magic numbers, FR-010/FR-011).
+
+**Checkpoint**: New L0 spaces are created with min 4 / max 8; subspaces unchanged. The generic add-guard (`innovation.flow.service.ts:359`) now permits up to 8 on L0.
+
+---
+
+## Phase 3: User Story 1 — Add a tab beyond the fixed 4 on an L0 space (P1)
+
+**Goal**: An authorized admin can add tabs to an L0 space up to 8; the 9th is rejected. Subspaces unchanged.
+
+**Independent Test**: Create an L0 space (4 states), add a 5th via `createStateOnInnovationFlow`, confirm persistence and tagset sync; add up to 8, confirm the 9th is rejected.
+
+- [X] T004 [US1] Verify `createStateOnInnovationFlow` in `src/domain/collaboration/innovation-flow/innovation.flow.service.ts` requires no logic change (it reads `settings.maximumNumberOfStates` generically). If any L0-specific branching exists, remove it so the bound is purely settings-driven (FR-004/FR-005). Confirm the resolver (`innovation.flow.resolver.mutations.ts`) still enforces the existing authorization privilege and DTO validation before the service call — no auth bypass introduced for L0 (FR-012). Document the no-change conclusion in the PR if unchanged.
+- [X] T005 [P] [US1] Add unit tests to `src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts`: (a) adding a state to an L0-style flow (settings min 4 / max 8) with 4 states succeeds and appends with next sort order; (b) adding when at 8 states throws `ValidationException` citing the max; (c) a subspace-style flow (min 1 / max 8) still behaves as before (regression).
+
+**Checkpoint**: US1 acceptance scenarios pass in isolation.
+
+---
+
+## Phase 4: User Story 2 — Keep the first 4 L0 phases fixed and undeletable (P1)
+
+**Goal**: An L0 space can never drop below 4 states; added tabs above the floor can be deleted with callout reassignment.
+
+**Independent Test**: Delete attempt at exactly 4 → rejected; delete at 5 → succeeds to 4.
+
+- [X] T006 [US2] Verify `deleteStateOnInnovationFlow` in `src/domain/collaboration/innovation-flow/innovation.flow.service.ts` requires no logic change (reads `settings.minimumNumberOfStates = 4` for L0). Confirm the floor holds and callout reassignment path is untouched (FR-006/FR-007).
+- [X] T007 [P] [US2] Add unit tests to `innovation.flow.service.spec.ts`: (a) deleting from an L0-style flow at exactly 4 states throws `ValidationException` citing the minimum; (b) deleting an added tab from an L0-style flow at 5 states succeeds and triggers callout reassignment to a remaining valid state.
+
+**Checkpoint**: US2 acceptance scenarios pass; SC-003 (never below 4) holds.
+
+---
+
+## Phase 5: User Story 3 — Apply a Space Template to an L0 space without overwriting the fixed phases (P2)
+
+**Goal**: Applying a Space Template to an L0 space preserves the first 4 fixed phases and appends template extras up to 8; overflow is rejected atomically. Subspace apply unchanged.
+
+**Independent Test**: Apply a multi-phase template to an L0 space → first 4 preserved, extras appended; apply an overflowing template → rejected, space unchanged.
+
+- [X] T008 [US3] Add `private isLevelZeroInnovationFlow(innovationFlowId)` to `src/domain/collaboration/innovation-flow/innovation.flow.service.ts` that resolves the owning Space `level` via the entity manager (`manager.getRepository(Space)` filtered by `collaboration.innovationFlow.id`; absent row ⇒ treated as non-L0/template, behave as today). Mirrors the `getCollaborationByInnovationFlowId` manager pattern. **Implementation note**: placed in InnovationFlowService (not the applier) so the space-level lookup and the fixed-phase preservation live together in the innovation-flow domain, avoiding a template→space module coupling. The Space *entity* is imported for `manager.getRepository` metadata only (no DI), and `space.entity` does not import innovation-flow, so there is no cycle.
+- [X] T009 [US3] Add `public updateInnovationFlowStatesFromTemplate(innovationFlow, templateStates)` to `innovation.flow.service.ts`: for L0 build the new set as `[existing first L0_FIXED_INNOVATION_FLOW_STATES states by sortOrder] + [template states not duplicating the fixed names, re-based after the fixed phases]`, capped at the flow's `maximumNumberOfStates`; if the combined set would exceed the max, throw `ValidationException` (FR-009) before any mutation (atomic). For non-L0 delegate to the existing wholesale `updateInnovationFlowStates` (FR-008/FR-011). Then point `template.applier.service.ts` `updateCollaborationFromTemplateContentSpace()` at the new method instead of `updateInnovationFlowStates`.
+- [X] T010 [P] [US3] Add unit tests to `src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts` for `updateInnovationFlowStatesFromTemplate`: (a) applying to an L0 flow preserves the 4 fixed states (names + leading order) and appends only non-duplicate extras; (b) applying a set that would exceed 8 throws `ValidationException` and performs no mutation; (c) a subspace flow falls through to the wholesale replacement (regression). Update `template.applier.service.spec.ts` mocks to the new method name.
+
+**Checkpoint**: US3 scenarios pass; SC-004 (fixed phases preserved 100%) holds.
+
+---
+
+## Phase 6: Data Migration (cross-cutting; required by FR-014)
+
+**Purpose**: Let existing L0 spaces gain the loosened maximum. Depends on the constant value (Phase 1) being settled; independent of the service/applier code so it MAY be developed in parallel with Phases 3–5.
+
+- [X] T011 Generate/author migration `src/migrations/<timestamp>-BackfillL0InnovationFlowMaxStates.ts` following the `1780500000000-BackfillInnovationFlowStateVisible.ts` precedent. `up()`: set `maximumNumberOfStates = 8` on `innovation_flow.settings` for flows whose owning `space.level = 0` and current max = 4 (idempotent; see data-model.md SQL). `down()`: reverse L0 flows at 8 back to 4 with the documented rollback note. Use the `space → collaboration → innovation_flow` join; `innovation_flow.settings` is `jsonb`, so use `jsonb_set(settings, '{maximumNumberOfStates}', '8'::jsonb, true)` directly (no casting).
+- [~] T012 Validate the migration with `pnpm run migration:run` against a local DB (or `.scripts/migrations/run_validate_migration.sh` if env available); confirm idempotency by running twice (second run is a no-op) and that subspace/template flows are untouched. **Deferred**: no live PostgreSQL/DSN available in this headless worker. The migration SQL is idempotent by the `= '4'` guard and reversible; validated by inspection against the `1780500000000-BackfillInnovationFlowStateVisible` precedent and the verified `space → collaboration → innovation_flow` join column names. Will run in CI / on the next migration cycle.
+
+---
+
+## Phase 7: Polish & Exit Gates
+
+- [X] T013 Run `pnpm run schema:print` and compare to the committed `schema.graphql` — confirmed **zero** schema diff (FR-013). No GraphQL contract change.
+- [X] T014 Run `pnpm lint` (tsc --noEmit + biome) — clean after `pnpm lint:fix` (import sorting + formatting in the 4 edited files).
+- [X] T015 Run `pnpm build` (production build) — succeeded.
+- [X] T016 Run `pnpm test:ci:no:coverage` — full suite green: 617 files / 6734 tests passed, 7 skipped, 0 failed (SC-005/SC-006).
+- [X] T017 Updated `specs/104-l0-additional-tabs/` artifacts to reflect the actual implementation (helper placed in InnovationFlowService; new `updateInnovationFlowStatesFromTemplate`; json→jsonb correction). spec/plan/tasks consistent.
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 (T001)** → blocks Phase 2 and the migration value.
+- **Phase 2 (T002-T003)** → blocks Phase 3/4 checkpoints (creation bounds must be right).
+- **Phase 3 (US1)**, **Phase 4 (US2)** → depend on Phase 2; `[P]` test tasks T005/T007 can run in parallel with each other (different concerns, same spec file — coordinate edits).
+- **Phase 5 (US3)** → depends on Phase 1 (constants) and is independent of US1/US2 service code (different file). T010 `[P]`.
+- **Phase 6 (migration)** → depends only on Phase 1; can proceed in parallel with Phases 3–5.
+- **Phase 7** → after all implementation; gates run in the order schema → lint → build → test (restart from T013 on any failure).
+
+## Parallel Opportunities
+
+- T005, T007, T010 (test authoring in distinct concerns) — note T005/T007 touch the same spec file, so serialize the actual writes even though logically parallel.
+- T008/T009 (applier) and T011 (migration) are in different files and can be built concurrently after T001.
+
+## Acceptance Criteria Mapping
+
+| Task | FR / SC / Story |
+|------|------------------|
+| T001 | FR-010 |
+| T002 | FR-001, FR-002, FR-003 / US1 |
+| T003 | FR-011 |
+| T004, T005 | FR-004, FR-005, FR-012, SC-001, SC-002 / US1 |
+| T006, T007 | FR-006, FR-007, SC-003 / US2 |
+| T008, T009, T010 | FR-008, FR-009, FR-011, SC-004 / US3 |
+| T011, T012 | FR-014 |
+| T013 | FR-013 |
+| T014-T016 | SC-005, SC-006 |

--- a/src/core/bootstrap/platform-template-definitions/default-templates/bootstrap.template.space.content.space.l0.ts
+++ b/src/core/bootstrap/platform-template-definitions/default-templates/bootstrap.template.space.content.space.l0.ts
@@ -20,7 +20,7 @@ export const bootstrapTemplateSpaceContentSpaceL0: CreateTemplateContentSpaceInp
           displayName: 'Space Innovation Flow',
         },
         settings: {
-          maximumNumberOfStates: 5,
+          maximumNumberOfStates: 8,
           minimumNumberOfStates: 4,
         },
         states: [

--- a/src/domain/collaboration/innovation-flow/innovation.flow.constants.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.constants.ts
@@ -1,0 +1,29 @@
+/**
+ * Bounds for the number of InnovationFlow states (tabs) a Space may hold,
+ * applied at Space creation time and read by the generic add/delete guards in
+ * {@link InnovationFlowService}.
+ *
+ * Single source of truth for story #6177 (epic alkem-io/alkemio#1930): L0 spaces
+ * were previously pinned to exactly 4 states (min 4 / max 4). They now allow up
+ * to the same maximum as subspaces (8) so admins can add tabs beyond the fixed 4
+ * (FR-001), while the minimum stays 4 so the first 4 fixed phases can never be
+ * removed (FR-002, FR-010).
+ */
+
+/** L0 (root space) minimum — keeps the 4 fixed phases as an undeletable floor. */
+export const L0_MIN_INNOVATION_FLOW_STATES = 4;
+
+/** L0 (root space) maximum — matches the subspace allowance so tabs can be added. */
+export const L0_MAX_INNOVATION_FLOW_STATES = 8;
+
+/**
+ * The count of fixed phases on an L0 space (the leading states a template apply
+ * must preserve). Equal to the L0 minimum by definition.
+ */
+export const L0_FIXED_INNOVATION_FLOW_STATES = L0_MIN_INNOVATION_FLOW_STATES;
+
+/** Subspace (L1/L2) minimum number of states. */
+export const SUBSPACE_MIN_INNOVATION_FLOW_STATES = 1;
+
+/** Subspace (L1/L2) maximum number of states. */
+export const SUBSPACE_MAX_INNOVATION_FLOW_STATES = 8;

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
@@ -855,4 +855,211 @@ describe('InnovationFlowService', () => {
       ).not.toHaveBeenCalled();
     });
   });
+
+  // Story #6177: L0 spaces use min 4 / max 8 (was 4/4). The add/delete guards
+  // are settings-driven, so these assert the loosened L0 bounds end-to-end.
+  describe('L0 bounds (story #6177)', () => {
+    const l0Settings = { minimumNumberOfStates: 4, maximumNumberOfStates: 8 };
+
+    it('US1: should add a 5th state to an L0 flow that has the 4 fixed states', async () => {
+      const flow = {
+        id: 'flow-l0',
+        states: [
+          { id: 's-1', sortOrder: 1 },
+          { id: 's-2', sortOrder: 2 },
+          { id: 's-3', sortOrder: 3 },
+          { id: 's-4', sortOrder: 4 },
+        ],
+        settings: l0Settings,
+      } as any;
+
+      const newState = { id: 's-5' } as any;
+      vi.mocked(
+        innovationFlowStateService.createInnovationFlowState
+      ).mockResolvedValue(newState);
+      vi.mocked(innovationFlowStateService.save).mockResolvedValue(newState);
+
+      const stateData = { displayName: 'Fifth' } as any;
+      const result = await service.createStateOnInnovationFlow(flow, stateData);
+
+      expect(result).toBe(newState);
+      // sortOrder should be max(1..4) + 1 = 5 (appended last)
+      expect(stateData.sortOrder).toBe(5);
+    });
+
+    it('US1: should reject adding a 9th state when an L0 flow is at the max of 8', async () => {
+      const flow = {
+        id: 'flow-l0',
+        states: Array.from({ length: 8 }, (_v, i) => ({
+          id: `s-${i + 1}`,
+          sortOrder: i + 1,
+        })),
+        settings: l0Settings,
+      } as any;
+
+      await expect(
+        service.createStateOnInnovationFlow(flow, {
+          displayName: 'Ninth',
+        } as any)
+      ).rejects.toThrow(ValidationException);
+      expect(
+        innovationFlowStateService.createInnovationFlowState
+      ).not.toHaveBeenCalled();
+    });
+
+    it('US2: should reject deleting from an L0 flow at exactly 4 states (the fixed floor)', async () => {
+      const flow = {
+        id: 'flow-l0',
+        states: [{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }, { id: 's-4' }],
+        settings: l0Settings,
+      } as any;
+
+      await expect(
+        service.deleteStateOnInnovationFlow(flow, { ID: 's-4' } as any)
+      ).rejects.toThrow(ValidationException);
+    });
+  });
+
+  // Story #6177: applying a Space Template to an L0 space must preserve the 4
+  // fixed phases and append only the template's additional states (capped at 8).
+  describe('updateInnovationFlowStatesFromTemplate (story #6177)', () => {
+    const l0Settings = { minimumNumberOfStates: 4, maximumNumberOfStates: 8 };
+
+    // Helper: stub the owning-space level lookup used by isLevelZeroInnovationFlow.
+    const mockOwningSpaceLevel = (level: number | undefined) => {
+      (repository as any).manager = {
+        getRepository: vi.fn().mockReturnValue({
+          findOne: vi
+            .fn()
+            .mockResolvedValue(
+              level === undefined ? null : { id: 'space-1', level }
+            ),
+        }),
+      };
+    };
+
+    const fixedL0States = [
+      {
+        id: 's-1',
+        displayName: 'Define',
+        description: 'd1',
+        settings: {},
+        sortOrder: 1,
+      },
+      {
+        id: 's-2',
+        displayName: 'Discover',
+        description: 'd2',
+        settings: {},
+        sortOrder: 2,
+      },
+      {
+        id: 's-3',
+        displayName: 'Develop',
+        description: 'd3',
+        settings: {},
+        sortOrder: 3,
+      },
+      {
+        id: 's-4',
+        displayName: 'Deliver',
+        description: 'd4',
+        settings: {},
+        sortOrder: 4,
+      },
+    ];
+
+    it('US3: preserves the 4 fixed L0 phases and appends only additional template states', async () => {
+      mockOwningSpaceLevel(0); // L0
+      const flow = {
+        id: 'flow-l0',
+        states: fixedL0States,
+        settings: l0Settings,
+      } as any;
+
+      const updateSpy = vi
+        .spyOn(service, 'updateInnovationFlowStates')
+        .mockResolvedValue(flow);
+
+      // Template carries the 4 fixed names plus two extras.
+      const templateStates = [
+        { displayName: 'Define', sortOrder: 1 },
+        { displayName: 'Discover', sortOrder: 2 },
+        { displayName: 'Develop', sortOrder: 3 },
+        { displayName: 'Deliver', sortOrder: 4 },
+        { displayName: 'Extra One', sortOrder: 5 },
+        { displayName: 'Extra Two', sortOrder: 6 },
+      ] as any;
+
+      await service.updateInnovationFlowStatesFromTemplate(
+        flow,
+        templateStates
+      );
+
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const combined = updateSpy.mock.calls[0][1];
+      const names = combined.map(s => s.displayName);
+      // First 4 are the preserved fixed phases in their original leading order.
+      expect(names.slice(0, 4)).toEqual([
+        'Define',
+        'Discover',
+        'Develop',
+        'Deliver',
+      ]);
+      // Only the non-duplicate template states are appended.
+      expect(names.slice(4)).toEqual(['Extra One', 'Extra Two']);
+      expect(combined).toHaveLength(6);
+    });
+
+    it('US3: rejects atomically when applying a template would exceed the L0 maximum', async () => {
+      mockOwningSpaceLevel(0); // L0
+      const flow = {
+        id: 'flow-l0',
+        states: fixedL0States,
+        settings: l0Settings,
+      } as any;
+
+      const updateSpy = vi
+        .spyOn(service, 'updateInnovationFlowStates')
+        .mockResolvedValue(flow);
+
+      // 4 fixed + 5 unique extras = 9 > max 8 → must reject.
+      const templateStates = Array.from({ length: 5 }, (_v, i) => ({
+        displayName: `Extra ${i + 1}`,
+        sortOrder: 10 + i,
+      })) as any;
+
+      await expect(
+        service.updateInnovationFlowStatesFromTemplate(flow, templateStates)
+      ).rejects.toThrow(ValidationException);
+      // No mutation attempted on overflow.
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('US3 regression: subspaces fall through to a wholesale replacement', async () => {
+      mockOwningSpaceLevel(1); // L1 subspace
+      const flow = {
+        id: 'flow-l1',
+        states: [{ id: 's-1', displayName: 'Old', sortOrder: 1 }],
+        settings: { minimumNumberOfStates: 1, maximumNumberOfStates: 8 },
+      } as any;
+
+      const updateSpy = vi
+        .spyOn(service, 'updateInnovationFlowStates')
+        .mockResolvedValue(flow);
+
+      const templateStates = [
+        { displayName: 'New A', sortOrder: 1 },
+        { displayName: 'New B', sortOrder: 2 },
+      ] as any;
+
+      await service.updateInnovationFlowStatesFromTemplate(
+        flow,
+        templateStates
+      );
+
+      // Subspace path passes the template states through untouched.
+      expect(updateSpy).toHaveBeenCalledWith(flow, templateStates);
+    });
+  });
 });

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -1,5 +1,6 @@
 import { LogContext, ProfileType } from '@common/enums';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { SpaceLevel } from '@common/enums/space.level';
 import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { VisualType } from '@common/enums/visual.type';
 import {
@@ -15,6 +16,7 @@ import { TagsetService } from '@domain/common/tagset/tagset.service';
 import { UpdateTagsetTemplateDefinitionInput } from '@domain/common/tagset-template';
 import { ITagsetTemplate } from '@domain/common/tagset-template/tagset.template.interface';
 import { TagsetTemplateService } from '@domain/common/tagset-template/tagset.template.service';
+import { Space } from '@domain/space/space/space.entity';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -34,6 +36,7 @@ import { DeleteStateOnInnovationFlowInput } from './dto/innovation.flow.dto.stat
 import { UpdateInnovationFlowCurrentStateInput } from './dto/innovation.flow.dto.state.select';
 import { UpdateInnovationFlowInput } from './dto/innovation.flow.dto.update';
 import { UpdateInnovationFlowStatesSortOrderInput } from './dto/innovation.flow.dto.update.states.sort.order';
+import { L0_FIXED_INNOVATION_FLOW_STATES } from './innovation.flow.constants';
 import { InnovationFlow } from './innovation.flow.entity';
 import { IInnovationFlow } from './innovation.flow.interface';
 
@@ -240,6 +243,105 @@ export class InnovationFlowService {
    * @param newStates
    * @returns
    */
+  /**
+   * Applies a set of template states to an InnovationFlow when a Space Template
+   * is applied (story #6177).
+   *
+   * For an L0 (root) space the first {@link L0_FIXED_INNOVATION_FLOW_STATES}
+   * "fixed phases" MUST NOT be overridden (FR-008): they are preserved by
+   * identity and leading order, and only the template's *additional* states
+   * (those not duplicating a fixed-phase name) are appended, capped at the
+   * flow's `maximumNumberOfStates`. If the combined unique set would exceed the
+   * maximum the apply is rejected atomically (FR-009) before any mutation.
+   *
+   * For subspaces (L1/L2) behavior is unchanged: a wholesale replacement via
+   * {@link updateInnovationFlowStates} (FR-011).
+   */
+  public async updateInnovationFlowStatesFromTemplate(
+    innovationFlow: IInnovationFlow,
+    templateStates: CreateInnovationFlowStateInput[]
+  ) {
+    const isLevelZero = await this.isLevelZeroInnovationFlow(innovationFlow.id);
+    if (!isLevelZero) {
+      // Subspace (or non-space) behavior is unchanged: replace all states.
+      return this.updateInnovationFlowStates(innovationFlow, templateStates);
+    }
+
+    if (!innovationFlow.states) {
+      throw new RelationshipNotFoundException(
+        'Unable to find states on InnovationFlow',
+        LogContext.INNOVATION_FLOW,
+        { innovationFlowId: innovationFlow.id }
+      );
+    }
+
+    // Preserve the leading fixed phases (by sort order) of the L0 space.
+    const fixedStates = [...innovationFlow.states]
+      .sort(sortBySortOrder)
+      .slice(0, L0_FIXED_INNOVATION_FLOW_STATES);
+    const fixedStateNames = new Set(
+      fixedStates.map(state => state.displayName)
+    );
+
+    const fixedStateInputs: CreateInnovationFlowStateInput[] = fixedStates.map(
+      state => ({
+        displayName: state.displayName,
+        description: state.description,
+        settings: state.settings,
+        sortOrder: state.sortOrder,
+      })
+    );
+
+    // Append only the template states that do not duplicate a fixed phase name,
+    // re-basing their sort order to come after the fixed phases.
+    const additionalStateInputs: CreateInnovationFlowStateInput[] = [
+      ...templateStates,
+    ]
+      .sort(sortBySortOrder)
+      .filter(state => !fixedStateNames.has(state.displayName))
+      .map((state, index) => ({
+        ...state,
+        sortOrder: L0_FIXED_INNOVATION_FLOW_STATES + index + 1,
+      }));
+
+    const combinedStates = [...fixedStateInputs, ...additionalStateInputs];
+
+    const maximumNumberOfStates = innovationFlow.settings.maximumNumberOfStates;
+    if (combinedStates.length > maximumNumberOfStates) {
+      throw new ValidationException(
+        'Applying this template would exceed the maximum number of states for this Space',
+        LogContext.INNOVATION_FLOW,
+        {
+          innovationFlowId: innovationFlow.id,
+          maximumNumberOfStates,
+          resultingStateCount: combinedStates.length,
+        }
+      );
+    }
+
+    return this.updateInnovationFlowStates(innovationFlow, combinedStates);
+  }
+
+  /**
+   * An InnovationFlow belongs to an L0 (root) space iff its owning Space has
+   * `level === 0`. Resolved via the entity manager (no module coupling), mirroring
+   * {@link getCollaborationByInnovationFlowId}. A flow with no owning Space row
+   * (e.g. a template content space) is treated as non-L0.
+   */
+  private async isLevelZeroInnovationFlow(
+    innovationFlowId: string
+  ): Promise<boolean> {
+    const spaceRepository =
+      this.innovationFlowRepository.manager.getRepository(Space);
+    const space = await spaceRepository.findOne({
+      where: {
+        collaboration: { innovationFlow: { id: innovationFlowId } },
+      },
+      select: { id: true, level: true },
+    });
+    return space?.level === SpaceLevel.L0;
+  }
+
   public async updateInnovationFlowStates(
     innovationFlow: IInnovationFlow,
     newStates: CreateInnovationFlowStateInput[]

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -39,6 +39,13 @@ import { ICredentialDefinition } from '@domain/actor/credential/credential.defin
 import { ICalloutsSet } from '@domain/collaboration/callouts-set/callouts.set.interface';
 import { CollaborationService } from '@domain/collaboration/collaboration/collaboration.service';
 import { CreateCollaborationInput } from '@domain/collaboration/collaboration/dto/collaboration.dto.create';
+import {
+  L0_FIXED_INNOVATION_FLOW_STATES,
+  L0_MAX_INNOVATION_FLOW_STATES,
+  L0_MIN_INNOVATION_FLOW_STATES,
+  SUBSPACE_MAX_INNOVATION_FLOW_STATES,
+  SUBSPACE_MIN_INNOVATION_FLOW_STATES,
+} from '@domain/collaboration/innovation-flow/innovation.flow.constants';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { ILicense } from '@domain/common/license/license.interface';
@@ -1275,14 +1282,25 @@ export class SpaceService {
         LogContext.SPACES
       );
     }
-    if (templateContentSpace.collaboration.innovationFlow.states.length < 4) {
+    if (
+      templateContentSpace.collaboration.innovationFlow.states.length <
+      L0_FIXED_INNOVATION_FLOW_STATES
+    ) {
       throw new ValidationException(
-        `Template content space innovation flow states must have at least 4 states: ${templateContentSpaceID}`,
-        LogContext.SPACES
+        'Template content space innovation flow states must satisfy the required minimum',
+        LogContext.SPACES,
+        {
+          templateContentSpaceID,
+          minimumRequiredStates: L0_FIXED_INNOVATION_FLOW_STATES,
+        }
       );
     }
-    templateContentSpace.collaboration.innovationFlow.settings.minimumNumberOfStates = 4;
-    templateContentSpace.collaboration.innovationFlow.settings.maximumNumberOfStates = 4;
+    // Story #6177: keep the L0 minimum at the fixed-phase count, but raise the
+    // maximum to the subspace allowance so admins can add tabs beyond the fixed 4.
+    templateContentSpace.collaboration.innovationFlow.settings.minimumNumberOfStates =
+      L0_MIN_INNOVATION_FLOW_STATES;
+    templateContentSpace.collaboration.innovationFlow.settings.maximumNumberOfStates =
+      L0_MAX_INNOVATION_FLOW_STATES;
 
     return await this.createSpace(
       spaceData,
@@ -1370,8 +1388,10 @@ export class SpaceService {
         LogContext.TEMPLATES
       );
     }
-    templateContentSubspace.collaboration.innovationFlow.settings.maximumNumberOfStates = 8;
-    templateContentSubspace.collaboration.innovationFlow.settings.minimumNumberOfStates = 1;
+    templateContentSubspace.collaboration.innovationFlow.settings.maximumNumberOfStates =
+      SUBSPACE_MAX_INNOVATION_FLOW_STATES;
+    templateContentSubspace.collaboration.innovationFlow.settings.minimumNumberOfStates =
+      SUBSPACE_MIN_INNOVATION_FLOW_STATES;
 
     let subspace = await this.createSpace(
       subspaceData,

--- a/src/domain/template/template-applier/template.applier.service.spec.ts
+++ b/src/domain/template/template-applier/template.applier.service.spec.ts
@@ -167,7 +167,7 @@ describe('TemplateApplierService', () => {
       inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState.mockReturnValue(
         []
       );
-      innovationFlowService.updateInnovationFlowStates.mockResolvedValue(
+      innovationFlowService.updateInnovationFlowStatesFromTemplate.mockResolvedValue(
         {} as any
       );
       storageAggregatorResolverService.getStorageAggregatorForCollaboration.mockResolvedValue(
@@ -195,6 +195,55 @@ describe('TemplateApplierService', () => {
       expect(targetCollab.calloutsSet.callouts).toEqual([]);
     });
 
+    it('should not delete existing callouts when the flow-state update rejects (atomicity)', async () => {
+      const sourceCollab = {
+        innovationFlow: {
+          states: [{ displayName: 'State1' }],
+        },
+        calloutsSet: { callouts: [] },
+      };
+
+      templateService.getTemplateOrFail.mockResolvedValue({
+        id: 'tpl-1',
+        contentSpace: {
+          id: 'tcs-1',
+          collaboration: sourceCollab,
+        },
+      } as any);
+
+      const existingCallout = { id: 'existing-callout-1' };
+      const targetCollab = {
+        id: 'collab-1',
+        innovationFlow: { states: [{ displayName: 'OldState' }] },
+        calloutsSet: { callouts: [existingCallout] },
+      } as any;
+
+      inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState.mockReturnValue(
+        []
+      );
+      // Simulate an L0 overflow rejection from the flow-state update.
+      innovationFlowService.updateInnovationFlowStatesFromTemplate.mockRejectedValue(
+        new Error('overflow')
+      );
+
+      await expect(
+        service.updateCollaborationFromSpaceTemplate(
+          {
+            collaborationID: 'collab-1',
+            spaceTemplateID: 'tpl-1',
+            addCallouts: false,
+            deleteExistingCallouts: true,
+          },
+          targetCollab,
+          'user-1'
+        )
+      ).rejects.toThrow('overflow');
+
+      // Atomicity: no callouts deleted, and the original callout is preserved.
+      expect(calloutService.deleteCallout).not.toHaveBeenCalled();
+      expect(targetCollab.calloutsSet.callouts).toEqual([existingCallout]);
+    });
+
     it('should add callouts from source when addCallouts is true', async () => {
       const sourceCallouts = [{ id: 'src-callout-1' }];
       const sourceCollab = {
@@ -219,7 +268,7 @@ describe('TemplateApplierService', () => {
       inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState.mockReturnValue(
         [{ displayName: 'New' }] as any
       );
-      innovationFlowService.updateInnovationFlowStates.mockResolvedValue(
+      innovationFlowService.updateInnovationFlowStatesFromTemplate.mockResolvedValue(
         {} as any
       );
       storageAggregatorResolverService.getStorageAggregatorForCollaboration.mockResolvedValue(
@@ -281,9 +330,11 @@ describe('TemplateApplierService', () => {
       inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState.mockReturnValue(
         stateInputs as any
       );
-      innovationFlowService.updateInnovationFlowStates.mockResolvedValue({
-        states: sourceStates,
-      } as any);
+      innovationFlowService.updateInnovationFlowStatesFromTemplate.mockResolvedValue(
+        {
+          states: sourceStates,
+        } as any
+      );
       storageAggregatorResolverService.getStorageAggregatorForCollaboration.mockResolvedValue(
         {} as any
       );
@@ -304,7 +355,7 @@ describe('TemplateApplierService', () => {
       );
 
       expect(
-        innovationFlowService.updateInnovationFlowStates
+        innovationFlowService.updateInnovationFlowStatesFromTemplate
       ).toHaveBeenCalledWith(
         expect.objectContaining({ states: [{ displayName: 'Old' }] }),
         stateInputs
@@ -334,7 +385,7 @@ describe('TemplateApplierService', () => {
       inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState.mockReturnValue(
         []
       );
-      innovationFlowService.updateInnovationFlowStates.mockResolvedValue(
+      innovationFlowService.updateInnovationFlowStatesFromTemplate.mockResolvedValue(
         {} as any
       );
       storageAggregatorResolverService.getStorageAggregatorForCollaboration.mockResolvedValue(

--- a/src/domain/template/template-applier/template.applier.service.ts
+++ b/src/domain/template/template-applier/template.applier.service.ts
@@ -102,7 +102,24 @@ export class TemplateApplierService {
       );
     }
 
-    // Delete existing callouts if requested (before updating flow states)
+    const newStates = sourceCollaboration.innovationFlow.states;
+    const newStatesInput: CreateInnovationFlowStateInput[] =
+      this.inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState(
+        newStates
+      );
+    // Story #6177: for an L0 (root) space this preserves the fixed first phases
+    // and appends only the template's additional states (capped at the L0 max);
+    // for subspaces it is a wholesale replacement (unchanged behavior). This can
+    // reject atomically on L0 overflow, so it MUST run before any callouts are
+    // deleted to keep the whole apply atomic.
+    targetCollaboration.innovationFlow =
+      await this.innovationFlowService.updateInnovationFlowStatesFromTemplate(
+        targetCollaboration.innovationFlow,
+        newStatesInput
+      );
+
+    // Delete existing callouts if requested (only after the flow-state update
+    // succeeds, so an overflow rejection above leaves callouts untouched).
     if (deleteExistingCallouts && targetCollaboration.calloutsSet?.callouts) {
       const existingCallouts = targetCollaboration.calloutsSet.callouts;
       this.logger.verbose?.(
@@ -121,17 +138,6 @@ export class TemplateApplierService {
         LogContext.TEMPLATES
       );
     }
-
-    const newStates = sourceCollaboration.innovationFlow.states;
-    const newStatesInput: CreateInnovationFlowStateInput[] =
-      this.inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState(
-        newStates
-      );
-    targetCollaboration.innovationFlow =
-      await this.innovationFlowService.updateInnovationFlowStates(
-        targetCollaboration.innovationFlow,
-        newStatesInput
-      );
 
     const storageAggregator =
       await this.storageAggregatorResolverService.getStorageAggregatorForCollaboration(

--- a/src/migrations/1781900000000-BackfillL0InnovationFlowMaxStates.ts
+++ b/src/migrations/1781900000000-BackfillL0InnovationFlowMaxStates.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Backfills the loosened maximum number of InnovationFlow states (tabs) onto
+ * existing L0 (root) spaces (story #6177, epic alkem-io/alkemio#1930).
+ *
+ * Previously L0 spaces were pinned to a small `maximumNumberOfStates` (the L0
+ * bootstrap template has historically seeded `5`, and older data may carry `4`).
+ * They now allow up to 8 (the subspace allowance) so admins can add tabs beyond
+ * the fixed 4. `minimumNumberOfStates` is intentionally left untouched (stays 4)
+ * so the 4 fixed phases remain an undeletable floor.
+ *
+ * Scope: only `innovation_flow` rows whose owning Space has `level = 0`. The
+ * `space.level = 0` join naturally excludes subspaces (L1/L2) and template
+ * content spaces (which are not rows in the `space` table).
+ *
+ * Idempotent: only updates rows whose current max is still one of the legacy
+ * pinned defaults (`4` or `5`), so re-running is a no-op and any value already at
+ * 8 is left alone. `maximumNumberOfStates` is not admin-settable from the client,
+ * so the legacy defaults are the only values this can encounter.
+ *
+ * Rollback note: `down()` lowers the bound back to 5 (the historical L0 default)
+ * for L0 flows currently at 8. It restores the *bound* only — if admins added
+ * tabs (6..8) before a rollback, those extra states remain in the data; the
+ * add-guard simply prevents further additions. Existing states stay valid.
+ *
+ * `innovation_flow.settings` is a `jsonb` column (converted from `json` by
+ * migration 1767883714610-convertJsonToJsonb), so `jsonb_set` is used directly.
+ */
+export class BackfillL0InnovationFlowMaxStates1781900000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE innovation_flow AS f
+      SET settings = jsonb_set(f.settings, '{maximumNumberOfStates}', '8'::jsonb, true)
+      FROM collaboration AS c
+      JOIN space AS s ON s."collaborationId" = c.id
+      WHERE c."innovationFlowId" = f.id
+        AND s.level = 0
+        AND (f.settings ->> 'maximumNumberOfStates') IN ('4', '5')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE innovation_flow AS f
+      SET settings = jsonb_set(f.settings, '{maximumNumberOfStates}', '5'::jsonb, true)
+      FROM collaboration AS c
+      JOIN space AS s ON s."collaborationId" = c.id
+      WHERE c."innovationFlowId" = f.id
+        AND s.level = 0
+        AND (f.settings ->> 'maximumNumberOfStates') = '8'
+    `);
+  }
+}


### PR DESCRIPTION
## Summary

Allows administrators to add **additional tabs beyond the fixed 4** on L0 (root) Spaces, bringing L0 in line with L1/L2 subspaces, while keeping the first 4 phases fixed and undeletable.

The number of InnovationFlow states (tabs) a Space may hold is bounded by `minimumNumberOfStates` / `maximumNumberOfStates` persisted on the flow. L0 was pinned to **4/4**; subspaces use **1/8**. This PR raises the L0 maximum to **8** (min stays **4**) and teaches the template applier to preserve the L0 fixed phases.

Closes #6177. Epic: alkem-io/alkemio#1930 "Additional Tabs Support in L0 spaces". Frontend slice: client-web#9857.

## What changed

- **`innovation.flow.constants.ts`** (new) — single source of truth for the L0 (min 4 / max 8) and subspace (min 1 / max 8) bounds, replacing scattered magic numbers (FR-010).
- **`space.service.ts`** — L0 space creation now sets `maximumNumberOfStates = 8` (was 4); `minimumNumberOfStates` stays 4. Subspace literals replaced with the same constants (no behavior change).
- **`InnovationFlowService.updateInnovationFlowStatesFromTemplate`** (new) — when a Space Template is applied to an **L0** space, the first 4 fixed phases are preserved by name + leading order and only the template's *additional* (non-duplicate) states are appended, capped at 8; an apply that would exceed 8 is **rejected atomically** before any mutation (FR-008, FR-009). Subspaces keep the existing wholesale replacement (FR-011). L0 detection is via the owning Space's `level`, resolved through the entity manager (no module coupling).
- **`BackfillL0InnovationFlowMaxStates` migration** — idempotently raises `maximumNumberOfStates` 4→8 on existing L0 innovation flows so the current fleet gains the capability (FR-014). Reversible; guarded on the old value of 4.

The existing `createStateOnInnovationFlow` / `deleteStateOnInnovationFlow` mutations are **reused unchanged** — they read the bounds generically, so there is **no GraphQL schema change** (verified by zero `schema:diff`, FR-013).

## Acceptance criteria (story #6177)

- [x] Rework the L0 tab-count constraints to be similar to L1/L2 — L0 max raised 4→8, min stays 4.
- [x] Revise the existing add-flow-state mutation for L0 — confirmed it works generically once the bound is loosened; no auth bypass introduced.
- [x] Revise template create/apply logic so the fixed first-4 L0 phases are not overridden — new preservation path; subspace behavior unchanged.

## Testing / gates

- Unit tests: L0 add-beyond-4, add-at-max (9th rejected), delete at the 4-floor (rejected), template preservation of the fixed 4, template overflow rejection, and subspace regression.
- Full suite: **6734 passed / 7 skipped / 0 failed**.
- `pnpm build`: green. `pnpm lint` (tsc + biome): clean. Schema diff: **zero** (no contract change).
- Migration `pnpm run migration:run` not executed in CI-less worker (no DSN); SQL is idempotent + reversible, validated by inspection against the `BackfillInnovationFlowStateVisible` precedent.

## SDD artifacts

Spec-driven; artifacts in `specs/104-l0-additional-tabs/`: `spec.md` (with Clarifications), `plan.md`, `research.md`, `data-model.md`, `contracts/graphql.md`, `quickstart.md`, `tasks.md`, `checklists/requirements.md`.

- Clarify loop: **2 iterations** (6 decisions resolved in iter 1; iter 2 clean).
- Analyze loop: **3 iterations** (iter 1 fixed a json→jsonb column-type error across artifacts; iter 2 added FR-012 coverage; iter 3 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * L0 spaces can now support up to **8** tabs instead of 4, with the first **4** tabs remaining non-deletable.
  * When applying a space template to an L0 space, the first **4** fixed tabs are preserved and additional template tabs are appended up to the L0 maximum.
* **Bug Fixes**
  * Template application now rejects atomically if it would exceed the L0 tab limit.
* **Tests**
  * Added comprehensive coverage for L0 tab management and template-application scenarios.
* **Chores**
  * Added a migration to backfill existing L0 spaces with the new maximum tab limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->