### PR TITLE
Fix migration: All L0 Spaces > Tab 2 (no matter what name) > first po…

### DIFF
--- a/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
@@ -210,6 +210,91 @@ describe('CalloutResolverMutations', () => {
         expect(calloutService.updateCallout).not.toHaveBeenCalled();
       });
     });
+
+    // A CONTRIBUTORS callout TEMPLATE has no calloutsSet, so it must be EXEMPT
+    // from the collaboration-only / admin-CREATE guard — its settings can be
+    // edited and the framing removed (→ NONE), but it must not be switched to
+    // another framing type.
+    describe('CONTRIBUTORS framing on templates', () => {
+      const setupUpdateSuccess = (callout: any) => {
+        vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(callout);
+        vi.mocked(calloutService.updateCallout).mockResolvedValue(callout);
+        const roomResolverService = (resolver as any).roomResolverService;
+        vi.mocked(
+          roomResolverService.getRoleSetAndPlatformRolesWithAccessForCallout
+        ).mockResolvedValue({
+          roleSet: { id: 'rs-1' },
+          platformRolesAccess: { roles: [] },
+        });
+        vi.mocked(
+          calloutAuthorizationService.applyAuthorizationPolicy
+        ).mockResolvedValue([{ id: 'updated-auth' }] as any);
+      };
+
+      it('allows editing a CONTRIBUTORS callout template (no calloutsSet) — no collaboration/admin guard', async () => {
+        const callout = {
+          id: 'tmpl-1',
+          isTemplate: true,
+          authorization: { id: 'auth-1' },
+          framing: { type: CalloutFramingType.CONTRIBUTORS },
+          // standalone callout template → no calloutsSet
+        } as any;
+        setupUpdateSuccess(callout);
+
+        await resolver.updateCallout(
+          { actorID: 'u1' } as any,
+          {
+            ID: 'tmpl-1',
+            settings: {
+              framing: { contributors: { contributorTypes: ['organization'] } },
+            },
+          } as any
+        );
+
+        expect(calloutService.updateCallout).toHaveBeenCalled();
+      });
+
+      it('allows removing the framing on a template (CONTRIBUTORS → NONE)', async () => {
+        const callout = {
+          id: 'tmpl-1',
+          isTemplate: true,
+          authorization: { id: 'auth-1' },
+          framing: { type: CalloutFramingType.CONTRIBUTORS },
+        } as any;
+        setupUpdateSuccess(callout);
+
+        await resolver.updateCallout(
+          { actorID: 'u1' } as any,
+          {
+            ID: 'tmpl-1',
+            framing: { type: CalloutFramingType.NONE },
+          } as any
+        );
+
+        expect(calloutService.updateCallout).toHaveBeenCalled();
+      });
+
+      it('rejects switching a CONTRIBUTORS template framing to another type', async () => {
+        const callout = {
+          id: 'tmpl-1',
+          isTemplate: true,
+          authorization: { id: 'auth-1' },
+          framing: { type: CalloutFramingType.CONTRIBUTORS },
+        } as any;
+        vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(callout);
+
+        await expect(
+          resolver.updateCallout(
+            { actorID: 'u1' } as any,
+            {
+              ID: 'tmpl-1',
+              framing: { type: CalloutFramingType.WHITEBOARD },
+            } as any
+          )
+        ).rejects.toThrow(ValidationException);
+        expect(calloutService.updateCallout).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('updateCalloutVisibility', () => {

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -121,16 +121,27 @@ export class CalloutResolverMutations {
       `update callout: ${callout.id}`
     );
 
-    // CONTRIBUTORS framing is admin-only and collaboration-only (FR-004a/FR-004f,
-    // R5). Mirror the create guard on the update path so the restriction can't be
-    // bypassed by converting an existing callout — or one living in a
-    // non-COLLABORATION callouts set (e.g. a VC knowledge base) — to CONTRIBUTORS
-    // via updateCallout, which otherwise only checks the generic UPDATE privilege.
-    // The resulting type is the incoming framing type when provided, else the
-    // stored one (so editing an existing CONTRIBUTORS callout is gated too).
+    // CONTRIBUTORS framing is admin-only and collaboration-only for LIVE callouts
+    // (FR-004a/FR-004f, R5). Mirror the create guard on the update path so the
+    // restriction can't be bypassed by converting an existing callout — or one
+    // living in a non-COLLABORATION callouts set (e.g. a VC knowledge base) — to
+    // CONTRIBUTORS via updateCallout, which otherwise only checks the generic
+    // UPDATE privilege. The resulting type is the incoming framing type when
+    // provided, else the stored one (so editing an existing CONTRIBUTORS callout
+    // is gated too).
+    //
+    // Template callouts (callout.isTemplate) are EXEMPT: a standalone callout
+    // template has no calloutsSet at all (calloutsSet is null), and template
+    // callouts are governed by template-edit authorization (the UPDATE privilege
+    // checked above), not the live-callout admin/collaboration rules. Without
+    // this exemption, editing a CONTRIBUTORS callout template throws "only
+    // available on COLLABORATION callouts sets" because its calloutsSet is null.
     const resultingFramingType =
       calloutData.framing?.type ?? callout.framing?.type;
-    if (resultingFramingType === CalloutFramingType.CONTRIBUTORS) {
+    if (
+      !callout.isTemplate &&
+      resultingFramingType === CalloutFramingType.CONTRIBUTORS
+    ) {
       if (callout.calloutsSet?.type !== CalloutsSetType.COLLABORATION) {
         throw new ValidationException(
           'CONTRIBUTORS framing is only available on COLLABORATION callouts sets.',
@@ -142,6 +153,23 @@ export class CalloutResolverMutations {
         callout.calloutsSet.authorization,
         AuthorizationPrivilege.CREATE,
         `update CONTRIBUTORS callout (admin-only) on callouts Set: ${callout.calloutsSet.id}`
+      );
+    }
+
+    // A CONTRIBUTORS callout TEMPLATE's framing may be edited (its contributor
+    // settings — types, list/map) or removed (set to NONE), but MUST NOT be
+    // switched to another framing type: templates only support keeping or
+    // clearing the contributors framing.
+    if (
+      callout.isTemplate &&
+      callout.framing?.type === CalloutFramingType.CONTRIBUTORS &&
+      calloutData.framing?.type != null &&
+      calloutData.framing.type !== CalloutFramingType.CONTRIBUTORS &&
+      calloutData.framing.type !== CalloutFramingType.NONE
+    ) {
+      throw new ValidationException(
+        'A CONTRIBUTORS callout template framing can only be kept or removed (set to NONE), not changed to another framing type.',
+        LogContext.COLLABORATION
       );
     }
 

--- a/src/migrations/1782467322859-BackfillContributorsCalloutL0Community.ts
+++ b/src/migrations/1782467322859-BackfillContributorsCalloutL0Community.ts
@@ -3,14 +3,38 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
 /**
  * One-time data migration (workspace#008-contributor-collection-callout, US6).
  *
- * Backfills exactly one PUBLISHED CONTRIBUTORS callout into the Community tab
- * (flow-state tagset containing 'Community') of every L0 space (space.level = 0)
- * that does not already have one there. Subspaces (level != 0) are untouched.
+ * Backfills exactly one PUBLISHED CONTRIBUTORS callout into the FIRST position
+ * of the SECOND flow-state tab of:
+ *   - every L0 space (space.level = 0), and
+ *   - every L0 space content template (template_content_space.level = 0), so
+ *     new spaces created from a template inherit the callout (the clone path
+ *     copies contributors framing). NOTE: this intentionally reverses the
+ *     original FR-023 "new spaces get nothing automatic" decision — keep spec
+ *     008 in sync.
+ * The second tab is resolved BY POSITION — the second entry of the flow-state
+ * tagsetTemplate's ordered `allowedValues` — regardless of its displayName, so
+ * a renamed / localized "Community" tab is still targeted correctly. Subspaces
+ * and subspace templates (level != 0) are untouched.
  *
- * Idempotency is scoped to the Community tab: a space whose only contributors
- * callout lives in another tab still receives one in the Community tab
- * (FR-025 rollout guarantee). Re-running is a no-op for Community tabs that
- * already hold a contributors callout.
+ * Template content spaces have no storageAggregatorId column; the callout's
+ * storage bucket reuses the aggregator already bound to a sibling callout's
+ * framing storage bucket in the same calloutsSet.
+ *
+ * Placement: the callout is given a `sortOrder` strictly below the minimum of
+ * the callouts already in that second tab, so it renders FIRST within the tab
+ * (where the hard-coded contributor widget used to render). Negative sortOrders
+ * are idiomatic in this codebase (create-at-front = MIN - 1).
+ *
+ * Idempotency / re-run (safe to run repeatedly, incl. on environments where an
+ * earlier version of this migration already ran):
+ *   - If the second tab's FIRST callout is already a contributors callout → skip.
+ *   - Else, if a prior run of THIS migration left a default-shape contributors
+ *     callout anywhere in the space (e.g. an earlier version placed it at the
+ *     bottom, or tagged a since-renamed tab) → MOVE it into the second tab at
+ *     first position (retag + reorder) instead of inserting a duplicate.
+ *   - Else, if the second tab already holds someone else's contributors callout
+ *     → skip (don't duplicate).
+ *   - Else → insert a fresh one at first position.
  *
  * The migration is SILENT — it inserts rows directly, bypassing the mutation's
  * notification / activity / publish adapters, so it emits no notifications,
@@ -18,7 +42,7 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
  *
  * ⚠️ REQUIRED POST-STEP (rollout runbook): the inserted callouts carry EMPTY
  * authorization policies (credentialRules '[]'). They are therefore unreadable —
- * and invisible in the Community tab — until an authorization reset recomputes
+ * and invisible in the second tab — until an authorization reset recomputes
  * them. After running this migration you MUST run the platform authorization
  * reset (GraphQL `mutation { authorizationPolicyResetAll }` as a global admin,
  * or the equivalent per-space reset) so the engine grants the standard
@@ -36,9 +60,9 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
  *   location, profile (type 'callout-framing') + its DEFAULT freeform tagset
  *     (REQUIRED: ProfileResolverFields.tagset throws ENTITY_NOT_FOUND without it).
  *   callout_framing (type 'contributors').
- *   classification + flow-state tagset (tags 'Community', type 'select-one'),
- *     linked to the calloutsSet's flow-state tagsetTemplate (REQUIRED:
- *     classification.flowState.allowedValues throws without it).
+ *   classification + flow-state tagset (tags = the second tab's displayName,
+ *     type 'select-one'), linked to the calloutsSet's flow-state tagsetTemplate
+ *     (REQUIRED: classification.flowState.allowedValues throws without it).
  *   callout_contribution_defaults (kept for the update/delete paths).
  *   callout (PUBLISHED; settings mirror DefaultCalloutSettings + the default
  *     contributors block: all three types, defaultContributorType USER,
@@ -76,6 +100,11 @@ export class BackfillContributorsCalloutL0Community1782467322859
         new_default_tagset_id uuid;
         new_default_tagset_auth_id uuid;
         flow_state_template_id uuid;
+        allowed_values TEXT;
+        second_tab_name TEXT;
+        first_is_contributors boolean;
+        existing_callout_id uuid;
+        existing_flowtag_id uuid;
         new_contrib_defaults_id uuid;
         new_name_id varchar(36);
         next_sort_order int;
@@ -101,27 +130,152 @@ export class BackfillContributorsCalloutL0Community1782467322859
         );
       BEGIN
         FOR rec IN
+          -- Live L0 spaces: storage aggregator taken directly from the space.
           SELECT
             cs.id AS callouts_set_id,
-            s.id AS space_id,
             s."storageAggregatorId" AS storage_aggregator_id
           FROM space s
           JOIN collaboration c ON c.id = s."collaborationId"
           JOIN callouts_set cs ON cs.id = c."calloutsSetId"
           WHERE s.level = 0
             AND s."storageAggregatorId" IS NOT NULL
-            AND NOT EXISTS (
-              SELECT 1
-              FROM callout co
-              JOIN callout_framing cf ON cf.id = co."framingId"
-              JOIN classification cl ON cl.id = co."classificationId"
-              JOIN tagset t ON t."classificationId" = cl.id
-              WHERE co."calloutsSetId" = cs.id
-                AND cf.type = 'contributors'
-                AND t.name = 'flow-state'
-                AND ('Community' = ANY(string_to_array(t.tags, ',')))
-            )
+          UNION ALL
+          -- L0 space content templates: template_content_space has NO
+          -- storageAggregatorId column, so reuse the storage aggregator already
+          -- bound to a sibling callout's framing storage bucket in the same
+          -- calloutsSet. Adding the callout here makes new spaces created from
+          -- the template inherit it (the clone path copies contributors framing).
+          SELECT
+            cs.id AS callouts_set_id,
+            (SELECT sb2."storageAggregatorId"
+               FROM callout co2
+               JOIN callout_framing cf2 ON cf2.id = co2."framingId"
+               JOIN profile p2 ON p2.id = cf2."profileId"
+               JOIN storage_bucket sb2 ON sb2.id = p2."storageBucketId"
+               WHERE co2."calloutsSetId" = cs.id
+                 AND sb2."storageAggregatorId" IS NOT NULL
+               LIMIT 1) AS storage_aggregator_id
+          FROM template_content_space tcs
+          JOIN collaboration c ON c.id = tcs."collaborationId"
+          JOIN callouts_set cs ON cs.id = c."calloutsSetId"
+          WHERE tcs.level = 0
         LOOP
+          -- The new flow-state tagset MUST reference the space's flow-state
+          -- tagsetTemplate (one per calloutsSet) so the client can resolve
+          -- classification.flowState.allowedValues. Reuse the template already
+          -- used by this calloutsSet's other callouts.
+          SELECT ts."tagsetTemplateId" INTO flow_state_template_id
+            FROM callout co2
+            JOIN callout_framing cf2 ON cf2.id = co2."framingId"
+            JOIN classification cl2 ON cl2.id = co2."classificationId"
+            JOIN tagset ts ON ts."classificationId" = cl2.id
+            WHERE co2."calloutsSetId" = rec.callouts_set_id
+              AND ts.name = 'flow-state'
+              AND ts."tagsetTemplateId" IS NOT NULL
+            LIMIT 1;
+          -- Without the flow-state template we cannot place a tab; skip
+          -- (does not happen for L0 spaces, which always have flow-tab callouts).
+          IF flow_state_template_id IS NULL THEN
+            CONTINUE;
+          END IF;
+
+          -- Resolve the SECOND tab BY POSITION (not by the literal name
+          -- 'Community'): the flow-state tab order is the tagsetTemplate's
+          -- ordered comma-separated allowedValues, so the second tab is the
+          -- second element. This is robust to a renamed / localized second tab.
+          SELECT tt."allowedValues" INTO allowed_values
+            FROM tagset_template tt
+            WHERE tt.id = flow_state_template_id;
+          second_tab_name := split_part(COALESCE(allowed_values, ''), ',', 2);
+          -- No second tab (fewer than two flow states) → nothing to target; skip.
+          IF second_tab_name IS NULL OR second_tab_name = '' THEN
+            CONTINUE;
+          END IF;
+
+          -- Idempotency (1/2): if the second tab's FIRST callout is already a
+          -- contributors callout, it is already placed correctly → skip. This is
+          -- the re-run no-op for environments already migrated by THIS version.
+          first_is_contributors := NULL;
+          SELECT (cf.type = 'contributors')
+            INTO first_is_contributors
+            FROM callout co
+            JOIN callout_framing cf ON cf.id = co."framingId"
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND second_tab_name = ANY(string_to_array(t.tags, ','))
+            ORDER BY co."sortOrder" ASC
+            LIMIT 1;
+          IF first_is_contributors IS TRUE THEN
+            CONTINUE;
+          END IF;
+
+          -- FIRST position within the second tab: sortOrder strictly below the
+          -- minimum of the callouts already in that tab. Empty tab → -10.
+          SELECT COALESCE(MIN(co."sortOrder"), 0) - 10
+            INTO next_sort_order
+            FROM callout co
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND second_tab_name = ANY(string_to_array(t.tags, ','));
+
+          -- Re-run repositioning: if a prior run of THIS migration already left a
+          -- default-shape contributors callout in this calloutsSet (an earlier
+          -- version placed it at the bottom, or tagged a since-renamed tab), MOVE
+          -- it into the second tab at first position rather than inserting a
+          -- duplicate. Matched by the migration's own default shape (generated
+          -- nameID, PUBLISHED but no publisher, no comments room) so user-created
+          -- contributors callouts are never touched.
+          existing_callout_id := NULL;
+          existing_flowtag_id := NULL;
+          SELECT co.id, t.id
+            INTO existing_callout_id, existing_flowtag_id
+            FROM callout co
+            JOIN callout_framing cf ON cf.id = co."framingId"
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND cf.type = 'contributors'
+              AND co."nameID" LIKE 'contributors-%'
+              AND co."publishedBy" IS NULL
+              AND co."commentsId" IS NULL
+            ORDER BY co."sortOrder" ASC
+            LIMIT 1;
+          IF existing_callout_id IS NOT NULL THEN
+            UPDATE tagset
+              SET tags = second_tab_name, "updatedDate" = NOW()
+              WHERE id = existing_flowtag_id;
+            UPDATE callout
+              SET "sortOrder" = next_sort_order, "updatedDate" = NOW()
+              WHERE id = existing_callout_id;
+            CONTINUE;
+          END IF;
+
+          -- Idempotency (2/2): don't duplicate a contributors callout a user may
+          -- already have placed elsewhere in the second tab (not at first, and
+          -- not default-shape, so not repositioned above).
+          IF EXISTS (
+            SELECT 1
+            FROM callout co
+            JOIN callout_framing cf ON cf.id = co."framingId"
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND cf.type = 'contributors'
+              AND second_tab_name = ANY(string_to_array(t.tags, ','))
+          ) THEN
+            CONTINUE;
+          END IF;
+
+          -- A fresh insert needs a storage aggregator to bind the callout's
+          -- framing storage bucket. Live L0 spaces always have one; an L0
+          -- template with no storage-bearing sibling callout (degenerate) is
+          -- skipped. The reposition path above needs no aggregator.
+          IF rec.storage_aggregator_id IS NULL THEN
+            CONTINUE;
+          END IF;
+
           new_callout_id          := gen_random_uuid();
           new_callout_auth_id     := gen_random_uuid();
           new_framing_id          := gen_random_uuid();
@@ -139,30 +293,6 @@ export class BackfillContributorsCalloutL0Community1782467322859
           new_default_tagset_auth_id := gen_random_uuid();
           new_contrib_defaults_id := gen_random_uuid();
           new_name_id := 'contributors-' || left(replace(gen_random_uuid()::text, '-', ''), 8);
-
-          SELECT COALESCE(MAX(co."sortOrder"), 0) + 10
-            INTO next_sort_order
-            FROM callout co
-            WHERE co."calloutsSetId" = rec.callouts_set_id;
-
-          -- The Community-tab flow-state tagset MUST reference the space's
-          -- flow-state tagsetTemplate (one per calloutsSet) so the client can
-          -- resolve classification.flowState.allowedValues. Reuse the template
-          -- already used by this calloutsSet's other callouts.
-          SELECT ts."tagsetTemplateId" INTO flow_state_template_id
-            FROM callout co2
-            JOIN callout_framing cf2 ON cf2.id = co2."framingId"
-            JOIN classification cl2 ON cl2.id = co2."classificationId"
-            JOIN tagset ts ON ts."classificationId" = cl2.id
-            WHERE co2."calloutsSetId" = rec.callouts_set_id
-              AND ts.name = 'flow-state'
-              AND ts."tagsetTemplateId" IS NOT NULL
-            LIMIT 1;
-          -- Without the flow-state template we cannot place a tab; skip
-          -- (does not happen for L0 spaces, which always have flow-tab callouts).
-          IF flow_state_template_id IS NULL THEN
-            CONTINUE;
-          END IF;
 
           INSERT INTO authorization_policy (id,"createdDate","updatedDate",version,"credentialRules","privilegeRules",type) VALUES
             (new_callout_auth_id,        NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'callout'),
@@ -193,10 +323,12 @@ export class BackfillContributorsCalloutL0Community1782467322859
           INSERT INTO classification (id,"createdDate","updatedDate",version,"authorizationId")
           VALUES (new_classification_id,NOW(),NOW(),1,new_classification_auth_id);
 
-          -- Flow-state classification tagset, linked to the calloutsSet's
-          -- flow-state tagsetTemplate so classification.flowState.allowedValues resolves.
+          -- Flow-state classification tagset, tagged with the SECOND tab's
+          -- displayName (resolved by position above) and linked to the
+          -- calloutsSet's flow-state tagsetTemplate so
+          -- classification.flowState.allowedValues resolves.
           INSERT INTO tagset (id,"createdDate","updatedDate",version,name,type,tags,"authorizationId","classificationId","tagsetTemplateId")
-          VALUES (new_tagset_id,NOW(),NOW(),1,'flow-state','select-one','Community',new_tagset_auth_id,new_classification_id,flow_state_template_id);
+          VALUES (new_tagset_id,NOW(),NOW(),1,'flow-state','select-one',second_tab_name,new_tagset_auth_id,new_classification_id,flow_state_template_id);
 
           INSERT INTO callout_contribution_defaults (id,"createdDate","updatedDate",version)
           VALUES (new_contrib_defaults_id,NOW(),NOW(),1);
@@ -213,10 +345,12 @@ export class BackfillContributorsCalloutL0Community1782467322859
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // Targeted reversal: remove only the PUBLISHED CONTRIBUTORS callouts in the
-    // Community tab of L0 spaces that still carry the exact default shape this
-    // migration produced (generated nameID, published but no publisher, no
-    // comments room) — so user-created contributors callouts are never deleted.
+    // Targeted reversal: remove only the PUBLISHED CONTRIBUTORS callouts in L0
+    // spaces that still carry the exact default shape this migration produced
+    // (generated nameID, published but no publisher, no comments room) — so
+    // user-created contributors callouts are never deleted. The tab is NOT
+    // filtered by name (the up() targets the second tab whatever its name), so
+    // this also cleans up callouts an earlier version of this migration placed.
     // Children are deleted explicitly; deleting the classification cascades its
     // flow-state tagset, and the profile's DEFAULT tagset is removed before the
     // profile (tagset.profileId FK).
@@ -242,21 +376,28 @@ export class BackfillContributorsCalloutL0Community1782467322859
             dt.id AS default_tagset_id,
             dt."authorizationId" AS default_tagset_auth_id,
             cd.id AS contrib_defaults_id
-          FROM space s
-          JOIN collaboration c ON c.id = s."collaborationId"
-          JOIN callouts_set cs ON cs.id = c."calloutsSetId"
-          JOIN callout co ON co."calloutsSetId" = cs.id
+          FROM (
+            -- Reverse both sources the up() targets: L0 live spaces and L0
+            -- space content templates.
+            SELECT c."calloutsSetId" AS callouts_set_id
+            FROM space s
+            JOIN collaboration c ON c.id = s."collaborationId"
+            WHERE s.level = 0
+            UNION ALL
+            SELECT c."calloutsSetId"
+            FROM template_content_space tcs
+            JOIN collaboration c ON c.id = tcs."collaborationId"
+            WHERE tcs.level = 0
+          ) src
+          JOIN callout co ON co."calloutsSetId" = src.callouts_set_id
           JOIN callout_framing cf ON cf.id = co."framingId"
           JOIN profile p ON p.id = cf."profileId"
           LEFT JOIN storage_bucket sb ON sb.id = p."storageBucketId"
           JOIN classification cl ON cl.id = co."classificationId"
-          JOIN tagset t ON t."classificationId" = cl.id
+          JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
           LEFT JOIN tagset dt ON dt."profileId" = p.id AND dt.name = 'default'
           LEFT JOIN callout_contribution_defaults cd ON cd.id = co."contributionDefaultsId"
-          WHERE s.level = 0
-            AND cf.type = 'contributors'
-            AND t.name = 'flow-state'
-            AND ('Community' = ANY(string_to_array(t.tags, ',')))
+          WHERE cf.type = 'contributors'
             AND co."nameID" LIKE 'contributors-%'
             AND co.settings->>'visibility' = 'published'
             AND co."commentsId" IS NULL


### PR DESCRIPTION
- Fix migration: All L0 Spaces > Tab 2 (no matter what name) > first po…sition get this new contributors callout, also templates
- Fix be able to edit callout templates with contributors framing, be able to set their settings

## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
