### PR TITLE
chore(wopi): route Collabora WOPI traffic through Traefik

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -648,7 +648,10 @@ services:
       - FILE_SERVICE_URL=http://file-service:4003
       - WOPI_COLLABORA_URL=http://collabora:9980
       - WOPI_BASE_URL=http://localhost:3000
-      - WOPI_CALLBACK_URL=http://wopi-service:8080
+      # WOPISrc handed to Collabora routes via Traefik's /wopi route so it rides
+      # the wopi-service failover (local primary → container fallback), instead
+      # of hitting a single instance directly.
+      - WOPI_CALLBACK_URL=http://traefik
       - WOPI_TOKEN_SECRET=dev-wopi-token-secret-change-in-production
       - WOPI_SERVER_PORT=8080
       - WOPI_PROOF_VALIDATION=false
@@ -660,13 +663,15 @@ services:
       - 8080
 
   collabora:
-    extra_hosts:
-      - 'wopi-service:host-gateway'
     container_name: alkemio_dev_collabora
     hostname: collabora
     image: collabora/code:24.04.12.2.1
     environment:
-      - aliasgroup1=http://wopi-service:8080
+      # Reach wopi through Traefik (not a direct port), so callbacks ride the
+      # wopi-service failover. A `wopi-service:host-gateway` extra_host here
+      # would shadow the container's Docker DNS name and pin Collabora to the
+      # host — exactly what we must avoid.
+      - aliasgroup1=http://traefik
       - username=admin
       - password=admin
       - extra_params=--o:ssl.enable=false --o:net.proto=IPv4 --o:security.seccomp=false --o:security.capabilities=false


### PR DESCRIPTION
## Summary

- reroutes Collabora's WOPI traffic in the local Docker Compose stack through Traefik instead of hitting the wopi-service container directly
- both WOPI_CALLBACK_URL and Collabora's aliasgroup1 now point at http://traefik
- the `wopi-service:host-gateway` `extra_host` is removed, so WOPI callbacks ride the wopi-service failover (local primary → container fallback) rather than being pinned to a single instance

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated local service routing so callbacks go through the reverse proxy, improving fallback behavior in development environments.
  * Adjusted Collabora connection settings to avoid being pinned to the host and use the expected local routing path instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->