### PR TITLE
feat(storage): allow .ics (text/calendar) file uploads

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -490,6 +490,7 @@ enum MimeType {
   GIF
   HEIC
   HEIF
+  ICS
   JPEG
   JPG
   ODG

--- a/src/common/enums/mime.file.type.document.spec.ts
+++ b/src/common/enums/mime.file.type.document.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_ALLOWED_MIME_TYPES, MimeFileType } from './mime.file.type';
+import { MimeTypeDocument } from './mime.file.type.document';
+
+describe('MimeTypeDocument', () => {
+  // Regression for alkem-io/server#6159 — admins must be able to upload
+  // iCalendar (.ics) files wherever document upload is supported.
+  it('includes the iCalendar (.ics) type mapped to text/calendar', () => {
+    expect(MimeTypeDocument.ICS).toBe('text/calendar');
+  });
+
+  it('exposes ICS via the combined MimeFileType', () => {
+    expect((MimeFileType as Record<string, string>).ICS).toBe('text/calendar');
+  });
+
+  it('allows text/calendar by default for new storage buckets', () => {
+    expect(DEFAULT_ALLOWED_MIME_TYPES).toContain('text/calendar');
+  });
+});

--- a/src/common/enums/mime.file.type.document.ts
+++ b/src/common/enums/mime.file.type.document.ts
@@ -8,6 +8,8 @@ export enum MimeTypeDocument {
   ODS = 'application/vnd.oasis.opendocument.spreadsheet',
   CSV = 'text/csv',
 
+  ICS = 'text/calendar',
+
   DOC = 'application/msword',
   DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   ODT = 'application/vnd.oasis.opendocument.text',

--- a/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
@@ -12,6 +12,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { Readable } from 'stream';
 import { CalloutContributionService } from '../callout-contribution/callout.contribution.service';
 import { CalloutContributionAuthorizationService } from '../callout-contribution/callout.contribution.service.authorization';
 import { CalloutResolverMutations } from './callout.resolver.mutations';
@@ -481,7 +482,7 @@ describe('CalloutResolverMutations', () => {
         actorContext,
         { calloutID: 'callout-1' } as any,
         {
-          createReadStream: () => ({}) as any,
+          createReadStream: () => Readable.from(Buffer.from('test')),
           filename: 'Imported.docx',
           mimetype: 'application/octet-stream',
         } as any
@@ -559,7 +560,7 @@ describe('CalloutResolverMutations', () => {
         actorContext,
         { calloutID: 'callout-1' } as any,
         {
-          createReadStream: () => ({}) as any,
+          createReadStream: () => Readable.from(Buffer.from('test')),
           filename: 'Imported.docx',
           mimetype: 'application/octet-stream',
         } as any

--- a/src/migrations/1782300000000-AddIcsMimeType.ts
+++ b/src/migrations/1782300000000-AddIcsMimeType.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIcsMimeType1782300000000 implements MigrationInterface {
+  name = 'AddIcsMimeType1782300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add text/calendar (.ics) to all storage buckets that already allow
+    // document MIME types (using application/pdf as the canonical marker)
+    // but don't already allow text/calendar. Guard against duplicates.
+    await queryRunner.query(
+      `UPDATE storage_bucket
+      SET "allowedMimeTypes" = "allowedMimeTypes" || ',text/calendar'
+      WHERE "allowedMimeTypes" LIKE '%application/pdf%'
+        AND "allowedMimeTypes" NOT LIKE '%text/calendar%'`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove text/calendar from all storage buckets that allow it.
+    await queryRunner.query(
+      `UPDATE storage_bucket
+      SET "allowedMimeTypes" = REPLACE("allowedMimeTypes", ',text/calendar', '')
+      WHERE "allowedMimeTypes" LIKE '%text/calendar%'`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds the iCalendar MIME type (`text/calendar`, `.ics`) to the server-side document upload allowlist so Space admins can upload `.ics` files wherever document upload is supported — post CTA buttons, post references, post reactions (links & files), About-this-Space references, and community-guidelines references.

Closes alkem-io/server#6159

## Root cause

Uploaded documents are validated against a per-bucket MIME allowlist. New storage buckets default to `DEFAULT_ALLOWED_MIME_TYPES`, which is `Object.values(MimeFileType)` — the union of `MimeTypeVisual` + `MimeTypeDocument`. `text/calendar` was simply absent from that enum, so `.ics` uploads were rejected with a `ValidationException` everywhere.

## Fix

- **Enum (single source of truth):** add `ICS = 'text/calendar'` to `MimeTypeDocument` (`src/common/enums/mime.file.type.document.ts`). This flows automatically into `DEFAULT_ALLOWED_MIME_TYPES`, so every newly-created bucket accepts `.ics`. Placed next to the other plain-text type (`CSV`) and follows the existing naming/casing.
- **Backfill migration:** `1782300000000-AddIcsMimeType` appends `text/calendar` to existing `storage_bucket` rows that already allow documents (using `application/pdf` as the canonical marker), guarded against duplicates, with a matching `down()`. This mirrors the established `1770909862763-AddHeicHeifMimeTypes` precedent — existing buckets persist their allowlist as a frozen comma-separated string column, so without the backfill only new buckets would accept `.ics`.
- **Schema:** regenerated `schema.graphql` — additive `ICS` value on the `MimeType` enum (non-breaking).

No new validation mechanism was introduced; the change rides the existing allowlist exactly like `pdf`/`csv`.

## Regression test

`src/common/enums/mime.file.type.document.spec.ts` asserts `MimeTypeDocument.ICS === 'text/calendar'`, that it is surfaced via the combined `MimeFileType`, and that `DEFAULT_ALLOWED_MIME_TYPES` contains `text/calendar` (i.e. new buckets accept it).

## Gates

- `pnpm test` — green (6922 passed, +3 new)
- `pnpm lint` (tsc --noEmit + biome) — clean
- `pnpm build` — clean
- `pnpm run schema:print && schema:sort` — only the additive `ICS` enum value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for iCalendar (`ICS`) as an allowed MIME type.
  * Updated default allowed file types so calendar files can be uploaded and stored.
* **Bug Fixes**
  * Updated existing storage bucket settings to include `text/calendar` where appropriate.
* **Tests**
  * Added coverage to verify the new `ICS` MIME type mapping and default allowed MIME type list.
  * Improved resolver test inputs to use a readable stream for document uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->