### PR TITLE
feat(mcp): bootstrap the virtual-assistant MCP API key from ASSISTANT_MCP_API_KEY

### DIFF
--- a/specs/105-bootstrap-assistant-mcp-key/contracts/README.md
+++ b/specs/105-bootstrap-assistant-mcp-key/contracts/README.md
@@ -1,0 +1,14 @@
+# Contracts: Bootstrap the virtual-assistant MCP API key
+
+This feature adds **no new wire interface** (no GraphQL, REST, or RMQ surface). Its "contract" is the
+**three-party agreement** around the shared `ASSISTANT_MCP_API_KEY` secret and the invariant of the
+row the server ensures from it.
+
+| Contract | Parties | File |
+|---|---|---|
+| Shared MCP-key secret ↔ ensured key row | ops/CI · server (bootstrap) · assistant-service | [secret-and-key-contract.md](./secret-and-key-contract.md) |
+
+> The contract matters because three independent parties must agree on **one** value: ops sets it,
+> the server registers its hash, and the assistant-service sends it as the delegation bearer. If any
+> disagree, delegated MCP fails (`capability_unavailable`). It is documented here so a future
+> environment, rotation, or re-cut keeps them aligned.

--- a/specs/105-bootstrap-assistant-mcp-key/contracts/secret-and-key-contract.md
+++ b/specs/105-bootstrap-assistant-mcp-key/contracts/secret-and-key-contract.md
@@ -1,0 +1,51 @@
+# Contract: Shared MCP-key secret ↔ ensured key row
+
+**Parties**: ops/CI (sets the secret) · `server` (`BootstrapService.ensureAssistantMcpApiKey` →
+`McpApiKeyService.ensureActorKeyFromPlaintext`) · `assistant-service` (sends the bearer).
+
+## The shared value
+
+`ASSISTANT_MCP_API_KEY` — a single secret in `alkemio-secrets`, format `mcp_<base64url(32 bytes)>`.
+
+- **ops/CI** MUST set a real value per cluster (the committed value is a non-production placeholder).
+- **server** receives it via `envFrom: secretRef: alkemio-secrets` (already wired — no manifest
+  change) and reads it at bootstrap **only** to compute `SHA-256`.
+- **assistant-service** receives the **same** secret and sends it verbatim as
+  `Authorization: Bearer <ASSISTANT_MCP_API_KEY>` for delegated MCP (`X-Alkemio-On-Behalf-Of` carries
+  the user). It is never logged or echoed to the browser.
+
+## The ensured row (server side)
+
+After bootstrap, the `mcp_api_key` table MUST contain exactly one **active** row satisfying:
+
+| Field | Value |
+|---|---|
+| `keyHash` | `SHA-256(ASSISTANT_MCP_API_KEY)` (hex) |
+| `actorId` | the `virtual-assistant` singleton actor |
+| `userId` | `null` |
+| `scopes` | `[{ operations: ['read', 'tools'] }]` |
+| `isActive` | `true` |
+
+## Ensure operation semantics (`ensureActorKeyFromPlaintext(actorId, plaintext, scopes)`)
+
+- **Input**: an actor id, a **known plaintext** (not generated here), the scopes. Output: the active
+  `McpApiKey`.
+- **Idempotent**: the keyHash lookup makes a steady-state run a **no-op** (no insert/update).
+- **Reactivate**: a matching-but-inactive row is reactivated and re-bound, never duplicated.
+- **Rotation**: any *other* active key bound to the same actor (different hash) is deactivated, so a
+  superseded secret stops authenticating.
+- **Never** generates a key, **never** writes a plaintext back to any store.
+
+## Failure modes (best-effort within bootstrap)
+
+| Condition | Behavior |
+|---|---|
+| `ASSISTANT_MCP_API_KEY` unset/empty | log a warning, **skip** (bootstrap continues); delegated MCP unavailable until set |
+| `virtual-assistant` actor not found | log a warning, **skip**; never throws |
+| DB error during ensure | propagates to bootstrap's try/catch (a genuine infra failure — not silently swallowed) |
+
+## Verification (server↔asvc end-to-end)
+
+With the row ensured and the asvc presenting the same secret as bearer, the `McpAuthGuard` /
+`mcp-delegation` strategy validates `SHA-256(bearer) == keyHash` for an active, actor-bound key →
+delegated session authenticates; tools + the budget resource resolve.

--- a/specs/105-bootstrap-assistant-mcp-key/contracts/secret-and-key-contract.md
+++ b/specs/105-bootstrap-assistant-mcp-key/contracts/secret-and-key-contract.md
@@ -32,9 +32,13 @@ After bootstrap, the `mcp_api_key` table MUST contain exactly one **active** row
   `McpApiKey`.
 - **Idempotent**: the keyHash lookup makes a steady-state run a **no-op** (no insert/update).
 - **Reactivate**: a matching-but-inactive (or mis-bound) row is reactivated and re-bound to the
-  **actor** — any `userId` is cleared so the userId/actorId XOR holds — never duplicated.
+  **actor** — any `userId` is cleared so the userId/actorId XOR holds, and its **`scopes` are
+  refreshed** to the requested set (no stale permissions) — never duplicated.
 - **Rotation**: any *other* active key bound to the same actor (different hash) is deactivated, so a
   superseded secret stops authenticating.
+- **Concurrent insert**: `keyHash` is unique; if a racing replica inserts the same hash between the
+  find and the save, the duplicate-key error is caught, the row is **re-read and re-asserted**
+  (never aborting startup).
 - **Never** generates a key, **never** writes a plaintext back to any store.
 
 ## Failure modes (best-effort within bootstrap)

--- a/specs/105-bootstrap-assistant-mcp-key/contracts/secret-and-key-contract.md
+++ b/specs/105-bootstrap-assistant-mcp-key/contracts/secret-and-key-contract.md
@@ -31,7 +31,8 @@ After bootstrap, the `mcp_api_key` table MUST contain exactly one **active** row
 - **Input**: an actor id, a **known plaintext** (not generated here), the scopes. Output: the active
   `McpApiKey`.
 - **Idempotent**: the keyHash lookup makes a steady-state run a **no-op** (no insert/update).
-- **Reactivate**: a matching-but-inactive row is reactivated and re-bound, never duplicated.
+- **Reactivate**: a matching-but-inactive (or mis-bound) row is reactivated and re-bound to the
+  **actor** — any `userId` is cleared so the userId/actorId XOR holds — never duplicated.
 - **Rotation**: any *other* active key bound to the same actor (different hash) is deactivated, so a
   superseded secret stops authenticating.
 - **Never** generates a key, **never** writes a plaintext back to any store.

--- a/specs/105-bootstrap-assistant-mcp-key/data-model.md
+++ b/specs/105-bootstrap-assistant-mcp-key/data-model.md
@@ -43,7 +43,7 @@ bootstrap **only** to compute `SHA-256` — it is never persisted in plaintext.
 
 ## State transitions (the bootstrap ensure)
 
-```
+```text
 ASSISTANT_MCP_API_KEY (env)
    │  h = SHA-256(plaintext)
    ▼
@@ -52,6 +52,6 @@ ASSISTANT_MCP_API_KEY (env)
    ▼
 findOne(keyHash = h):
    ├─ found, active, actor-bound   → no-op
-   ├─ found, inactive/mis-bound    → isActive = true, actorId = virtual-assistant
+   ├─ found, inactive/mis-bound    → isActive = true, actorId = virtual-assistant, userId = null
    └─ not found                    → INSERT { keyHash: h, actorId, scopes:[{operations:[read,tools]}], isActive }
 ```

--- a/specs/105-bootstrap-assistant-mcp-key/data-model.md
+++ b/specs/105-bootstrap-assistant-mcp-key/data-model.md
@@ -51,7 +51,8 @@ ASSISTANT_MCP_API_KEY (env)
    │
    ▼
 findOne(keyHash = h):
-   ├─ found, active, actor-bound   → no-op
-   ├─ found, inactive/mis-bound    → isActive = true, actorId = virtual-assistant, userId = null
-   └─ not found                    → INSERT { keyHash: h, actorId, scopes:[{operations:[read,tools]}], isActive }
+   ├─ found, active, actor-bound, scopes match  → no-op
+   ├─ found, inactive/mis-bound/stale scopes    → isActive = true, actorId = virtual-assistant, userId = null, scopes = requested
+   └─ not found                                 → INSERT { keyHash: h, actorId, scopes:[{operations:[read,tools]}], isActive }
+                                                  (on unique-violation race → re-read + re-assert)
 ```

--- a/specs/105-bootstrap-assistant-mcp-key/data-model.md
+++ b/specs/105-bootstrap-assistant-mcp-key/data-model.md
@@ -1,0 +1,57 @@
+# Phase 1 Data Model: Bootstrap the virtual-assistant MCP API key
+
+**Feature**: `105-bootstrap-assistant-mcp-key` | **Date**: 2026-06-26 | **Spec**: [spec.md](./spec.md)
+
+## No schema change
+
+This feature introduces **no migration, no new table or column, and no new GraphQL type**. It only
+**ensures one row** in the existing `mcp_api_key` table at bootstrap. The entities below already
+exist; they are described for the invariants this feature relies on.
+
+## Entities
+
+### `mcp_api_key` (existing table — the credential validated by the MCP host)
+
+| Field | Type | Notes (relevant to this feature) |
+|---|---|---|
+| `id` | uuid | PK |
+| `keyHash` | string | **SHA-256 hex** of the plaintext. The server stores this; never the plaintext. Lookup key. |
+| `userId` | uuid? | Exactly **one of** `userId` / `actorId`. This feature leaves it null. |
+| `actorId` | uuid? | Bound to the **`virtual-assistant`** actor for the delegation trust anchor (T040). |
+| `scopes` | jsonb | `[{ operations: string[] }]`. This feature sets `[{ operations: ['read', 'tools'] }]`. |
+| `isActive` | boolean | Only active keys validate. Rotation deactivates superseded rows. |
+| `expiresAt` | timestamptz? | Unused here (the bootstrap key does not expire). |
+| `createdDate` | timestamptz | — |
+
+**Invariant (T040)**: a key that can **delegate** MUST be `actorId`-bound to `virtual-assistant`
+(`userId` null). A user-bound or unbound key cannot delegate. This feature only ever writes an
+actor-bound row.
+
+### `virtual_assistant` actor (existing — migration-seeded singleton)
+
+The platform `virtual-assistant` actor (resolved by stable `nameID`, migrations
+`1780483789227-AddVirtualAssistantActorType` / `1780483789228-VirtualAssistant`). The trust anchor
+the key binds to. This feature reads it (`getSingletonOrFail`); it does not create or modify it.
+
+## Non-persisted configuration
+
+### `ASSISTANT_MCP_API_KEY` (shared secret — not a DB entity)
+
+One value in `alkemio-secrets`, injected into **both** the assistant-service (its delegation bearer)
+and the server (via `envFrom: alkemio-secrets`). The single source of truth. The server reads it at
+bootstrap **only** to compute `SHA-256` — it is never persisted in plaintext.
+
+## State transitions (the bootstrap ensure)
+
+```
+ASSISTANT_MCP_API_KEY (env)
+   │  h = SHA-256(plaintext)
+   ▼
+[for each active key bound to virtual-assistant with keyHash ≠ h] → isActive = false   (rotation)
+   │
+   ▼
+findOne(keyHash = h):
+   ├─ found, active, actor-bound   → no-op
+   ├─ found, inactive/mis-bound    → isActive = true, actorId = virtual-assistant
+   └─ not found                    → INSERT { keyHash: h, actorId, scopes:[{operations:[read,tools]}], isActive }
+```

--- a/specs/105-bootstrap-assistant-mcp-key/plan.md
+++ b/specs/105-bootstrap-assistant-mcp-key/plan.md
@@ -19,6 +19,30 @@ no plaintext is written back, no manifest/secret is added.
   (`src/domain/community/virtual-assistant`), the shared `ASSISTANT_MCP_API_KEY` secret.
 - **No new**: table/migration, GraphQL type, queue, env var, or k8s manifest change.
 
+## Constitution Check
+
+- **Emit events / no direct repo writes from resolvers**: N/A — this is a startup bootstrap step, not
+  a resolver; it legitimately uses the `mcp_api_key` repository via `McpApiKeyService` (the same
+  service the MCP host uses).
+- **Schema contract**: no GraphQL change → no `schema.graphql` regeneration, no breaking-change gate.
+- **Secrets governance**: no committed production secret; the server only reads the
+  externally-provided `ASSISTANT_MCP_API_KEY` and stores its hash. ✅ passes.
+
+## Project Structure (this feature)
+
+```
+specs/105-bootstrap-assistant-mcp-key/
+├── spec.md          # what & why (user stories, FRs, success criteria)
+├── plan.md          # this file — technical design
+├── research.md      # Phase 0 — decisions & alternatives
+├── data-model.md    # Phase 1 — entities (no schema change)
+├── contracts/       # Phase 1 — the shared-secret ↔ ensured-key agreement
+│   ├── README.md
+│   └── secret-and-key-contract.md
+├── quickstart.md    # Phase 1 — validation scenarios (A fresh / B idempotent / C rotation / D fail-soft)
+└── tasks.md         # Phase 2 — dependency-ordered tasks (retrofit: [X] complete)
+```
+
 ## Wiring (the load-bearing fact)
 
 The server deployment already does `envFrom: secretRef: alkemio-secrets`, and `ASSISTANT_MCP_API_KEY`
@@ -76,4 +100,4 @@ sends Authorization: Bearer <plaintext>  ───────────▶  B
 
 Deploy-runbook line in the workspace `specs/004-web-ai-assistant/contracts/config-and-secrets.md`:
 "set a real `ASSISTANT_MCP_API_KEY` per cluster; the server bootstraps the matching `mcp_api_key` row."
-(Spec acceptance item AC-4 / SC docs.)
+(Maps to **issue #1937 acceptance criterion #4** — the runbook item; tracked as tasks.md T011.)

--- a/specs/105-bootstrap-assistant-mcp-key/plan.md
+++ b/specs/105-bootstrap-assistant-mcp-key/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Bootstrap the virtual-assistant MCP API key
+
+**Branch**: `feat/1937-bootstrap-assistant-mcp-key` | **Date**: 2026-06-26 | **Spec**: [spec.md](./spec.md)
+
+> **⚠️ Retroactive backfill.** Observed from the shipped code (PR #6203), not designed ahead of it.
+
+## Summary
+
+A single idempotent step in the existing server `BootstrapService` ensures the `virtual-assistant`
+actor's `mcp_api_key` exists, derived from the shared `ASSISTANT_MCP_API_KEY` secret. The plaintext
+is the **input** (the asvc's bearer); the server stores only its SHA-256 hash. No key is generated,
+no plaintext is written back, no manifest/secret is added.
+
+## Technical Context
+
+- **Language/stack**: TypeScript 5.3, NestJS 10, TypeORM 0.3, PostgreSQL 17.5.
+- **Existing surfaces reused**: `BootstrapService` (`src/core/bootstrap`), `McpApiKeyService` +
+  `mcp_api_key` entity (`src/services/mcp-server/auth`), `VirtualAssistantService.getSingletonOrFail()`
+  (`src/domain/community/virtual-assistant`), the shared `ASSISTANT_MCP_API_KEY` secret.
+- **No new**: table/migration, GraphQL type, queue, env var, or k8s manifest change.
+
+## Wiring (the load-bearing fact)
+
+The server deployment already does `envFrom: secretRef: alkemio-secrets`, and `ASSISTANT_MCP_API_KEY`
+is already a key in that secret (the asvc consumes it as its bearer). ⇒ **the server already receives
+the value as an env var** — it just never read it. So the only "wiring" is the server *reading*
+`process.env.ASSISTANT_MCP_API_KEY`. Ops sets one value; both sides use it.
+
+## Flow
+
+```
+alkemio-secrets: ASSISTANT_MCP_API_KEY = "mcp_<…>"   (one value, set once per cluster)
+        ┌───────────────────────────────┴───────────────────────────────┐
+        ▼                                                                ▼
+assistant-service                                              server (envFrom)
+sends Authorization: Bearer <plaintext>  ───────────▶  BootstrapService.ensureAssistantMcpApiKey():
+                                                         • read ASSISTANT_MCP_API_KEY (skip+warn if unset)
+                                                         • resolve virtual-assistant singleton (skip+warn if absent)
+                                                         • McpApiKeyService.ensureActorKeyFromPlaintext(
+                                                             actorId, plaintext, [{operations:[read,tools]}])
+        │                                                        │  keyHash = SHA-256(plaintext)
+        └──────────────▶  McpAuthGuard validates the bearer ◀────┘  bound to virtual-assistant, active
+```
+
+## Key decisions
+
+- **D1 — ensure-from-env, not server-generates.** The plaintext is the input, so the server never
+  holds a secret it must distribute. The alternative (server generates a key and writes the plaintext
+  into the secret store) needs secret-write access and is racy across replicas — rejected.
+- **D2 — idempotent + rotation-aware.** Keyed on `keyHash`: create-if-absent, no-op if present,
+  reactivate a matching-but-inactive row, and deactivate other active actor-bound keys whose hash
+  differs (so a rotated secret cleanly supersedes the old one).
+- **D3 — best-effort within bootstrap.** Missing secret / missing actor → log + skip, never throw;
+  the platform still boots, only delegated MCP is unavailable (mirrors the assistant's own
+  fail-soft posture).
+- **D4 — lightweight DI.** `McpApiKeyService` is stateless (repo + logger), so `BootstrapModule`
+  **provides it directly** (+ `TypeOrmModule.forFeature([McpApiKey])`) rather than importing the
+  heavy `McpServerModule` — avoids a circular-dependency risk.
+
+## Files touched (PR #6203)
+
+| File | Change |
+|---|---|
+| `src/services/mcp-server/auth/mcp-api-key.service.ts` | `+ ensureActorKeyFromPlaintext()` (idempotent, rotation-aware) |
+| `src/core/bootstrap/bootstrap.service.ts` | `+ ensureAssistantMcpApiKey()` step in `bootstrap()` |
+| `src/core/bootstrap/bootstrap.module.ts` | import `VirtualAssistantModule`; provide `McpApiKeyService` + register `McpApiKey` |
+| `src/services/mcp-server/auth/mcp-api-key.service.spec.ts` | new unit tests (create / idempotent / reactivate / rotation) |
+
+## Testing
+
+- Unit: `mcp-api-key.service.spec.ts` covers create / idempotent no-op / reactivate / rotation.
+- Regression: `bootstrap.service.spec.ts` auto-mocks the two new ctor deps (`useMocker`) — unchanged, green.
+- The full server suite passes (run by the pre-commit hook).
+
+## Follow-up (not in this PR — different repo)
+
+Deploy-runbook line in the workspace `specs/004-web-ai-assistant/contracts/config-and-secrets.md`:
+"set a real `ASSISTANT_MCP_API_KEY` per cluster; the server bootstraps the matching `mcp_api_key` row."
+(Spec acceptance item AC-4 / SC docs.)

--- a/specs/105-bootstrap-assistant-mcp-key/quickstart.md
+++ b/specs/105-bootstrap-assistant-mcp-key/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart / Validation: Bootstrap the virtual-assistant MCP API key
+
+**Feature**: `105-bootstrap-assistant-mcp-key` | **Spec**: [spec.md](./spec.md)
+
+How to validate the feature against its success criteria. Each scenario maps to a User Story.
+
+## Prerequisites
+
+- A server DB with migrations applied (so the `virtual-assistant` actor exists).
+- `ASSISTANT_MCP_API_KEY` set to a real value (`mcp_<…>`) in the env both the server and asvc read
+  (`alkemio-secrets`).
+
+## Scenario A — Fresh deploy works (US1 / SC-001)
+
+1. Start from an **empty** `mcp_api_key` table.
+2. Start the server (bootstrap runs).
+3. Assert the row exists and is correct:
+   ```sql
+   SELECT "actorId", "userId", "isActive", scopes
+   FROM mcp_api_key
+   WHERE "keyHash" = encode(digest(:assistant_mcp_api_key, 'sha256'), 'hex');
+   -- expect: actorId = <virtual-assistant>, userId NULL, isActive true, scopes [{operations:[read,tools]}]
+   ```
+4. From the assistant-service (or a raw MCP client) open a **delegated** session with that same key
+   as `Authorization: Bearer …` + `X-Alkemio-On-Behalf-Of: <user>` → the session authenticates and a
+   tool call / budget read succeeds (no `capability_unavailable`).
+
+✅ **Pass**: working delegated MCP with **zero** manual DB/secret steps.
+
+## Scenario B — Idempotent restart (US2 / SC-002)
+
+1. With the row already present, restart the server (bootstrap runs again).
+2. Assert there is still exactly **one** active `virtual-assistant` key and its `id`/`createdDate`
+   are unchanged (no insert, no churn).
+
+✅ **Pass**: re-running bootstrap is a no-op.
+
+## Scenario C — Rotation (US3 / SC-004)
+
+1. Note the current active key's `id`.
+2. Change `ASSISTANT_MCP_API_KEY` to a new value; restart the server.
+3. Assert: the old `id` row is now `isActive = false`, and a new active row exists whose `keyHash =
+   SHA-256(new value)`.
+4. A bearer using the **old** secret no longer authenticates; the new one does.
+
+✅ **Pass**: exactly one active key (the new one); the old credential is retired.
+
+## Scenario D — Misconfiguration is non-fatal (Edge / FR-006)
+
+1. Unset `ASSISTANT_MCP_API_KEY` and start the server.
+2. Assert the server **still boots**; the log shows a warning that the virtual-assistant MCP key
+   bootstrap was skipped; only delegated MCP is unavailable.
+
+✅ **Pass**: bootstrap never fails on a missing secret/actor.
+
+## Automated coverage
+
+- `src/services/mcp-server/auth/mcp-api-key.service.spec.ts` — unit tests for the ensure logic
+  (create / idempotent / reactivate / rotation) back Scenarios A–C.
+- `src/core/bootstrap/bootstrap.service.spec.ts` — existing suite stays green (auto-mocks the two new
+  deps), guarding the wiring (Scenario D's skip path is the warn-and-return branch).

--- a/specs/105-bootstrap-assistant-mcp-key/research.md
+++ b/specs/105-bootstrap-assistant-mcp-key/research.md
@@ -1,0 +1,70 @@
+# Phase 0 Research: Bootstrap the virtual-assistant MCP API key
+
+**Feature**: `105-bootstrap-assistant-mcp-key` | **Date**: 2026-06-26 | **Spec**: [spec.md](./spec.md)
+
+> Retroactive backfill — the decisions below are **observed from the shipped code** (PR #6203) and
+> the analysis in issue #1937, recorded as the Phase 0 rationale.
+
+## Unknowns from the spec → resolved
+
+| Unknown | Resolution |
+|---|---|
+| How does the asvc's plaintext key reach the server without distributing a secret? | It doesn't need to — the **plaintext is the input**. Both sides read the same `ASSISTANT_MCP_API_KEY`; the server only derives `SHA-256(it)` (R1). |
+| Where does the ensure step run? | The existing `BootstrapService`, which already runs idempotent `ensureX()` steps every startup, after migrations (R2). |
+| How is the `virtual-assistant` actor resolved? | `VirtualAssistantService.getSingletonOrFail()` (by stable nameID) — the actor is migration-seeded (R2). |
+| How to avoid duplicate / stale keys across restarts and rotation? | Key on `keyHash`: create-if-absent, no-op if present, reactivate-if-inactive, deactivate other active actor keys on rotation (R3). |
+
+## R1 — Ensure-FROM-env, not server-generates
+
+**Decision**: The server reads `ASSISTANT_MCP_API_KEY` and ensures a row with `keyHash = SHA-256(it)`.
+It never generates a key.
+
+**Alternatives considered**:
+- **Server generates the key on bootstrap** → it holds a plaintext the asvc needs, so it must
+  *write the plaintext into the secret store*. Needs secret-write privilege, is racy across replicas,
+  and breaks the committed-secret model. **Rejected.**
+- **GraphQL/REST mutation to create the key** → the existing `POST /api-keys` endpoint binds to the
+  *authenticated caller's* actor and the `virtual-assistant` is a service actor with no login →
+  cannot create a virtual-assistant-bound key, and still needs a manual caller. **Insufficient.**
+- **Seed via DB migration** → migrations can't see the runtime secret and shouldn't carry
+  credentials; the secret may differ per cluster and rotate. **Rejected.**
+
+**Rationale**: ensure-from-env keeps the secret as the single source of truth, needs zero new
+privilege, and is naturally idempotent.
+
+## R2 — Run in `BootstrapService`, after migrations
+
+**Decision**: Add `ensureAssistantMcpApiKey()` to `BootstrapService.bootstrap()`.
+
+**Rationale**: bootstrap already does idempotent platform seeding on every startup and runs **after**
+migrations — so the `virtual-assistant` actor (seeded by migration `1780483789227/228`) reliably
+exists. A migration would run too early and can't read the secret.
+
+## R3 — Idempotency & rotation keyed on `keyHash`
+
+**Decision**: `ensureActorKeyFromPlaintext`: (a) deactivate any active actor-bound key whose hash ≠
+current (rotation); (b) find by `keyHash` → reactivate/rebind if found, else create.
+
+**Rationale**: deterministic and write-free in the steady state (the common restart case); a rotated
+secret cleanly supersedes the old key without manual cleanup or leaving a stale valid credential.
+
+## R4 — Best-effort within bootstrap (skip, don't fail)
+
+**Decision**: missing secret or missing actor → log a warning and return; never throw.
+
+**Rationale**: the platform must still boot if the assistant isn't configured in an env; only
+delegated MCP is unavailable. Mirrors the asvc's own fail-soft posture (`capability_unavailable`).
+
+## R5 — Lightweight DI (avoid `McpServerModule`)
+
+**Decision**: `BootstrapModule` provides `McpApiKeyService` directly (+ `TypeOrmModule.forFeature([McpApiKey])`)
+and imports `VirtualAssistantModule`.
+
+**Rationale**: `McpApiKeyService` is stateless (repo + logger). Importing the full `McpServerModule`
+into `BootstrapModule` risks a circular dependency and pulls in unneeded providers.
+
+## Wiring confirmation (no infra change)
+
+Confirmed the server deployment already does `envFrom: secretRef: alkemio-secrets`, and
+`ASSISTANT_MCP_API_KEY` already exists in that secret (the asvc consumes it). ⇒ the server already
+receives the value as an env var; no manifest/secret change is required.

--- a/specs/105-bootstrap-assistant-mcp-key/spec.md
+++ b/specs/105-bootstrap-assistant-mcp-key/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Bootstrap the virtual-assistant MCP API key
+
+**Feature Branch**: `feat/1937-bootstrap-assistant-mcp-key`
+
+**Created**: 2026-06-26
+
+**Status**: Backfilled (retroactive) — shipped, then spec'd (PR #6203, issue #1937)
+
+**Input**: "Delegated MCP (the Web AI Assistant) authenticates with the `virtual-assistant` actor's
+`mcp_api_key` as its trust anchor, but nothing creates that key — a fresh deploy leaves the
+`mcp_api_key` table empty, so every delegated MCP session is refused (`capability_unavailable`)
+until the key is provisioned by hand on every cluster."
+
+> **⚠️ Retroactive backfill.** This spec was written **after** the fix shipped, to record the source
+> of truth. It is single-repo (server only) — it ships as one PR, so it is **not** a workspace
+> vertical spec. The implementation is PR #6203 (`bootstrap.service.ts`, `mcp-api-key.service.ts`,
+> `bootstrap.module.ts`). Parent context: the `004-web-ai-assistant` epic (#1900), server T027/T040.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A fresh deploy yields a working delegated MCP session (Priority: P1)
+
+An operator deploys the server + assistant-service to a new cluster with a real
+`ASSISTANT_MCP_API_KEY` secret set. The assistant works immediately — it can call MCP tools and read
+its budget — **without anyone touching the database or running manual key-provisioning steps**.
+
+**Why this priority**: This is the entire point. Without it the assistant is dead on arrival in
+every environment (the `mcp_api_key` table is empty on a fresh deploy), and the failure is silent —
+it surfaces only as `capability_unavailable` in the assistant UI. acc/prod hit the same wall.
+
+**Independent Test**: On a clean DB with `ASSISTANT_MCP_API_KEY` set, start the server (bootstrap
+runs), then have the assistant-service open a delegated MCP session with that same key as its bearer
+— the session authenticates and tools/budget resolve, with no manual DB or secret surgery.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty `mcp_api_key` table and `ASSISTANT_MCP_API_KEY` set, **When** the server
+   bootstraps, **Then** an active `mcp_api_key` row exists whose `keyHash = SHA-256(ASSISTANT_MCP_API_KEY)`,
+   bound to the `virtual-assistant` actor, scoped `[read, tools]`.
+2. **Given** that row exists, **When** the assistant-service presents `ASSISTANT_MCP_API_KEY` as its
+   delegation bearer, **Then** the MCP host validates it and the delegated session succeeds.
+
+---
+
+### User Story 2 - Re-running bootstrap is safe (idempotent) (Priority: P2)
+
+The server restarts (or redeploys) repeatedly. Each bootstrap run leaves the key exactly as it was
+— no duplicate rows, no unexpected rotation, no churn.
+
+**Why this priority**: Bootstrap runs on **every** startup. A non-idempotent step would multiply
+rows or rotate the live key on each restart, breaking the running assistant.
+
+**Independent Test**: Run bootstrap twice against the same secret; assert the second run performs no
+write and the single active row is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** the key row already matches the secret, **When** bootstrap runs again, **Then** it is a
+   no-op (no insert, no update).
+2. **Given** a matching row exists but is inactive, **When** bootstrap runs, **Then** it is
+   reactivated (not duplicated).
+
+---
+
+### User Story 3 - A rotated secret cleanly supersedes the old key (Priority: P3)
+
+An operator rotates `ASSISTANT_MCP_API_KEY` to a new value. After the next bootstrap, only the new
+key authenticates; the old key no longer does.
+
+**Why this priority**: Secret rotation must not leave a stale, still-valid credential active
+(security), nor require manual cleanup.
+
+**Independent Test**: With an existing active `virtual-assistant` key, bootstrap with a different
+secret value; assert the old row is deactivated and a new active row (the new hash) exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active `virtual-assistant` key with hash A, **When** bootstrap runs with a secret
+   hashing to B (≠ A), **Then** the hash-A row is deactivated and a hash-B row is active.
+
+---
+
+### Edge Cases
+
+- **Secret unset / placeholder-empty**: bootstrap logs a warning and **skips** — it does **not** fail
+  the whole bootstrap (the rest of the platform still comes up; only delegated MCP is unavailable).
+- **`virtual-assistant` actor absent** (e.g. migrations not yet run): log a warning and skip — never
+  throw. (In practice the actor is created by migration `1780483789227/228`, which run before
+  bootstrap.)
+- **Pre-existing key bound to a *user*** with the same hash (shouldn't happen): the ensure re-asserts
+  actor-binding so the trust-anchor invariant holds.
+- **Multiple active keys for the actor** after a rotation: all whose hash ≠ current are deactivated.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: On startup the server MUST ensure an `mcp_api_key` row exists for the `virtual-assistant`
+  actor whose `keyHash` is the SHA-256 of the configured `ASSISTANT_MCP_API_KEY`, active, scoped
+  `[read, tools]` — created if absent, left unchanged if already correct.
+- **FR-002**: The key MUST be **actor-bound** to `virtual-assistant` only (never user-bound),
+  preserving the delegation trust-anchor invariant (server T040): a user-bound or unbound key must
+  not be able to delegate.
+- **FR-003**: The server MUST derive the row from the **shared secret** the assistant-service already
+  uses as its bearer; it MUST **never generate** a key the asvc would then need delivered to it, and
+  MUST **never** write a plaintext credential back to any store. The server only ever reads the
+  secret to compute its hash.
+- **FR-004**: The step MUST be **idempotent** — re-running bootstrap performs no write when the row
+  already matches; a matching-but-inactive row is reactivated rather than duplicated.
+- **FR-005**: On **secret rotation** (the configured value changes), the step MUST deactivate any
+  other active key bound to the `virtual-assistant` actor, so a superseded secret stops
+  authenticating.
+- **FR-006**: The step MUST be **best-effort within bootstrap**: a missing secret or a missing
+  `virtual-assistant` actor MUST be logged and skipped, and MUST NOT fail the overall bootstrap.
+
+### Key Entities *(include if feature involves data)*
+
+- **`mcp_api_key`** (existing table): the credential the MCP host validates. Stores `keyHash`
+  (SHA-256, never the plaintext), an exclusive `userId` **xor** `actorId` binding, `scopes`,
+  `isActive`. This feature ensures one **actor-bound** row for `virtual-assistant`.
+- **`virtual-assistant` actor** (existing, migration-seeded singleton): the delegation trust anchor
+  the key binds to; resolved by its stable `nameID`.
+- **`ASSISTANT_MCP_API_KEY`** (existing shared secret): one value in `alkemio-secrets`, already
+  injected into **both** the assistant-service (as its bearer) and the server (via
+  `envFrom: alkemio-secrets`). The single source of truth — no new secret or manifest is introduced.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A fresh deploy of server + assistant-service yields a working delegated MCP session
+  with **zero** manual DB or secret surgery.
+- **SC-002**: Re-running bootstrap (every restart) produces **no** duplicate key rows and **no**
+  unexpected rotation.
+- **SC-003**: The provisioned key is bound to the `virtual-assistant` actor **only** (a user-bound or
+  unbound key still cannot delegate).
+- **SC-004**: Rotating `ASSISTANT_MCP_API_KEY` and redeploying leaves exactly **one** active
+  `virtual-assistant` key — the new one; the old one no longer authenticates.
+
+## Assumptions
+
+- The `virtual-assistant` actor exists by bootstrap time (created by migration, which runs first).
+- `ASSISTANT_MCP_API_KEY` is set to a real value per cluster by ops/CI (the committed value is a
+  non-production placeholder); the asvc and server read the **same** secret.
+- The server already receives the secret via `envFrom: alkemio-secrets` — confirmed, so no
+  deployment/manifest change is required.
+- SHA-256 of the plaintext is the validation hash (matches the existing `validateApiKey` path).

--- a/specs/105-bootstrap-assistant-mcp-key/spec.md
+++ b/specs/105-bootstrap-assistant-mcp-key/spec.md
@@ -88,8 +88,13 @@ secret value; assert the old row is deactivated and a new active row (the new ha
   throw. (In practice the actor is created by migration `1780483789227/228`, which run before
   bootstrap.)
 - **Pre-existing key bound to a *user*** with the same hash (shouldn't happen): the ensure re-asserts
-  actor-binding so the trust-anchor invariant holds.
+  actor-binding (clearing `userId`) so the trust-anchor invariant holds.
+- **Stale scopes on a reactivated key**: reactivation refreshes the row's `scopes` to the requested
+  set, so a re-enabled key never returns with outdated permissions.
 - **Multiple active keys for the actor** after a rotation: all whose hash ≠ current are deactivated.
+- **Concurrent bootstraps (multi-replica)**: `keyHash` is unique, so two replicas racing to INSERT
+  could collide. The duplicate-key error is caught and the row re-read + re-asserted — bootstrap
+  never aborts on the race.
 
 ## Requirements *(mandatory)*
 
@@ -106,7 +111,9 @@ secret value; assert the old row is deactivated and a new active row (the new ha
   MUST **never** write a plaintext credential back to any store. The server only ever reads the
   secret to compute its hash.
 - **FR-004**: The step MUST be **idempotent** — re-running bootstrap performs no write when the row
-  already matches; a matching-but-inactive row is reactivated rather than duplicated.
+  already matches (binding, active, **and scopes**); a matching-but-inactive or stale-scoped row is
+  reactivated/refreshed rather than duplicated; and a concurrent-insert race on the unique `keyHash`
+  MUST be caught and re-asserted rather than aborting bootstrap.
 - **FR-005**: On **secret rotation** (the configured value changes), the step MUST deactivate any
   other active key bound to the `virtual-assistant` actor, so a superseded secret stops
   authenticating.

--- a/specs/105-bootstrap-assistant-mcp-key/tasks.md
+++ b/specs/105-bootstrap-assistant-mcp-key/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Bootstrap the virtual-assistant MCP API key
+
+**Feature**: `105-bootstrap-assistant-mcp-key` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+> **⚠️ Retroactive backfill.** The code already shipped (PR #6203); tasks are recorded as **done
+> (`[X]`)** to reflect the implemented work. The one open item is a doc follow-up in another repo.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: independent of the other tasks in its group (different file / no ordering dependency).
+- **[US#]**: the user story the task serves.
+
+## Phase 1: Setup
+
+No new setup — the feature reuses existing surfaces (`BootstrapService`, `McpApiKeyService`, the
+`mcp_api_key` entity, `VirtualAssistantService`, the `ASSISTANT_MCP_API_KEY` secret).
+
+## Phase 2: Foundational (blocking prerequisite for all stories)
+
+- [X] **T001** Add `McpApiKeyService.ensureActorKeyFromPlaintext(actorId, plaintext, scopes, name?)` —
+  hash the plaintext, create-if-absent / reactivate-if-inactive, and deactivate other active
+  actor-bound keys whose hash differs (rotation). Never generates a key.
+  → `src/services/mcp-server/auth/mcp-api-key.service.ts` (FR-001, FR-002, FR-003, FR-004, FR-005)
+
+## Phase 3: User Story 1 — Fresh deploy yields a working delegated session (P1) 🎯 MVP
+
+- [X] **T002** [US1] Add `BootstrapService.ensureAssistantMcpApiKey()` and call it from `bootstrap()`:
+  read `process.env.ASSISTANT_MCP_API_KEY` (skip+warn if unset), resolve the `virtual-assistant`
+  singleton via `getSingletonOrFail()` (skip+warn if absent), then call T001 with
+  `[{ operations: ['read', 'tools'] }]`. → `src/core/bootstrap/bootstrap.service.ts` (FR-001, FR-006)
+- [X] **T003** [US1] DI wiring: import `VirtualAssistantModule`, provide `McpApiKeyService`, register
+  `McpApiKey` via `TypeOrmModule.forFeature`. → `src/core/bootstrap/bootstrap.module.ts`
+- [X] **T004** [P] [US1] Unit test: creates an actor-bound row with `keyHash = SHA-256(plaintext)`,
+  `userId` null, `[read,tools]`, active. → `src/services/mcp-server/auth/mcp-api-key.service.spec.ts`
+- [X] **T005** [US1] Regression: confirm `bootstrap.service.spec.ts` still passes with the two new
+  constructor deps (auto-mocked via `useMocker`). → `src/core/bootstrap/bootstrap.service.spec.ts`
+
+## Phase 4: User Story 2 — Idempotent re-run (P2)
+
+- [X] **T006** [P] [US2] Unit tests: no write when an active correctly-bound key already exists;
+  reactivate a matching-but-inactive key (no duplicate).
+  → `src/services/mcp-server/auth/mcp-api-key.service.spec.ts` (FR-004)
+
+## Phase 5: User Story 3 — Clean rotation (P3)
+
+- [X] **T007** [P] [US3] Unit test: a stale active actor key (different hash) is deactivated and the
+  new key is created. → `src/services/mcp-server/auth/mcp-api-key.service.spec.ts` (FR-005)
+
+## Phase 6: Polish & docs
+
+- [X] **T008** [P] Validate: biome + tsc clean; `mcp-api-key` + `bootstrap` suites green; full
+  pre-commit suite green on the code commit.
+- [X] **T009** [P] Retrofit the SDD artifact set (this directory): spec.md, plan.md, research.md,
+  data-model.md, contracts/, quickstart.md, tasks.md.
+- [X] **T010** [P] Automated coverage for the FR-006 skip path — `bootstrap.service.spec.ts` asserts
+  `ensureAssistantMcpApiKey` skips (no key write) when the secret is unset / the actor is absent, and
+  ensures the `[read, tools]` key when both are present. → `src/core/bootstrap/bootstrap.service.spec.ts` (FR-006)
+
+## Deferred (cross-repo follow-up — not in PR #6203)
+
+- [ ] **T011** [P] Deploy-runbook note in the **workspace** repo (agents-hq)
+  `specs/004-web-ai-assistant/contracts/config-and-secrets.md`: "set a real `ASSISTANT_MCP_API_KEY`
+  per cluster; the server bootstraps the matching `mcp_api_key` row." Maps to **issue #1937
+  acceptance criterion #4** (the runbook item). Tracked separately because it lives in another repo.
+
+## Dependencies
+
+- **T001** (foundational ensure method) blocks **T002** (bootstrap step) and the tests **T004/T006/T007**.
+- **T003** (DI) is required for **T002** to resolve at runtime.
+- **T002 + T003** together deliver US1 (the MVP); US2 and US3 are properties of **T001** verified by
+  **T006 / T007** (no extra production code).
+
+## Mapping (traceability)
+
+| Story | FRs | Tasks | Validation |
+|---|---|---|---|
+| US1 (fresh deploy) | FR-001, FR-002, FR-003, FR-006 | T001–T005, **T010** | quickstart Scenario A, D; T004 + T010 (unit) |
+| US2 (idempotent) | FR-004 | T001, T006 | quickstart Scenario B; T006 (unit) |
+| US3 (rotation) | FR-005 | T001, T007 | quickstart Scenario C; T007 (unit) |

--- a/specs/105-bootstrap-assistant-mcp-key/tasks.md
+++ b/specs/105-bootstrap-assistant-mcp-key/tasks.md
@@ -58,7 +58,7 @@ No new setup — the feature reuses existing surfaces (`BootstrapService`, `McpA
 
 ## Deferred (cross-repo follow-up — not in PR #6203)
 
-- [ ] **T011** [P] Deploy-runbook note in the **workspace** repo (agents-hq)
+- [X] **T011** [P] Deploy-runbook note in the **workspace** repo (agents-hq, commit 6e86462)
   `specs/004-web-ai-assistant/contracts/config-and-secrets.md`: "set a real `ASSISTANT_MCP_API_KEY`
   per cluster; the server bootstraps the matching `mcp_api_key` row." Maps to **issue #1937
   acceptance criterion #4** (the runbook item). Tracked separately because it lives in another repo.

--- a/src/core/bootstrap/bootstrap.module.ts
+++ b/src/core/bootstrap/bootstrap.module.ts
@@ -9,6 +9,7 @@ import { OrganizationModule } from '@domain/community/organization/organization.
 import { OrganizationLookupModule } from '@domain/community/organization-lookup/organization.lookup.module';
 import { UserModule } from '@domain/community/user/user.module';
 import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
+import { VirtualAssistantModule } from '@domain/community/virtual-assistant/virtual.assistant.module';
 import { AccountModule } from '@domain/space/account/account.module';
 import { Space } from '@domain/space/space/space.entity';
 import { SpaceModule } from '@domain/space/space/space.module';
@@ -26,6 +27,8 @@ import { PlatformTemplatesModule } from '@platform/platform-templates/platform.t
 import { AiPersonaModule } from '@services/ai-server/ai-persona';
 import { AiServerModule } from '@services/ai-server/ai-server/ai.server.module';
 import { SearchIngestModule } from '@services/api/search/ingest';
+import { McpApiKey } from '@services/mcp-server/auth/mcp-api-key.entity';
+import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
 import { AdminAuthorizationModule } from '@src/platform-admin/domain/authorization/admin.authorization.module';
 import { BootstrapService } from './bootstrap.service';
 
@@ -47,7 +50,8 @@ import { BootstrapService } from './bootstrap.service';
     PlatformModule,
     PlatformAuthorizationPolicyModule,
     CommunicationModule,
-    TypeOrmModule.forFeature([Space]),
+    TypeOrmModule.forFeature([Space, McpApiKey]),
+    VirtualAssistantModule,
     SearchIngestModule,
     TemplatesSetModule,
     TemplatesManagerModule,
@@ -59,7 +63,7 @@ import { BootstrapService } from './bootstrap.service';
     PlatformWellKnownVirtualContributorsModule,
     RoleSetModule,
   ],
-  providers: [BootstrapService],
+  providers: [BootstrapService, McpApiKeyService],
   exports: [BootstrapService],
 })
 export class BootstrapModule {}

--- a/src/core/bootstrap/bootstrap.service.spec.ts
+++ b/src/core/bootstrap/bootstrap.service.spec.ts
@@ -1,4 +1,5 @@
-import { AuthorizationCredential } from '@common/enums';
+import { AuthorizationCredential, LogContext } from '@common/enums';
+import { EntityNotFoundException } from '@common/exceptions';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { VirtualAssistantService } from '@domain/community/virtual-assistant/virtual.assistant.service';
 import { Account } from '@domain/space/account/account.entity';
@@ -328,6 +329,9 @@ describe('BootstrapService', () => {
       keyMock = module.get(McpApiKeyService);
       vaMock = module.get(VirtualAssistantService);
       keyMock.ensureActorKeyFromPlaintext = vi.fn().mockResolvedValue({});
+      vaMock.getSingletonOrFail = vi
+        .fn()
+        .mockResolvedValue({ id: 'va-default' });
     });
     afterEach(() => {
       if (saved === undefined) delete process.env[ENV_KEY];
@@ -336,22 +340,35 @@ describe('BootstrapService', () => {
 
     const ensure = () => (service as any).ensureAssistantMcpApiKey();
 
-    it('skips (no key write) when ASSISTANT_MCP_API_KEY is unset (FR-006)', async () => {
+    it('skips before resolving the actor when ASSISTANT_MCP_API_KEY is unset (FR-006)', async () => {
       delete process.env[ENV_KEY];
+
+      await ensure();
+
+      expect(vaMock.getSingletonOrFail).not.toHaveBeenCalled();
+      expect(keyMock.ensureActorKeyFromPlaintext).not.toHaveBeenCalled();
+    });
+
+    it('skips on the expected not-found (actor absent) without writing a key (FR-006)', async () => {
+      process.env[ENV_KEY] = 'mcp_test';
+      vaMock.getSingletonOrFail = vi
+        .fn()
+        .mockRejectedValue(
+          new EntityNotFoundException('absent', LogContext.COMMUNITY)
+        );
 
       await ensure();
 
       expect(keyMock.ensureActorKeyFromPlaintext).not.toHaveBeenCalled();
     });
 
-    it('skips when the virtual-assistant actor is absent (FR-006)', async () => {
+    it('rethrows an unexpected (transient/DB) error instead of masking it as "actor absent"', async () => {
       process.env[ENV_KEY] = 'mcp_test';
       vaMock.getSingletonOrFail = vi
         .fn()
-        .mockRejectedValue(new Error('not found'));
+        .mockRejectedValue(new Error('db connection lost'));
 
-      await ensure();
-
+      await expect(ensure()).rejects.toThrow('db connection lost');
       expect(keyMock.ensureActorKeyFromPlaintext).not.toHaveBeenCalled();
     });
 

--- a/src/core/bootstrap/bootstrap.service.spec.ts
+++ b/src/core/bootstrap/bootstrap.service.spec.ts
@@ -1,9 +1,11 @@
 import { AuthorizationCredential } from '@common/enums';
 import { ActorContext } from '@core/actor-context/actor.context';
+import { VirtualAssistantService } from '@domain/community/virtual-assistant/virtual.assistant.service';
 import { Account } from '@domain/space/account/account.entity';
 import { Space } from '@domain/space/space/space.entity';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
@@ -313,6 +315,58 @@ describe('BootstrapService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('ensureAssistantMcpApiKey (#1937)', () => {
+    const ENV_KEY = 'ASSISTANT_MCP_API_KEY';
+    let saved: string | undefined;
+    let keyMock: any;
+    let vaMock: any;
+
+    beforeEach(() => {
+      saved = process.env[ENV_KEY];
+      keyMock = module.get(McpApiKeyService);
+      vaMock = module.get(VirtualAssistantService);
+      keyMock.ensureActorKeyFromPlaintext = vi.fn().mockResolvedValue({});
+    });
+    afterEach(() => {
+      if (saved === undefined) delete process.env[ENV_KEY];
+      else process.env[ENV_KEY] = saved;
+    });
+
+    const ensure = () => (service as any).ensureAssistantMcpApiKey();
+
+    it('skips (no key write) when ASSISTANT_MCP_API_KEY is unset (FR-006)', async () => {
+      delete process.env[ENV_KEY];
+
+      await ensure();
+
+      expect(keyMock.ensureActorKeyFromPlaintext).not.toHaveBeenCalled();
+    });
+
+    it('skips when the virtual-assistant actor is absent (FR-006)', async () => {
+      process.env[ENV_KEY] = 'mcp_test';
+      vaMock.getSingletonOrFail = vi
+        .fn()
+        .mockRejectedValue(new Error('not found'));
+
+      await ensure();
+
+      expect(keyMock.ensureActorKeyFromPlaintext).not.toHaveBeenCalled();
+    });
+
+    it('ensures the [read,tools] actor-bound key when secret + actor present (FR-001/FR-002)', async () => {
+      process.env[ENV_KEY] = 'mcp_test';
+      vaMock.getSingletonOrFail = vi.fn().mockResolvedValue({ id: 'va-1' });
+
+      await ensure();
+
+      expect(keyMock.ensureActorKeyFromPlaintext).toHaveBeenCalledWith(
+        'va-1',
+        'mcp_test',
+        [{ operations: ['read', 'tools'] }]
+      );
+    });
   });
 
   describe('bootstrap', () => {

--- a/src/core/bootstrap/bootstrap.service.ts
+++ b/src/core/bootstrap/bootstrap.service.ts
@@ -28,6 +28,7 @@ import { OrganizationLookupService } from '@domain/community/organization-lookup
 import { UserService } from '@domain/community/user/user.service';
 import { UserAuthorizationService } from '@domain/community/user/user.service.authorization';
 import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
+import { VirtualAssistantService } from '@domain/community/virtual-assistant/virtual.assistant.service';
 import { AccountService } from '@domain/space/account/account.service';
 import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
 import { AccountLicenseService } from '@domain/space/account/account.service.license';
@@ -49,6 +50,7 @@ import { PlatformWellKnownVirtualContributorsService } from '@platform/platform.
 import { PlatformTemplatesService } from '@platform/platform-templates/platform.templates.service';
 import { AiServerService } from '@services/ai-server/ai-server/ai.server.service';
 import { AiServerAuthorizationService } from '@services/ai-server/ai-server/ai.server.service.authorization';
+import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
 import { AdminAuthorizationService } from '@src/platform-admin/domain/authorization/admin.authorization.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Repository } from 'typeorm';
@@ -93,7 +95,9 @@ export class BootstrapService {
     private licensePlanService: LicensePlanService,
     private readonly messagingService: MessagingService,
     private platformWellKnownVirtualContributorsService: PlatformWellKnownVirtualContributorsService,
-    private roleSetService: RoleSetService
+    private roleSetService: RoleSetService,
+    private readonly virtualAssistantService: VirtualAssistantService,
+    private readonly mcpApiKeyService: McpApiKeyService
   ) {}
 
   async bootstrap() {
@@ -141,6 +145,10 @@ export class BootstrapService {
 
       await this.bootstrapLicensePlans();
       await this.ensureAuthorizationsPopulated();
+      // Register the virtual-assistant MCP trust-anchor key from the shared
+      // ASSISTANT_MCP_API_KEY secret so delegated MCP works on a fresh deploy
+      // with no manual DB surgery (issue #1937).
+      await this.ensureAssistantMcpApiKey();
       await this.ensureSpaceSingleton(anonymousActorContext);
       // reset auth as last in the actions
       // await this.ensureSpaceNamesInElastic();
@@ -152,6 +160,46 @@ export class BootstrapService {
       );
       throw new BootstrapException(error.message, { originalException: error });
     }
+  }
+
+  /**
+   * Ensure the `virtual-assistant` actor's MCP API key exists, derived from the
+   * shared `ASSISTANT_MCP_API_KEY` secret (issue #1937). The assistant-service
+   * sends this same plaintext as its delegation bearer; the server stores only
+   * its SHA-256 hash, bound to the virtual-assistant actor. Idempotent (a no-op
+   * once the row matches). Skipped — with a warning, never failing bootstrap —
+   * when the secret is unset or the actor is absent.
+   */
+  private async ensureAssistantMcpApiKey(): Promise<void> {
+    const plaintext = process.env.ASSISTANT_MCP_API_KEY?.trim();
+    if (!plaintext) {
+      this.logger.warn?.(
+        'ASSISTANT_MCP_API_KEY is not set — skipping virtual-assistant MCP key bootstrap; delegated MCP (the Web AI Assistant) is unavailable until it is provisioned',
+        LogContext.BOOTSTRAP
+      );
+      return;
+    }
+
+    const virtualAssistant = await this.virtualAssistantService
+      .getSingletonOrFail()
+      .catch(() => undefined);
+    if (!virtualAssistant) {
+      this.logger.warn?.(
+        'virtual-assistant actor not found — skipping MCP key bootstrap (the actor is created by migration; ensure migrations have run)',
+        LogContext.BOOTSTRAP
+      );
+      return;
+    }
+
+    await this.mcpApiKeyService.ensureActorKeyFromPlaintext(
+      virtualAssistant.id,
+      plaintext,
+      [{ operations: ['read', 'tools'] }]
+    );
+    this.logger.verbose?.(
+      `Ensured virtual-assistant MCP API key from ASSISTANT_MCP_API_KEY (actor ${virtualAssistant.id})`,
+      LogContext.BOOTSTRAP
+    );
   }
 
   /**

--- a/src/core/bootstrap/bootstrap.service.ts
+++ b/src/core/bootstrap/bootstrap.service.ts
@@ -15,6 +15,7 @@ import { VirtualContributorBodyOfKnowledgeType } from '@common/enums/virtual.con
 import { VirtualContributorDataAccessMode } from '@common/enums/virtual.contributor.data.access.mode';
 import { VirtualContributorInteractionMode } from '@common/enums/virtual.contributor.interaction.mode';
 import { VirtualContributorWellKnown } from '@common/enums/virtual.contributor.well.known';
+import { EntityNotFoundException } from '@common/exceptions';
 import { BootstrapException } from '@common/exceptions/bootstrap.exception';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { ActorContextService } from '@core/actor-context/actor.context.service';
@@ -28,6 +29,7 @@ import { OrganizationLookupService } from '@domain/community/organization-lookup
 import { UserService } from '@domain/community/user/user.service';
 import { UserAuthorizationService } from '@domain/community/user/user.service.authorization';
 import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
+import { IVirtualAssistant } from '@domain/community/virtual-assistant/virtual.assistant.interface';
 import { VirtualAssistantService } from '@domain/community/virtual-assistant/virtual.assistant.service';
 import { AccountService } from '@domain/space/account/account.service';
 import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
@@ -180,15 +182,21 @@ export class BootstrapService {
       return;
     }
 
-    const virtualAssistant = await this.virtualAssistantService
-      .getSingletonOrFail()
-      .catch(() => undefined);
-    if (!virtualAssistant) {
-      this.logger.warn?.(
-        'virtual-assistant actor not found — skipping MCP key bootstrap (the actor is created by migration; ensure migrations have run)',
-        LogContext.BOOTSTRAP
-      );
-      return;
+    let virtualAssistant: IVirtualAssistant;
+    try {
+      virtualAssistant =
+        await this.virtualAssistantService.getSingletonOrFail();
+    } catch (error) {
+      if (error instanceof EntityNotFoundException) {
+        this.logger.warn?.(
+          'virtual-assistant actor not found — skipping MCP key bootstrap (the actor is created by migration; ensure migrations have run)',
+          LogContext.BOOTSTRAP
+        );
+        return;
+      }
+      // A transient/DB error must NOT masquerade as "actor absent" and silently
+      // disable delegated MCP — surface it to bootstrap's error handler.
+      throw error;
     }
 
     await this.mcpApiKeyService.ensureActorKeyFromPlaintext(

--- a/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
@@ -75,6 +75,29 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
     expect(repo.save.mock.calls[0][0].isActive).toBe(true);
   });
 
+  it('clears userId when re-asserting on a user-bound matching-hash row (FR-002 XOR)', async () => {
+    const { service, repo } = build();
+    // A pre-existing row with the SAME hash but bound to a user (not the actor) —
+    // re-asserting must move it to actor-binding AND clear userId, never leave both set.
+    const existing = {
+      id: 'k1',
+      userId: 'some-user',
+      actorId: ACTOR,
+      keyHash: sha256('mcp_secret'),
+      isActive: true,
+    };
+    repo.find.mockResolvedValue([]);
+    repo.findOne.mockResolvedValue(existing);
+
+    await service.ensureActorKeyFromPlaintext(ACTOR, 'mcp_secret', SCOPES);
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    const saved = repo.save.mock.calls[0][0];
+    expect(saved.actorId).toBe(ACTOR);
+    expect(saved.userId == null).toBe(true); // null/undefined — XOR holds
+    expect(saved.isActive).toBe(true);
+  });
+
   it('rotation: deactivates a stale active key and creates the new one', async () => {
     const { service, repo } = build();
     const stale = {

--- a/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
@@ -1,0 +1,96 @@
+import { createHash } from 'crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpApiKeyService } from './mcp-api-key.service';
+
+const ACTOR = 'actor-virtual-assistant';
+const SCOPES: any = [{ operations: ['read', 'tools'] }];
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
+
+const build = () => {
+  const repo = {
+    find: vi.fn().mockResolvedValue([]),
+    findOne: vi.fn().mockResolvedValue(null),
+    save: vi.fn(async (e: any) => ({ id: e.id ?? 'new-id', ...e })),
+  };
+  const logger = { verbose: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const service = new McpApiKeyService(repo as any, logger as any);
+  return { service, repo };
+};
+
+describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates an actor-bound key (hash of the plaintext) when none exists', async () => {
+    const { service, repo } = build();
+
+    await service.ensureActorKeyFromPlaintext(ACTOR, 'mcp_secret', SCOPES);
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    const saved = repo.save.mock.calls[0][0];
+    expect(saved.actorId).toBe(ACTOR);
+    expect(saved.userId).toBeUndefined(); // actor-bound only (trust-anchor invariant)
+    expect(saved.isActive).toBe(true);
+    expect(saved.keyHash).toBe(sha256('mcp_secret')); // stores the HASH, not the secret
+    expect(saved.keyHash).toHaveLength(64);
+  });
+
+  it('is idempotent — no write when an active, correctly-bound key already exists', async () => {
+    const { service, repo } = build();
+    const existing = {
+      id: 'k1',
+      actorId: ACTOR,
+      keyHash: sha256('mcp_secret'),
+      isActive: true,
+    };
+    repo.find.mockResolvedValue([existing]); // active for actor, same hash → not stale
+    repo.findOne.mockResolvedValue(existing);
+
+    const res = await service.ensureActorKeyFromPlaintext(
+      ACTOR,
+      'mcp_secret',
+      SCOPES
+    );
+
+    expect(res).toBe(existing);
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  it('reactivates a matching but deactivated key', async () => {
+    const { service, repo } = build();
+    const existing = {
+      id: 'k1',
+      actorId: ACTOR,
+      keyHash: sha256('mcp_secret'),
+      isActive: false,
+    };
+    repo.find.mockResolvedValue([]); // no ACTIVE keys for the actor
+    repo.findOne.mockResolvedValue(existing);
+
+    await service.ensureActorKeyFromPlaintext(ACTOR, 'mcp_secret', SCOPES);
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(repo.save.mock.calls[0][0].isActive).toBe(true);
+  });
+
+  it('rotation: deactivates a stale active key and creates the new one', async () => {
+    const { service, repo } = build();
+    const stale = {
+      id: 'old',
+      actorId: ACTOR,
+      keyHash: 'oldhash',
+      isActive: true,
+    };
+    repo.find.mockResolvedValue([stale]); // active, different hash → rotated
+    repo.findOne.mockResolvedValue(null); // new hash not present yet
+
+    await service.ensureActorKeyFromPlaintext(ACTOR, 'mcp_rotated', SCOPES);
+
+    expect(repo.save).toHaveBeenCalledTimes(2);
+    const staleSave = repo.save.mock.calls.find(c => c[0].id === 'old')![0];
+    expect(staleSave.isActive).toBe(false); // old key retired
+    const created = repo.save.mock.calls.find(c => c[0].id !== 'old')![0];
+    expect(created.actorId).toBe(ACTOR);
+    expect(created.keyHash).toBe(sha256('mcp_rotated'));
+    expect(created.isActive).toBe(true);
+  });
+});

--- a/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
@@ -44,6 +44,7 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
       actorId: ACTOR,
       keyHash: sha256('mcp_secret'),
       isActive: true,
+      scopes: SCOPES,
     };
     repo.find.mockResolvedValue([existing]); // active for actor, same hash → not stale
     repo.findOne.mockResolvedValue(existing);
@@ -58,13 +59,14 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
     expect(repo.save).not.toHaveBeenCalled();
   });
 
-  it('reactivates a matching but deactivated key', async () => {
+  it('reactivates a deactivated key AND refreshes stale scopes', async () => {
     const { service, repo } = build();
     const existing = {
       id: 'k1',
       actorId: ACTOR,
       keyHash: sha256('mcp_secret'),
       isActive: false,
+      scopes: [{ operations: ['read'] }], // stale — missing 'tools'
     };
     repo.find.mockResolvedValue([]); // no ACTIVE keys for the actor
     repo.findOne.mockResolvedValue(existing);
@@ -72,7 +74,9 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
     await service.ensureActorKeyFromPlaintext(ACTOR, 'mcp_secret', SCOPES);
 
     expect(repo.save).toHaveBeenCalledTimes(1);
-    expect(repo.save.mock.calls[0][0].isActive).toBe(true);
+    const saved = repo.save.mock.calls[0][0];
+    expect(saved.isActive).toBe(true);
+    expect(saved.scopes).toEqual(SCOPES); // refreshed, not stale
   });
 
   it('clears userId when re-asserting on a user-bound matching-hash row (FR-002 XOR)', async () => {
@@ -85,6 +89,7 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
       actorId: ACTOR,
       keyHash: sha256('mcp_secret'),
       isActive: true,
+      scopes: SCOPES,
     };
     repo.find.mockResolvedValue([]);
     repo.findOne.mockResolvedValue(existing);
@@ -118,5 +123,29 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
     expect(created.actorId).toBe(ACTOR);
     expect(created.keyHash).toBe(sha256('mcp_rotated'));
     expect(created.isActive).toBe(true);
+  });
+
+  it('survives a concurrent insert race — re-reads on a unique violation, no throw', async () => {
+    const { service, repo } = build();
+    // A racing replica inserted the same hash between our find and save.
+    const raced = {
+      id: 'raced',
+      actorId: ACTOR,
+      keyHash: sha256('mcp_secret'),
+      isActive: true,
+      scopes: SCOPES,
+    };
+    repo.findOne
+      .mockResolvedValueOnce(null) // initial find: absent
+      .mockResolvedValueOnce(raced); // re-read after the duplicate-key error
+    repo.save.mockRejectedValueOnce({ code: '23505' }); // our INSERT loses the race
+
+    const res = await service.ensureActorKeyFromPlaintext(
+      ACTOR,
+      'mcp_secret',
+      SCOPES
+    );
+
+    expect(res).toBe(raced); // re-read row returned; startup not aborted
   });
 });

--- a/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
@@ -32,6 +32,9 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
     expect(saved.isActive).toBe(true);
     expect(saved.keyHash).toBe(sha256('mcp_secret')); // stores the HASH, not the secret
     expect(saved.keyHash).toHaveLength(64);
+    // FR-003: the plaintext is never persisted (no plaintext field, hash ≠ secret)
+    expect(saved.keyHash).not.toBe('mcp_secret');
+    expect((saved as any).apiKey).toBeUndefined();
   });
 
   it('is idempotent — no write when an active, correctly-bound key already exists', async () => {

--- a/src/services/mcp-server/auth/mcp-api-key.service.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.ts
@@ -122,20 +122,7 @@ export class McpApiKeyService {
       where: { keyHash },
     });
     if (existing) {
-      // Idempotent: re-assert it is active and ACTOR-bound — and clear any
-      // `userId` so the userId/actorId XOR (trust-anchor invariant) holds even if
-      // the matching-hash row was previously a user-bound key. Otherwise no-op.
-      if (
-        !existing.isActive ||
-        existing.actorId !== actorId ||
-        existing.userId
-      ) {
-        existing.isActive = true;
-        existing.actorId = actorId;
-        existing.userId = null as unknown as undefined; // NULL the column (TypeORM skips `undefined`)
-        return this.mcpApiKeyRepository.save(existing);
-      }
-      return existing;
+      return this.reassertActorKey(existing, actorId, scopes);
     }
 
     const apiKey = new McpApiKey();
@@ -144,13 +131,63 @@ export class McpApiKeyService {
     apiKey.keyHash = keyHash;
     apiKey.scopes = scopes;
     apiKey.isActive = true;
-    const saved = await this.mcpApiKeyRepository.save(apiKey);
+    try {
+      const saved = await this.mcpApiKeyRepository.save(apiKey);
+      this.logger.verbose?.(
+        `Ensured actor-bound MCP API key ${saved.id} for actor ${actorId}`,
+        LogContext.MCP_SERVER
+      );
+      return saved;
+    } catch (error) {
+      // A concurrent bootstrap (another replica) may have inserted the same
+      // unique `keyHash` between our find and save — re-read and re-assert rather
+      // than aborting startup on the duplicate-key error.
+      if (this.isUniqueViolation(error)) {
+        const raced = await this.mcpApiKeyRepository.findOne({
+          where: { keyHash },
+        });
+        if (raced) {
+          return this.reassertActorKey(raced, actorId, scopes);
+        }
+      }
+      throw error;
+    }
+  }
 
-    this.logger.verbose?.(
-      `Ensured actor-bound MCP API key ${saved.id} for actor ${actorId}`,
-      LogContext.MCP_SERVER
-    );
-    return saved;
+  /**
+   * Re-assert an existing row as the active, ACTOR-bound key with the given
+   * scopes. Clears any `userId` (XOR trust-anchor invariant) and **refreshes
+   * `scopes`** so a reactivated key never returns with stale permissions. A true
+   * no-op (no write) when the row already matches on all four.
+   */
+  private async reassertActorKey(
+    existing: McpApiKey,
+    actorId: string,
+    scopes: McpApiKeyScope[]
+  ): Promise<McpApiKey> {
+    const scopesMatch =
+      JSON.stringify(existing.scopes) === JSON.stringify(scopes);
+    if (
+      !existing.isActive ||
+      existing.actorId !== actorId ||
+      existing.userId ||
+      !scopesMatch
+    ) {
+      existing.isActive = true;
+      existing.actorId = actorId;
+      existing.userId = null as unknown as undefined; // NULL the column (TypeORM skips `undefined`)
+      existing.scopes = scopes;
+      return this.mcpApiKeyRepository.save(existing);
+    }
+    return existing;
+  }
+
+  /** Postgres `unique_violation` (23505), surfaced via TypeORM's QueryFailedError. */
+  private isUniqueViolation(error: unknown): boolean {
+    const code =
+      (error as { code?: string; driverError?: { code?: string } })?.code ??
+      (error as { driverError?: { code?: string } })?.driverError?.code;
+    return code === '23505';
   }
 
   /**

--- a/src/services/mcp-server/auth/mcp-api-key.service.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.ts
@@ -122,10 +122,17 @@ export class McpApiKeyService {
       where: { keyHash },
     });
     if (existing) {
-      // Idempotent: re-assert active + actor-bound; otherwise no-op.
-      if (!existing.isActive || existing.actorId !== actorId) {
+      // Idempotent: re-assert it is active and ACTOR-bound — and clear any
+      // `userId` so the userId/actorId XOR (trust-anchor invariant) holds even if
+      // the matching-hash row was previously a user-bound key. Otherwise no-op.
+      if (
+        !existing.isActive ||
+        existing.actorId !== actorId ||
+        existing.userId
+      ) {
         existing.isActive = true;
         existing.actorId = actorId;
+        existing.userId = null as unknown as undefined; // NULL the column (TypeORM skips `undefined`)
         return this.mcpApiKeyRepository.save(existing);
       }
       return existing;

--- a/src/services/mcp-server/auth/mcp-api-key.service.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.ts
@@ -84,6 +84,69 @@ export class McpApiKeyService {
   }
 
   /**
+   * Ensure an ACTOR-bound MCP key exists for a KNOWN plaintext (idempotent).
+   *
+   * Unlike {@link createApiKey}, this does **not** generate a secret — the
+   * plaintext is the input (the asvc's `ASSISTANT_MCP_API_KEY`), so the server
+   * only ever stores its hash. Used by bootstrap to register the
+   * `virtual-assistant` trust-anchor key from the shared secret (issue #1937):
+   * create-if-absent, no-op if already present. Any OTHER active key bound to the
+   * same actor (an older/rotated secret) is deactivated, so the current secret
+   * cleanly supersedes it.
+   */
+  async ensureActorKeyFromPlaintext(
+    actorId: string,
+    plainTextKey: string,
+    scopes: McpApiKeyScope[],
+    name = 'virtual-assistant (bootstrap)'
+  ): Promise<McpApiKey> {
+    const keyHash = this.hashApiKey(plainTextKey);
+
+    // Rotation: retire any active key bound to this actor whose hash differs —
+    // the secret changed, so the old row must stop authenticating.
+    const activeForActor = await this.mcpApiKeyRepository.find({
+      where: { actorId, isActive: true },
+    });
+    for (const stale of activeForActor) {
+      if (stale.keyHash !== keyHash) {
+        stale.isActive = false;
+        await this.mcpApiKeyRepository.save(stale);
+        this.logger.verbose?.(
+          `Deactivated rotated MCP API key ${stale.id} for actor ${actorId}`,
+          LogContext.MCP_SERVER
+        );
+      }
+    }
+
+    const existing = await this.mcpApiKeyRepository.findOne({
+      where: { keyHash },
+    });
+    if (existing) {
+      // Idempotent: re-assert active + actor-bound; otherwise no-op.
+      if (!existing.isActive || existing.actorId !== actorId) {
+        existing.isActive = true;
+        existing.actorId = actorId;
+        return this.mcpApiKeyRepository.save(existing);
+      }
+      return existing;
+    }
+
+    const apiKey = new McpApiKey();
+    apiKey.name = name;
+    apiKey.actorId = actorId;
+    apiKey.keyHash = keyHash;
+    apiKey.scopes = scopes;
+    apiKey.isActive = true;
+    const saved = await this.mcpApiKeyRepository.save(apiKey);
+
+    this.logger.verbose?.(
+      `Ensured actor-bound MCP API key ${saved.id} for actor ${actorId}`,
+      LogContext.MCP_SERVER
+    );
+    return saved;
+  }
+
+  /**
    * Validate an API key and return the entity if valid
    */
   async validateApiKey(plainTextKey: string): Promise<McpApiKey | null> {


### PR DESCRIPTION
## Summary

Closes #1937. Delegated MCP (the Web AI Assistant) authenticates with the `virtual-assistant` actor's `mcp_api_key` as its trust anchor — but **nothing created that key**, so a fresh deploy left the `mcp_api_key` table empty and every delegated session was refused (`capability_unavailable`) until someone hand-provisioned the key on each cluster.

This adds an **idempotent server bootstrap step** that registers the key from the **shared `ASSISTANT_MCP_API_KEY` secret** — the asvc already sends it as its delegation bearer, and the **server already receives it via `envFrom: alkemio-secrets`** (confirmed — *no manifest/secret change needed*). Ops sets one value; both sides use it.

### How it works
The plaintext is the **input**, never an output the server has to hand back:

```
alkemio-secrets: ASSISTANT_MCP_API_KEY  ──▶  asvc: Bearer <plaintext>  ─┐
                              └──▶ server bootstrap: ensure mcp_api_key  │
                                   keyHash = SHA-256(it), actor=virtual- │
                                   assistant, [read,tools]               │
                                            server validates bearer ◀────┘
```

- `McpApiKeyService.ensureActorKeyFromPlaintext(actorId, plaintext, scopes)` — stores `SHA-256(plaintext)` bound to the actor; create-if-absent, no-op if present; deactivates any *other* active key for that actor (clean rotation). It never generates a secret.
- `BootstrapService.ensureAssistantMcpApiKey()` — reads `ASSISTANT_MCP_API_KEY`, resolves the `virtual-assistant` singleton (migration-seeded, so it exists by bootstrap), ensures the `[read, tools]` key. **Skipped with a warning — never fails bootstrap —** when the secret is unset or the actor is absent.

### Acceptance criteria (from #1937)
- [x] Fresh deploy of server + asvc → working delegated MCP session, **no manual DB/secret surgery**.
- [x] **Idempotent** — keyed on `keyHash`; re-runs are no-ops.
- [x] Bound to the **`virtual-assistant` actor only** (actor-bound, `userId` null) — preserves the T040 trust-anchor invariant.
- [ ] **Runbook note** (workspace `config-and-secrets.md`): "set a real `ASSISTANT_MCP_API_KEY` per cluster; the server bootstraps the matching key row." — *follow-up in agents-hq (different repo); happy to do it.*

### Tests
`mcp-api-key.service.spec.ts` (new): create / idempotent-no-op / reactivate / rotation-retires-stale. The existing `bootstrap.service.spec.ts` auto-mocks the two new ctor deps (`useMocker`) — 17/17 still green. Full local suite passed in the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * During bootstrap, the server now ensures the `virtual-assistant` has an MCP API key derived from `ASSISTANT_MCP_API_KEY` (stored/verified via SHA-256 hash) with the required scopes.
* **Bug Fixes**
  * Bootstrap is fail-soft: it logs and skips when the secret or `virtual-assistant` actor is missing; it’s idempotent and rotation-aware (reactivates matching keys and deactivates stale ones).
* **Documentation**
  * Added specs, quickstart/validation, and contract docs describing the hash-based invariant and expected behaviors.
* **Tests**
  * Added unit and bootstrap tests covering creation, idempotency, reactivation, rotation, and skip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->