### PR TITLE
feat(mcp): emit a versioned element delta from edit_whiteboard_elements

### DIFF
--- a/src/services/mcp-server/tools/edit-whiteboard-elements.tool.spec.ts
+++ b/src/services/mcp-server/tools/edit-whiteboard-elements.tool.spec.ts
@@ -266,9 +266,15 @@ describe('EditWhiteboardElementsTool', () => {
       ctx
     );
     expect(res.isError).toBeFalsy();
-    expect(emit).toHaveBeenCalledWith(expect.anything(), {
-      whiteboardId: WB_ID,
-    });
+    expect(emit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ whiteboardId: WB_ID })
+    );
+    // The event now carries the element delta (the added text) so the
+    // collaboration service can merge it as a collaborator update.
+    const [, payload] = emit.mock.calls[0];
+    expect(Array.isArray(payload.elements)).toBe(true);
+    expect(payload.elements.length).toBeGreaterThan(0);
 
     const throwing = buildTool();
     throwing.emit.mockImplementation(() => {
@@ -279,6 +285,27 @@ describe('EditWhiteboardElementsTool', () => {
       ctx
     );
     expect(res2.isError).toBeFalsy();
+  });
+
+  it('emits an isDeleted tombstone in the delta for a removed element', async () => {
+    const shape = {
+      id: 's',
+      type: 'rectangle',
+      version: 3,
+      isDeleted: false,
+      boundElements: [],
+    };
+    const { tool, emit } = buildTool({ content: sceneWith([shape]) });
+    await tool.execute(
+      { whiteboardId: WB_ID, operations: [{ op: 'remove', elementId: 's' }] },
+      ctx
+    );
+    const [, payload] = emit.mock.calls[0];
+    const tombstone = payload.elements.find((e: any) => e.id === 's');
+    // The delete must propagate via a tombstone — omission would let a live
+    // session that still holds the element re-add it on reconcile.
+    expect(tombstone).toBeDefined();
+    expect(tombstone.isDeleted).toBe(true);
   });
 
   it('rejects an empty operations array and unknown ops', async () => {

--- a/src/services/mcp-server/tools/edit-whiteboard-elements.tool.ts
+++ b/src/services/mcp-server/tools/edit-whiteboard-elements.tool.ts
@@ -272,9 +272,12 @@ export class EditWhiteboardElementsTool implements McpTool {
       );
 
       try {
+        // Carry the element delta so the collaboration service merges it as a
+        // normal collaborator update (preserving live edits) instead of falling
+        // back to a full-scene reconcile. See WhiteboardCollaborationController.
         this.whiteboardCollaborationClient.emit(
           WhiteboardIntegrationEventPattern.CONTENT_UPDATED_EXTERNALLY,
-          { whiteboardId: updated.id }
+          { whiteboardId: updated.id, elements: applied.delta }
         );
       } catch (emitError) {
         this.logger.warn?.(
@@ -327,9 +330,16 @@ export class EditWhiteboardElementsTool implements McpTool {
   private applyOperations(
     elements: SceneElement[],
     operations: EditOp[]
-  ): { added: string[]; summary: string[] } | { error: string } {
+  ):
+    | { added: string[]; summary: string[]; delta: SceneElement[] }
+    | { error: string } {
     const byId = new Map<string, SceneElement>(
       elements.map(e => [e.id, e] as const)
+    );
+    // Snapshot the pre-edit serialized state so the DELTA can be derived after the
+    // ops run, with no per-op bookkeeping: identical JSON afterwards == untouched.
+    const before = new Map<string, string>(
+      elements.map(e => [e.id, JSON.stringify(e)] as const)
     );
     // One cursor for the whole call, anchored below the PRE-CALL content, so all
     // additions flow into the same empty block and never overlap.
@@ -547,7 +557,29 @@ export class EditWhiteboardElementsTool implements McpTool {
       }
     }
 
-    return { added, summary };
+    // Derive the delta the collaboration service merges into any OPEN room: every
+    // element that is new or whose serialized form changed (e.g. a `connect`
+    // mutates its endpoints' bindings), plus an isDeleted tombstone — reconstructed
+    // from the pre-edit snapshot — for each element the ops removed. Omitting a
+    // removed element would not propagate the delete (reconciliation keeps an
+    // element a live session still holds); a tombstone does. The collaboration
+    // service re-stamps these to win, so a live editor sees the assistant's edits
+    // and deletes without losing in-flight edits to untouched elements.
+    const delta: SceneElement[] = [];
+    const survivingIds = new Set<string>();
+    for (const e of elements) {
+      survivingIds.add(e.id);
+      if (before.get(e.id) !== JSON.stringify(e)) {
+        delta.push(e);
+      }
+    }
+    for (const [id, serialized] of before) {
+      if (!survivingIds.has(id)) {
+        delta.push({ ...JSON.parse(serialized), isDeleted: true });
+      }
+    }
+
+    return { added, summary, delta };
   }
 
   private errorResult(message: string): McpToolResult {

--- a/src/services/mcp-server/tools/update-whiteboard-content.tool.ts
+++ b/src/services/mcp-server/tools/update-whiteboard-content.tool.ts
@@ -194,6 +194,12 @@ export class UpdateWhiteboardContentTool implements McpTool {
       // method — emitting there would echo on every autosave. A broker hiccup
       // must never break the tool result, so failures are swallowed.
       try {
+        // No element delta: this tool OVERWRITES the whole scene, so there is no
+        // safe per-element delta to merge. We intentionally send only the
+        // whiteboardId — the collaboration service then takes its SAFE full-scene
+        // reconcile path (applies the write where it out-versions live state,
+        // never clobbering a concurrent in-flight edit). edit_whiteboard_elements
+        // is the delta-carrying path for incremental edits.
         this.whiteboardCollaborationClient.emit(
           WhiteboardIntegrationEventPattern.CONTENT_UPDATED_EXTERNALLY,
           { whiteboardId: updated.id }


### PR DESCRIPTION
## Summary

The server half of **Option A** for whiteboard live-push (workspace `specs/006-whiteboard-live-external-writes`).
So the collaboration service can merge an external whiteboard write as a normal collaborator update
(instead of reloading/replacing the scene), it needs the *changed elements* — this PR makes
`edit_whiteboard_elements` send them.

- **`edit_whiteboard_elements`**: derive a **delta** in `applyOperations` (diff the pre-edit
  serialized elements against the post-edit scene) and emit it on the `contentUpdatedExternally`
  event. The delta is every new/changed element **plus an `isDeleted` tombstone** — reconstructed
  from the pre-edit snapshot — for each removed element. Omitting a removed element would not
  propagate the delete (reconciliation keeps an element a live session still holds); a tombstone
  does. The diff approach also captures `connect`'s endpoint-binding mutations with no per-op
  bookkeeping. The collaboration service re-stamps the delta to win, so a live editor sees the
  assistant's edits/deletes without losing in-flight edits to untouched elements.
- **`update_whiteboard_content`**: documented as intentionally **delta-less** — it overwrites the
  whole scene, so it stays on the collaboration service's *safe* full-scene reconcile path (no
  concurrent-edit clobber). No behaviour change.

Verified end-to-end live: an MCP `edit_whiteboard_elements` call emitted the delta and the
collaboration service merged + broadcast `SCENE_UPDATE` to an open board.

Companion: whiteboard-collaboration-service #237 (consumes the delta).

## Schema Contract Checklist (Feature 002)

N/A — no GraphQL schema change (MCP-tool internals only; `schema.graphql` untouched).

### Other Notes

Tests: `edit-whiteboard-elements.tool.spec.ts` — emit assertion now checks the carried delta; added
a test proving `remove` emits an `isDeleted` tombstone. 9/9 in the tool spec pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Whiteboard element edits now send more complete live-update information, including added, changed, and removed elements.
  * Deleting an element now correctly appears in collaboration updates as a removed item.
  * Full whiteboard updates continue to notify collaborators without overwriting unrelated concurrent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->