### PR TITLE
fix(collabora): forward actor name to WOPI for editor identity (#6170)

### DIFF
--- a/src/domain/actor/actor.display.name.spec.ts
+++ b/src/domain/actor/actor.display.name.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { IActor } from './actor/actor.interface';
-import { getMatrixDisplayName } from './actor.matrix.display.name';
+import { getActorDisplayName } from './actor.display.name';
 
-describe('getMatrixDisplayName', () => {
+describe('getActorDisplayName', () => {
   const makeActor = (
     profileDisplayName: string | undefined,
     nameID: string
@@ -16,29 +16,29 @@ describe('getMatrixDisplayName', () => {
     }) as any;
 
   it('returns trimmed profile.displayName when populated', () => {
-    expect(getMatrixDisplayName(makeActor('Jane Doe', 'jane-doe'))).toBe(
+    expect(getActorDisplayName(makeActor('Jane Doe', 'jane-doe'))).toBe(
       'Jane Doe'
     );
-    expect(getMatrixDisplayName(makeActor('  Jane Doe  ', 'jane-doe'))).toBe(
+    expect(getActorDisplayName(makeActor('  Jane Doe  ', 'jane-doe'))).toBe(
       'Jane Doe'
     );
   });
 
   it('falls back to nameID when profile.displayName is whitespace-only', () => {
-    expect(getMatrixDisplayName(makeActor('   ', 'jane-doe'))).toBe('jane-doe');
+    expect(getActorDisplayName(makeActor('   ', 'jane-doe'))).toBe('jane-doe');
   });
 
   it('falls back to nameID when profile.displayName is empty string', () => {
-    expect(getMatrixDisplayName(makeActor('', 'jane-doe'))).toBe('jane-doe');
+    expect(getActorDisplayName(makeActor('', 'jane-doe'))).toBe('jane-doe');
   });
 
   it('falls back to nameID when profile is undefined', () => {
-    expect(getMatrixDisplayName(makeActor(undefined, 'jane-doe'))).toBe(
+    expect(getActorDisplayName(makeActor(undefined, 'jane-doe'))).toBe(
       'jane-doe'
     );
   });
 
   it('returns nameID empty string when both are empty (defensive — not reachable in production given PG NOT NULL constraints)', () => {
-    expect(getMatrixDisplayName(makeActor(undefined, ''))).toBe('');
+    expect(getActorDisplayName(makeActor(undefined, ''))).toBe('');
   });
 });

--- a/src/domain/actor/actor.display.name.ts
+++ b/src/domain/actor/actor.display.name.ts
@@ -1,12 +1,12 @@
 import { IActor } from '@domain/actor/actor/actor.interface';
 
 /**
- * Canonical Matrix-side displayName formula for any Actor.
+ * Canonical, PII-safe displayName formula for any Actor.
  *
  * Returns `actor.profile.displayName` (trimmed) when non-empty, otherwise falls
  * back to `actor.nameID`. Email is explicitly NEVER used as a fallback (FR-018:
- * email is PII and would leak into Matrix room state if surfaced as a member's
- * displayName).
+ * email is PII and must not leak into any surface that shows a member's name —
+ * e.g. Matrix room state or the Collabora editor's UserFriendlyName).
  *
  * This formula is uniform across all Actor types (User, VirtualContributor,
  * Organization, Space, Account, ...) — `profile` and `nameID` are inherited
@@ -19,16 +19,17 @@ import { IActor } from '@domain/actor/actor/actor.interface';
  * `user.identity.service.ts:312`), so the helper yields the same string as
  * today's `firstName + lastName` formula for the 99% case. It diverges only
  * when a profile owner later edits their displayName, in which case the
- * Matrix-side name correctly follows the edit instead of being frozen.
+ * displayed name correctly follows the edit instead of being frozen.
  *
  * Used at:
- *   - The new `room.info` RPC handler (feature 099-element-room-check)
+ *   - The `room.info` RPC handler (feature 099-element-room-check)
  *   - `UserService.syncActor` (replaces the email-leaking formula)
  *   - `AdminCommunicationSpaceSyncService.syncDisplayNames` (User + VC iterations)
  *   - `VirtualContributorService.syncActor`
+ *   - `MessagingService` member-name resolution
  *
  * Pure function. No DI, no logging, no side effects.
  */
-export const getMatrixDisplayName = (actor: IActor): string => {
+export const getActorDisplayName = (actor: IActor): string => {
   return actor.profile?.displayName?.trim() || actor.nameID;
 };

--- a/src/domain/collaboration/collabora-document/collabora.document.module.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.module.ts
@@ -1,4 +1,5 @@
 import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { ActorLookupModule } from '@domain/actor/actor-lookup/actor.lookup.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { ProfileModule } from '@domain/common/profile/profile.module';
 import { DocumentModule } from '@domain/storage/document/document.module';
@@ -20,6 +21,7 @@ import { CollaboraDocumentAuthorizationService } from './collabora.document.serv
 @Module({
   imports: [
     AuthorizationModule,
+    ActorLookupModule,
     AuthorizationPolicyModule,
     DocumentModule,
     ProfileModule,

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
@@ -105,6 +105,42 @@ describe('CollaboraDocumentResolverQueries', () => {
       );
     });
 
+    it('still returns the editor URL when actor-name resolution fails (best-effort, #6170)', async () => {
+      vi.mocked(
+        collaboraDocumentService.getCollaboraDocumentOrFail
+      ).mockResolvedValue({
+        id: 'collab-doc-1',
+        authorization: { id: 'auth-1' },
+        profile: { displayName: 'Quarterly Report' },
+      } as any);
+      vi.mocked(collaboraDocumentService.getEditorUrl).mockResolvedValue({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+
+      const actorLookupService = (resolver as any).actorLookupService;
+      vi.mocked(actorLookupService.getActorById).mockRejectedValue(
+        new Error('db down')
+      );
+
+      const actorContext = { actorID: 'user-1', isGuest: false } as any;
+      const result = await resolver.collaboraEditorUrl(
+        actorContext,
+        'collab-doc-1'
+      );
+
+      // Lookup failure is swallowed: name omitted, document still opens.
+      expect(collaboraDocumentService.getEditorUrl).toHaveBeenCalledWith(
+        'collab-doc-1',
+        'user-1',
+        undefined
+      );
+      expect(result).toEqual({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+    });
+
     it('uses the guest name from the ActorContext without an actor lookup (#6170)', async () => {
       vi.mocked(
         collaboraDocumentService.getCollaboraDocumentOrFail

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
@@ -74,5 +74,64 @@ describe('CollaboraDocumentResolverQueries', () => {
         accessTokenTTL: 3600,
       });
     });
+
+    it("forwards an authenticated user's profile display name to the WOPI service (#6170)", async () => {
+      vi.mocked(
+        collaboraDocumentService.getCollaboraDocumentOrFail
+      ).mockResolvedValue({
+        id: 'collab-doc-1',
+        authorization: { id: 'auth-1' },
+        profile: { displayName: 'Quarterly Report' },
+      } as any);
+      vi.mocked(collaboraDocumentService.getEditorUrl).mockResolvedValue({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+
+      const actorLookupService = (resolver as any).actorLookupService;
+      vi.mocked(actorLookupService.getActorById).mockResolvedValue({
+        profile: { displayName: 'Alice Anderson' },
+        nameID: 'alice',
+      } as any);
+
+      const actorContext = { actorID: 'user-1', isGuest: false } as any;
+      await resolver.collaboraEditorUrl(actorContext, 'collab-doc-1');
+
+      expect(actorLookupService.getActorById).toHaveBeenCalledWith('user-1');
+      expect(collaboraDocumentService.getEditorUrl).toHaveBeenCalledWith(
+        'collab-doc-1',
+        'user-1',
+        'Alice Anderson'
+      );
+    });
+
+    it('uses the guest name from the ActorContext without an actor lookup (#6170)', async () => {
+      vi.mocked(
+        collaboraDocumentService.getCollaboraDocumentOrFail
+      ).mockResolvedValue({
+        id: 'collab-doc-1',
+        authorization: { id: 'auth-1' },
+        profile: { displayName: 'Quarterly Report' },
+      } as any);
+      vi.mocked(collaboraDocumentService.getEditorUrl).mockResolvedValue({
+        editorUrl: 'https://collabora/editor',
+        accessTokenTTL: 3600,
+      });
+
+      const actorLookupService = (resolver as any).actorLookupService;
+      const actorContext = {
+        actorID: 'guest-abc',
+        isGuest: true,
+        guestName: 'Guest Bob',
+      } as any;
+      await resolver.collaboraEditorUrl(actorContext, 'collab-doc-1');
+
+      expect(actorLookupService.getActorById).not.toHaveBeenCalled();
+      expect(collaboraDocumentService.getEditorUrl).toHaveBeenCalledWith(
+        'collab-doc-1',
+        'guest-abc',
+        'Guest Bob'
+      );
+    });
   });
 });

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
@@ -101,8 +101,12 @@ export class CollaboraDocumentResolverQueries {
    * Guests carry their name on the ActorContext (no Actor row exists for the
    * synthetic guest id); authenticated users get the canonical, PII-safe
    * `getActorDisplayName` (profile.displayName → nameID, never email).
-   * Returns undefined when no name can be resolved (e.g. anonymous), letting
-   * the WOPI service apply its own fallback.
+   * Returns undefined when no name can be resolved (anonymous, or a failed
+   * lookup), letting the WOPI service apply its own fallback.
+   *
+   * Best-effort by design: `actorName` is optional and the editor flow works
+   * without it, so a failed actor lookup must NEVER block opening the document
+   * (mirrors the best-effort analytics block in collaboraEditorUrl, FR-008).
    */
   private async resolveActorName(
     actorContext: ActorContext
@@ -110,9 +114,21 @@ export class CollaboraDocumentResolverQueries {
     if (actorContext.isGuest) {
       return actorContext.guestName;
     }
-    const actor = await this.actorLookupService.getActorById(
-      actorContext.actorID
-    );
-    return actor ? getActorDisplayName(actor) : undefined;
+    try {
+      const actor = await this.actorLookupService.getActorById(
+        actorContext.actorID
+      );
+      return actor ? getActorDisplayName(actor) : undefined;
+    } catch (e: any) {
+      this.logger.warn?.(
+        {
+          message: 'Failed to resolve actor name for Collabora editor',
+          actorId: actorContext.actorID,
+          error: e?.message,
+        },
+        LogContext.COLLABORATION
+      );
+      return undefined;
+    }
   }
 }

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
@@ -2,6 +2,8 @@ import { CurrentActor } from '@common/decorators';
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
+import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { Inject } from '@nestjs/common';
 import { Args, Query, Resolver } from '@nestjs/graphql';
@@ -22,7 +24,8 @@ export class CollaboraDocumentResolverQueries {
     private authorizationService: AuthorizationService,
     private collaboraDocumentService: CollaboraDocumentService,
     private contributionReporter: ContributionReporterService,
-    private communityResolverService: CommunityResolverService
+    private communityResolverService: CommunityResolverService,
+    private actorLookupService: ActorLookupService
   ) {}
 
   @Query(() => CollaboraEditorUrlResult, {
@@ -49,9 +52,14 @@ export class CollaboraDocumentResolverQueries {
     // Identity is resolved from the ActorContext (alkemio_session cookie /
     // forwardAuth), not an inbound Bearer JWT. The WOPI service trusts the
     // X-Alkemio-Actor-Id header the adapter stamps on the internal call.
+    // The actor name is resolved here (the only layer that sees guest names)
+    // and forwarded so the WOPI CheckFileInfo UserFriendlyName is the real name
+    // instead of "UnknownUser" (#6170 — forwardAuth no longer carries it).
+    const actorName = await this.resolveActorName(actorContext);
     const editorUrl = await this.collaboraDocumentService.getEditorUrl(
       collaboraDocumentID,
-      actorContext.actorID
+      actorContext.actorID,
+      actorName
     );
 
     // Lifecycle analytics (US4 / FR-014): one COLLABORA_DOCUMENT_OPENED record
@@ -86,5 +94,25 @@ export class CollaboraDocumentResolverQueries {
     }
 
     return editorUrl;
+  }
+
+  /**
+   * Resolves the human-readable name to surface in the Collabora editor.
+   * Guests carry their name on the ActorContext (no Actor row exists for the
+   * synthetic guest id); authenticated users get the canonical, PII-safe
+   * `getMatrixDisplayName` (profile.displayName → nameID, never email).
+   * Returns undefined when no name can be resolved (e.g. anonymous), letting
+   * the WOPI service apply its own fallback.
+   */
+  private async resolveActorName(
+    actorContext: ActorContext
+  ): Promise<string | undefined> {
+    if (actorContext.isGuest) {
+      return actorContext.guestName;
+    }
+    const actor = await this.actorLookupService.getActorById(
+      actorContext.actorID
+    );
+    return actor ? getMatrixDisplayName(actor) : undefined;
   }
 }

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
@@ -2,7 +2,7 @@ import { CurrentActor } from '@common/decorators';
 import { AuthorizationPrivilege, LogContext } from '@common/enums';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { UUID } from '@domain/common/scalars/scalar.uuid';
 import { Inject } from '@nestjs/common';
@@ -100,7 +100,7 @@ export class CollaboraDocumentResolverQueries {
    * Resolves the human-readable name to surface in the Collabora editor.
    * Guests carry their name on the ActorContext (no Actor row exists for the
    * synthetic guest id); authenticated users get the canonical, PII-safe
-   * `getMatrixDisplayName` (profile.displayName → nameID, never email).
+   * `getActorDisplayName` (profile.displayName → nameID, never email).
    * Returns undefined when no name can be resolved (e.g. anonymous), letting
    * the WOPI service apply its own fallback.
    */
@@ -113,6 +113,6 @@ export class CollaboraDocumentResolverQueries {
     const actor = await this.actorLookupService.getActorById(
       actorContext.actorID
     );
-    return actor ? getMatrixDisplayName(actor) : undefined;
+    return actor ? getActorDisplayName(actor) : undefined;
   }
 }

--- a/src/domain/collaboration/collabora-document/collabora.document.service.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.service.ts
@@ -263,7 +263,8 @@ export class CollaboraDocumentService {
 
   public async getEditorUrl(
     collaboraDocumentID: string,
-    actorID: string
+    actorID: string,
+    actorName?: string
   ): Promise<{ editorUrl: string; accessTokenTTL: number }> {
     const collaboraDocument = await this.getCollaboraDocumentOrFail(
       collaboraDocumentID,
@@ -282,7 +283,8 @@ export class CollaboraDocumentService {
 
     const result = await this.wopiServiceAdapter.issueToken(
       collaboraDocument.document.id,
-      actorID
+      actorID,
+      actorName
     );
 
     return {

--- a/src/domain/communication/messaging/messaging.service.ts
+++ b/src/domain/communication/messaging/messaging.service.ts
@@ -10,7 +10,7 @@ import {
   ValidationException,
 } from '@common/exceptions';
 import { Actor } from '@domain/actor/actor/actor.entity';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -652,7 +652,7 @@ export class MessagingService {
    * `room.info` RPC handler body (feature 099-element-room-check).
    *
    * Look up the Conversation by the supplied Room id; return type + members
-   * with displayNames resolved via `getMatrixDisplayName`. A miss returns the
+   * with displayNames resolved via `getActorDisplayName`. A miss returns the
    * empty-members miss envelope (NOT an error) — the adapter retries
    * reconciliation on subsequent room events.
    */
@@ -676,7 +676,7 @@ export class MessagingService {
     const actorIds = memberships.map(m => m.actorID);
     // Resolve members against the Actor base table so VirtualContributors,
     // Organizations, etc. render correctly — not just Users. profile is
-    // eager:false on Actor, so load it explicitly (getMatrixDisplayName reads
+    // eager:false on Actor, so load it explicitly (getActorDisplayName reads
     // profile.displayName per FR-018).
     const actors = await this.entityManager.find(Actor, {
       where: { id: In(actorIds) },
@@ -688,7 +688,7 @@ export class MessagingService {
       const actor = actorsById.get(m.actorID);
       return {
         actorId: m.actorID,
-        displayName: actor ? getMatrixDisplayName(actor) : m.actorID,
+        displayName: actor ? getActorDisplayName(actor) : m.actorID,
       };
     });
 

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -23,7 +23,7 @@ import { IPaginatedType } from '@core/pagination/paginated.type';
 import { getPaginationResults } from '@core/pagination/pagination.fn';
 import { actorDefaults } from '@domain/actor/actor/actor.defaults';
 import { ActorService } from '@domain/actor/actor/actor.service';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -231,7 +231,7 @@ export class UserService {
 
     // Sync the user to the communication adapter
     // User.id (which is Actor.id) is used as the AlkemioActorID for all communication operations
-    const displayName = getMatrixDisplayName(user);
+    const displayName = getActorDisplayName(user);
 
     try {
       await this.communicationAdapter.syncActor(user.id, displayName);

--- a/src/domain/community/virtual-contributor/virtual.contributor.service.ts
+++ b/src/domain/community/virtual-contributor/virtual.contributor.service.ts
@@ -14,7 +14,7 @@ import { Invitation } from '@domain/access/invitation/invitation.entity';
 import { IActor } from '@domain/actor/actor/actor.interface';
 import { ActorService } from '@domain/actor/actor/actor.service';
 import { ActorQueryArgs } from '@domain/actor/actor/dto';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { ICredential } from '@domain/actor/credential/credential.interface';
 import { CredentialsSearchInput } from '@domain/actor/credential/dto/credentials.dto.search';
 import { CreateCalloutInput } from '@domain/collaboration/callout/dto/callout.dto.create';
@@ -199,7 +199,7 @@ export class VirtualContributorService {
 
     // Sync the VC to the communication adapter
     // VirtualContributor.id (which is Actor.id) is used as the AlkemioActorID
-    const displayName = getMatrixDisplayName(virtualContributor);
+    const displayName = getActorDisplayName(virtualContributor);
     try {
       await this.communicationAdapter.syncActor(
         virtualContributor.id,

--- a/src/platform-admin/domain/communication/admin.communication.space.sync.service.ts
+++ b/src/platform-admin/domain/communication/admin.communication.space.sync.service.ts
@@ -2,7 +2,7 @@ import { JoinRuleInvite, JoinRulePublic } from '@alkemio/matrix-adapter-lib';
 import { LogContext } from '@common/enums';
 import { RoomType } from '@common/enums/room.type';
 import { FORUM_CATEGORY_NAMESPACE } from '@constants/forum.constants';
-import { getMatrixDisplayName } from '@domain/actor/actor.matrix.display.name';
+import { getActorDisplayName } from '@domain/actor/actor.display.name';
 import { Room } from '@domain/communication/room/room.entity';
 import { User } from '@domain/community/user/user.entity';
 import { VirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.entity';
@@ -505,7 +505,7 @@ export class AdminCommunicationSpaceSyncService {
 
     let synced = 0;
     for (const user of users) {
-      const displayName = getMatrixDisplayName(user);
+      const displayName = getActorDisplayName(user);
       try {
         await this.communicationAdapter.syncActor(user.id, displayName);
         synced++;
@@ -519,7 +519,7 @@ export class AdminCommunicationSpaceSyncService {
     }
 
     for (const vc of vcs) {
-      const displayName = getMatrixDisplayName(vc);
+      const displayName = getActorDisplayName(vc);
       try {
         await this.communicationAdapter.syncActor(vc.id, displayName);
         synced++;

--- a/src/services/adapters/wopi-service-adapter/wopi.service.adapter.ts
+++ b/src/services/adapters/wopi-service-adapter/wopi.service.adapter.ts
@@ -1,4 +1,5 @@
 import { LogContext } from '@common/enums';
+import { HEADER_ACTOR_ID } from '@core/auth/oidc/constants';
 import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -42,7 +43,8 @@ export class WopiServiceAdapter {
    */
   async issueToken(
     documentId: string,
-    actorID: string
+    actorID: string,
+    actorName?: string
   ): Promise<WopiTokenResult> {
     const url = `${this.baseUrl}/wopi/token`;
 
@@ -54,10 +56,14 @@ export class WopiServiceAdapter {
     const request$ = this.httpService
       .post<WopiTokenResult>(
         url,
-        { documentId },
+        // actorName is sent in the body (UTF-8, native) rather than a header
+        // so arbitrary-Unicode names need no encoding. The WOPI service maps it
+        // to the WOPI CheckFileInfo UserFriendlyName. Omitted when unknown
+        // (e.g. anonymous), letting the WOPI service keep its own fallback.
+        { documentId, actorName },
         {
           headers: {
-            'X-Alkemio-Actor-Id': actorID,
+            [HEADER_ACTOR_ID]: actorID,
             'Content-Type': 'application/json',
           },
         }


### PR DESCRIPTION
Closes #6170

## Problem
Users editing Collabora documents are shown as `UnknownUser_<id>` (#6170). Regression from the Oathkeeper sunset: WOPI previously derived the user's name from the forwarded Kratos session/JWT. The new forwardAuth path stamps only `X-Alkemio-Actor-Id` — identity, but no name.

## Fix
Resolve the actor's name in the `collaboraEditorUrl` resolver — the only layer that sees guest names — and forward it to the WOPI token-mint call:
- **Guest** → `ActorContext.guestName`
- **User** → `ActorLookupService.getActorById` → `getMatrixDisplayName` (profile displayName → nameID, **never email**, PII-safe)

Sent in the `/wopi/token` **request body** (`actorName`), not a header — UTF-8 native, so arbitrary-Unicode names need no encoding. The WOPI service maps it to the CheckFileInfo `UserFriendlyName`.

## Two-sided change
Pairs with **alkem-io/wopi-service#22** (consumes `actorName` from the body). `actorName` is optional → independent deploy order; bug closes once both land.

## Tests
- resolver spec: authenticated user's name forwarded; guest name used without an actor lookup.
- Full suite green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display names are now shown consistently across collaboration, messaging, and sync flows.
  * Guest users can see their chosen guest name in editor links.

* **Bug Fixes**
  * Improved fallback handling for missing or blank profile names.
  * Prevented email from being used as a display-name fallback.
  * Updated room member names to use the correct actor display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->