### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -4309,6 +4309,7 @@ enum MimeType {
   GIF
   HEIC
   HEIF
+  ICS
   JPEG
   JPG
   ODG


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size:   301645 bytes
Snapshot md5: e6d5e051d47fd67298dc1f83adc2bb85

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `ICS` MIME type in the schema, expanding the list of recognized document types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->