### PR TITLE
fix(bootstrap): refuse to provision an ASSISTANT_MCP_API_KEY without the mcp_ prefix

### DIFF
--- a/src/core/bootstrap/bootstrap.service.spec.ts
+++ b/src/core/bootstrap/bootstrap.service.spec.ts
@@ -349,6 +349,15 @@ describe('BootstrapService', () => {
       expect(keyMock.ensureActorKeyFromPlaintext).not.toHaveBeenCalled();
     });
 
+    it("skips before resolving the actor when the key lacks the 'mcp_' prefix (it could never authenticate)", async () => {
+      process.env[ENV_KEY] = 'not-a-valid-mcp-key';
+
+      await ensure();
+
+      expect(vaMock.getSingletonOrFail).not.toHaveBeenCalled();
+      expect(keyMock.ensureActorKeyFromPlaintext).not.toHaveBeenCalled();
+    });
+
     it('skips on the expected not-found (actor absent) without writing a key (FR-006)', async () => {
       process.env[ENV_KEY] = 'mcp_test';
       vaMock.getSingletonOrFail = vi

--- a/src/core/bootstrap/bootstrap.service.ts
+++ b/src/core/bootstrap/bootstrap.service.ts
@@ -170,13 +170,23 @@ export class BootstrapService {
    * sends this same plaintext as its delegation bearer; the server stores only
    * its SHA-256 hash, bound to the virtual-assistant actor. Idempotent (a no-op
    * once the row matches). Skipped — with a warning, never failing bootstrap —
-   * when the secret is unset or the actor is absent.
+   * when the secret is unset, malformed, or the actor is absent.
    */
   private async ensureAssistantMcpApiKey(): Promise<void> {
     const plaintext = process.env.ASSISTANT_MCP_API_KEY?.trim();
     if (!plaintext) {
       this.logger.warn?.(
         'ASSISTANT_MCP_API_KEY is not set — skipping virtual-assistant MCP key bootstrap; delegated MCP (the Web AI Assistant) is unavailable until it is provisioned',
+        LogContext.BOOTSTRAP
+      );
+      return;
+    }
+    // The MCP API-key strategy only engages `Authorization: Bearer mcp_…`
+    // headers, so a key without the prefix would bootstrap a row that can
+    // never authenticate: every asvc call 401s while bootstrap logs success.
+    if (!plaintext.startsWith('mcp_')) {
+      this.logger.warn?.(
+        "ASSISTANT_MCP_API_KEY does not start with 'mcp_' — skipping virtual-assistant MCP key bootstrap; the MCP host only accepts 'Bearer mcp_…' keys, so this key could never authenticate. Provision a key in the format mcp_<base64url(32)>",
         LogContext.BOOTSTRAP
       );
       return;


### PR DESCRIPTION
## Problem

The MCP API-key strategy only engages `Authorization: Bearer mcp_…` headers (`mcp-api-key.strategy.ts`), but the #1937 bootstrap (`ensureAssistantMcpApiKey`) hashes **any** non-empty `ASSISTANT_MCP_API_KEY` into an `mcp_api_key` row and logs success.

A key without the `mcp_` prefix therefore bootstraps a row that **can never authenticate**: the guard skips it, the generic `AuthInterceptor` rejects the bearer as an invalid Hydra JWT, and every assistant-service MCP call 401s — the assistant returns `capability_unavailable` on every tool-using turn while bootstrap logs look healthy.

**This happened on acceptance** (2026-07-02): the provisioned secret was a 32-char value without the prefix. Fixed there by rotating the secret; this PR closes the footgun so prod can't repeat it.

## Fix

Skip the bootstrap with a loud warning when the key lacks the `mcp_` prefix — mirroring the existing unset-secret behavior (warn, never fail bootstrap). The warning names the required format `mcp_<base64url(32)>`.

## Testing

- New spec: prefix-less key → warns + skips before resolving the actor, no key written.
- `bootstrap.service.spec.ts`: 22/22 pass; biome + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)