### PR TITLE
Analytics: authorType dimension to author; actor type keys

### DIFF
--- a/src/domain/actor/actor-lookup/actor.lookup.service.spec.ts
+++ b/src/domain/actor/actor-lookup/actor.lookup.service.spec.ts
@@ -289,7 +289,7 @@ describe('ActorLookupService', () => {
     });
   });
 
-  // 012-collabora-actor-type: tolerant batch lookup used by the Collabora
+  // agents-hq workspace spec 012-collabora-actor-type: tolerant batch lookup used by the Collabora
   // analytics consumer — resolvable ids only, never throws (FR-005/009).
   describe('getActorTypesByIds', () => {
     it('should return empty map for empty input', async () => {

--- a/src/domain/actor/actor-lookup/actor.lookup.service.spec.ts
+++ b/src/domain/actor/actor-lookup/actor.lookup.service.spec.ts
@@ -289,6 +289,86 @@ describe('ActorLookupService', () => {
     });
   });
 
+  // 012-collabora-actor-type: tolerant batch lookup used by the Collabora
+  // analytics consumer — resolvable ids only, never throws (FR-005/009).
+  describe('getActorTypesByIds', () => {
+    it('should return empty map for empty input', async () => {
+      const result = await service.getActorTypesByIds([]);
+      expect(result.size).toBe(0);
+      expect(entityManager.find).not.toHaveBeenCalled();
+    });
+
+    it('should silently skip non-UUID ids without throwing', async () => {
+      actorTypeCacheService.getActorTypes.mockResolvedValue(new Map());
+
+      const result = await service.getActorTypesByIds([
+        'not-a-uuid',
+        'also-no',
+      ]);
+
+      expect(result.size).toBe(0);
+      // never reaches the DB when no id is a valid UUID
+      expect(entityManager.find).not.toHaveBeenCalled();
+    });
+
+    it('should return cached types without DB query', async () => {
+      const cachedMap = new Map([[VALID_UUID, ActorType.USER]]);
+      actorTypeCacheService.getActorTypes.mockResolvedValue(cachedMap);
+
+      const result = await service.getActorTypesByIds([VALID_UUID]);
+
+      expect(result.get(VALID_UUID)).toBe(ActorType.USER);
+      expect(entityManager.find).not.toHaveBeenCalled();
+    });
+
+    it('should query DB for uncached IDs and cache results', async () => {
+      actorTypeCacheService.getActorTypes.mockResolvedValue(new Map());
+      entityManager.find.mockResolvedValue([
+        { id: VALID_UUID, type: ActorType.USER },
+        { id: VALID_UUID_2, type: ActorType.VIRTUAL_CONTRIBUTOR },
+      ]);
+      actorTypeCacheService.setActorTypes.mockResolvedValue(undefined);
+
+      const result = await service.getActorTypesByIds([
+        VALID_UUID,
+        VALID_UUID_2,
+      ]);
+
+      expect(result.size).toBe(2);
+      expect(result.get(VALID_UUID)).toBe(ActorType.USER);
+      expect(result.get(VALID_UUID_2)).toBe(ActorType.VIRTUAL_CONTRIBUTOR);
+      expect(actorTypeCacheService.setActorTypes).toHaveBeenCalled();
+    });
+
+    it('should omit unresolvable ids from the map without throwing (no caching of nothing)', async () => {
+      actorTypeCacheService.getActorTypes.mockResolvedValue(new Map());
+      // only one of the two requested ids exists in the DB
+      entityManager.find.mockResolvedValue([
+        { id: VALID_UUID, type: ActorType.USER },
+      ]);
+      actorTypeCacheService.setActorTypes.mockResolvedValue(undefined);
+
+      const result = await service.getActorTypesByIds([
+        VALID_UUID,
+        VALID_UUID_2,
+      ]);
+
+      expect(result.size).toBe(1);
+      expect(result.get(VALID_UUID)).toBe(ActorType.USER);
+      expect(result.has(VALID_UUID_2)).toBe(false);
+    });
+
+    it('should not write to cache when nothing is resolved', async () => {
+      actorTypeCacheService.getActorTypes.mockResolvedValue(new Map());
+      entityManager.find.mockResolvedValue([]); // none found
+
+      const result = await service.getActorTypesByIds([VALID_UUID]);
+
+      expect(result.size).toBe(0);
+      expect(actorTypeCacheService.setActorTypes).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getActorAuthorizationOrFail', () => {
     it('should throw for invalid UUID', async () => {
       await expect(

--- a/src/domain/actor/actor-lookup/actor.lookup.service.ts
+++ b/src/domain/actor/actor-lookup/actor.lookup.service.ts
@@ -243,6 +243,61 @@ export class ActorLookupService {
   }
 
   /**
+   * Tolerant batch type lookup: resolve the {@link ActorType} for each of the
+   * given ids, returning a map of ONLY the resolvable ids. Unlike
+   * {@link validateActorsAndGetTypes}, this NEVER throws — non-UUID ids are
+   * silently skipped and ids with no matching `Actor` are simply absent from
+   * the returned map. Callers bucket any absent id under a reserved `unknown`
+   * key (FR-005/009). Reuses the same cache-then-DB path as
+   * {@link validateActorsAndGetTypes}: a single
+   * `Actor.find({ where: { id: In(uncachedIds) } })` for the cache misses.
+   * Used by the Collabora analytics consumer to group recorded actor ids by
+   * type. See feature 012-collabora-actor-type.
+   */
+  async getActorTypesByIds(ids: string[]): Promise<Map<string, ActorType>> {
+    if (ids.length === 0) {
+      return new Map();
+    }
+
+    // Silently drop invalid UUIDs (tolerant — never throws).
+    const validIds = ids.filter(id => isUUID(id));
+    if (validIds.length === 0) {
+      return new Map();
+    }
+
+    // Check cache for all valid IDs
+    const cachedTypes =
+      await this.actorTypeCacheService.getActorTypes(validIds);
+
+    // Find IDs not in cache
+    const uncachedIds = validIds.filter(id => !cachedTypes.has(id));
+
+    // If all IDs are cached, return immediately
+    if (uncachedIds.length === 0) {
+      return cachedTypes;
+    }
+
+    // Query DB only for uncached IDs — missing ids are simply not returned
+    // (no throw on a partial result, unlike validateActorsAndGetTypes).
+    const actors = await this.entityManager.find(Actor, {
+      where: { id: In(uncachedIds) },
+      select: { id: true, type: true },
+      loadEagerRelations: false,
+    });
+
+    // Cache and merge whatever was found; unresolved ids stay absent.
+    const newTypes = new Map(actors.map(a => [a.id, a.type]));
+    if (newTypes.size > 0) {
+      await this.actorTypeCacheService.setActorTypes(newTypes);
+      for (const [id, type] of newTypes) {
+        cachedTypes.set(id, type);
+      }
+    }
+
+    return cachedTypes;
+  }
+
+  /**
    * Get authorization policy for any actor without loading the full entity.
    * Works for User, Organization, VirtualContributor, Space, Account.
    * Use when you only need the authorization policy.

--- a/src/domain/actor/actor-lookup/actor.lookup.service.ts
+++ b/src/domain/actor/actor-lookup/actor.lookup.service.ts
@@ -252,7 +252,7 @@ export class ActorLookupService {
    * {@link validateActorsAndGetTypes}: a single
    * `Actor.find({ where: { id: In(uncachedIds) } })` for the cache misses.
    * Used by the Collabora analytics consumer to group recorded actor ids by
-   * type. See feature 012-collabora-actor-type.
+   * type. See the agents-hq workspace spec 012-collabora-actor-type.
    */
   async getActorTypesByIds(ids: string[]): Promise<Map<string, ActorType>> {
     if (ids.length === 0) {

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
@@ -141,6 +141,37 @@ describe('CollaboraDocumentResolverQueries', () => {
       });
     });
 
+    it('forwards undefined (not an empty string) when the actor has no display name', async () => {
+      vi.mocked(
+        collaboraDocumentService.getCollaboraDocumentOrFail
+      ).mockResolvedValue({
+        id: 'collab-doc-1',
+        authorization: { id: 'auth-1' },
+        profile: { displayName: 'Quarterly Report' },
+      } as any);
+      vi.mocked(collaboraDocumentService.getEditorUrl).mockResolvedValue({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+
+      const actorLookupService = (resolver as any).actorLookupService;
+      // Blank displayName and empty nameID → getActorDisplayName returns ''.
+      vi.mocked(actorLookupService.getActorById).mockResolvedValue({
+        profile: { displayName: '  ' },
+        nameID: '',
+      } as any);
+
+      const actorContext = { actorID: 'user-1', isGuest: false } as any;
+      await resolver.collaboraEditorUrl(actorContext, 'collab-doc-1');
+
+      // '' is coalesced to undefined so WOPI applies its own fallback.
+      expect(collaboraDocumentService.getEditorUrl).toHaveBeenCalledWith(
+        'collab-doc-1',
+        'user-1',
+        undefined
+      );
+    });
+
     it('uses the guest name from the ActorContext without an actor lookup (#6170)', async () => {
       vi.mocked(
         collaboraDocumentService.getCollaboraDocumentOrFail

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
@@ -101,8 +101,9 @@ export class CollaboraDocumentResolverQueries {
    * Guests carry their name on the ActorContext (no Actor row exists for the
    * synthetic guest id); authenticated users get the canonical, PII-safe
    * `getActorDisplayName` (profile.displayName → nameID, never email).
-   * Returns undefined when no name can be resolved (anonymous, or a failed
-   * lookup), letting the WOPI service apply its own fallback.
+   * Returns undefined when no name can be resolved (anonymous, a failed
+   * lookup, or a resolved actor whose display name is blank), letting the WOPI
+   * service apply its own fallback rather than surfacing an empty name.
    *
    * Best-effort by design: `actorName` is optional and the editor flow works
    * without it, so a failed actor lookup must NEVER block opening the document
@@ -118,7 +119,9 @@ export class CollaboraDocumentResolverQueries {
       const actor = await this.actorLookupService.getActorById(
         actorContext.actorID
       );
-      return actor ? getActorDisplayName(actor) : undefined;
+      // getActorDisplayName can return '' (blank displayName and empty nameID);
+      // coalesce to undefined so WOPI applies its fallback, not a blank name.
+      return (actor && getActorDisplayName(actor)) || undefined;
     } catch (e: any) {
       this.logger.warn?.(
         {

--- a/src/services/collaborative-document-integration/collaborative-document-integration.module.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.module.ts
@@ -1,5 +1,6 @@
 import { ActorContextModule } from '@core/actor-context/actor.context.module';
 import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { ActorLookupModule } from '@domain/actor/actor-lookup/actor.lookup.module';
 import { CollaboraDocumentModule } from '@domain/collaboration/collabora-document/collabora.document.module';
 import { MemoModule } from '@domain/common/memo';
 import { Module } from '@nestjs/common';
@@ -12,6 +13,7 @@ import { CollaborativeDocumentIntegrationService } from './collaborative-documen
   imports: [
     AuthorizationModule,
     ActorContextModule,
+    ActorLookupModule,
     MemoModule,
     CollaboraDocumentModule,
     ContributionReporterModule,

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
@@ -493,6 +493,22 @@ describe('CollaborativeDocumentIntegrationService', () => {
       expect(arg.writeActors.unknown).toEqual(['ghost']);
     });
 
+    // Each group holds distinct actor_ids (record-shape contract): a repeated
+    // id within one set is de-duplicated, not emitted twice.
+    it('should de-duplicate a repeated id within a group', async () => {
+      arrange(new Map([['user-1', ActorType.USER]]));
+
+      await service.officeDocumentContributions({
+        documentId: STORAGE_DOCUMENT_ID,
+        writeActors: ['user-1', 'user-1'],
+        readonlyActors: [],
+      } as any);
+
+      const arg =
+        contributionReporter.officeDocumentContribution.mock.calls[0][0];
+      expect(arg.writeActors[ActorType.USER]).toEqual(['user-1']);
+    });
+
     // SC-006: the set of recorded ids equals the input — no ids gained or lost
     // by the grouping (an unresolvable id moves to `unknown`, it is not dropped).
     it('should preserve the full input id-set across the type groups (no ids lost)', async () => {

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
@@ -1,7 +1,9 @@
 import { AuthorizationPrivilege } from '@common/enums';
+import { ActorType } from '@common/enums/actor.type';
 import { EntityNotFoundException } from '@common/exceptions';
 import { ActorContextService } from '@core/actor-context/actor.context.service';
 import { AuthorizationService } from '@core/authorization/authorization.service';
+import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { CollaboraDocumentService } from '@domain/collaboration/collabora-document/collabora.document.service';
 import { MemoService } from '@domain/common/memo';
 import { ConfigService } from '@nestjs/config';
@@ -44,6 +46,9 @@ describe('CollaborativeDocumentIntegrationService', () => {
     getCommunityForCollaboraDocumentOrFail: Mock;
     getLevelZeroSpaceIdForCommunity: Mock;
   };
+  let actorLookupService: {
+    getActorTypesByIds: Mock;
+  };
 
   const configServiceMock = {
     get: vi.fn((key: string) => {
@@ -75,6 +80,7 @@ describe('CollaborativeDocumentIntegrationService', () => {
     collaboraDocumentService = module.get(CollaboraDocumentService) as any;
     contributionReporter = module.get(ContributionReporterService) as any;
     communityResolver = module.get(CommunityResolverService) as any;
+    actorLookupService = module.get(ActorLookupService) as any;
   });
 
   describe('accessGranted', () => {
@@ -304,7 +310,10 @@ describe('CollaborativeDocumentIntegrationService', () => {
     const STORAGE_DOCUMENT_ID = 'storage-doc-1';
     const COLLABORA_DOCUMENT_ID = 'collabora-doc-1';
 
-    const arrange = () => {
+    // 012: the consumer resolves each actor id → ActorType once via the tolerant
+    // batch lookup, then groups writeActors/readonlyActors by type. Pass the
+    // type-by-id map a test wants the lookup to return.
+    const arrange = (typeById: Map<string, ActorType> = new Map()) => {
       collaboraDocumentService.getCollaboraDocumentByStorageDocumentId.mockResolvedValue(
         {
           id: COLLABORA_DOCUMENT_ID,
@@ -317,16 +326,23 @@ describe('CollaborativeDocumentIntegrationService', () => {
       communityResolver.getLevelZeroSpaceIdForCommunity.mockResolvedValue(
         'space-root'
       );
+      actorLookupService.getActorTypesByIds.mockResolvedValue(typeById);
       contributionReporter.officeDocumentContribution.mockReturnValue(
         undefined
       );
     };
 
-    // T012: a storage documentId comes in → CollaboraDocument is reverse-resolved
-    // by document.id → ONE aggregate record indexed under the resolved
-    // CollaboraDocument.id, carrying both arrays.
+    // a storage documentId comes in → CollaboraDocument is reverse-resolved by
+    // document.id → ONE aggregate record indexed under the resolved
+    // CollaboraDocument.id, carrying both type-grouped actor sets.
     it('should reverse-resolve by storage document id and index ONE aggregate record under CollaboraDocument.id', async () => {
-      arrange();
+      arrange(
+        new Map([
+          ['user-1', ActorType.USER],
+          ['user-2', ActorType.USER],
+          ['user-3', ActorType.USER],
+        ])
+      );
 
       await service.officeDocumentContributions({
         documentId: STORAGE_DOCUMENT_ID,
@@ -360,46 +376,92 @@ describe('CollaborativeDocumentIntegrationService', () => {
         communityResolver.getLevelZeroSpaceIdForCommunity
       ).toHaveBeenCalledWith('community-1');
 
-      // T015: ONE aggregate record, id = resolved CollaboraDocument.id (NOT the storage id)
+      // ONE aggregate record, id = resolved CollaboraDocument.id (NOT the storage id)
       expect(
         contributionReporter.officeDocumentContribution
       ).toHaveBeenCalledTimes(1);
-      expect(
-        contributionReporter.officeDocumentContribution
-      ).toHaveBeenCalledWith({
-        id: COLLABORA_DOCUMENT_ID,
-        name: 'My Document',
-        space: 'space-root',
-        writeActors: ['user-1', 'user-2'],
-        readonlyActors: ['user-3'],
-      });
-
-      // explicitly: the storage id is never used as the record id
       const arg =
         contributionReporter.officeDocumentContribution.mock.calls[0][0];
+      expect(arg.id).toBe(COLLABORA_DOCUMENT_ID);
+      expect(arg.name).toBe('My Document');
+      expect(arg.space).toBe('space-root');
+      // type-grouped, single-key (all users today). Assert by set membership.
+      expect(Object.keys(arg.writeActors)).toEqual([ActorType.USER]);
+      expect(arg.writeActors[ActorType.USER]).toEqual(
+        expect.arrayContaining(['user-1', 'user-2'])
+      );
+      expect(arg.writeActors[ActorType.USER]).toHaveLength(2);
+      expect(arg.readonlyActors).toEqual({ [ActorType.USER]: ['user-3'] });
+
+      // explicitly: the storage id is never used as the record id
       expect(arg.id).not.toBe(STORAGE_DOCUMENT_ID);
     });
 
-    // T014: both arrays pass through verbatim (no fan-out, no dropping readonlyActors)
-    it('should pass writeActors and readonlyActors through verbatim', async () => {
-      arrange();
-      const writeActors = ['w1', 'w2'];
-      const readonlyActors = ['r1'];
+    // SC-001/SC-005: mixed-type write actors are grouped under their distinct,
+    // independently-addressable type keys (membership, not order).
+    it('should group writeActors by actor type and keep groups independently addressable', async () => {
+      arrange(
+        new Map([
+          ['u1', ActorType.USER],
+          ['u2', ActorType.USER],
+          ['vc1', ActorType.VIRTUAL_CONTRIBUTOR],
+          ['u3', ActorType.USER],
+        ])
+      );
 
       await service.officeDocumentContributions({
         documentId: STORAGE_DOCUMENT_ID,
-        writeActors,
-        readonlyActors,
+        writeActors: ['u1', 'vc1', 'u2'],
+        readonlyActors: ['u3'],
+      } as any);
+
+      // the lookup is consulted ONCE for the union of both sets
+      expect(actorLookupService.getActorTypesByIds).toHaveBeenCalledTimes(1);
+      const lookupArg = actorLookupService.getActorTypesByIds.mock.calls[0][0];
+      expect(lookupArg).toEqual(
+        expect.arrayContaining(['u1', 'u2', 'vc1', 'u3'])
+      );
+
+      const arg =
+        contributionReporter.officeDocumentContribution.mock.calls[0][0];
+      expect(Object.keys(arg.writeActors)).toEqual(
+        expect.arrayContaining([ActorType.USER, ActorType.VIRTUAL_CONTRIBUTOR])
+      );
+      // distinct keys hold the right ids (segmentability, SC-005)
+      expect(arg.writeActors[ActorType.USER]).toEqual(
+        expect.arrayContaining(['u1', 'u2'])
+      );
+      expect(arg.writeActors[ActorType.USER]).toHaveLength(2);
+      expect(arg.writeActors[ActorType.VIRTUAL_CONTRIBUTOR]).toEqual(['vc1']);
+      expect(arg.readonlyActors).toEqual({ [ActorType.USER]: ['u3'] });
+    });
+
+    // SC-002: every actor is a user → a single-key object, never a flat array.
+    it('should produce a single-key object when every actor is a user', async () => {
+      arrange(
+        new Map([
+          ['user-1', ActorType.USER],
+          ['user-2', ActorType.USER],
+        ])
+      );
+
+      await service.officeDocumentContributions({
+        documentId: STORAGE_DOCUMENT_ID,
+        writeActors: ['user-1', 'user-2'],
+        readonlyActors: [],
       } as any);
 
       const arg =
         contributionReporter.officeDocumentContribution.mock.calls[0][0];
-      expect(arg.writeActors).toEqual(writeActors);
-      expect(arg.readonlyActors).toEqual(readonlyActors);
+      expect(Array.isArray(arg.writeActors)).toBe(false);
+      expect(arg.writeActors).toEqual({
+        [ActorType.USER]: expect.arrayContaining(['user-1', 'user-2']),
+      });
     });
 
-    it('should index a record with an empty readonlyActors array when none are read-only', async () => {
-      arrange();
+    // FR-003: an empty actor set serializes as {} (empty object), not [] / null.
+    it('should index an empty readonlyActors set as {} when none are read-only', async () => {
+      arrange(new Map([['user-1', ActorType.USER]]));
 
       await service.officeDocumentContributions({
         documentId: STORAGE_DOCUMENT_ID,
@@ -409,11 +471,54 @@ describe('CollaborativeDocumentIntegrationService', () => {
 
       const arg =
         contributionReporter.officeDocumentContribution.mock.calls[0][0];
-      expect(arg.readonlyActors).toEqual([]);
-      expect(arg.writeActors).toEqual(['user-1']);
+      expect(arg.readonlyActors).toEqual({});
+      expect(arg.writeActors).toEqual({ [ActorType.USER]: ['user-1'] });
     });
 
-    // T013 + FR-008: no CollaboraDocument backs the storage document id → discard without throwing
+    // FR-005: an id the lookup cannot resolve is bucketed under `unknown`,
+    // never dropped.
+    it('should bucket an unresolvable id under the reserved unknown key', async () => {
+      // ghost is absent from the returned map (tolerant lookup omits it)
+      arrange(new Map([['user-1', ActorType.USER]]));
+
+      await service.officeDocumentContributions({
+        documentId: STORAGE_DOCUMENT_ID,
+        writeActors: ['user-1', 'ghost'],
+        readonlyActors: [],
+      } as any);
+
+      const arg =
+        contributionReporter.officeDocumentContribution.mock.calls[0][0];
+      expect(arg.writeActors[ActorType.USER]).toEqual(['user-1']);
+      expect(arg.writeActors.unknown).toEqual(['ghost']);
+    });
+
+    // SC-006: the set of recorded ids equals the input — no ids gained or lost
+    // by the grouping (an unresolvable id moves to `unknown`, it is not dropped).
+    it('should preserve the full input id-set across the type groups (no ids lost)', async () => {
+      arrange(
+        new Map([
+          ['u1', ActorType.USER],
+          ['vc1', ActorType.VIRTUAL_CONTRIBUTOR],
+        ])
+      );
+
+      await service.officeDocumentContributions({
+        documentId: STORAGE_DOCUMENT_ID,
+        writeActors: ['u1', 'vc1', 'ghost'],
+        readonlyActors: ['r-ghost'],
+      } as any);
+
+      const arg =
+        contributionReporter.officeDocumentContribution.mock.calls[0][0];
+      const writeIds = Object.values(arg.writeActors).flat();
+      const readIds = Object.values(arg.readonlyActors).flat();
+      expect(writeIds).toEqual(expect.arrayContaining(['u1', 'vc1', 'ghost']));
+      expect(writeIds).toHaveLength(3);
+      expect(readIds).toEqual(['r-ghost']);
+    });
+
+    // FR-008: no CollaboraDocument backs the storage document id → discard without throwing
     it('should discard the event without throwing when no CollaboraDocument resolves for the storage document id', async () => {
       collaboraDocumentService.getCollaboraDocumentByStorageDocumentId.mockResolvedValue(
         null
@@ -468,7 +573,7 @@ describe('CollaborativeDocumentIntegrationService', () => {
     const STORAGE_DOCUMENT_ID = 'storage-doc-1';
     const COLLABORA_DOCUMENT_ID = 'collabora-doc-1';
 
-    const arrange = () => {
+    const arrange = (typeById: Map<string, ActorType> = new Map()) => {
       collaboraDocumentService.getCollaboraDocumentByStorageDocumentId.mockResolvedValue(
         {
           id: COLLABORA_DOCUMENT_ID,
@@ -481,14 +586,21 @@ describe('CollaborativeDocumentIntegrationService', () => {
       communityResolver.getLevelZeroSpaceIdForCommunity.mockResolvedValue(
         'space-root'
       );
+      actorLookupService.getActorTypesByIds.mockResolvedValue(typeById);
       contributionReporter.officeDocumentView.mockReturnValue(undefined);
     };
 
-    // T030: a storage documentId comes in → CollaboraDocument is reverse-resolved
+    // a storage documentId comes in → CollaboraDocument is reverse-resolved
     // by document.id → ONE aggregate VIEW record indexed under the resolved
-    // CollaboraDocument.id, carrying both arrays.
+    // CollaboraDocument.id, carrying both type-grouped actor sets.
     it('should reverse-resolve by storage document id and index ONE aggregate VIEW record under CollaboraDocument.id', async () => {
-      arrange();
+      arrange(
+        new Map([
+          ['user-1', ActorType.USER],
+          ['user-2', ActorType.USER],
+          ['user-3', ActorType.USER],
+        ])
+      );
 
       await service.officeDocumentViews({
         documentId: STORAGE_DOCUMENT_ID,
@@ -514,33 +626,45 @@ describe('CollaborativeDocumentIntegrationService', () => {
       expect(
         contributionReporter.officeDocumentContribution
       ).not.toHaveBeenCalled();
-      expect(contributionReporter.officeDocumentView).toHaveBeenCalledWith({
-        id: COLLABORA_DOCUMENT_ID,
-        name: 'My Document',
-        space: 'space-root',
-        writeActors: ['user-1', 'user-2'],
-        readonlyActors: ['user-3'],
-      });
+
+      const arg = contributionReporter.officeDocumentView.mock.calls[0][0];
+      expect(arg.id).toBe(COLLABORA_DOCUMENT_ID);
+      expect(arg.name).toBe('My Document');
+      expect(arg.space).toBe('space-root');
+      // structural parity with the contribution record: type-grouped sets
+      expect(arg.writeActors[ActorType.USER]).toEqual(
+        expect.arrayContaining(['user-1', 'user-2'])
+      );
+      expect(arg.writeActors[ActorType.USER]).toHaveLength(2);
+      expect(arg.readonlyActors).toEqual({ [ActorType.USER]: ['user-3'] });
 
       // the storage id is never used as the record id
-      const arg = contributionReporter.officeDocumentView.mock.calls[0][0];
       expect(arg.id).not.toBe(STORAGE_DOCUMENT_ID);
     });
 
-    it('should pass writeActors and readonlyActors through verbatim', async () => {
-      arrange();
-      const writeActors = ['w1', 'w2'];
-      const readonlyActors = ['r1'];
+    // structural parity (SC-003): the view path groups by type identically to
+    // the contribution path, including mixed types and an empty set → {}.
+    it('should group view actors by type identically to the contribution record', async () => {
+      arrange(
+        new Map([
+          ['w1', ActorType.USER],
+          ['w2', ActorType.VIRTUAL_CONTRIBUTOR],
+        ])
+      );
 
       await service.officeDocumentViews({
         documentId: STORAGE_DOCUMENT_ID,
-        writeActors,
-        readonlyActors,
+        writeActors: ['w1', 'w2'],
+        readonlyActors: [],
       } as any);
 
       const arg = contributionReporter.officeDocumentView.mock.calls[0][0];
-      expect(arg.writeActors).toEqual(writeActors);
-      expect(arg.readonlyActors).toEqual(readonlyActors);
+      expect(Object.keys(arg.writeActors)).toEqual(
+        expect.arrayContaining([ActorType.USER, ActorType.VIRTUAL_CONTRIBUTOR])
+      );
+      expect(arg.writeActors[ActorType.USER]).toEqual(['w1']);
+      expect(arg.writeActors[ActorType.VIRTUAL_CONTRIBUTOR]).toEqual(['w2']);
+      expect(arg.readonlyActors).toEqual({});
     });
 
     // FR-008: no CollaboraDocument backs the storage document id → discard without throwing

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -1,7 +1,9 @@
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
+import { ActorType } from '@common/enums/actor.type';
 import { EntityNotFoundException } from '@common/exceptions';
 import { ActorContextService } from '@core/actor-context/actor.context.service';
 import { AuthorizationService } from '@core/authorization/authorization.service';
+import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { CollaboraDocumentService } from '@domain/collaboration/collabora-document/collabora.document.service';
 import { MemoService } from '@domain/common/memo';
 import { Inject, Injectable } from '@nestjs/common';
@@ -9,6 +11,10 @@ import { ConfigService } from '@nestjs/config';
 import { MemoContributionsInputData } from '@services/collaborative-document-integration/inputs/memo.contributions.input.data';
 import { OfficeDocumentContributionsInputData } from '@services/collaborative-document-integration/inputs/office.document.contributions.input.data';
 import { ContributionReporterService } from '@services/external/elasticsearch/contribution-reporter';
+import {
+  TypedActorSet,
+  UNKNOWN_ACTOR_TYPE,
+} from '@services/external/elasticsearch/types/typed.actor.set';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { AlkemioConfig } from '@src/types';
 import { WINSTON_MODULE_NEST_PROVIDER, WinstonLogger } from 'nest-winston';
@@ -42,7 +48,8 @@ export class CollaborativeDocumentIntegrationService {
     private readonly collaboraDocumentService: CollaboraDocumentService,
     private readonly configService: ConfigService<AlkemioConfig, true>,
     private readonly contributionReporter: ContributionReporterService,
-    private readonly communityResolver: CommunityResolverService
+    private readonly communityResolver: CommunityResolverService,
+    private readonly actorLookupService: ActorLookupService
   ) {
     this.maxCollaboratorsInRoom = this.configService.get(
       'collaboration.memo.max_collaborators_in_room',
@@ -251,8 +258,8 @@ export class CollaborativeDocumentIntegrationService {
       id: string;
       name: string;
       space: string;
-      writeActors: string[];
-      readonlyActors: string[];
+      writeActors: TypedActorSet;
+      readonlyActors: TypedActorSet;
     }) => void
   ): Promise<void> {
     try {
@@ -284,12 +291,19 @@ export class CollaborativeDocumentIntegrationService {
         );
       const displayName = collaboraDocument.profile?.displayName ?? '';
 
+      // Resolve actor types ONCE for the union of both sets (tolerant batch
+      // lookup — unresolvable ids are simply absent and fall to `unknown`),
+      // then partition each set by type. The set of ids is unchanged (SC-006);
+      // only their shape changes (flat array → type-keyed object).
+      const allIds = [...new Set([...writeActors, ...readonlyActors])];
+      const typeById = await this.actorLookupService.getActorTypesByIds(allIds);
+
       report({
         id: collaboraDocument.id,
         name: displayName,
         space: levelZeroSpaceID,
-        writeActors,
-        readonlyActors,
+        writeActors: this.groupActorsByType(writeActors, typeById),
+        readonlyActors: this.groupActorsByType(readonlyActors, typeById),
       });
     } catch (e: any) {
       this.logger.warn?.(
@@ -301,6 +315,27 @@ export class CollaborativeDocumentIntegrationService {
         LogContext.COLLAB_DOCUMENT_INTEGRATION
       );
     }
+  }
+
+  /**
+   * Partition a flat list of actor ids into a {@link TypedActorSet}: an object
+   * keyed by each id's resolved {@link ActorType} (from `typeById`), falling
+   * back to the reserved `unknown` bucket for any id absent from the map
+   * (FR-005). Only non-empty groups appear; an empty input yields `{}`
+   * (FR-003). Ordering within a group is unspecified (FR-002) — this folds in
+   * encounter order, but callers must not rely on it. See feature
+   * 012-collabora-actor-type.
+   */
+  private groupActorsByType(
+    ids: string[],
+    typeById: Map<string, ActorType>
+  ): TypedActorSet {
+    const grouped: TypedActorSet = {};
+    for (const id of ids) {
+      const key = typeById.get(id) ?? UNKNOWN_ACTOR_TYPE;
+      (grouped[key] ??= []).push(id);
+    }
+    return grouped;
   }
 }
 

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -322,16 +322,18 @@ export class CollaborativeDocumentIntegrationService {
    * keyed by each id's resolved {@link ActorType} (from `typeById`), falling
    * back to the reserved `unknown` bucket for any id absent from the map
    * (FR-005). Only non-empty groups appear; an empty input yields `{}`
-   * (FR-003). Ordering within a group is unspecified (FR-002) — this folds in
-   * encounter order, but callers must not rely on it. See feature
-   * 012-collabora-actor-type (in the agents-hq workspace repo).
+   * (FR-003). Ids are de-duplicated so each group holds distinct actor_ids
+   * (matches the record-shape contract) even if the producer repeats one.
+   * Ordering within a group is unspecified (FR-002) — this folds in encounter
+   * order, but callers must not rely on it. See feature 012-collabora-actor-type
+   * (in the agents-hq workspace repo).
    */
   private groupActorsByType(
     ids: string[],
     typeById: Map<string, ActorType>
   ): TypedActorSet {
     const grouped: TypedActorSet = {};
-    for (const id of ids) {
+    for (const id of new Set(ids)) {
       const key = typeById.get(id) ?? UNKNOWN_ACTOR_TYPE;
       (grouped[key] ??= []).push(id);
     }

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -324,7 +324,7 @@ export class CollaborativeDocumentIntegrationService {
    * (FR-005). Only non-empty groups appear; an empty input yields `{}`
    * (FR-003). Ordering within a group is unspecified (FR-002) — this folds in
    * encounter order, but callers must not rely on it. See feature
-   * 012-collabora-actor-type.
+   * 012-collabora-actor-type (in the agents-hq workspace repo).
    */
   private groupActorsByType(
     ids: string[],

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.spec.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.spec.ts
@@ -688,6 +688,33 @@ describe('ContributionReporterService', () => {
       expect(indexedDocument.authorType).toBe('unknown');
       expect(indexedDocument.guest).toBe(true);
     });
+
+    // 012 / research R4: a resolvable NON-user actor (VC/org/space/account)
+    // records its id + ActorType, NOT the anonymous fallback. The lifecycle
+    // path must match the aggregate path, which already types every actor.
+    it('should record a resolvable non-user actor with its id and ActorType', async () => {
+      mockActorService.getActorOrNull.mockResolvedValue({
+        id: 'vc-1',
+        type: ActorType.VIRTUAL_CONTRIBUTOR,
+      });
+
+      service.collaboraDocumentOpened(
+        { id: 'doc-vc', name: 'VC Opened', space: 'space-root' },
+        { actorID: 'vc-1' }
+      );
+
+      await vi.waitFor(() => {
+        expect(mockIndex).toHaveBeenCalledTimes(1);
+      });
+
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(indexedDocument.author).toBe('vc-1');
+      expect(indexedDocument.authorType).toBe(ActorType.VIRTUAL_CONTRIBUTOR);
+      expect(indexedDocument.anonymous).toBe(false);
+      expect(indexedDocument.guest).toBe(false);
+      // No user lookup for a non-user actor.
+      expect(mockUserLookupService.getUserByIdOrFail).not.toHaveBeenCalled();
+    });
   });
 
   describe('pollVoteContribution', () => {

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.spec.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.spec.ts
@@ -372,40 +372,16 @@ describe('ContributionReporterService', () => {
   });
 
   describe('officeDocumentContribution', () => {
-    it('should index ONE aggregate OFFICE_DOCUMENT_CONTRIBUTION document carrying both user arrays', async () => {
+    it('should index ONE aggregate OFFICE_DOCUMENT_CONTRIBUTION document carrying both type-keyed actor sets verbatim', async () => {
       service.officeDocumentContribution({
         id: 'doc-1',
         name: 'My Document',
         space: 'space-root',
-        writeActors: ['user-1', 'user-2'],
-        readonlyActors: ['user-3'],
-      });
-
-      await vi.waitFor(() => {
-        expect(mockIndex).toHaveBeenCalledTimes(1);
-      });
-
-      expect(mockIndex).toHaveBeenCalledWith(
-        expect.objectContaining({
-          document: expect.objectContaining({
-            type: 'OFFICE_DOCUMENT_CONTRIBUTION',
-            id: 'doc-1',
-            name: 'My Document',
-            space: 'space-root',
-            writeActors: ['user-1', 'user-2'],
-            readonlyActors: ['user-3'],
-          }),
-        })
-      );
-    });
-
-    it('should not attach a per-user author shape to the aggregate document', async () => {
-      service.officeDocumentContribution({
-        id: 'doc-2',
-        name: 'Another Document',
-        space: 'space-root',
-        writeActors: ['user-1'],
-        readonlyActors: [],
+        writeActors: {
+          [ActorType.USER]: ['user-1', 'user-2'],
+          [ActorType.VIRTUAL_CONTRIBUTOR]: ['vc-1'],
+        },
+        readonlyActors: { [ActorType.USER]: ['user-3'] },
       });
 
       await vi.waitFor(() => {
@@ -413,73 +389,106 @@ describe('ContributionReporterService', () => {
       });
 
       const indexedDocument = mockIndex.mock.calls[0][0].document;
-      expect(indexedDocument).not.toHaveProperty('author');
-      expect(indexedDocument).not.toHaveProperty('anonymous');
-      expect(indexedDocument).not.toHaveProperty('guest');
-      // resolve once, not per-user — actor lookup is never consulted
-      expect(mockActorService.getActorOrNull).not.toHaveBeenCalled();
+      expect(indexedDocument.type).toBe('OFFICE_DOCUMENT_CONTRIBUTION');
+      expect(indexedDocument.id).toBe('doc-1');
+      expect(indexedDocument.name).toBe('My Document');
+      expect(indexedDocument.space).toBe('space-root');
+      // the typed map is written verbatim — no flattening (assert by membership)
+      expect(indexedDocument.writeActors[ActorType.USER]).toEqual(
+        expect.arrayContaining(['user-1', 'user-2'])
+      );
+      expect(
+        indexedDocument.writeActors[ActorType.VIRTUAL_CONTRIBUTOR]
+      ).toEqual(['vc-1']);
+      expect(indexedDocument.readonlyActors).toEqual({
+        [ActorType.USER]: ['user-3'],
+      });
     });
 
-    it('should preserve an empty readonlyActors array', async () => {
+    // FR-008 / C1: ONLY the typed shape is written — no flat-array field is
+    // emitted alongside it (no dual-write).
+    it('should write only the typed shape with no flat-array fallback alongside it', async () => {
       service.officeDocumentContribution({
-        id: 'doc-3',
-        name: 'Doc',
+        id: 'doc-2',
+        name: 'Another Document',
         space: 'space-root',
-        writeActors: ['user-1'],
-        readonlyActors: [],
+        writeActors: { [ActorType.USER]: ['user-1'] },
+        readonlyActors: {},
       });
 
       await vi.waitFor(() => {
         expect(mockIndex).toHaveBeenCalledTimes(1);
       });
 
-      expect(mockIndex).toHaveBeenCalledWith(
-        expect.objectContaining({
-          document: expect.objectContaining({
-            type: 'OFFICE_DOCUMENT_CONTRIBUTION',
-            writeActors: ['user-1'],
-            readonlyActors: [],
-          }),
-        })
-      );
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      // typed objects, never arrays
+      expect(Array.isArray(indexedDocument.writeActors)).toBe(false);
+      expect(Array.isArray(indexedDocument.readonlyActors)).toBe(false);
+      // no per-user author shape on the aggregate
+      expect(indexedDocument).not.toHaveProperty('author');
+      expect(indexedDocument).not.toHaveProperty('anonymous');
+      expect(indexedDocument).not.toHaveProperty('guest');
+      // the reporter does no resolution — it writes what it is given
+      expect(mockActorService.getActorOrNull).not.toHaveBeenCalled();
+    });
+
+    // SC-005: distinct type keys are independently addressable in the index.
+    it('should keep distinct actor-type groups independently addressable', async () => {
+      service.officeDocumentContribution({
+        id: 'doc-seg',
+        name: 'Segmentable Document',
+        space: 'space-root',
+        writeActors: {
+          [ActorType.USER]: ['user-1'],
+          [ActorType.VIRTUAL_CONTRIBUTOR]: ['vc-1'],
+        },
+        readonlyActors: {},
+      });
+
+      await vi.waitFor(() => {
+        expect(mockIndex).toHaveBeenCalledTimes(1);
+      });
+
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(indexedDocument.writeActors[ActorType.USER]).toEqual(['user-1']);
+      expect(
+        indexedDocument.writeActors[ActorType.VIRTUAL_CONTRIBUTOR]
+      ).toEqual(['vc-1']);
+    });
+
+    // FR-003: an empty actor set is preserved as {} (empty object).
+    it('should preserve an empty readonlyActors set as {}', async () => {
+      service.officeDocumentContribution({
+        id: 'doc-3',
+        name: 'Doc',
+        space: 'space-root',
+        writeActors: { [ActorType.USER]: ['user-1'] },
+        readonlyActors: {},
+      });
+
+      await vi.waitFor(() => {
+        expect(mockIndex).toHaveBeenCalledTimes(1);
+      });
+
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(indexedDocument.type).toBe('OFFICE_DOCUMENT_CONTRIBUTION');
+      expect(indexedDocument.writeActors).toEqual({
+        [ActorType.USER]: ['user-1'],
+      });
+      expect(indexedDocument.readonlyActors).toEqual({});
     });
   });
 
   describe('officeDocumentView', () => {
-    it('should index ONE aggregate OFFICE_DOCUMENT_VIEW document carrying both user arrays', async () => {
+    it('should index ONE aggregate OFFICE_DOCUMENT_VIEW document carrying both type-keyed actor sets verbatim', async () => {
       service.officeDocumentView({
         id: 'doc-1',
         name: 'My Document',
         space: 'space-root',
-        writeActors: ['user-1', 'user-2'],
-        readonlyActors: ['user-3'],
-      });
-
-      await vi.waitFor(() => {
-        expect(mockIndex).toHaveBeenCalledTimes(1);
-      });
-
-      expect(mockIndex).toHaveBeenCalledWith(
-        expect.objectContaining({
-          document: expect.objectContaining({
-            type: 'OFFICE_DOCUMENT_VIEW',
-            id: 'doc-1',
-            name: 'My Document',
-            space: 'space-root',
-            writeActors: ['user-1', 'user-2'],
-            readonlyActors: ['user-3'],
-          }),
-        })
-      );
-    });
-
-    it('should not attach a per-user author shape to the aggregate document', async () => {
-      service.officeDocumentView({
-        id: 'doc-2',
-        name: 'Another Document',
-        space: 'space-root',
-        writeActors: ['user-1'],
-        readonlyActors: [],
+        writeActors: {
+          [ActorType.USER]: ['user-1', 'user-2'],
+        },
+        readonlyActors: { [ActorType.USER]: ['user-3'] },
       });
 
       await vi.waitFor(() => {
@@ -487,6 +496,35 @@ describe('ContributionReporterService', () => {
       });
 
       const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(indexedDocument.type).toBe('OFFICE_DOCUMENT_VIEW');
+      expect(indexedDocument.id).toBe('doc-1');
+      expect(indexedDocument.name).toBe('My Document');
+      expect(indexedDocument.space).toBe('space-root');
+      expect(indexedDocument.writeActors[ActorType.USER]).toEqual(
+        expect.arrayContaining(['user-1', 'user-2'])
+      );
+      expect(indexedDocument.readonlyActors).toEqual({
+        [ActorType.USER]: ['user-3'],
+      });
+    });
+
+    // FR-008: only the typed shape is written — no flat-array field alongside.
+    it('should write only the typed shape with no flat-array fallback alongside it', async () => {
+      service.officeDocumentView({
+        id: 'doc-2',
+        name: 'Another Document',
+        space: 'space-root',
+        writeActors: { [ActorType.USER]: ['user-1'] },
+        readonlyActors: {},
+      });
+
+      await vi.waitFor(() => {
+        expect(mockIndex).toHaveBeenCalledTimes(1);
+      });
+
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(Array.isArray(indexedDocument.writeActors)).toBe(false);
+      expect(Array.isArray(indexedDocument.readonlyActors)).toBe(false);
       expect(indexedDocument).not.toHaveProperty('author');
       expect(indexedDocument).not.toHaveProperty('anonymous');
       expect(indexedDocument).not.toHaveProperty('guest');
@@ -494,28 +532,25 @@ describe('ContributionReporterService', () => {
       expect(mockActorService.getActorOrNull).not.toHaveBeenCalled();
     });
 
-    it('should preserve an empty readonlyActors array', async () => {
+    it('should preserve an empty readonlyActors set as {}', async () => {
       service.officeDocumentView({
         id: 'doc-3',
         name: 'Doc',
         space: 'space-root',
-        writeActors: ['user-1'],
-        readonlyActors: [],
+        writeActors: { [ActorType.USER]: ['user-1'] },
+        readonlyActors: {},
       });
 
       await vi.waitFor(() => {
         expect(mockIndex).toHaveBeenCalledTimes(1);
       });
 
-      expect(mockIndex).toHaveBeenCalledWith(
-        expect.objectContaining({
-          document: expect.objectContaining({
-            type: 'OFFICE_DOCUMENT_VIEW',
-            writeActors: ['user-1'],
-            readonlyActors: [],
-          }),
-        })
-      );
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(indexedDocument.type).toBe('OFFICE_DOCUMENT_VIEW');
+      expect(indexedDocument.writeActors).toEqual({
+        [ActorType.USER]: ['user-1'],
+      });
+      expect(indexedDocument.readonlyActors).toEqual({});
     });
   });
 
@@ -546,6 +581,8 @@ describe('ContributionReporterService', () => {
             name: 'My Document',
             space: 'space-root',
             author: 'user-1',
+            // 012: scalar actorType alongside the author id
+            authorType: ActorType.USER,
           }),
         })
       );
@@ -579,6 +616,7 @@ describe('ContributionReporterService', () => {
             name: 'Imported Document',
             space: 'space-root',
             author: 'user-1',
+            authorType: ActorType.USER,
           }),
         })
       );
@@ -612,9 +650,43 @@ describe('ContributionReporterService', () => {
             name: 'Opened Document',
             space: 'space-root',
             author: 'user-1',
+            authorType: ActorType.USER,
           }),
         })
       );
+    });
+
+    // FR-005 / SC-004: a guest/anonymous/unresolvable actor context yields
+    // authorType "unknown" — a discrete, filterable scalar (SC-005).
+    it('should set authorType "unknown" for an anonymous actor context', async () => {
+      service.collaboraDocumentOpened(
+        { id: 'doc-anon', name: 'Anon Opened', space: 'space-root' },
+        { isAnonymous: true }
+      );
+
+      await vi.waitFor(() => {
+        expect(mockIndex).toHaveBeenCalledTimes(1);
+      });
+
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(indexedDocument.type).toBe('COLLABORA_DOCUMENT_OPENED');
+      expect(indexedDocument.authorType).toBe('unknown');
+      expect(indexedDocument.anonymous).toBe(true);
+    });
+
+    it('should set authorType "unknown" for a guest actor context', async () => {
+      service.collaboraDocumentOpened(
+        { id: 'doc-guest', name: 'Guest Opened', space: 'space-root' },
+        { guestName: 'Guest User' }
+      );
+
+      await vi.waitFor(() => {
+        expect(mockIndex).toHaveBeenCalledTimes(1);
+      });
+
+      const indexedDocument = mockIndex.mock.calls[0][0].document;
+      expect(indexedDocument.authorType).toBe('unknown');
+      expect(indexedDocument.guest).toBe(true);
     });
   });
 

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
@@ -348,7 +348,7 @@ export class ContributionReporterService {
    * document per user. The consumer resolves space/displayName once upstream
    * and groups each actor set by `ActorType`; both maps pass through verbatim
    * (this reporter does no resolution and writes only the typed shape). See
-   * features 003-collabora-doc-contributions and 012-collabora-actor-type.
+   * agents-hq workspace specs 003-collabora-doc-contributions and 012-collabora-actor-type.
    */
   public officeDocumentContribution(contribution: {
     id: string;

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
@@ -478,36 +478,51 @@ export class ContributionReporterService {
       const actor = await this.actorService.getActorOrNull(
         actorContext.actorID
       );
-      if (actor && actor.type === 'user') {
-        try {
-          const user = await this.userLookupService.getUserByIdOrFail(actor.id);
-          return {
-            author: actor.id,
-            anonymous: false,
-            alkemio: isFromAlkemioTeam(user.email),
-            guest: false,
-            // 012: the acting actor's resolved ActorType.
-            authorType: actor.type,
-          };
-        } catch (e) {
-          this.logger.error(
-            {
-              message:
-                'Unable to fetch user details for actor in ContributionReporterService',
-              actorContext,
-              actorId: actor.id,
-            },
-            e instanceof Error ? e.stack : String(e),
-            LogContext.CONTRIBUTION_REPORTER
-          );
-          return {
-            author: actor.id,
-            anonymous: false,
-            alkemio: false,
-            guest: false,
-            authorType: actor.type,
-          };
+      if (actor) {
+        // 012 / research R4: any resolvable actor records its id + ActorType.
+        // The `alkemio`-team flag is user-specific (derived from email), so the
+        // user lookup only runs for users; non-user actors (VC/org/space/
+        // account) record their id and type without it, matching the aggregate
+        // path which types every actor.
+        if (actor.type === 'user') {
+          try {
+            const user = await this.userLookupService.getUserByIdOrFail(
+              actor.id
+            );
+            return {
+              author: actor.id,
+              anonymous: false,
+              alkemio: isFromAlkemioTeam(user.email),
+              guest: false,
+              authorType: actor.type,
+            };
+          } catch (e) {
+            this.logger.error(
+              {
+                message:
+                  'Unable to fetch user details for actor in ContributionReporterService',
+                actorContext,
+                actorId: actor.id,
+              },
+              e instanceof Error ? e.stack : String(e),
+              LogContext.CONTRIBUTION_REPORTER
+            );
+            return {
+              author: actor.id,
+              anonymous: false,
+              alkemio: false,
+              guest: false,
+              authorType: actor.type,
+            };
+          }
         }
+        return {
+          author: actor.id,
+          anonymous: false,
+          alkemio: false,
+          guest: false,
+          authorType: actor.type,
+        };
       }
     }
     if (actorContext.guestName) {

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
@@ -19,6 +19,7 @@ import {
   OfficeDocumentContributionDocument,
 } from '../types';
 import { ContributionAuthorDetails } from '../types/contribution.author.details';
+import { TypedActorSet, UNKNOWN_ACTOR_TYPE } from '../types/typed.actor.set';
 import { isElasticError, isElasticResponseError } from '../utils';
 
 const isFromAlkemioTeam = (email: string) => /.*@alkem\.io/.test(email);
@@ -343,16 +344,18 @@ export class ContributionReporterService {
   /**
    * Indexes ONE aggregate `contribution` document per (Collabora document,
    * window) for a window in which the document was genuinely **edited**,
-   * carrying both `writeActors` and `readonlyActors` arrays — NOT one document per
-   * user. Resolve space/displayName once upstream and pass both arrays through
-   * verbatim. See feature 003-collabora-doc-contributions.
+   * carrying both `writeActors` and `readonlyActors` type-keyed sets — NOT one
+   * document per user. The consumer resolves space/displayName once upstream
+   * and groups each actor set by `ActorType`; both maps pass through verbatim
+   * (this reporter does no resolution and writes only the typed shape). See
+   * features 003-collabora-doc-contributions and 012-collabora-actor-type.
    */
   public officeDocumentContribution(contribution: {
     id: string;
     name: string;
     space: string;
-    writeActors: string[];
-    readonlyActors: string[];
+    writeActors: TypedActorSet;
+    readonlyActors: TypedActorSet;
   }): void {
     this.officeDocumentAggregate(
       CONTRIBUTION_TYPE.OFFICE_DOCUMENT_CONTRIBUTION,
@@ -364,16 +367,17 @@ export class ContributionReporterService {
    * Companion of {@link officeDocumentContribution}: indexes ONE aggregate
    * `contribution` document per (Collabora document, window) for a window in
    * which the document was **active but not edited** (viewed). Same aggregate
-   * shape — both `writeActors` and `readonlyActors` arrays — differing ONLY by the
-   * `OFFICE_DOCUMENT_VIEW` type. See feature 003-collabora-doc-contributions
-   * (FR-012). Mutually exclusive with the contribution record per window.
+   * shape — both `writeActors` and `readonlyActors` type-keyed sets — differing
+   * ONLY by the `OFFICE_DOCUMENT_VIEW` type. See feature
+   * 003-collabora-doc-contributions (FR-012). Mutually exclusive with the
+   * contribution record per window.
    */
   public officeDocumentView(contribution: {
     id: string;
     name: string;
     space: string;
-    writeActors: string[];
-    readonlyActors: string[];
+    writeActors: TypedActorSet;
+    readonlyActors: TypedActorSet;
   }): void {
     this.officeDocumentAggregate(
       CONTRIBUTION_TYPE.OFFICE_DOCUMENT_VIEW,
@@ -393,8 +397,8 @@ export class ContributionReporterService {
       id: string;
       name: string;
       space: string;
-      writeActors: string[];
-      readonlyActors: string[];
+      writeActors: TypedActorSet;
+      readonlyActors: TypedActorSet;
     }
   ): void {
     void this.createAggregateDocument({
@@ -482,6 +486,8 @@ export class ContributionReporterService {
             anonymous: false,
             alkemio: isFromAlkemioTeam(user.email),
             guest: false,
+            // 012: the acting actor's resolved ActorType.
+            authorType: actor.type,
           };
         } catch (e) {
           this.logger.error(
@@ -499,6 +505,7 @@ export class ContributionReporterService {
             anonymous: false,
             alkemio: false,
             guest: false,
+            authorType: actor.type,
           };
         }
       }
@@ -509,6 +516,7 @@ export class ContributionReporterService {
         anonymous: false,
         guest: true,
         guestName: actorContext.guestName,
+        authorType: UNKNOWN_ACTOR_TYPE,
       };
     }
     if (actorContext.isAnonymous) {
@@ -516,6 +524,7 @@ export class ContributionReporterService {
         alkemio: false,
         anonymous: true,
         guest: false,
+        authorType: UNKNOWN_ACTOR_TYPE,
       };
     }
 
@@ -531,6 +540,7 @@ export class ContributionReporterService {
       alkemio: false,
       anonymous: true,
       guest: false,
+      authorType: UNKNOWN_ACTOR_TYPE,
     };
   }
 

--- a/src/services/external/elasticsearch/types/contribution.author.details.ts
+++ b/src/services/external/elasticsearch/types/contribution.author.details.ts
@@ -4,6 +4,13 @@ export type ContributionAuthorDetails = {
    */
   author?: string;
   /**
+   * The acting actor's ActorType (e.g. `"user"`), or `"unknown"` for
+   * guest/anonymous/unresolvable contexts. Set on the shared author-details
+   * path so it appears on all single-author contribution records. See feature
+   * 012-collabora-actor-type.
+   */
+  authorType?: string;
+  /**
    * Event caused by an anonymous user.
    */
   anonymous: boolean;

--- a/src/services/external/elasticsearch/types/contribution.author.details.ts
+++ b/src/services/external/elasticsearch/types/contribution.author.details.ts
@@ -7,7 +7,7 @@ export type ContributionAuthorDetails = {
    * The acting actor's ActorType (e.g. `"user"`), or `"unknown"` for
    * guest/anonymous/unresolvable contexts. Set on the shared author-details
    * path so it appears on all single-author contribution records. See feature
-   * 012-collabora-actor-type.
+   * 012-collabora-actor-type (in the agents-hq workspace repo).
    */
   authorType?: string;
   /**

--- a/src/services/external/elasticsearch/types/contribution.author.details.ts
+++ b/src/services/external/elasticsearch/types/contribution.author.details.ts
@@ -1,3 +1,6 @@
+import { ActorType } from '@common/enums/actor.type';
+import { UNKNOWN_ACTOR_TYPE } from './typed.actor.set';
+
 export type ContributionAuthorDetails = {
   /**
    * Id of the user when not anonymous or guest.
@@ -6,10 +9,12 @@ export type ContributionAuthorDetails = {
   /**
    * The acting actor's ActorType (e.g. `"user"`), or `"unknown"` for
    * guest/anonymous/unresolvable contexts. Set on the shared author-details
-   * path so it appears on all single-author contribution records. See feature
-   * 012-collabora-actor-type (in the agents-hq workspace repo).
+   * path so it appears on all single-author contribution records. Typed like
+   * the aggregate `TypedActorSet` keys so the scalar can never drift from the
+   * `writeActors.<type>` group keys. See feature 012-collabora-actor-type (in
+   * the agents-hq workspace repo).
    */
-  authorType?: string;
+  authorType?: ActorType | typeof UNKNOWN_ACTOR_TYPE;
   /**
    * Event caused by an anonymous user.
    */

--- a/src/services/external/elasticsearch/types/index.ts
+++ b/src/services/external/elasticsearch/types/index.ts
@@ -4,3 +4,4 @@ export * from './contribution.type';
 export * from './contribution-details';
 export * from './elastic.response.error';
 export * from './office.document.contribution.document';
+export * from './typed.actor.set';

--- a/src/services/external/elasticsearch/types/office.document.contribution.document.ts
+++ b/src/services/external/elasticsearch/types/office.document.contribution.document.ts
@@ -8,7 +8,7 @@ import { TypedActorSet } from './typed.actor.set';
  * aggregate document per (document, window) carrying two actor sets:
  * `writeActors` (write-capable active actors) and `readonlyActors` (read-only
  * active actors), each grouped by the actor's {@link ActorType}. See features
- * 003-collabora-doc-contributions and 012-collabora-actor-type.
+ * agents-hq workspace specs 003-collabora-doc-contributions and 012-collabora-actor-type.
  */
 export type OfficeDocumentContributionDocument = {
   /**

--- a/src/services/external/elasticsearch/types/office.document.contribution.document.ts
+++ b/src/services/external/elasticsearch/types/office.document.contribution.document.ts
@@ -1,12 +1,14 @@
 import { ContributionType } from './contribution.type';
+import { TypedActorSet } from './typed.actor.set';
 
 /**
  * Aggregate Elasticsearch `contribution` document for a Collabora document
  * edited within a window. Unlike the per-user contribution documents (which
  * carry a single `author` via {@link ContributionAuthorDetails}), this is ONE
- * aggregate document per (document, window) carrying two user arrays:
- * `writeActors` (write-capable active users) and `readonlyActors` (read-only
- * active users). See feature 003-collabora-doc-contributions.
+ * aggregate document per (document, window) carrying two actor sets:
+ * `writeActors` (write-capable active actors) and `readonlyActors` (read-only
+ * active actors), each grouped by the actor's {@link ActorType}. See features
+ * 003-collabora-doc-contributions and 012-collabora-actor-type.
  */
 export type OfficeDocumentContributionDocument = {
   /**
@@ -35,13 +37,18 @@ export type OfficeDocumentContributionDocument = {
    */
   space: string;
   /**
-   * Distinct write-capable users active in the edited window — bare actor-id
-   * strings (Elasticsearch indexes a string array as a multi-valued field,
-   * shown comma-joined and individually filterable in Kibana).
+   * Distinct write-capable actors active in the edited window, grouped by the
+   * actor's {@link ActorType} — an object keyed by the exact discriminator
+   * value (e.g. `user`, `virtual-contributor`) plus the reserved `unknown`
+   * bucket, whose value is the array of actor-id strings of that type. Only
+   * non-empty groups are present; an empty set is `{}`. Each key dynamic-maps
+   * to its own multi-valued keyword sub-field, individually filterable in
+   * Kibana (e.g. `writeActors.user`).
    */
-  writeActors: string[];
+  writeActors: TypedActorSet;
   /**
-   * Distinct read-only users active in the edited window — bare actor-id strings.
+   * Distinct read-only actors active in the edited window, grouped by
+   * {@link ActorType} — same type-keyed shape as {@link writeActors}.
    */
-  readonlyActors: string[];
+  readonlyActors: TypedActorSet;
 };

--- a/src/services/external/elasticsearch/types/typed.actor.set.ts
+++ b/src/services/external/elasticsearch/types/typed.actor.set.ts
@@ -1,0 +1,25 @@
+import { ActorType } from '@common/enums/actor.type';
+
+/**
+ * Reserved analytics-only bucket key for an `actor_id` whose `ActorType`
+ * cannot be resolved at index time (e.g. the actor was deleted between
+ * emission and indexing, or the id is malformed). Not a member of the domain
+ * `ActorType` enum — it exists only in the analytics record so counts never
+ * silently shrink (FR-005). See feature 012-collabora-actor-type.
+ */
+export const UNKNOWN_ACTOR_TYPE = 'unknown';
+
+/**
+ * The type-keyed shape of the Collabora window-aggregate actor sets
+ * (`writeActors` / `readonlyActors`). An object keyed by the exact `ActorType`
+ * discriminator value (plus the reserved {@link UNKNOWN_ACTOR_TYPE}) whose
+ * value is the array of distinct `actor_id`s of that type. Only non-empty
+ * groups are present; an empty set serializes as `{}` (FR-002/003).
+ *
+ * Defined once here and imported by the Elasticsearch record type, the
+ * `ContributionReporterService` signatures, and the consumer grouping helper so
+ * the shape can never drift across the three call sites.
+ */
+export type TypedActorSet = Partial<
+  Record<ActorType | typeof UNKNOWN_ACTOR_TYPE, string[]>
+>;

--- a/src/services/external/elasticsearch/types/typed.actor.set.ts
+++ b/src/services/external/elasticsearch/types/typed.actor.set.ts
@@ -5,7 +5,7 @@ import { ActorType } from '@common/enums/actor.type';
  * cannot be resolved at index time (e.g. the actor was deleted between
  * emission and indexing, or the id is malformed). Not a member of the domain
  * `ActorType` enum — it exists only in the analytics record so counts never
- * silently shrink (FR-005). See feature 012-collabora-actor-type.
+ * silently shrink (FR-005). See the agents-hq workspace spec 012-collabora-actor-type.
  */
 export const UNKNOWN_ACTOR_TYPE = 'unknown';
 


### PR DESCRIPTION
## Summary

 - **Type-keyed actor sets** — reshape `writeActors`/`readonlyActors` on the `OFFICE_DOCUMENT_CONTRIBUTION` / `OFFICE_DOCUMENT_VIEW` records from `string[]` to `Record<ActorType, string[]>` (only non-empty groups; `{}` when empty), via a new shared `TypedActorSet` alias + `UNKNOWN_ACTOR_TYPE` const so the shape can't drift.
  - **`authorType` on lifecycle records** — add scalar `authorType` to `ContributionAuthorDetails`, set from the resolved actor's type (`unknown` for guest/anonymous/unresolvable).
  - **Tolerant batch type resolution** — `ActorLookupService.getActorTypesByIds` resolves actor → `ActorType` in one cached batch; missing/unresolvable ids fall to the `unknown` bucket and never fail the record.
  - **Resolution at index time, in the consumer** — `CollaborativeDocumentIntegrationService` groups actors by type after consuming the event; the `wopi-service → server` RabbitMQ contract is unchanged.
  - **Reporter is a thin writer** — `ContributionReporterService` signatures take `TypedActorSet` and write only the typed shape (no dual-write; clean cutover).
  - **Tests** — unit coverage for the batch lookup, the grouping path, and the reporter signatures.

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tolerant actor-type resolution for batch ID inputs.
  * Document activity reporting and Elasticsearch indexing now use actor-type grouped sets, including an explicit `unknown` bucket.
* **Bug Fixes**
  * Invalid/non-resolvable actor IDs no longer disrupt reporting; unresolved entries are handled without failing.
  * Actor display-name resolution now treats blank guest names as `undefined` to trigger proper fallbacks.
* **Chores**
  * Updated integration and Elasticsearch reporter tests, plus shared reporting/index document shapes, to match the new typed payload format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->