### PR TITLE
feat(auth-reset): config-driven queue + dedicated worker role

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -442,6 +442,18 @@ microservices:
       # RabbitMQ password
       password: ${RABBITMQ_PASSWORD}:alkemio!
 
+    # Authorization / license reset queue + deployment role.
+    auth_reset:
+      # Queue the reset events flow over. Publisher (normal server) and the
+      # dedicated consumer (worker) MUST agree on this name.
+      queue: ${RABBITMQ_AUTH_RESET_QUEUE}:alkemio-auth-reset
+
+      # Set to true ONLY on the dedicated, KEDA-scaled auth-reset worker
+      # deployment. That process binds ONLY this queue. The normal server keeps
+      # this false: it publishes reset events but never consumes them, so it
+      # never competes with the worker for messages.
+      worker: ${AUTH_RESET_WORKER}:false
+
     # configuration for the event bus used by the AiServer
     event_bus:
       exchange: ${RABBITMQ_EVENT_BUS_EXCHANGE}:event-bus

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -442,17 +442,11 @@ microservices:
       # RabbitMQ password
       password: ${RABBITMQ_PASSWORD}:alkemio!
 
-    # Authorization / license reset queue + deployment role.
+    # Authorization / license reset queue. Consumed by the dedicated worker
+    # (src/main.worker.ts); the normal server publishes reset events here but
+    # never consumes them. Publisher and worker MUST agree on this name.
     auth_reset:
-      # Queue the reset events flow over. Publisher (normal server) and the
-      # dedicated consumer (worker) MUST agree on this name.
       queue: ${RABBITMQ_AUTH_RESET_QUEUE}:alkemio-auth-reset
-
-      # Set to true ONLY on the dedicated, KEDA-scaled auth-reset worker
-      # deployment. That process binds ONLY this queue. The normal server keeps
-      # this false: it publishes reset events but never consumes them, so it
-      # never competes with the worker for messages.
-      worker: ${AUTH_RESET_WORKER}:false
 
     # configuration for the event bus used by the AiServer
     event_bus:

--- a/src/core/bootstrap/auth-reset.worker.module.ts
+++ b/src/core/bootstrap/auth-reset.worker.module.ts
@@ -115,11 +115,6 @@ import { WorkerEventBusModule } from './worker.event-bus.module';
     WinstonModule.forRootAsync({
       useClass: WinstonConfigService,
     }),
-    // Client proxies (publishers, lazy). Its GraphQL-subscription PubSub engines
-    // would normally open a RabbitMQ connection+consumer each, but main.worker.ts
-    // sets ALKEMIO_DISABLE_SUBSCRIPTIONS=true so subscriptionFactory returns
-    // in-memory PubSub — the worker opens NO subscription connections.
-    MicroservicesModule,
     // In-process CQRS EventBus only (no AI event-bus RabbitMQ connection). The
     // full EventBusModule is deliberately NOT in this graph.
     WorkerEventBusModule,

--- a/src/core/bootstrap/auth-reset.worker.module.ts
+++ b/src/core/bootstrap/auth-reset.worker.module.ts
@@ -1,7 +1,6 @@
 import configuration from '@config/configuration';
 import { WinstonConfigService } from '@config/winston.config';
 import { GraphqlGuardModule } from '@core/authorization/graphql.guard.module';
-import { MicroservicesModule } from '@core/microservices/microservices.module';
 import { Cipher, EncryptionModule } from '@hedger/nestjs-encryption';
 import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';

--- a/src/core/bootstrap/auth-reset.worker.module.ts
+++ b/src/core/bootstrap/auth-reset.worker.module.ts
@@ -1,0 +1,133 @@
+import configuration from '@config/configuration';
+import { WinstonConfigService } from '@config/winston.config';
+import { GraphqlGuardModule } from '@core/authorization/graphql.guard.module';
+import { MicroservicesModule } from '@core/microservices/microservices.module';
+import { Cipher, EncryptionModule } from '@hedger/nestjs-encryption';
+import { CacheModule } from '@nestjs/cache-manager';
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthResetSubscriberModule } from '@services/auth-reset/subscriber/auth-reset.subscriber.module';
+import { AlkemioConfig } from '@src/types';
+import * as redisStore from 'cache-manager-redis-store';
+import { WinstonModule } from 'nest-winston';
+import { join } from 'path';
+import { WorkerEventBusModule } from './worker.event-bus.module';
+
+/**
+ * Restricted root module for the dedicated auth-reset worker (src/main.worker.ts).
+ *
+ * It loads ONLY what the authorization/license reset consumer needs: the shared
+ * infrastructure (config, database, cache, event bus, logging, encryption,
+ * RabbitMQ client proxies) plus AuthResetSubscriberModule. It deliberately does
+ * NOT import GraphQLModule/Apollo, the REST controllers, OIDC/authentication,
+ * BootstrapModule (seeding) or any resolver module — none of that is needed to
+ * consume the queue, and skipping it keeps the worker lean and fast to boot.
+ *
+ * Infrastructure blocks below are kept in sync with AppModule's root setup.
+ */
+@Module({
+  imports: [
+    EncryptionModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService<AlkemioConfig, true>) => {
+        const key = configService.get('security.encryption_key', {
+          infer: true,
+        });
+        return {
+          key,
+          cipher: Cipher.AES_256_CBC,
+        };
+      },
+    }),
+    ConfigModule.forRoot({
+      envFilePath: ['.env'],
+      isGlobal: true,
+      load: [configuration],
+    }),
+    // Required: CommunicationAdapterEventService (in the reset graph) injects
+    // EventEmitter2, and domain services emit lifecycle events through it.
+    EventEmitterModule.forRoot({
+      global: true,
+    }),
+    // NOTE: ScheduleModule is deliberately NOT imported. Nothing in the reset
+    // graph injects SchedulerRegistry, and omitting it means the only @Cron in
+    // the graph (PushSubscriptionService stale-subscription cleanup) is never
+    // wired, so the worker runs reset work ONLY. Do not add it back.
+    CacheModule.registerAsync({
+      isGlobal: true,
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService<AlkemioConfig, true>) => {
+        const { host, port, timeout } = configService.get('storage.redis', {
+          infer: true,
+        });
+        return {
+          store: redisStore,
+          host,
+          port,
+          redisOptions: { connectTimeout: timeout * 1000 },
+        };
+      },
+      inject: [ConfigService],
+    }),
+    TypeOrmModule.forRootAsync({
+      name: 'default',
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService<AlkemioConfig, true>) => {
+        const dbOptions = configService.get('storage.database', {
+          infer: true,
+        });
+
+        const pgbouncerEnabled = dbOptions.pgbouncer?.enabled ?? false;
+        const statementTimeoutMs =
+          dbOptions.pgbouncer?.statement_timeout_ms ?? 60000;
+
+        return {
+          type: 'postgres' as const,
+          synchronize: false,
+          cache: true,
+          entities: [join(__dirname, '..', '..', '**', '*.entity.{ts,js}')],
+          subscribers: [
+            join(__dirname, '..', '..', '**', '*.write.guard.{ts,js}'),
+          ],
+          host: dbOptions.host,
+          port: dbOptions.port,
+          username: dbOptions.username,
+          password: dbOptions.password,
+          database: dbOptions.database,
+          logging: dbOptions.logging,
+          extra: {
+            max: dbOptions.pool?.max ?? 50,
+            idleTimeoutMillis: dbOptions.pool?.idle_timeout_ms ?? 30000,
+            connectionTimeoutMillis:
+              dbOptions.pool?.connection_timeout_ms ?? 10000,
+            ...(pgbouncerEnabled && {
+              statement_timeout: statementTimeoutMs,
+              idle_in_transaction_session_timeout: statementTimeoutMs * 2,
+            }),
+          },
+        };
+      },
+    }),
+    WinstonModule.forRootAsync({
+      useClass: WinstonConfigService,
+    }),
+    // Client proxies (publishers, lazy). Its GraphQL-subscription PubSub engines
+    // would normally open a RabbitMQ connection+consumer each, but main.worker.ts
+    // sets ALKEMIO_DISABLE_SUBSCRIPTIONS=true so subscriptionFactory returns
+    // in-memory PubSub — the worker opens NO subscription connections.
+    MicroservicesModule,
+    // In-process CQRS EventBus only (no AI event-bus RabbitMQ connection). The
+    // full EventBusModule is deliberately NOT in this graph.
+    WorkerEventBusModule,
+    // @Global — provides GraphqlGuard (+ re-exports AuthorizationModule and
+    // ActorContextModule) that domain modules using @UseGuards(GraphqlGuard)
+    // silently depend on. Ambient global AppModule supplies.
+    GraphqlGuardModule,
+    AuthResetSubscriberModule,
+  ],
+})
+export class AuthResetWorkerModule {}

--- a/src/core/bootstrap/worker.event-bus.module.ts
+++ b/src/core/bootstrap/worker.event-bus.module.ts
@@ -1,0 +1,31 @@
+import { Global, Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+
+/**
+ * Minimal EventBus provider for the auth-reset worker.
+ *
+ * The reset graph (via AiServerModule's AiPersonaEngineAdapter) injects the CQRS
+ * `EventBus`, but the worker must NOT run the full AI EventBusModule — that one
+ * opens RabbitMQ publisher/subscriber connections and asserts the AI event-bus
+ * exchange/queues on boot, which is exactly the extra server activity we don't
+ * want. CqrsModule provides an in-process EventBus that satisfies DI; the reset
+ * path never publishes engine events, so no broker connection is needed.
+ *
+ * ⚠️ ISOLATION INVARIANT — this swap is load-bearing. EventBusModule is the
+ * golevelup `'default'` connection (its forRootAsync sets no `name`). Every
+ * `@RabbitSubscribe` handler that rides into the reset graph transitively
+ * (CommunicationAdapterEventService → Matrix msg/reaction/edit queues,
+ * PushDeliveryService → alkemio-push-notifications, MatrixRoomCheckController)
+ * targets that `'default'` connection. Because EventBusModule is absent here,
+ * the `'default'` connection — and its handler-discovery service — never exists,
+ * so NONE of those handlers bind and the worker consumes only the auth_reset
+ * queue. Do NOT import EventBusModule (or any other unnamed golevelup
+ * RabbitMQModule.forRoot) into the worker graph, or the worker becomes a
+ * competing consumer that steals Matrix/push messages from the API server.
+ */
+@Global()
+@Module({
+  imports: [CqrsModule],
+  exports: [CqrsModule],
+})
+export class WorkerEventBusModule {}

--- a/src/core/microservices/client.proxy.factory.ts
+++ b/src/core/microservices/client.proxy.factory.ts
@@ -8,8 +8,11 @@ const QUEUE_CONTEXT_MAP: { [key in MessagingQueue]?: LogContext } = {
   [MessagingQueue.AUTH_RESET]: LogContext.AUTH,
 };
 
-export const clientProxyFactory = (queue: MessagingQueue, durable = true) => {
-  const context = QUEUE_CONTEXT_MAP[queue];
+export const clientProxyFactory = (
+  queue: MessagingQueue | string,
+  durable = true
+) => {
+  const context = QUEUE_CONTEXT_MAP[queue as MessagingQueue];
   return async (
     logger: LoggerService,
     configService: ConfigService<AlkemioConfig, true>

--- a/src/core/microservices/microservices.module.ts
+++ b/src/core/microservices/microservices.module.ts
@@ -12,9 +12,16 @@ import {
   WHITEBOARD_COLLABORATION_SERVICE,
 } from '@common/constants/providers';
 import { MessagingQueue } from '@common/enums/messaging.queue';
-import { Global, Inject, Module, OnModuleDestroy } from '@nestjs/common';
+import {
+  Global,
+  Inject,
+  LoggerService,
+  Module,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RABBITMQ_EXCHANGE_NAME_DIRECT } from '@src/common/constants';
+import { AlkemioConfig } from '@src/types';
 import { PubSubEngine } from 'graphql-subscriptions';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
@@ -71,7 +78,18 @@ const subscriptionFactoryProviders = subscriptionConfig.map(
     },
     {
       provide: AUTH_RESET_SERVICE,
-      useFactory: clientProxyFactory(MessagingQueue.AUTH_RESET),
+      // Queue name comes from config (microservices.rabbitmq.auth_reset.queue)
+      // so publisher and the dedicated worker consumer stay in lock-step.
+      useFactory: (
+        logger: LoggerService,
+        configService: ConfigService<AlkemioConfig, true>
+      ) => {
+        const queue = configService.get(
+          'microservices.rabbitmq.auth_reset.queue',
+          { infer: true }
+        );
+        return clientProxyFactory(queue)(logger, configService);
+      },
       inject: [WINSTON_MODULE_NEST_PROVIDER, ConfigService],
     },
     {

--- a/src/core/microservices/subscription.factory.spec.ts
+++ b/src/core/microservices/subscription.factory.spec.ts
@@ -42,9 +42,37 @@ describe('subscriptionFactory', () => {
 
     expect(result).toBeInstanceOf(PubSub);
     expect(logger.log).toHaveBeenCalledWith(
-      'Skipping RabbitMQ connection for schema bootstrap',
+      'Skipping RabbitMQ subscription connection (in-memory PubSub)',
       LogContext.SUBSCRIPTIONS
     );
+  });
+
+  it('should return an in-memory PubSub when ALKEMIO_DISABLE_SUBSCRIPTIONS=true (auth-reset worker)', async () => {
+    const prev = process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS;
+    process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS = 'true';
+    try {
+      // isBootstrap=false, but the env flag must still short-circuit to an
+      // in-memory PubSub so the worker opens no RabbitMQ subscription consumers.
+      const result = await subscriptionFactory(
+        logger,
+        configService as any,
+        'exchange',
+        'queue',
+        false
+      );
+
+      expect(result).toBeInstanceOf(PubSub);
+      expect(logger.log).toHaveBeenCalledWith(
+        'Skipping RabbitMQ subscription connection (in-memory PubSub)',
+        LogContext.SUBSCRIPTIONS
+      );
+    } finally {
+      if (prev === undefined) {
+        delete process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS;
+      } else {
+        process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS = prev;
+      }
+    }
   });
 
   it('should return undefined when amqp connection fails', async () => {

--- a/src/core/microservices/subscription.factory.ts
+++ b/src/core/microservices/subscription.factory.ts
@@ -48,9 +48,15 @@ export async function subscriptionFactory(
   queueName: string,
   isBootstrap = false
 ): Promise<PubSubEngine | undefined> {
-  if (isBootstrap) {
+  // Processes that do not serve GraphQL subscriptions (schema bootstrap, the
+  // dedicated auth-reset worker) must not open a RabbitMQ connection + consumer
+  // per subscription topic. Both fall back to an in-memory PubSub. The worker
+  // flag is read from process.env (not a DI token) so it cannot be shadowed by
+  // the @Global IS_SCHEMA_BOOTSTRAP=false that MicroservicesModule declares and
+  // that is pulled in transitively by domain modules (e.g. UserModule).
+  if (isBootstrap || process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS === 'true') {
     logger.log?.(
-      'Skipping RabbitMQ connection for schema bootstrap',
+      'Skipping RabbitMQ subscription connection (in-memory PubSub)',
       LogContext.SUBSCRIPTIONS
     );
     return new PubSub();

--- a/src/domain/actor/actor.display.name.spec.ts
+++ b/src/domain/actor/actor.display.name.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { IActor } from './actor/actor.interface';
-import { getMatrixDisplayName } from './actor.matrix.display.name';
+import { getActorDisplayName } from './actor.display.name';
 
-describe('getMatrixDisplayName', () => {
+describe('getActorDisplayName', () => {
   const makeActor = (
     profileDisplayName: string | undefined,
     nameID: string
@@ -16,29 +16,29 @@ describe('getMatrixDisplayName', () => {
     }) as any;
 
   it('returns trimmed profile.displayName when populated', () => {
-    expect(getMatrixDisplayName(makeActor('Jane Doe', 'jane-doe'))).toBe(
+    expect(getActorDisplayName(makeActor('Jane Doe', 'jane-doe'))).toBe(
       'Jane Doe'
     );
-    expect(getMatrixDisplayName(makeActor('  Jane Doe  ', 'jane-doe'))).toBe(
+    expect(getActorDisplayName(makeActor('  Jane Doe  ', 'jane-doe'))).toBe(
       'Jane Doe'
     );
   });
 
   it('falls back to nameID when profile.displayName is whitespace-only', () => {
-    expect(getMatrixDisplayName(makeActor('   ', 'jane-doe'))).toBe('jane-doe');
+    expect(getActorDisplayName(makeActor('   ', 'jane-doe'))).toBe('jane-doe');
   });
 
   it('falls back to nameID when profile.displayName is empty string', () => {
-    expect(getMatrixDisplayName(makeActor('', 'jane-doe'))).toBe('jane-doe');
+    expect(getActorDisplayName(makeActor('', 'jane-doe'))).toBe('jane-doe');
   });
 
   it('falls back to nameID when profile is undefined', () => {
-    expect(getMatrixDisplayName(makeActor(undefined, 'jane-doe'))).toBe(
+    expect(getActorDisplayName(makeActor(undefined, 'jane-doe'))).toBe(
       'jane-doe'
     );
   });
 
   it('returns nameID empty string when both are empty (defensive — not reachable in production given PG NOT NULL constraints)', () => {
-    expect(getMatrixDisplayName(makeActor(undefined, ''))).toBe('');
+    expect(getActorDisplayName(makeActor(undefined, ''))).toBe('');
   });
 });

--- a/src/domain/actor/actor.display.name.ts
+++ b/src/domain/actor/actor.display.name.ts
@@ -1,12 +1,12 @@
 import { IActor } from '@domain/actor/actor/actor.interface';
 
 /**
- * Canonical Matrix-side displayName formula for any Actor.
+ * Canonical, PII-safe displayName formula for any Actor.
  *
  * Returns `actor.profile.displayName` (trimmed) when non-empty, otherwise falls
  * back to `actor.nameID`. Email is explicitly NEVER used as a fallback (FR-018:
- * email is PII and would leak into Matrix room state if surfaced as a member's
- * displayName).
+ * email is PII and must not leak into any surface that shows a member's name —
+ * e.g. Matrix room state or the Collabora editor's UserFriendlyName).
  *
  * This formula is uniform across all Actor types (User, VirtualContributor,
  * Organization, Space, Account, ...) — `profile` and `nameID` are inherited
@@ -19,16 +19,17 @@ import { IActor } from '@domain/actor/actor/actor.interface';
  * `user.identity.service.ts:312`), so the helper yields the same string as
  * today's `firstName + lastName` formula for the 99% case. It diverges only
  * when a profile owner later edits their displayName, in which case the
- * Matrix-side name correctly follows the edit instead of being frozen.
+ * displayed name correctly follows the edit instead of being frozen.
  *
  * Used at:
- *   - The new `room.info` RPC handler (feature 099-element-room-check)
+ *   - The `room.info` RPC handler (feature 099-element-room-check)
  *   - `UserService.syncActor` (replaces the email-leaking formula)
  *   - `AdminCommunicationSpaceSyncService.syncDisplayNames` (User + VC iterations)
  *   - `VirtualContributorService.syncActor`
+ *   - `MessagingService` member-name resolution
  *
  * Pure function. No DI, no logging, no side effects.
  */
-export const getMatrixDisplayName = (actor: IActor): string => {
+export const getActorDisplayName = (actor: IActor): string => {
   return actor.profile?.displayName?.trim() || actor.nameID;
 };

--- a/src/domain/collaboration/collabora-document/collabora.document.module.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.module.ts
@@ -1,4 +1,5 @@
 import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { ActorLookupModule } from '@domain/actor/actor-lookup/actor.lookup.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { ProfileModule } from '@domain/common/profile/profile.module';
 import { DocumentModule } from '@domain/storage/document/document.module';
@@ -20,6 +21,7 @@ import { CollaboraDocumentAuthorizationService } from './collabora.document.serv
 @Module({
   imports: [
     AuthorizationModule,
+    ActorLookupModule,
     AuthorizationPolicyModule,
     DocumentModule,
     ProfileModule,

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
@@ -74,5 +74,100 @@ describe('CollaboraDocumentResolverQueries', () => {
         accessTokenTTL: 3600,
       });
     });
+
+    it("forwards an authenticated user's profile display name to the WOPI service (#6170)", async () => {
+      vi.mocked(
+        collaboraDocumentService.getCollaboraDocumentOrFail
+      ).mockResolvedValue({
+        id: 'collab-doc-1',
+        authorization: { id: 'auth-1' },
+        profile: { displayName: 'Quarterly Report' },
+      } as any);
+      vi.mocked(collaboraDocumentService.getEditorUrl).mockResolvedValue({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+
+      const actorLookupService = (resolver as any).actorLookupService;
+      vi.mocked(actorLookupService.getActorById).mockResolvedValue({
+        profile: { displayName: 'Alice Anderson' },
+        nameID: 'alice',
+      } as any);
+
+      const actorContext = { actorID: 'user-1', isGuest: false } as any;
+      await resolver.collaboraEditorUrl(actorContext, 'collab-doc-1');
+
+      expect(actorLookupService.getActorById).toHaveBeenCalledWith('user-1');
+      expect(collaboraDocumentService.getEditorUrl).toHaveBeenCalledWith(
+        'collab-doc-1',
+        'user-1',
+        'Alice Anderson'
+      );
+    });
+
+    it('still returns the editor URL when actor-name resolution fails (best-effort, #6170)', async () => {
+      vi.mocked(
+        collaboraDocumentService.getCollaboraDocumentOrFail
+      ).mockResolvedValue({
+        id: 'collab-doc-1',
+        authorization: { id: 'auth-1' },
+        profile: { displayName: 'Quarterly Report' },
+      } as any);
+      vi.mocked(collaboraDocumentService.getEditorUrl).mockResolvedValue({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+
+      const actorLookupService = (resolver as any).actorLookupService;
+      vi.mocked(actorLookupService.getActorById).mockRejectedValue(
+        new Error('db down')
+      );
+
+      const actorContext = { actorID: 'user-1', isGuest: false } as any;
+      const result = await resolver.collaboraEditorUrl(
+        actorContext,
+        'collab-doc-1'
+      );
+
+      // Lookup failure is swallowed: name omitted, document still opens.
+      expect(collaboraDocumentService.getEditorUrl).toHaveBeenCalledWith(
+        'collab-doc-1',
+        'user-1',
+        undefined
+      );
+      expect(result).toEqual({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+    });
+
+    it('uses the guest name from the ActorContext without an actor lookup (#6170)', async () => {
+      vi.mocked(
+        collaboraDocumentService.getCollaboraDocumentOrFail
+      ).mockResolvedValue({
+        id: 'collab-doc-1',
+        authorization: { id: 'auth-1' },
+        profile: { displayName: 'Quarterly Report' },
+      } as any);
+      vi.mocked(collaboraDocumentService.getEditorUrl).mockResolvedValue({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+
+      const actorLookupService = (resolver as any).actorLookupService;
+      const actorContext = {
+        actorID: 'guest-abc',
+        isGuest: true,
+        guestName: 'Guest Bob',
+      } as any;
+      await resolver.collaboraEditorUrl(actorContext, 'collab-doc-1');
+
+      expect(actorLookupService.getActorById).not.toHaveBeenCalled();
+      expect(collaboraDocumentService.getEditorUrl).toHaveBeenCalledWith(
+        'collab-doc-1',
+        'guest-abc',
+        'Guest Bob'
+      );
+    });
   });
 });

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
@@ -2,6 +2,8 @@ import { CurrentActor } from '@common/decorators';
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
+import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { Inject } from '@nestjs/common';
 import { Args, Query, Resolver } from '@nestjs/graphql';
@@ -22,7 +24,8 @@ export class CollaboraDocumentResolverQueries {
     private authorizationService: AuthorizationService,
     private collaboraDocumentService: CollaboraDocumentService,
     private contributionReporter: ContributionReporterService,
-    private communityResolverService: CommunityResolverService
+    private communityResolverService: CommunityResolverService,
+    private actorLookupService: ActorLookupService
   ) {}
 
   @Query(() => CollaboraEditorUrlResult, {
@@ -49,9 +52,14 @@ export class CollaboraDocumentResolverQueries {
     // Identity is resolved from the ActorContext (alkemio_session cookie /
     // forwardAuth), not an inbound Bearer JWT. The WOPI service trusts the
     // X-Alkemio-Actor-Id header the adapter stamps on the internal call.
+    // The actor name is resolved here (the only layer that sees guest names)
+    // and forwarded so the WOPI CheckFileInfo UserFriendlyName is the real name
+    // instead of "UnknownUser" (#6170 — forwardAuth no longer carries it).
+    const actorName = await this.resolveActorName(actorContext);
     const editorUrl = await this.collaboraDocumentService.getEditorUrl(
       collaboraDocumentID,
-      actorContext.actorID
+      actorContext.actorID,
+      actorName
     );
 
     // Lifecycle analytics (US4 / FR-014): one COLLABORA_DOCUMENT_OPENED record
@@ -86,5 +94,41 @@ export class CollaboraDocumentResolverQueries {
     }
 
     return editorUrl;
+  }
+
+  /**
+   * Resolves the human-readable name to surface in the Collabora editor.
+   * Guests carry their name on the ActorContext (no Actor row exists for the
+   * synthetic guest id); authenticated users get the canonical, PII-safe
+   * `getActorDisplayName` (profile.displayName → nameID, never email).
+   * Returns undefined when no name can be resolved (anonymous, or a failed
+   * lookup), letting the WOPI service apply its own fallback.
+   *
+   * Best-effort by design: `actorName` is optional and the editor flow works
+   * without it, so a failed actor lookup must NEVER block opening the document
+   * (mirrors the best-effort analytics block in collaboraEditorUrl, FR-008).
+   */
+  private async resolveActorName(
+    actorContext: ActorContext
+  ): Promise<string | undefined> {
+    if (actorContext.isGuest) {
+      return actorContext.guestName;
+    }
+    try {
+      const actor = await this.actorLookupService.getActorById(
+        actorContext.actorID
+      );
+      return actor ? getActorDisplayName(actor) : undefined;
+    } catch (e: any) {
+      this.logger.warn?.(
+        {
+          message: 'Failed to resolve actor name for Collabora editor',
+          actorId: actorContext.actorID,
+          error: e?.message,
+        },
+        LogContext.COLLABORATION
+      );
+      return undefined;
+    }
   }
 }

--- a/src/domain/collaboration/collabora-document/collabora.document.service.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.service.ts
@@ -263,7 +263,8 @@ export class CollaboraDocumentService {
 
   public async getEditorUrl(
     collaboraDocumentID: string,
-    actorID: string
+    actorID: string,
+    actorName?: string
   ): Promise<{ editorUrl: string; accessTokenTTL: number }> {
     const collaboraDocument = await this.getCollaboraDocumentOrFail(
       collaboraDocumentID,
@@ -282,7 +283,8 @@ export class CollaboraDocumentService {
 
     const result = await this.wopiServiceAdapter.issueToken(
       collaboraDocument.document.id,
-      actorID
+      actorID,
+      actorName
     );
 
     return {

--- a/src/domain/communication/messaging/messaging.service.ts
+++ b/src/domain/communication/messaging/messaging.service.ts
@@ -10,7 +10,7 @@ import {
   ValidationException,
 } from '@common/exceptions';
 import { Actor } from '@domain/actor/actor/actor.entity';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -652,7 +652,7 @@ export class MessagingService {
    * `room.info` RPC handler body (feature 099-element-room-check).
    *
    * Look up the Conversation by the supplied Room id; return type + members
-   * with displayNames resolved via `getMatrixDisplayName`. A miss returns the
+   * with displayNames resolved via `getActorDisplayName`. A miss returns the
    * empty-members miss envelope (NOT an error) — the adapter retries
    * reconciliation on subsequent room events.
    */
@@ -676,7 +676,7 @@ export class MessagingService {
     const actorIds = memberships.map(m => m.actorID);
     // Resolve members against the Actor base table so VirtualContributors,
     // Organizations, etc. render correctly — not just Users. profile is
-    // eager:false on Actor, so load it explicitly (getMatrixDisplayName reads
+    // eager:false on Actor, so load it explicitly (getActorDisplayName reads
     // profile.displayName per FR-018).
     const actors = await this.entityManager.find(Actor, {
       where: { id: In(actorIds) },
@@ -688,7 +688,7 @@ export class MessagingService {
       const actor = actorsById.get(m.actorID);
       return {
         actorId: m.actorID,
-        displayName: actor ? getMatrixDisplayName(actor) : m.actorID,
+        displayName: actor ? getActorDisplayName(actor) : m.actorID,
       };
     });
 

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -23,7 +23,7 @@ import { IPaginatedType } from '@core/pagination/paginated.type';
 import { getPaginationResults } from '@core/pagination/pagination.fn';
 import { actorDefaults } from '@domain/actor/actor/actor.defaults';
 import { ActorService } from '@domain/actor/actor/actor.service';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -231,7 +231,7 @@ export class UserService {
 
     // Sync the user to the communication adapter
     // User.id (which is Actor.id) is used as the AlkemioActorID for all communication operations
-    const displayName = getMatrixDisplayName(user);
+    const displayName = getActorDisplayName(user);
 
     try {
       await this.communicationAdapter.syncActor(user.id, displayName);

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -14,7 +14,7 @@ import { Invitation } from '@domain/access/invitation/invitation.entity';
 import { IActor } from '@domain/actor/actor/actor.interface';
 import { ActorService } from '@domain/actor/actor/actor.service';
 import { ActorQueryArgs } from '@domain/actor/actor/dto';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { ICredential } from '@domain/actor/credential/credential.interface';
 import { CredentialsSearchInput } from '@domain/actor/credential/dto/credentials.dto.search';
 import { CreateCalloutInput } from '@domain/collaboration/callout/dto/callout.dto.create';
@@ -199,7 +199,7 @@ export class VirtualContributorService {
 
     // Sync the VC to the communication adapter
     // VirtualContributor.id (which is Actor.id) is used as the AlkemioActorID
-    const displayName = getMatrixDisplayName(virtualContributor);
+    const displayName = getActorDisplayName(virtualContributor);
     try {
       await this.communicationAdapter.syncActor(
         virtualContributor.id,

--- a/src/main.server.ts
+++ b/src/main.server.ts
@@ -1,0 +1,229 @@
+import { MessagingQueue } from '@common/enums';
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NestFactory } from '@nestjs/core';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { AlkemioConfig } from '@src/types';
+import { json } from 'body-parser';
+import { useContainer } from 'class-validator';
+import cookieParser from 'cookie-parser';
+import { NextFunction, Request, Response } from 'express';
+import session from 'express-session';
+import { renderGraphiQL } from 'graphql-helix';
+import { graphqlUploadExpress } from 'graphql-upload';
+import helmet from 'helmet';
+import Redis from 'ioredis';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { AppModule } from './app.module';
+import { NonInteractiveLoginConfig } from './core/auth/non-interactive-login/non-interactive-login.config';
+import { setSessionMiddlewares } from './core/auth/oidc/session-middleware.holder';
+import {
+  buildOidcSessionRedisStore,
+  buildSessionRenewalMiddleware,
+} from './core/auth/oidc/session-store.redis';
+import { BootstrapService } from './core/bootstrap/bootstrap.service';
+import { faviconMiddleware } from './core/middleware/favicon.middleware';
+
+/**
+ * Bootstrap the full Alkemio API server (AppModule): GraphQL/Apollo, REST,
+ * OIDC, all queue consumers EXCEPT auth-reset. Selected by the main.ts
+ * dispatcher when AUTH_RESET_WORKER is not 'true'.
+ */
+export const bootstrapServer = async () => {
+  const app = await NestFactory.create(AppModule, {
+    /***
+     * if the logger is provided at a later stage via 'useLogger' after the app has initialized, Nest falls back to the default logger
+     * while initializing, which logs a lot of info logs, which we don't have control over and don't want tracked.
+     * The logger is disabled while the app is loading ONLY on production to avoid the messages;
+     * then the costume logger is applied as usual
+     */
+    logger: process.env.NODE_ENV === 'production' ? false : undefined,
+    // Disable default body parsers - we configure them manually below
+    bodyParser: false,
+  });
+  const configService: ConfigService<AlkemioConfig, true> =
+    app.get(ConfigService);
+  const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
+  const bootstrapService: BootstrapService = app.get(BootstrapService);
+
+  app.useLogger(logger);
+
+  // Defense-in-depth boot guard for the non-interactive-login feature.
+  // Throws (and aborts startup) if NODE_ENV=production collides with
+  // identity.authentication.providers.non_interactive_login.enabled, or
+  // if the feature is enabled without a strong signing_key.
+  app.get(NonInteractiveLoginConfig).assertSafe();
+  useContainer(app.select(AppModule), { fallbackOnErrors: true });
+
+  await bootstrapService.bootstrap();
+  const { enabled, methods, origin, allowed_headers } = configService.get(
+    'security.cors',
+    { infer: true }
+  );
+  if (enabled) {
+    // `Access-Control-Allow-Origin: *` is incompatible with credentials, so
+    // when origin is the wildcard we reflect the request Origin instead.
+    const corsOrigin =
+      typeof origin === 'string' && origin.trim() === '*' ? true : origin;
+    app.enableCors({
+      origin: corsOrigin,
+      allowedHeaders: allowed_headers,
+      methods,
+      // Required so the browser sends the alkemio_session cookie on
+      // cross-origin GraphQL requests from the SPA (and accepts Set-Cookie
+      // on the OIDC callback). Client must use credentials: 'include'.
+      credentials: true,
+    });
+  }
+
+  app.getHttpAdapter().getInstance().set('trust proxy', 1);
+
+  app.use(faviconMiddleware);
+  const cookieParserMiddleware = cookieParser();
+  app.use(cookieParserMiddleware);
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+    })
+  );
+
+  // T016 — express-session + connect-redis bootstrap. MUST run before any
+  // OIDC controller so the callback can regenerate() against a live store.
+  // Key layout: `alkemio:sid:<sid>`. The cookie carries the sid only — no
+  // tokens. Two clocks (FR-018 / FR-020a): a 14-day sliding idle window
+  // (cookie maxAge + Redis key TTL) and a 30-day fixed absolute ceiling
+  // (`absolute_expires_at` payload check). `rolling` is false and the idle
+  // window is renewed lazily by sessionRenewalMiddleware so we don't re-issue
+  // the cookie / re-write Redis on every request.
+  const oidcConfig = configService.get(
+    'identity.authentication.providers.oidc',
+    {
+      infer: true,
+    }
+  );
+  const redisConfig = configService.get('storage.redis', { infer: true });
+  const sessionRedis = new Redis({
+    host: redisConfig.host,
+    port: Number(redisConfig.port),
+  });
+  const idleTtlS = oidcConfig.cookie.idle_ttl_s;
+  const sessionStore = buildOidcSessionRedisStore(sessionRedis, idleTtlS);
+  const sessionMiddleware = session({
+    store: sessionStore,
+    secret: oidcConfig.session_signing_key,
+    name: oidcConfig.cookie.name,
+    resave: false,
+    saveUninitialized: false,
+    // Renewal is handled lazily by sessionRenewalMiddleware (Kratos-style
+    // back-half extend) — keep express-session from re-issuing the cookie on
+    // every request.
+    rolling: false,
+    cookie: {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      secure: oidcConfig.cookie.secure,
+      domain: oidcConfig.cookie.domain || undefined,
+      maxAge: idleTtlS * 1000,
+    },
+  });
+  app.use(sessionMiddleware);
+  // FR-018 — lazily slide the idle window only when it crosses the half-life
+  // mark. MUST run after express-session has populated req.session.
+  app.use(buildSessionRenewalMiddleware(idleTtlS));
+
+  // FR-023 (WS addendum) — graphql-ws upgrades bypass the Express pipeline,
+  // so cookie-parser and express-session never run on the upgrade
+  // IncomingMessage and `req.sessionID`/`req.cookies` are undefined.
+  // Publish both instances so the GraphQL context callback can replay them
+  // against the upgrade request before CookieSessionStrategy reads them.
+  setSessionMiddlewares(cookieParserMiddleware, sessionMiddleware);
+
+  app.use(
+    graphqlUploadExpress({
+      maxFileSize: configService.get('storage.file.max_file_size', {
+        infer: true,
+      }),
+    })
+  );
+
+  const { max_json_payload_size, port } = configService.get('hosting', {
+    infer: true,
+  });
+  // JSON body parsing - skip for MCP routes (MCP SDK handles its own parsing)
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    if (req.path.startsWith('/rest/mcp')) {
+      return next();
+    }
+    json({ limit: max_json_payload_size })(req, res, next);
+  });
+
+  // Serve the GraphiQL interface at '/graphiql'
+  app.use('/graphiql', (_req: Request, res: Response) => {
+    res.send(
+      renderGraphiQL({
+        endpoint: '/graphql',
+        //subscriptionsEndpoint: '/graphql',
+      })
+    );
+  });
+
+  await app.listen(port);
+
+  const connectionOptions = configService.get(
+    'microservices.rabbitmq.connection',
+    { infer: true }
+  );
+
+  const heartbeat = process.env.NODE_ENV === 'production' ? 30 : 120;
+  const amqpEndpoint = `amqp://${connectionOptions.user}:${connectionOptions.password}@${connectionOptions.host}:${connectionOptions.port}?heartbeat=${heartbeat}`;
+  // The auth-reset queue is intentionally NOT bound here. It is consumed by the
+  // dedicated worker (src/main.worker.ts / AuthResetWorkerModule). auth-reset is
+  // a single durable queue with competing consumers, so the API server must not
+  // bind it or it would steal a share of the reset messages. The server still
+  // PUBLISHES reset events (AUTH_RESET_SERVICE proxy).
+  //
+  // Kratos events (e.g. USER_PASSWORD_CHANGED published by the Go kratos-webhooks
+  // service). Dedicated durable queue — do NOT also bind it via @golevelup
+  // @RabbitSubscribe; a competing consumer would steal messages (see the
+  // golevelup note below).
+  connectMicroservice(app, amqpEndpoint, MessagingQueue.KRATOS_EVENTS);
+  connectMicroservice(app, amqpEndpoint, MessagingQueue.WHITEBOARDS);
+  connectMicroservice(app, amqpEndpoint, MessagingQueue.FILES);
+  connectMicroservice(app, amqpEndpoint, MessagingQueue.IN_APP_NOTIFICATIONS);
+  connectMicroservice(
+    app,
+    amqpEndpoint,
+    MessagingQueue.COLLABORATION_DOCUMENT_SERVICE
+  );
+  // Note: Push notifications use @golevelup/nestjs-rabbitmq @RabbitSubscribe decorators
+  // in PushDeliveryService. No NestJS microservice connection needed — a competing
+  // Transport.RMQ consumer would steal messages from the golevelup handler.
+  //
+  // Matrix Adapter events also use @golevelup/nestjs-rabbitmq @RabbitSubscribe decorators
+  // which are compatible with the Go Matrix Adapter's Watermill publishing.
+  // No NestJS microservice connection needed for Matrix Adapter queue.
+  await app.startAllMicroservices();
+};
+
+const connectMicroservice = (
+  app: INestApplication,
+  amqpEndpoint: string,
+  queue: MessagingQueue
+) => {
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.RMQ,
+    options: {
+      urls: [amqpEndpoint],
+      queue,
+      queueOptions: { durable: true },
+      socketOptions: {
+        reconnectTimeInSeconds: 5,
+        heartbeatIntervalInSeconds:
+          process.env.NODE_ENV === 'production' ? 30 : 240,
+      },
+      //be careful with this flag, if set to true, message acknowledgment will be automatic. Double acknowledgment throws an error and disconnects the queue.
+      noAck: false,
+    },
+  });
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,237 +1,29 @@
-import { ConfigService } from '@nestjs/config';
-import { NestFactory } from '@nestjs/core';
-import session from 'express-session';
-import helmet from 'helmet';
-import Redis from 'ioredis';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { AppModule } from './app.module';
 import './config/aliases';
-import { MessagingQueue } from '@common/enums';
-import { INestApplication } from '@nestjs/common';
-import { MicroserviceOptions, Transport } from '@nestjs/microservices';
-import { AlkemioConfig } from '@src/types';
-import { json } from 'body-parser';
-import { useContainer } from 'class-validator';
-import cookieParser from 'cookie-parser';
-import { NextFunction, Request, Response } from 'express';
-import { renderGraphiQL } from 'graphql-helix';
-import { graphqlUploadExpress } from 'graphql-upload';
 // biome-ignore lint/correctness/noUnusedImports: apmAgent import has side effects that initialize APM
 import { apmAgent } from './apm';
-import { NonInteractiveLoginConfig } from './core/auth/non-interactive-login/non-interactive-login.config';
-import { setSessionMiddlewares } from './core/auth/oidc/session-middleware.holder';
-import {
-  buildOidcSessionRedisStore,
-  buildSessionRenewalMiddleware,
-} from './core/auth/oidc/session-store.redis';
-import { BootstrapService } from './core/bootstrap/bootstrap.service';
-import { faviconMiddleware } from './core/middleware/favicon.middleware';
 
+/**
+ * Process entry point / role dispatcher.
+ *
+ * The deployment role is chosen from a raw environment variable (read directly
+ * from process.env — NOT via ConfigService, which would require booting a Nest
+ * module first). Each branch dynamically imports ONLY its own bootstrap, so the
+ * two roles build completely isolated DI trees: the auth-reset worker never
+ * loads AppModule (GraphQL/REST/OIDC/all other consumers), and the server never
+ * loads AuthResetWorkerModule.
+ *
+ *   AUTH_RESET_WORKER=true  -> dedicated auth-reset queue consumer
+ *   (unset / anything else) -> full Alkemio API server
+ */
 const bootstrap = async () => {
-  const app = await NestFactory.create(AppModule, {
-    /***
-     * if the logger is provided at a later stage via 'useLogger' after the app has initialized, Nest falls back to the default logger
-     * while initializing, which logs a lot of info logs, which we don't have control over and don't want tracked.
-     * The logger is disabled while the app is loading ONLY on production to avoid the messages;
-     * then the costume logger is applied as usual
-     */
-    logger: process.env.NODE_ENV === 'production' ? false : undefined,
-    // Disable default body parsers - we configure them manually below
-    bodyParser: false,
-  });
-  const configService: ConfigService<AlkemioConfig, true> =
-    app.get(ConfigService);
-  const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
-  const bootstrapService: BootstrapService = app.get(BootstrapService);
-
-  app.useLogger(logger);
-
-  // Defense-in-depth boot guard for the non-interactive-login feature.
-  // Throws (and aborts startup) if NODE_ENV=production collides with
-  // identity.authentication.providers.non_interactive_login.enabled, or
-  // if the feature is enabled without a strong signing_key.
-  app.get(NonInteractiveLoginConfig).assertSafe();
-  useContainer(app.select(AppModule), { fallbackOnErrors: true });
-
-  await bootstrapService.bootstrap();
-  const { enabled, methods, origin, allowed_headers } = configService.get(
-    'security.cors',
-    { infer: true }
-  );
-  if (enabled) {
-    // `Access-Control-Allow-Origin: *` is incompatible with credentials, so
-    // when origin is the wildcard we reflect the request Origin instead.
-    const corsOrigin =
-      typeof origin === 'string' && origin.trim() === '*' ? true : origin;
-    app.enableCors({
-      origin: corsOrigin,
-      allowedHeaders: allowed_headers,
-      methods,
-      // Required so the browser sends the alkemio_session cookie on
-      // cross-origin GraphQL requests from the SPA (and accepts Set-Cookie
-      // on the OIDC callback). Client must use credentials: 'include'.
-      credentials: true,
-    });
+  if (process.env.AUTH_RESET_WORKER === 'true') {
+    const { bootstrapAuthResetWorker } = await import('./main.worker');
+    await bootstrapAuthResetWorker();
+    return;
   }
 
-  app.getHttpAdapter().getInstance().set('trust proxy', 1);
-
-  app.use(faviconMiddleware);
-  const cookieParserMiddleware = cookieParser();
-  app.use(cookieParserMiddleware);
-  app.use(
-    helmet({
-      contentSecurityPolicy: false,
-    })
-  );
-
-  // T016 — express-session + connect-redis bootstrap. MUST run before any
-  // OIDC controller so the callback can regenerate() against a live store.
-  // Key layout: `alkemio:sid:<sid>`. The cookie carries the sid only — no
-  // tokens. Two clocks (FR-018 / FR-020a): a 14-day sliding idle window
-  // (cookie maxAge + Redis key TTL) and a 30-day fixed absolute ceiling
-  // (`absolute_expires_at` payload check). `rolling` is false and the idle
-  // window is renewed lazily by sessionRenewalMiddleware so we don't re-issue
-  // the cookie / re-write Redis on every request.
-  const oidcConfig = configService.get(
-    'identity.authentication.providers.oidc',
-    {
-      infer: true,
-    }
-  );
-  const redisConfig = configService.get('storage.redis', { infer: true });
-  const sessionRedis = new Redis({
-    host: redisConfig.host,
-    port: Number(redisConfig.port),
-  });
-  const idleTtlS = oidcConfig.cookie.idle_ttl_s;
-  const sessionStore = buildOidcSessionRedisStore(sessionRedis, idleTtlS);
-  const sessionMiddleware = session({
-    store: sessionStore,
-    secret: oidcConfig.session_signing_key,
-    name: oidcConfig.cookie.name,
-    resave: false,
-    saveUninitialized: false,
-    // Renewal is handled lazily by sessionRenewalMiddleware (Kratos-style
-    // back-half extend) — keep express-session from re-issuing the cookie on
-    // every request.
-    rolling: false,
-    cookie: {
-      httpOnly: true,
-      sameSite: 'lax',
-      path: '/',
-      secure: oidcConfig.cookie.secure,
-      domain: oidcConfig.cookie.domain || undefined,
-      maxAge: idleTtlS * 1000,
-    },
-  });
-  app.use(sessionMiddleware);
-  // FR-018 — lazily slide the idle window only when it crosses the half-life
-  // mark. MUST run after express-session has populated req.session.
-  app.use(buildSessionRenewalMiddleware(idleTtlS));
-
-  // FR-023 (WS addendum) — graphql-ws upgrades bypass the Express pipeline,
-  // so cookie-parser and express-session never run on the upgrade
-  // IncomingMessage and `req.sessionID`/`req.cookies` are undefined.
-  // Publish both instances so the GraphQL context callback can replay them
-  // against the upgrade request before CookieSessionStrategy reads them.
-  setSessionMiddlewares(cookieParserMiddleware, sessionMiddleware);
-
-  app.use(
-    graphqlUploadExpress({
-      maxFileSize: configService.get('storage.file.max_file_size', {
-        infer: true,
-      }),
-    })
-  );
-
-  const { max_json_payload_size, port } = configService.get('hosting', {
-    infer: true,
-  });
-  // JSON body parsing - skip for MCP routes (MCP SDK handles its own parsing)
-  app.use((req: Request, res: Response, next: NextFunction) => {
-    if (req.path.startsWith('/rest/mcp')) {
-      return next();
-    }
-    json({ limit: max_json_payload_size })(req, res, next);
-  });
-
-  // Serve the GraphiQL interface at '/graphiql'
-  app.use('/graphiql', (_req: Request, res: Response) => {
-    res.send(
-      renderGraphiQL({
-        endpoint: '/graphql',
-        //subscriptionsEndpoint: '/graphql',
-      })
-    );
-  });
-
-  await app.listen(port);
-
-  const connectionOptions = configService.get(
-    'microservices.rabbitmq.connection',
-    { infer: true }
-  );
-
-  const heartbeat = process.env.NODE_ENV === 'production' ? 30 : 120;
-  const amqpEndpoint = `amqp://${connectionOptions.user}:${connectionOptions.password}@${connectionOptions.host}:${connectionOptions.port}?heartbeat=${heartbeat}`;
-  // Deployment-role split (microservices.rabbitmq.auth_reset). On the dedicated,
-  // KEDA-scaled worker deployment `worker: true` binds ONLY the auth-reset
-  // queue; the normal server keeps it false, binds every OTHER queue and never
-  // consumes auth-reset. Because auth-reset is a single durable queue with
-  // competing consumers, the normal server MUST NOT bind it or it would steal
-  // a share of the reset messages. One image, behaviour selected by config.
-  const authReset = configService.get('microservices.rabbitmq.auth_reset', {
-    infer: true,
-  });
-
-  if (authReset.worker) {
-    connectMicroservice(app, amqpEndpoint, authReset.queue);
-  } else {
-    // Kratos events (e.g. USER_PASSWORD_CHANGED published by the Go kratos-webhooks
-    // service). Dedicated durable queue — do NOT also bind it via @golevelup
-    // @RabbitSubscribe; a competing consumer would steal messages (see the
-    // golevelup note below).
-    connectMicroservice(app, amqpEndpoint, MessagingQueue.KRATOS_EVENTS);
-    connectMicroservice(app, amqpEndpoint, MessagingQueue.WHITEBOARDS);
-    connectMicroservice(app, amqpEndpoint, MessagingQueue.FILES);
-    connectMicroservice(app, amqpEndpoint, MessagingQueue.IN_APP_NOTIFICATIONS);
-    connectMicroservice(
-      app,
-      amqpEndpoint,
-      MessagingQueue.COLLABORATION_DOCUMENT_SERVICE
-    );
-  }
-  // Note: Push notifications use @golevelup/nestjs-rabbitmq @RabbitSubscribe decorators
-  // in PushDeliveryService. No NestJS microservice connection needed — a competing
-  // Transport.RMQ consumer would steal messages from the golevelup handler.
-  //
-  // Matrix Adapter events also use @golevelup/nestjs-rabbitmq @RabbitSubscribe decorators
-  // which are compatible with the Go Matrix Adapter's Watermill publishing.
-  // No NestJS microservice connection needed for Matrix Adapter queue.
-  await app.startAllMicroservices();
-};
-
-const connectMicroservice = (
-  app: INestApplication,
-  amqpEndpoint: string,
-  queue: MessagingQueue | string
-) => {
-  app.connectMicroservice<MicroserviceOptions>({
-    transport: Transport.RMQ,
-    options: {
-      urls: [amqpEndpoint],
-      queue,
-      queueOptions: { durable: true },
-      socketOptions: {
-        reconnectTimeInSeconds: 5,
-        heartbeatIntervalInSeconds:
-          process.env.NODE_ENV === 'production' ? 30 : 240,
-      },
-      //be careful with this flag, if set to true, message acknowledgment will be automatic. Double acknowledgment throws an error and disconnects the queue.
-      noAck: false,
-    },
-  });
+  const { bootstrapServer } = await import('./main.server');
+  await bootstrapServer();
 };
 
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,20 +175,33 @@ const bootstrap = async () => {
 
   const heartbeat = process.env.NODE_ENV === 'production' ? 30 : 120;
   const amqpEndpoint = `amqp://${connectionOptions.user}:${connectionOptions.password}@${connectionOptions.host}:${connectionOptions.port}?heartbeat=${heartbeat}`;
-  connectMicroservice(app, amqpEndpoint, MessagingQueue.AUTH_RESET);
-  // Kratos events (e.g. USER_PASSWORD_CHANGED published by the Go kratos-webhooks
-  // service). Dedicated durable queue — do NOT also bind it via @golevelup
-  // @RabbitSubscribe; a competing consumer would steal messages (see the
-  // golevelup note below).
-  connectMicroservice(app, amqpEndpoint, MessagingQueue.KRATOS_EVENTS);
-  connectMicroservice(app, amqpEndpoint, MessagingQueue.WHITEBOARDS);
-  connectMicroservice(app, amqpEndpoint, MessagingQueue.FILES);
-  connectMicroservice(app, amqpEndpoint, MessagingQueue.IN_APP_NOTIFICATIONS);
-  connectMicroservice(
-    app,
-    amqpEndpoint,
-    MessagingQueue.COLLABORATION_DOCUMENT_SERVICE
-  );
+  // Deployment-role split (microservices.rabbitmq.auth_reset). On the dedicated,
+  // KEDA-scaled worker deployment `worker: true` binds ONLY the auth-reset
+  // queue; the normal server keeps it false, binds every OTHER queue and never
+  // consumes auth-reset. Because auth-reset is a single durable queue with
+  // competing consumers, the normal server MUST NOT bind it or it would steal
+  // a share of the reset messages. One image, behaviour selected by config.
+  const authReset = configService.get('microservices.rabbitmq.auth_reset', {
+    infer: true,
+  });
+
+  if (authReset.worker) {
+    connectMicroservice(app, amqpEndpoint, authReset.queue);
+  } else {
+    // Kratos events (e.g. USER_PASSWORD_CHANGED published by the Go kratos-webhooks
+    // service). Dedicated durable queue — do NOT also bind it via @golevelup
+    // @RabbitSubscribe; a competing consumer would steal messages (see the
+    // golevelup note below).
+    connectMicroservice(app, amqpEndpoint, MessagingQueue.KRATOS_EVENTS);
+    connectMicroservice(app, amqpEndpoint, MessagingQueue.WHITEBOARDS);
+    connectMicroservice(app, amqpEndpoint, MessagingQueue.FILES);
+    connectMicroservice(app, amqpEndpoint, MessagingQueue.IN_APP_NOTIFICATIONS);
+    connectMicroservice(
+      app,
+      amqpEndpoint,
+      MessagingQueue.COLLABORATION_DOCUMENT_SERVICE
+    );
+  }
   // Note: Push notifications use @golevelup/nestjs-rabbitmq @RabbitSubscribe decorators
   // in PushDeliveryService. No NestJS microservice connection needed — a competing
   // Transport.RMQ consumer would steal messages from the golevelup handler.
@@ -202,7 +215,7 @@ const bootstrap = async () => {
 const connectMicroservice = (
   app: INestApplication,
   amqpEndpoint: string,
-  queue: MessagingQueue
+  queue: MessagingQueue | string
 ) => {
   app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.RMQ,

--- a/src/main.worker.ts
+++ b/src/main.worker.ts
@@ -101,6 +101,13 @@ export const bootstrapAuthResetWorker = async () => {
     );
   }
 
+  // Run module lifecycle hooks (onModuleInit / onApplicationBootstrap) BEFORE
+  // the RMQ consumer starts pulling messages. NestFactory.create() only builds
+  // the DI graph; with no app.listen() (headless worker) nothing else triggers
+  // these hooks, and startAllMicroservices() does not. Without this the consumer
+  // could receive a reset before TypeORM/cache/bootstrap init completed.
+  await app.init();
+
   await app.startAllMicroservices();
   // Intentionally no app.listen() — headless consumer, no HTTP surface.
 };

--- a/src/main.worker.ts
+++ b/src/main.worker.ts
@@ -3,7 +3,7 @@
 // RabbitMQ connections/consumers (those are wired into domain modules we pull in).
 process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS = 'true';
 
-import { MessagingQueue } from '@common/enums';
+import { LogContext, MessagingQueue } from '@common/enums';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
@@ -52,6 +52,12 @@ export const bootstrapAuthResetWorker = async () => {
       urls: [amqpEndpoint],
       queue,
       queueOptions: { durable: true },
+      // One unacked message per pod at a time. The RMQ default is 0 (unlimited):
+      // a single pod would pull the whole queue and run every reset concurrently,
+      // each holding large authorization arrays (OOM risk against the 3.5Gi limit)
+      // and trampling the parent->child ordering the inheritance chain depends on.
+      // With 1, work is spread across pods as competing consumers, one reset each.
+      prefetchCount: 1,
       socketOptions: {
         reconnectTimeInSeconds: 5,
         heartbeatIntervalInSeconds:
@@ -61,6 +67,39 @@ export const bootstrapAuthResetWorker = async () => {
       noAck: false,
     },
   });
+
+  // --- Graceful shutdown (worker-only) ---------------------------------------
+  // This binary runs as PID 1 (Dockerfile `CMD ["node", "dist/main.js"]`, no
+  // init wrapper). The Linux kernel does NOT apply the default "terminate"
+  // disposition to PID 1 for SIGTERM/SIGINT unless the process installs its own
+  // handler — so without the line below a SIGTERM (sent by kubelet on
+  // scale-down/rollout) would be IGNORED and the pod would sit until the
+  // terminationGracePeriodSeconds deadline, then get SIGKILLed.
+  //
+  // enableShutdownHooks() registers process SIGTERM/SIGINT listeners that call
+  // app.close(), which closes the RMQ microservice: the consumer is cancelled
+  // (no new deliveries) and the channel/connection are torn down, then the
+  // process exits promptly — well inside the grace window instead of stalling
+  // to SIGKILL.
+  //
+  // In-flight safety: a reset already running when SIGTERM lands continues on
+  // the event loop. If it finishes and acks before app.close() tears the
+  // channel down, the message is consumed normally. If the channel closes
+  // first, the still-unacked message is requeued by the broker and redelivered
+  // on the next scale-up — the handlers are idempotent and carry an explicit
+  // retry counter, so no work is lost either way.
+  app.enableShutdownHooks();
+
+  // Observability only — Nest's enableShutdownHooks listener does the actual
+  // app.close(). This just records that a shutdown signal arrived.
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    process.on(signal, () =>
+      logger.log?.(
+        `Received ${signal}: draining auth-reset worker and shutting down.`,
+        LogContext.AUTH
+      )
+    );
+  }
 
   await app.startAllMicroservices();
   // Intentionally no app.listen() — headless consumer, no HTTP surface.

--- a/src/main.worker.ts
+++ b/src/main.worker.ts
@@ -1,0 +1,67 @@
+// MUST be set before any module is imported: makes subscriptionFactory return
+// in-memory PubSub everywhere, so the worker opens no GraphQL-subscription
+// RabbitMQ connections/consumers (those are wired into domain modules we pull in).
+process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS = 'true';
+
+import { MessagingQueue } from '@common/enums';
+import { ConfigService } from '@nestjs/config';
+import { NestFactory } from '@nestjs/core';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { AlkemioConfig } from '@src/types';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { AuthResetWorkerModule } from './core/bootstrap/auth-reset.worker.module';
+
+/**
+ * Bootstrap the dedicated authorization/license reset worker.
+ *
+ * Boots the restricted AuthResetWorkerModule (no GraphQL/REST/OIDC/bootstrap)
+ * and binds ONLY the auth-reset RabbitMQ queue. No HTTP server is started — this
+ * is a headless queue consumer. Selected by the main.ts dispatcher when
+ * AUTH_RESET_WORKER === 'true'. The full server publishes reset events but never
+ * consumes this queue.
+ */
+export const bootstrapAuthResetWorker = async () => {
+  // ALKEMIO_DISABLE_SUBSCRIPTIONS is set unconditionally at module top-level
+  // (line 4) — that runs the instant main.ts imports this module, before
+  // NestFactory builds the graph. No need to re-set it here.
+  const app = await NestFactory.create(AuthResetWorkerModule, {
+    logger: process.env.NODE_ENV === 'production' ? false : undefined,
+    bodyParser: false,
+  });
+
+  const configService: ConfigService<AlkemioConfig, true> =
+    app.get(ConfigService);
+  const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
+  app.useLogger(logger);
+
+  const connectionOptions = configService.get(
+    'microservices.rabbitmq.connection',
+    { infer: true }
+  );
+  const queue =
+    configService.get('microservices.rabbitmq.auth_reset.queue', {
+      infer: true,
+    }) ?? MessagingQueue.AUTH_RESET;
+
+  const heartbeat = process.env.NODE_ENV === 'production' ? 30 : 120;
+  const amqpEndpoint = `amqp://${connectionOptions.user}:${connectionOptions.password}@${connectionOptions.host}:${connectionOptions.port}?heartbeat=${heartbeat}`;
+
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.RMQ,
+    options: {
+      urls: [amqpEndpoint],
+      queue,
+      queueOptions: { durable: true },
+      socketOptions: {
+        reconnectTimeInSeconds: 5,
+        heartbeatIntervalInSeconds:
+          process.env.NODE_ENV === 'production' ? 30 : 240,
+      },
+      // Manual ack — the controller acks/rejects explicitly (retry handling).
+      noAck: false,
+    },
+  });
+
+  await app.startAllMicroservices();
+  // Intentionally no app.listen() — headless consumer, no HTTP surface.
+};

--- a/src/platform-admin/domain/communication/admin.communication.space.sync.service.ts
+++ b/src/platform-admin/domain/communication/admin.communication.space.sync.service.ts
@@ -2,7 +2,7 @@ import { JoinRuleInvite, JoinRulePublic } from '@alkemio/matrix-adapter-lib';
 import { LogContext } from '@common/enums';
 import { RoomType } from '@common/enums/room.type';
 import { FORUM_CATEGORY_NAMESPACE } from '@constants/forum.constants';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { Room } from '@domain/communication/room/room.entity';
 import { User } from '@domain/community/user/user.entity';
 import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
@@ -505,7 +505,7 @@ export class AdminCommunicationSpaceSyncService {
 
     let synced = 0;
     for (const user of users) {
-      const displayName = getMatrixDisplayName(user);
+      const displayName = getActorDisplayName(user);
       try {
         await this.communicationAdapter.syncActor(user.id, displayName);
         synced++;
@@ -519,7 +519,7 @@ export class AdminCommunicationSpaceSyncService {
     }
 
     for (const vc of vcs) {
-      const displayName = getMatrixDisplayName(vc);
+      const displayName = getActorDisplayName(vc);
       try {
         await this.communicationAdapter.syncActor(vc.id, displayName);
         synced++;

--- a/src/services/adapters/communication-adapter/communication.rpc.module.ts
+++ b/src/services/adapters/communication-adapter/communication.rpc.module.ts
@@ -39,6 +39,15 @@ const rabbitMqImport = RabbitMQModule.forRootAsync({
     const timeout = communicationsConfig?.matrix?.connection_timeout ?? 10000;
 
     return {
+      // ⚠️ This named connection rides into the auth-reset worker graph (via
+      // CommunicationAdapterModule ← UserModule/SpaceModule/AiServerModule) and
+      // is intentionally kept there for CommunicationAdapter's OUTBOUND RPC. It
+      // is safe in the worker ONLY because no `@RabbitSubscribe` handler targets
+      // it: handlers omit `name`, so they bind to golevelup's `'default'`
+      // connection (EventBusModule), which the worker excludes. Do NOT add
+      // `name: 'communication-adapter'` to any `@RabbitSubscribe` decorator, or
+      // this connection's discovery binds it and the worker starts consuming
+      // that queue — competing with the API server. See worker.event-bus.module.
       name: 'communication-adapter',
       uri,
       connectionInitOptions: {

--- a/src/services/adapters/wopi-service-adapter/wopi.service.adapter.ts
+++ b/src/services/adapters/wopi-service-adapter/wopi.service.adapter.ts
@@ -1,4 +1,5 @@
 import { LogContext } from '@common/enums';
+import { HEADER_ACTOR_ID } from '@core/auth/oidc/constants';
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -42,7 +43,8 @@ export class WopiServiceAdapter {
    */
   async issueToken(
     documentId: string,
-    actorID: string
+    actorID: string,
+    actorName?: string
   ): Promise<WopiTokenResult> {
     const url = `${this.baseUrl}/wopi/token`;
 
@@ -54,10 +56,14 @@ export class WopiServiceAdapter {
     const request$ = this.httpService
       .post<WopiTokenResult>(
         url,
-        { documentId },
+        // actorName is sent in the body (UTF-8, native) rather than a header
+        // so arbitrary-Unicode names need no encoding. The WOPI service maps it
+        // to the WOPI CheckFileInfo UserFriendlyName. Omitted when unknown
+        // (e.g. anonymous), letting the WOPI service keep its own fallback.
+        { documentId, actorName },
         {
           headers: {
-            'X-Alkemio-Actor-Id': actorID,
+            [HEADER_ACTOR_ID]: actorID,
             'Content-Type': 'application/json',
           },
         }

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -237,6 +237,16 @@ export class ConversionService {
       );
     }
 
+    // The persisted platformRolesAccess JSON was derived from the OLD parent
+    // hierarchy (alkem-io/client-web#9891). For a subspace it gates platform
+    // (anonymous/guest/registered) READ behind the parent's grants, so a space
+    // promoted out of a private parent keeps platform users locked out of its
+    // dashboard until the value is recomputed. Recompute for the new L0 root
+    // (no parent) and cascade to the migrated descendants before the
+    // authorization policy is applied, since applyAuthorizationPolicy only
+    // reads platformRolesAccess and would otherwise propagate the stale rules.
+    await this.spaceService.updatePlatformRolesAccessRecursively(spaceL1);
+
     // Drop the now-stale SUBSPACE_CREATED entry on the source L0's activity
     // log — the moved space is no longer a subspace of that L0.
     await this.activityService.removeSubspaceCreatedActivityForResource(

--- a/src/services/auth-reset/subscriber/auth-reset.controller.spec.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.controller.spec.ts
@@ -10,6 +10,7 @@ import { UserAuthorizationService } from '@domain/community/user/user.service.au
 import { AccountService } from '@domain/space/account/account.service';
 import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
 import { AccountLicenseService } from '@domain/space/account/account.service.license';
+import { ConfigService } from '@nestjs/config';
 import { RmqContext } from '@nestjs/microservices';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PlatformAuthorizationService } from '@platform/platform/platform.service.authorization';
@@ -72,7 +73,16 @@ describe('AuthResetController', () => {
     vi.restoreAllMocks();
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MockWinstonProvider],
+      providers: [
+        MockWinstonProvider,
+        {
+          provide: ConfigService,
+          useValue: {
+            // Controller reads microservices.rabbitmq.auth_reset.queue here.
+            get: vi.fn().mockReturnValue(MessagingQueue.AUTH_RESET),
+          },
+        },
+      ],
       controllers: [AuthResetController],
     })
       .useMocker(defaultMockerFactory)

--- a/src/services/auth-reset/subscriber/auth-reset.controller.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.controller.ts
@@ -1,4 +1,4 @@
-import { LogContext, MessagingQueue } from '@common/enums';
+import { LogContext } from '@common/enums';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { LicenseService } from '@domain/common/license/license.service';
 import { OrganizationService } from '@domain/community/organization/organization.service';
@@ -11,6 +11,7 @@ import { AccountService } from '@domain/space/account/account.service';
 import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
 import { AccountLicenseService } from '@domain/space/account/account.service.license';
 import { Controller, Inject, LoggerService } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   Ctx,
   EventPattern,
@@ -22,6 +23,7 @@ import { PlatformAuthorizationService } from '@platform/platform/platform.servic
 import { PlatformLicenseService } from '@platform/platform/platform.service.license';
 import { AiServerAuthorizationService } from '@services/ai-server/ai-server/ai.server.service.authorization';
 import { TaskService } from '@services/task/task.service';
+import { AlkemioConfig } from '@src/types';
 import { Channel, Message } from 'amqplib';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { AuthResetEventPayload } from '../auth-reset.payload.interface';
@@ -48,8 +50,18 @@ export class AuthResetController {
     private organizationLicenseService: OrganizationLicenseService,
     private aiServerAuthorizationService: AiServerAuthorizationService,
     private userService: UserService,
-    private taskService: TaskService
-  ) {}
+    private taskService: TaskService,
+    configService: ConfigService<AlkemioConfig, true>
+  ) {
+    // Same config key the publisher proxy and main.ts bind use, so retry
+    // re-publishes land back on the exact queue this worker consumes.
+    this.authResetQueue = configService.get(
+      'microservices.rabbitmq.auth_reset.queue',
+      { infer: true }
+    );
+  }
+
+  private readonly authResetQueue: string;
 
   @EventPattern(RESET_EVENT_TYPE.AUTHORIZATION_RESET_ACCOUNT, Transport.RMQ)
   public async authResetAccount(
@@ -91,7 +103,7 @@ export class AuthResetController {
           } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });
@@ -138,7 +150,7 @@ export class AuthResetController {
           } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });
@@ -190,7 +202,7 @@ export class AuthResetController {
           } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });
@@ -234,7 +246,7 @@ export class AuthResetController {
           }/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });
@@ -277,7 +289,7 @@ export class AuthResetController {
           }/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });
@@ -321,7 +333,7 @@ export class AuthResetController {
           }/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });
@@ -371,7 +383,7 @@ export class AuthResetController {
           } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });
@@ -427,7 +439,7 @@ export class AuthResetController {
           } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
           LogContext.AUTH
         );
-        channel.publish('', MessagingQueue.AUTH_RESET, originalMsg.content, {
+        channel.publish('', this.authResetQueue, originalMsg.content, {
           headers: { [RETRY_HEADER]: retryCount + 1 },
           persistent: true, // Make the message durable
         });

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -201,8 +201,10 @@ export type AlkemioConfig = {
         password: string;
       };
       auth_reset: {
+        // Queue the auth/license reset events flow over. Publisher (normal
+        // server) and the dedicated worker (src/main.worker.ts) MUST agree on
+        // this name.
         queue: string;
-        worker: boolean;
       };
       event_bus: {
         exchange: string;

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -200,6 +200,10 @@ export type AlkemioConfig = {
         user: string;
         password: string;
       };
+      auth_reset: {
+        queue: string;
+        worker: boolean;
+      };
       event_bus: {
         exchange: string;
         ingest_body_of_knowledge_queue: string;


### PR DESCRIPTION
## Summary

Splits the `alkemio-auth-reset` RabbitMQ consumer out of the main server into a dedicated, config-driven worker role so it can scale independently (KEDA scale-to-zero).

- **Config is the single source of truth.** The auth-reset queue name and worker flag live in `alkemio.yml` (`microservices.rabbitmq.auth_reset`), threaded through all three call sites that name the queue: the `main.ts` bind, the `AUTH_RESET_SERVICE` publisher proxy, and the controller retry-republish.
- **Main server publishes, no longer consumes.** Normal deployments emit reset events but do not bind the queue.
- **Dedicated worker** (`worker=true`) binds ONLY the auth-reset queue, with its own resources for a KEDA scale-to-zero deployment.
- **Bootstrap split** into `main.server.ts` / `main.worker.ts` entrypoints; `MicroservicesModule` decomposed into role-scoped modules (`auth-reset.worker.module.ts`, `worker.event-bus.module.ts`, `communication.rpc.module.ts`).
- Added `nest enableShutdownHooks` for clean worker shutdown.

## Changes

- `clientProxyFactory` / `connectMicroservice` widened to accept a string queue name.
- New config keys in `alkemio.yml` + `src/types/alkemio.config.ts`.
- Specs updated for `subscription.factory` and `auth-reset.controller`.

## Test plan

- [ ] Main server starts, publishes reset events, does NOT consume `alkemio-auth-reset`.
- [ ] Worker (`worker=true`) binds only the auth-reset queue and processes events.
- [ ] `pnpm lint` + `pnpm test:ci:no:coverage` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated worker mode for authorization/license reset processing (headless consumer without HTTP).
  * Introduced a configuration-driven RabbitMQ queue for auth-reset so the server and worker stay aligned.

* **Bug Fixes**
  * Improved reset retry publishing to always target the configured auth-reset queue.
  * Ensured the worker-only flow doesn’t start competing RabbitMQ consumers.

* **Documentation**
  * Expanded startup/config guidance to clarify server vs. worker behavior and queue isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Part of #6205
