### PR TITLE
feat(search): fold callout framing resources and contributions into callout matches

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -8422,6 +8422,10 @@ input SearchInput {
   """Return results that satisfy these conditions."""
   filters: [SearchFilterInput!]
   """
+  When searching Callouts (COLLABORATION_TOOLS / CALLOUT), also match in the Callout framing resources (whiteboard, memo) and its contributions (post, whiteboard, memo). Any match folds up to the containing Callout, deduped, in calloutResults.
+  """
+  foldCalloutResources: Boolean = false
+  """
   Restrict the search to a single flow state, identified by the InnovationFlowState UUID. The state UUID is globally unique and transitively identifies its Collaboration, so no separate CalloutsSet filter is needed. Default is all flow states.
   """
   searchInFlowStateFilter: UUID

--- a/src/services/api/search/dto/inputs/search.dto.input.ts
+++ b/src/services/api/search/dto/inputs/search.dto.input.ts
@@ -36,4 +36,12 @@ export class SearchInput {
     description: 'Return results that satisfy these conditions.',
   })
   filters?: SearchFilterInput[];
+
+  @Field(() => Boolean, {
+    nullable: true,
+    defaultValue: false,
+    description:
+      'When searching Callouts (COLLABORATION_TOOLS / CALLOUT), also match in the Callout framing resources (whiteboard, memo) and its contributions (post, whiteboard, memo). Any match folds up to the containing Callout, deduped, in calloutResults.',
+  })
+  foldCalloutResources?: boolean;
 }

--- a/src/services/api/search/extract/search.extract.service.spec.ts
+++ b/src/services/api/search/extract/search.extract.service.spec.ts
@@ -248,6 +248,68 @@ describe('SearchExtractService', () => {
       expect(body.query.bool.filter).toBeUndefined();
     });
 
+    it('keeps Callout search scoped to the callouts index when foldCalloutResources is off', async () => {
+      mockClient.msearch.mockResolvedValue({ responses: [] });
+
+      await service.search({
+        terms: ['governance'],
+        filters: [{ category: SearchCategory.COLLABORATION_TOOLS, size: 10 }],
+      } as any);
+
+      const searches = mockClient.msearch.mock.calls[0][0].searches as any[];
+      // headers are the even items; collect every index targeted
+      const indices = searches
+        .filter((_item, i) => i % 2 === 0)
+        .flatMap(header => header.index);
+      expect(indices).toEqual(['test-callouts']);
+    });
+
+    it('widens a Callout search to post/whiteboard/memo indices when foldCalloutResources is on', async () => {
+      mockClient.msearch.mockResolvedValue({ responses: [] });
+
+      await service.search({
+        terms: ['governance'],
+        foldCalloutResources: true,
+        filters: [{ category: SearchCategory.COLLABORATION_TOOLS, size: 10 }],
+      } as any);
+
+      const searches = mockClient.msearch.mock.calls[0][0].searches as any[];
+      const indices = searches
+        .filter((_item, i) => i % 2 === 0)
+        .flatMap(header => header.index);
+      // callouts plus the fold-up resource indices, each at most once
+      expect(indices).toEqual(
+        expect.arrayContaining([
+          'test-callouts',
+          'test-posts',
+          'test-whiteboards',
+          'test-memos',
+        ])
+      );
+      // single whiteboards/memos index covers both framing and contributions
+      expect(indices.filter(name => name === 'test-whiteboards')).toHaveLength(
+        1
+      );
+      expect(indices.filter(name => name === 'test-memos')).toHaveLength(1);
+    });
+
+    it('does not widen non-Callout searches even when foldCalloutResources is on', async () => {
+      mockClient.msearch.mockResolvedValue({ responses: [] });
+
+      await service.search({
+        terms: ['governance'],
+        foldCalloutResources: true,
+        filters: [{ category: SearchCategory.SPACES, size: 10 }],
+      } as any);
+
+      const searches = mockClient.msearch.mock.calls[0][0].searches as any[];
+      const indices = searches
+        .filter((_item, i) => i % 2 === 0)
+        .flatMap(header => header.index);
+      expect(indices).not.toContain('test-posts');
+      expect(indices).not.toContain('test-callouts');
+    });
+
     it('should handle search results with _ignored fields', async () => {
       mockClient.msearch.mockResolvedValue({
         responses: [

--- a/src/services/api/search/extract/search.extract.service.ts
+++ b/src/services/api/search/extract/search.extract.service.ts
@@ -357,7 +357,17 @@ export class SearchExtractService {
       flowStateIdFilter: searchInFlowStateFilter,
     });
 
-    const categoriesRequested = filters?.length ?? 0;
+    // Budget the default per-category size off the categories actually being
+    // queried, not just the explicit filters: foldCalloutResources appends the
+    // CONTRIBUTIONS/FRAMINGS indices on top of the requested COLLABORATION_TOOLS
+    // filter, and those folded categories would otherwise each take the full
+    // default size and overfetch. For non-folding searches this equals
+    // filters.length, so behaviour is unchanged.
+    const categoriesQueried = new Set(
+      indicesToSearchOn.map(index => index.category)
+    ).size;
+    const categoriesRequested =
+      categoriesQueried || (filters?.length ?? 0) || 1;
     const searchRequests = buildMultiSearchRequestItems(
       indicesToSearchOn,
       query,

--- a/src/services/api/search/extract/search.extract.service.ts
+++ b/src/services/api/search/extract/search.extract.service.ts
@@ -186,9 +186,18 @@ export class SearchExtractService {
       throw new Error('Elasticsearch client not initialized');
     }
 
-    const { terms, searchInSpaceFilter, searchInFlowStateFilter, filters } =
-      searchData;
-    const indicesToSearchOn = this.getIndices(onlyPublicResults, filters);
+    const {
+      terms,
+      searchInSpaceFilter,
+      searchInFlowStateFilter,
+      filters,
+      foldCalloutResources,
+    } = searchData;
+    const indicesToSearchOn = this.getIndices(
+      onlyPublicResults,
+      filters,
+      foldCalloutResources
+    );
 
     if (indicesToSearchOn.length === 0) {
       return [];
@@ -207,7 +216,8 @@ export class SearchExtractService {
 
   private getIndices(
     onlyPublicResults = false,
-    filters?: SearchFilterInput[]
+    filters?: SearchFilterInput[],
+    foldCalloutResources = false
   ): SearchIndex[] {
     const categories = filters
       ?.map(filter => filter.category)
@@ -237,19 +247,70 @@ export class SearchExtractService {
           )
         : filteredIndicesByCategory;
 
+    // foldCalloutResources widens a Callout search so framing resources and
+    // contributions (post/whiteboard/memo) are matched too and fold up to their
+    // containing callout. We must therefore also query those indices even though
+    // they belong to other categories; the type filter above would otherwise
+    // strip them. Bypasses it by appending here, deduped by index name.
+    const indicesToSearchOn = foldCalloutResources
+      ? this.withCalloutResourceIndices(
+          filteredIndicesByCategoryAndType,
+          categories
+        )
+      : filteredIndicesByCategoryAndType;
+
     if (onlyPublicResults) {
       const publicIndices = Object.values(
         getPublicIndexStore(this.indexPattern)
       ).flat();
       // if we want only public results - filter the public indices with the user defined filter
       return intersectionWith(
-        filteredIndicesByCategoryAndType,
+        indicesToSearchOn,
         publicIndices,
         (a, b) => a.name === b.name
       );
     }
     // these indices may include private data
-    return filteredIndicesByCategoryAndType;
+    return indicesToSearchOn;
+  }
+
+  /**
+   * Appends the post/whiteboard/memo indices so a Callout search (the
+   * COLLABORATION_TOOLS category) also matches in the framing resources and
+   * contributions that fold up to a callout. The single whiteboards/memos
+   * indices hold both framing- and contribution-level instances, so each index
+   * is needed at most once. No-op unless Callouts are in scope (collaboration
+   * tools requested, or no category filter — meaning all categories). Deduped by
+   * index name to avoid searching an already-included index twice.
+   */
+  private withCalloutResourceIndices(
+    indices: SearchIndex[],
+    categories?: SearchCategory[]
+  ): SearchIndex[] {
+    const calloutsInScope =
+      !categories ||
+      categories.length === 0 ||
+      categories.includes(SearchCategory.COLLABORATION_TOOLS);
+    if (!calloutsInScope) {
+      return indices;
+    }
+
+    const indexStore = getIndexStore(this.indexPattern);
+    const resourceIndices = [
+      ...indexStore[SearchCategory.CONTRIBUTIONS],
+      ...indexStore[SearchCategory.FRAMINGS],
+    ];
+
+    const existingNames = new Set(indices.map(index => index.name));
+    const additions = resourceIndices.filter(index => {
+      if (existingNames.has(index.name)) {
+        return false;
+      }
+      existingNames.add(index.name);
+      return true;
+    });
+
+    return [...indices, ...additions];
   }
 
   /***

--- a/src/services/api/search/result/search.result.service.ts
+++ b/src/services/api/search/result/search.result.service.ts
@@ -136,19 +136,26 @@ export class SearchResultService {
       users,
       organizations
     );
-    // callout framings:
-    const framingResults = buildResults(
-      filtersByCategory.framings?.[0],
-      whiteboards.filter(whiteboard => !whiteboard.isContribution),
-      memos.filter(memo => !memo.isContribution)
-    );
-    // contributions include posts, whiteboards, and memos
-    const contributionResults = buildResults(
-      filtersByCategory.contributions?.[0],
-      posts,
-      whiteboards.filter(whiteboard => whiteboard.isContribution),
-      memos.filter(memo => memo.isContribution)
-    );
+    // callout framings. When foldToCallouts widened the search to pull these
+    // indices purely to fold them into callouts, the framings category is not in
+    // the requested filters; in that case this bucket stays empty so the hits
+    // surface only as folded callouts (and aren't dumped here unbounded).
+    const framingResults = filtersByCategory.framings?.[0]
+      ? buildResults(
+          filtersByCategory.framings[0],
+          whiteboards.filter(whiteboard => !whiteboard.isContribution),
+          memos.filter(memo => !memo.isContribution)
+        )
+      : EMPTY_RESULT_SET;
+    // contributions include posts, whiteboards, and memos. Same guard as framings.
+    const contributionResults = filtersByCategory.contributions?.[0]
+      ? buildResults(
+          filtersByCategory.contributions[0],
+          posts,
+          whiteboards.filter(whiteboard => whiteboard.isContribution),
+          memos.filter(memo => memo.isContribution)
+        )
+      : EMPTY_RESULT_SET;
     const spaceResults = buildResults(
       filtersByCategory.spaces?.[0],
       spaces,
@@ -1292,6 +1299,13 @@ export class SearchResultService {
     return [...memberIds, ...adminIds, ...leadIds];
   }
 }
+
+// an empty, well-formed result set for categories that were not requested
+const EMPTY_RESULT_SET: {
+  results: ISearchResult[];
+  cursor?: string;
+  total: number;
+} = { results: [], cursor: undefined, total: -1 };
 
 const buildResults = (
   filter?: SearchFilterInput,

--- a/src/services/api/search/result/search.result.service.ts
+++ b/src/services/api/search/result/search.result.service.ts
@@ -82,9 +82,10 @@ export class SearchResultService {
    * @param actorContext The agent info of the user making the search request.
    * @param filters Used to filter the end results.
    * @param spaceId The space ID to filter the search results by.
-   * @param options.foldToCallouts When true (a flow-state scoped search),
-   *   matching posts/whiteboards/memos are folded up to their containing callout
-   *   and merged into `calloutResults`, deduped by callout id (FR-017).
+   * @param options.foldToCallouts When true — set by a flow-state scoped search
+   *   or by the `foldCalloutResources` opt-in — matching posts/whiteboards/memos
+   *   are folded up to their containing callout and merged into `calloutResults`,
+   *   deduped by callout id (FR-017).
    */
   public async resolveSearchResults(
     rawSearchResults: ISearchResult[],
@@ -146,7 +147,7 @@ export class SearchResultService {
           whiteboards.filter(whiteboard => !whiteboard.isContribution),
           memos.filter(memo => !memo.isContribution)
         )
-      : EMPTY_RESULT_SET;
+      : emptyResultSet();
     // contributions include posts, whiteboards, and memos. Same guard as framings.
     const contributionResults = filtersByCategory.contributions?.[0]
       ? buildResults(
@@ -155,7 +156,7 @@ export class SearchResultService {
           whiteboards.filter(whiteboard => whiteboard.isContribution),
           memos.filter(memo => memo.isContribution)
         )
-      : EMPTY_RESULT_SET;
+      : emptyResultSet();
     const spaceResults = buildResults(
       filtersByCategory.spaces?.[0],
       spaces,
@@ -1300,12 +1301,14 @@ export class SearchResultService {
   }
 }
 
-// an empty, well-formed result set for categories that were not requested
-const EMPTY_RESULT_SET: {
+// a fresh, well-formed empty result set for categories that were not requested.
+// Returns a new object (and new results array) each call so buckets stay
+// independent and no downstream mutation can leak across them.
+const emptyResultSet = (): {
   results: ISearchResult[];
   cursor?: string;
   total: number;
-} = { results: [], cursor: undefined, total: -1 };
+} => ({ results: [], cursor: undefined, total: -1 });
 
 const buildResults = (
   filter?: SearchFilterInput,

--- a/src/services/api/search/search.service.spec.ts
+++ b/src/services/api/search/search.service.spec.ts
@@ -217,5 +217,23 @@ describe('SearchService', () => {
         { foldToCallouts: true }
       );
     });
+
+    it('enables callout folding when foldCalloutResources opt-in is set', async () => {
+      const searchData = {
+        terms: ['test'],
+        filters: [{ category: SearchCategory.COLLABORATION_TOOLS, size: 10 }],
+        foldCalloutResources: true,
+      } as any;
+
+      await service.search(searchData, actorContext);
+
+      expect(searchResultService.resolveSearchResults).toHaveBeenCalledWith(
+        expect.anything(),
+        actorContext,
+        searchData.filters,
+        undefined,
+        { foldToCallouts: true }
+      );
+    });
   });
 });

--- a/src/services/api/search/search.service.ts
+++ b/src/services/api/search/search.service.ts
@@ -63,11 +63,14 @@ export class SearchService {
       searchData,
       onlyPublicResults
     );
-    // When a flow-state scoped search is requested, callout-level folding is
-    // applied: a matching post/whiteboard/memo folds up to its containing
-    // callout, deduped, in calloutResults (FR-017). Folding is keyed on the
-    // presence of the flow-state scope, which is the surface this feature adds.
-    const foldToCallouts = Boolean(searchData.searchInFlowStateFilter);
+    // Callout-level folding: a matching post/whiteboard/memo folds up to its
+    // containing callout, deduped, in calloutResults (FR-017). Triggered either
+    // by a flow-state scoped search, or by an explicit foldCalloutResources opt-in
+    // that widens a Callout search to match in its framing resources and
+    // contributions.
+    const foldToCallouts =
+      Boolean(searchData.searchInFlowStateFilter) ||
+      Boolean(searchData.foldCalloutResources);
 
     return this.searchResultService.resolveSearchResults(
       searchResults,


### PR DESCRIPTION
## Summary

Adds an opt-in `foldCalloutResources` flag to `SearchInput`. When set, a Callout search (`COLLABORATION_TOOLS` / `CALLOUT`) also matches in the callout **framing resources** (whiteboard, memo) and its **contributions** (post, whiteboard, memo). Any match folds up to the containing Callout, deduped, in `calloutResults`.

## Behaviour

- **Opt-in only** — flag defaults to `false`; default search and existing flow-state search take identical code paths.
- Reuses the existing `buildFoldedCalloutResults` fold/dedup machinery (keyed on `callout.id`), so a Callout matching in its title **and** several contributions **and** its framing whiteboard returns exactly one result, scored by its best-matching child.
- `getIndices` widens to the `posts`/`whiteboards`/`memos` indices only when the flag is on and Callouts are in scope (deduped by index name — one `whiteboards`/`memos` index holds both framing- and contribution-level instances).
- Result resolver guards `contributionResults`/`framingResults` so fold-pulled hits aren't dumped unbounded into buckets whose category wasn't explicitly requested.

## Side-effect verdict

Safe. Three risks analysed and neutralised (default-search folding, cross-bucket duplication, unbounded leak). Schema diff is additive (non-breaking).

## Tests

Full suite green (6941 passed). New coverage: index widening on/off, non-Callout no-op, fold trigger.

## Client

Paired client change wires `foldCalloutResources: true` into the flow-state / KB search hook (separate PR in `client-web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `foldCalloutResources` setting to expand callout searches to include related framing and contribution content, then fold/deduplicate those matches under the main callout results.

* **Bug Fixes**
  * Ensured result categories (such as framings/contributions) return empty, well-formed results when they aren’t included in the selected search filters, preventing unexpected matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->