### PR TITLE
fix(conversion): recompute platformRolesAccess on L1→L0 promotion

### DIFF
--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -237,6 +237,16 @@ export class ConversionService {
       );
     }
 
+    // The persisted platformRolesAccess JSON was derived from the OLD parent
+    // hierarchy (alkem-io/client-web#9891). For a subspace it gates platform
+    // (anonymous/guest/registered) READ behind the parent's grants, so a space
+    // promoted out of a private parent keeps platform users locked out of its
+    // dashboard until the value is recomputed. Recompute for the new L0 root
+    // (no parent) and cascade to the migrated descendants before the
+    // authorization policy is applied, since applyAuthorizationPolicy only
+    // reads platformRolesAccess and would otherwise propagate the stale rules.
+    await this.spaceService.updatePlatformRolesAccessRecursively(spaceL1);
+
     // Drop the now-stale SUBSPACE_CREATED entry on the source L0's activity
     // log — the moved space is no longer a subspace of that L0.
     await this.activityService.removeSubspaceCreatedActivityForResource(


### PR DESCRIPTION
## Problem

Promoting an L1 subspace to a top-level L0 space (`convertSpaceL1ToSpaceL0`) left platform users (anonymous/guest/registered) unable to open the promoted space's dashboard — they hit an error page until an admin edited a Space setting (which silently recomputed the missing data).

Fixes alkem-io/client-web#9891

## Root cause

`Space.platformRolesAccess` is a **persisted JSON cache** of per-platform-role privileges. It is computed only at space creation and on settings updates; `applyAuthorizationPolicy` merely *reads* it (so an auth reset alone never repaired it).

The computation is level-conditional:
- **L0 + PUBLIC** → registered/guest/anonymous get `READ` directly.
- **L1/L2** → those roles get `READ` only if the parent space granted it (`hasReadOnParent`). A subspace under a private parent therefore has `registered.grantedPrivileges = []`.

`convertSpaceL1ToSpaceL0OrFail` flipped `level = L0` but never recomputed `platformRolesAccess`, so a space promoted out of a private parent kept its locked-down subspace cache and denied platform-user `READ` on the new L0.

## Fix

Recompute `platformRolesAccess` for the new L0 root (no parent) and cascade to the migrated descendants, after the children are re-parented and before the authorization policy is applied:

```ts
await this.spaceService.updatePlatformRolesAccessRecursively(spaceL1);
```

## Testing

- `tsc --noEmit` clean.
- Manual repro: Private L0 → Public L1 child → promote → promoted L0's `platformRolesAccess.registered` now contains `read` (was `[]`); registered non-member can load the dashboard instead of the error page.

## Follow-up (not in this PR)

The same recompute is missing on the other level/parent-changing conversions in `conversion.service.ts` — L2→L1, L1→L2, and the L1 cross-L0 / L2 *move* operations. Same staleness class; worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where platform access rules could remain outdated after promoting a subspace to a new root level.
  * Access permissions are now recalculated and saved automatically for the updated hierarchy, helping ensure users receive the correct platform access behavior after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->