### PR TITLE
feat(auth-reset): graceful drain of in-flight resets on SIGTERM

### DIFF
--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -47,8 +44,12 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # amd64 only — matches the release build (build-release-docker-hub.yml,
+          # linux/amd64) and what we actually deploy. Building linux/arm64 here
+          # ran the full pnpm install + tsc compile under QEMU emulation (~5-10x
+          # slower), pushing this gate to 12-15 min to validate an architecture
+          # that is never released. Native single-arch keeps it ~2 min.
+          platforms: linux/amd64
           push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/src/core/microservices/drainable-rmq.server.ts
+++ b/src/core/microservices/drainable-rmq.server.ts
@@ -1,0 +1,29 @@
+import { ServerRMQ } from '@nestjs/microservices';
+
+/**
+ * A `Transport.RMQ` server that supports graceful draining.
+ *
+ * Stock `ServerRMQ` only exposes `close()`, which tears down the channel and
+ * connection — ripping any in-flight message off the consumer. `stopConsuming()`
+ * instead issues an AMQP `basic.cancel` on the underlying channel: the broker
+ * stops delivering NEW messages to this consumer, but the channel stays open so
+ * a reset that is mid-flight can still ack the message it is processing.
+ *
+ * Used by the auth-reset worker's SIGTERM handler to "stop taking new jobs"
+ * before waiting for the active reset to drain.
+ */
+export class DrainableRmqServer extends ServerRMQ {
+  /**
+   * Cancel this pod's consumer so the broker stops delivering new messages.
+   * Safe to call before the channel is up (no-op) and idempotent.
+   */
+  public async stopConsuming(): Promise<void> {
+    // `channel` is a ChannelWrapper (amqp-connection-manager). cancelAll()
+    // cancels every consumer on the channel AND removes them from the wrapper's
+    // setup list, so an underlying reconnect won't silently re-subscribe. This
+    // channel has exactly one consumer (the auth-reset queue).
+    if (this.channel) {
+      await this.channel.cancelAll();
+    }
+  }
+}

--- a/src/main.worker.ts
+++ b/src/main.worker.ts
@@ -93,10 +93,16 @@ export const bootstrapAuthResetWorker = async () => {
   // The timeout MUST sit comfortably below the pod's terminationGracePeriod so
   // step 3 runs before SIGKILL. Handlers are idempotent and carry an explicit
   // x-retry-count header, so a requeue on timeout loses no work.
-  // Max wait for the in-flight reset (a ceiling, not a fixed wait);
-  // keep it a few seconds BELOW the deployment's terminationGracePeriodSeconds so app.close() runs before SIGKILL.
+  // Total budget for the WHOLE shutdown (drain + close). Keep it a few seconds
+  // BELOW the deployment's terminationGracePeriodSeconds so the process exits on
+  // its own before the grace-period SIGKILL.
   const drainTimeoutMs =
     Number(process.env.AUTH_RESET_DRAIN_TIMEOUT_SECONDS ?? 55) * 1000;
+  // Carve the budget in two: most of it waits for the in-flight reset, a small
+  // reserve (derived from the same budget) is left for app.close() so a
+  // long-running reset can't starve the teardown.
+  const closeBudgetMs = Math.min(5000, Math.floor(drainTimeoutMs / 5));
+  const drainWaitMs = Math.max(0, drainTimeoutMs - closeBudgetMs);
   let shuttingDown = false;
   const shutdown = async (signal: NodeJS.Signals) => {
     if (shuttingDown) {
@@ -107,12 +113,27 @@ export const bootstrapAuthResetWorker = async () => {
       `Received ${signal}: cancelling auth-reset consumer, draining in-flight work.`,
       LogContext.AUTH
     );
+
+    // Absolute backstop tied to drainTimeoutMs: whatever stalls — a reset that
+    // never finishes OR a hanging app.close() (it awaits every onModuleDestroy
+    // and closes the DB pool / Redis cache / RMQ connection; the legacy redis
+    // cache store and pooled connections are common offenders) — the process
+    // force-exits at the full budget instead of sitting in Terminating until
+    // the grace-period SIGKILL.
+    setTimeout(() => {
+      logger.warn?.(
+        `Shutdown did not complete within ${drainTimeoutMs}ms; forcing exit.`,
+        LogContext.AUTH
+      );
+      process.exit(0);
+    }, drainTimeoutMs).unref();
+
     try {
       await rmqServer.stopConsuming();
-      const drained = await workerState.waitForIdle(drainTimeoutMs);
+      const drained = await workerState.waitForIdle(drainWaitMs);
       if (!drained) {
         logger.warn?.(
-          `Auth-reset drain timed out after ${drainTimeoutMs}ms with ${workerState.activeCount} reset(s) in flight; unacked message(s) will be requeued on close.`,
+          `Auth-reset drain timed out after ${drainWaitMs}ms with ${workerState.activeCount} reset(s) in flight; unacked message(s) will be requeued on close.`,
           LogContext.AUTH
         );
       }
@@ -123,21 +144,6 @@ export const bootstrapAuthResetWorker = async () => {
         LogContext.AUTH
       );
     } finally {
-      // A hanging teardown must NOT hold the pod in Terminating until the
-      // grace-period SIGKILL. app.close() awaits every module's onModuleDestroy
-      // and closes the DB pool / Redis cache / RMQ connection; if any of those
-      // stalls (the legacy redis cache store and pooled connections are common
-      // offenders) it never resolves, and a plain `await app.close()` would
-      // swallow the exit below. Cap it and force-exit regardless.
-      const HARD_EXIT_MS = 5000;
-      setTimeout(() => {
-        logger.warn?.(
-          `app.close() did not finish within ${HARD_EXIT_MS}ms; forcing exit.`,
-          LogContext.AUTH
-        );
-        process.exit(0);
-      }, HARD_EXIT_MS).unref();
-
       try {
         logger.log?.('Closing auth-reset worker app...', LogContext.AUTH);
         await app.close();

--- a/src/main.worker.ts
+++ b/src/main.worker.ts
@@ -4,9 +4,11 @@
 process.env.ALKEMIO_DISABLE_SUBSCRIPTIONS = 'true';
 
 import { LogContext, MessagingQueue } from '@common/enums';
+import { DrainableRmqServer } from '@core/microservices/drainable-rmq.server';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
-import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { MicroserviceOptions } from '@nestjs/microservices';
+import { AuthResetWorkerState } from '@services/auth-reset/subscriber/auth-reset.worker-state.service';
 import { AlkemioConfig } from '@src/types';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { AuthResetWorkerModule } from './core/bootstrap/auth-reset.worker.module';
@@ -46,59 +48,87 @@ export const bootstrapAuthResetWorker = async () => {
   const heartbeat = process.env.NODE_ENV === 'production' ? 30 : 120;
   const amqpEndpoint = `amqp://${connectionOptions.user}:${connectionOptions.password}@${connectionOptions.host}:${connectionOptions.port}?heartbeat=${heartbeat}`;
 
-  app.connectMicroservice<MicroserviceOptions>({
-    transport: Transport.RMQ,
-    options: {
-      urls: [amqpEndpoint],
-      queue,
-      queueOptions: { durable: true },
-      // One unacked message per pod at a time. The RMQ default is 0 (unlimited):
-      // a single pod would pull the whole queue and run every reset concurrently,
-      // each holding large authorization arrays (OOM risk against the 3.5Gi limit)
-      // and trampling the parent->child ordering the inheritance chain depends on.
-      // With 1, work is spread across pods as competing consumers, one reset each.
-      prefetchCount: 1,
-      socketOptions: {
-        reconnectTimeInSeconds: 5,
-        heartbeatIntervalInSeconds:
-          process.env.NODE_ENV === 'production' ? 30 : 240,
-      },
-      // Manual ack — the controller acks/rejects explicitly (retry handling).
-      noAck: false,
+  // Custom RMQ strategy (instead of transport+options) so the SIGTERM handler
+  // below can cancel the consumer WITHOUT tearing the channel out from under an
+  // in-flight reset. Same options as the stock Transport.RMQ server.
+  const rmqServer = new DrainableRmqServer({
+    urls: [amqpEndpoint],
+    queue,
+    queueOptions: { durable: true },
+    // One unacked message per pod at a time. The RMQ default is 0 (unlimited):
+    // a single pod would pull the whole queue and run every reset concurrently,
+    // each holding large authorization arrays (OOM risk against the 3.5Gi limit)
+    // and trampling the parent->child ordering the inheritance chain depends on.
+    // With 1, work is spread across pods as competing consumers, one reset each.
+    prefetchCount: 1,
+    socketOptions: {
+      reconnectTimeInSeconds: 5,
+      heartbeatIntervalInSeconds:
+        process.env.NODE_ENV === 'production' ? 30 : 240,
     },
+    // Manual ack — the controller acks/rejects explicitly (retry handling).
+    noAck: false,
   });
+  app.connectMicroservice<MicroserviceOptions>({ strategy: rmqServer });
 
-  // --- Graceful shutdown (worker-only) ---------------------------------------
+  const workerState = app.get(AuthResetWorkerState);
+
+  // --- Graceful drain on shutdown (worker-only) ------------------------------
   // This binary runs as PID 1 (Dockerfile `CMD ["node", "dist/main.js"]`, no
   // init wrapper). The Linux kernel does NOT apply the default "terminate"
   // disposition to PID 1 for SIGTERM/SIGINT unless the process installs its own
-  // handler — so without the line below a SIGTERM (sent by kubelet on
+  // handler — so without the handler below a SIGTERM (sent by kubelet on
   // scale-down/rollout) would be IGNORED and the pod would sit until the
   // terminationGracePeriodSeconds deadline, then get SIGKILLed.
   //
-  // enableShutdownHooks() registers process SIGTERM/SIGINT listeners that call
-  // app.close(), which closes the RMQ microservice: the consumer is cancelled
-  // (no new deliveries) and the channel/connection are torn down, then the
-  // process exits promptly — well inside the grace window instead of stalling
-  // to SIGKILL.
+  // Drain sequence:
+  //   1. rmqServer.stopConsuming() — AMQP basic.cancel: the broker stops
+  //      delivering NEW resets to this pod. The channel stays OPEN so an
+  //      in-flight reset can still ack the message it is processing.
+  //   2. workerState.waitForIdle() — wait for the active reset (0 or 1, given
+  //      prefetchCount: 1) to finish and ack, bounded by the drain timeout.
+  //   3. app.close() — tear down. Any message still unacked at this point is
+  //      requeued by the broker and redelivered to a live pod later.
   //
-  // In-flight safety: a reset already running when SIGTERM lands continues on
-  // the event loop. If it finishes and acks before app.close() tears the
-  // channel down, the message is consumed normally. If the channel closes
-  // first, the still-unacked message is requeued by the broker and redelivered
-  // on the next scale-up — the handlers are idempotent and carry an explicit
-  // retry counter, so no work is lost either way.
-  app.enableShutdownHooks();
-
-  // Observability only — Nest's enableShutdownHooks listener does the actual
-  // app.close(). This just records that a shutdown signal arrived.
-  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
-    process.on(signal, () =>
-      logger.log?.(
-        `Received ${signal}: draining auth-reset worker and shutting down.`,
-        LogContext.AUTH
-      )
+  // The timeout MUST sit comfortably below the pod's terminationGracePeriod so
+  // step 3 runs before SIGKILL. Handlers are idempotent and carry an explicit
+  // x-retry-count header, so a requeue on timeout loses no work.
+  // Max wait for the in-flight reset (a ceiling, not a fixed wait);
+  // keep it a few seconds BELOW the deployment's terminationGracePeriodSeconds so app.close() runs before SIGKILL.
+  const drainTimeoutMs =
+    Number(process.env.AUTH_RESET_DRAIN_TIMEOUT_SECONDS ?? 55) * 1000;
+  let shuttingDown = false;
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    logger.log?.(
+      `Received ${signal}: cancelling auth-reset consumer, draining in-flight work.`,
+      LogContext.AUTH
     );
+    try {
+      await rmqServer.stopConsuming();
+      const drained = await workerState.waitForIdle(drainTimeoutMs);
+      if (!drained) {
+        logger.warn?.(
+          `Auth-reset drain timed out after ${drainTimeoutMs}ms with ${workerState.activeCount} reset(s) in flight; unacked message(s) will be requeued on close.`,
+          LogContext.AUTH
+        );
+      }
+    } catch (error: any) {
+      logger.error?.(
+        `Error during auth-reset worker drain: ${error?.message}`,
+        error?.stack,
+        LogContext.AUTH
+      );
+    } finally {
+      await app.close();
+      process.exit(0);
+    }
+  };
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    process.on(signal, () => void shutdown(signal));
   }
 
   // Run module lifecycle hooks (onModuleInit / onApplicationBootstrap) BEFORE

--- a/src/main.worker.ts
+++ b/src/main.worker.ts
@@ -123,8 +123,34 @@ export const bootstrapAuthResetWorker = async () => {
         LogContext.AUTH
       );
     } finally {
-      await app.close();
-      process.exit(0);
+      // A hanging teardown must NOT hold the pod in Terminating until the
+      // grace-period SIGKILL. app.close() awaits every module's onModuleDestroy
+      // and closes the DB pool / Redis cache / RMQ connection; if any of those
+      // stalls (the legacy redis cache store and pooled connections are common
+      // offenders) it never resolves, and a plain `await app.close()` would
+      // swallow the exit below. Cap it and force-exit regardless.
+      const HARD_EXIT_MS = 5000;
+      setTimeout(() => {
+        logger.warn?.(
+          `app.close() did not finish within ${HARD_EXIT_MS}ms; forcing exit.`,
+          LogContext.AUTH
+        );
+        process.exit(0);
+      }, HARD_EXIT_MS).unref();
+
+      try {
+        logger.log?.('Closing auth-reset worker app...', LogContext.AUTH);
+        await app.close();
+        logger.log?.('Auth-reset worker app closed cleanly.', LogContext.AUTH);
+      } catch (error: any) {
+        logger.error?.(
+          `Error closing auth-reset worker app: ${error?.message}`,
+          error?.stack,
+          LogContext.AUTH
+        );
+      } finally {
+        process.exit(0);
+      }
     }
   };
   for (const signal of ['SIGTERM', 'SIGINT'] as const) {

--- a/src/main.worker.ts
+++ b/src/main.worker.ts
@@ -96,8 +96,17 @@ export const bootstrapAuthResetWorker = async () => {
   // Total budget for the WHOLE shutdown (drain + close). Keep it a few seconds
   // BELOW the deployment's terminationGracePeriodSeconds so the process exits on
   // its own before the grace-period SIGKILL.
+  // Guard the parse: a non-numeric value would yield NaN (breaking the timeout
+  // math so waitForIdle never bounds) and an empty string would yield 0
+  // (disabling the drain entirely) — fall back to 55 unless it is a finite,
+  // positive number.
+  const parsedDrainSeconds = Number(
+    process.env.AUTH_RESET_DRAIN_TIMEOUT_SECONDS
+  );
   const drainTimeoutMs =
-    Number(process.env.AUTH_RESET_DRAIN_TIMEOUT_SECONDS ?? 55) * 1000;
+    (Number.isFinite(parsedDrainSeconds) && parsedDrainSeconds > 0
+      ? parsedDrainSeconds
+      : 55) * 1000;
   // Carve the budget in two: most of it waits for the in-flight reset, a small
   // reserve (derived from the same budget) is left for app.close() so a
   // long-running reset can't starve the teardown.

--- a/src/services/auth-reset/subscriber/auth-reset.controller.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.controller.ts
@@ -92,7 +92,12 @@ export class AuthResetController {
     );
     const channel: Channel = context.getChannelRef();
     const originalMsg = context.getMessage() as Message;
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
+    // Normalize the retry header: it is an RMQ integration boundary, so a
+    // missing or malformed value must not leak a non-number into `retryCount + 1`
+    // (string concatenation) or the limit comparison. Fall back to 0.
+    const parsedRetry = Number(originalMsg.properties.headers?.[RETRY_HEADER]);
+    const retryCount =
+      Number.isInteger(parsedRetry) && parsedRetry >= 0 ? parsedRetry : 0;
 
     this.workerState.begin();
     try {
@@ -101,7 +106,10 @@ export class AuthResetController {
       const message = `Finished resetting ${subject}.`;
       this.logger.verbose?.(message, LogContext.AUTH_POLICY);
       if (task) {
-        this.taskService.updateTaskResults(task, message);
+        // Awaited so the task cache write completes before the message is acked,
+        // but isolated (recordTaskResult swallows its own errors) so a task-cache
+        // hiccup can never requeue a reset that already succeeded.
+        await this.recordTaskResult(task, message);
       }
       channel.ack(originalMsg);
     } catch (error: any) {
@@ -109,7 +117,7 @@ export class AuthResetController {
         const message = `Resetting ${subject} failed! Max retries reached. Rejecting message.`;
         this.logger.error(message, error?.stack, LogContext.AUTH);
         if (task) {
-          this.taskService.updateTaskErrors(task, message);
+          await this.recordTaskError(task, message);
         }
         channel.reject(originalMsg, false); // Reject and don't requeue
       } else {
@@ -127,6 +135,34 @@ export class AuthResetController {
       }
     } finally {
       this.workerState.end();
+    }
+  }
+
+  /**
+   * Persist a task result, swallowing any failure. Task tracking is best-effort
+   * telemetry — it must never throw back into the reset flow (which would requeue
+   * an already-successful reset), so its errors are logged and contained here.
+   */
+  private async recordTaskResult(task: string, message: string): Promise<void> {
+    try {
+      await this.taskService.updateTaskResults(task, message);
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to persist task result for task ${task}: ${error?.message}`,
+        LogContext.AUTH
+      );
+    }
+  }
+
+  /** As {@link recordTaskResult}, for the terminal (max-retries) error path. */
+  private async recordTaskError(task: string, message: string): Promise<void> {
+    try {
+      await this.taskService.updateTaskErrors(task, message);
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to persist task error for task ${task}: ${error?.message}`,
+        LogContext.AUTH
+      );
     }
   }
 

--- a/src/services/auth-reset/subscriber/auth-reset.controller.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.controller.ts
@@ -28,6 +28,7 @@ import { Channel, Message } from 'amqplib';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { AuthResetEventPayload } from '../auth-reset.payload.interface';
 import { RESET_EVENT_TYPE } from '../reset.event.type';
+import { AuthResetWorkerState } from './auth-reset.worker-state.service';
 
 const MAX_RETRIES = 5;
 const RETRY_HEADER = 'x-retry-count';
@@ -36,6 +37,7 @@ export class AuthResetController {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService,
+    private readonly workerState: AuthResetWorkerState,
     private accountService: AccountService,
     private authorizationPolicyService: AuthorizationPolicyService,
     private licenseService: LicenseService,
@@ -63,44 +65,58 @@ export class AuthResetController {
 
   private readonly authResetQueue: string;
 
-  @EventPattern(RESET_EVENT_TYPE.AUTHORIZATION_RESET_ACCOUNT, Transport.RMQ)
-  public async authResetAccount(
-    @Payload() payload: AuthResetEventPayload,
-    @Ctx() context: RmqContext
-  ) {
+  /**
+   * Shared processing shell for every reset event.
+   *
+   * Centralizes the delivery lifecycle so all handlers behave identically:
+   *  - tracks the job via {@link AuthResetWorkerState} so a SIGTERM drain can
+   *    wait for the in-flight reset to finish (begin/end around the work);
+   *  - on success: acks and records the task result (when a task is supplied);
+   *  - on failure under the retry limit: re-publishes with an incremented
+   *    `x-retry-count` header and acks the original (counter survives);
+   *  - on failure at the limit: rejects without requeue (dead message) and
+   *    records the task error.
+   *
+   * `subject` is a human phrase like `authorization for account with id <uuid>`
+   * used to build the start/success/failure log lines uniformly.
+   */
+  private async handleReset(
+    context: RmqContext,
+    subject: string,
+    work: () => Promise<void>,
+    task?: string
+  ): Promise<void> {
     this.logger.verbose?.(
-      `Starting reset of authorization for account with id ${payload.id}.`,
+      `Starting reset of ${subject}.`,
       LogContext.AUTH_POLICY
     );
     const channel: Channel = context.getChannelRef();
     const originalMsg = context.getMessage() as Message;
-
     const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
 
+    this.workerState.begin();
     try {
-      const account = await this.accountService.getAccountOrFail(payload.id);
-      const updatedAuthorizations =
-        await this.accountAuthorizationService.applyAuthorizationPolicy(
-          account
-        );
-      await this.authorizationPolicyService.saveAll(updatedAuthorizations);
+      await work();
 
-      const message = `Finished resetting authorization for account with id ${payload.id}.`;
+      const message = `Finished resetting ${subject}.`;
       this.logger.verbose?.(message, LogContext.AUTH_POLICY);
-      this.taskService.updateTaskResults(payload.task, message);
+      if (task) {
+        this.taskService.updateTaskResults(task, message);
+      }
       channel.ack(originalMsg);
     } catch (error: any) {
       if (retryCount >= MAX_RETRIES) {
-        const message = `Resetting authorization for account with id ${payload.id} failed! Max retries reached. Rejecting message.`;
+        const message = `Resetting ${subject} failed! Max retries reached. Rejecting message.`;
         this.logger.error(message, error?.stack, LogContext.AUTH);
-        this.taskService.updateTaskErrors(payload.task, message);
-
+        if (task) {
+          this.taskService.updateTaskErrors(task, message);
+        }
         channel.reject(originalMsg, false); // Reject and don't requeue
       } else {
         this.logger.warn(
-          `Processing  authorization reset for account with id ${
-            payload.id
-          } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
+          `Processing reset of ${subject} failed. Retrying (${
+            retryCount + 1
+          }/${MAX_RETRIES})`,
           LogContext.AUTH
         );
         channel.publish('', this.authResetQueue, originalMsg.content, {
@@ -109,7 +125,29 @@ export class AuthResetController {
         });
         channel.ack(originalMsg); // Acknowledge the original message
       }
+    } finally {
+      this.workerState.end();
     }
+  }
+
+  @EventPattern(RESET_EVENT_TYPE.AUTHORIZATION_RESET_ACCOUNT, Transport.RMQ)
+  public async authResetAccount(
+    @Payload() payload: AuthResetEventPayload,
+    @Ctx() context: RmqContext
+  ) {
+    await this.handleReset(
+      context,
+      `authorization for account with id ${payload.id}`,
+      async () => {
+        const account = await this.accountService.getAccountOrFail(payload.id);
+        const updatedAuthorizations =
+          await this.accountAuthorizationService.applyAuthorizationPolicy(
+            account
+          );
+        await this.authorizationPolicyService.saveAll(updatedAuthorizations);
+      },
+      payload.task
+    );
   }
 
   @EventPattern(RESET_EVENT_TYPE.LICENSE_RESET_ACCOUNT, Transport.RMQ)
@@ -117,46 +155,17 @@ export class AuthResetController {
     @Payload() payload: AuthResetEventPayload,
     @Ctx() context: RmqContext
   ) {
-    this.logger.verbose?.(
-      `Starting reset of license for account with id ${payload.id}.`,
-      LogContext.AUTH_POLICY
+    await this.handleReset(
+      context,
+      `license for account with id ${payload.id}`,
+      async () => {
+        const account = await this.accountService.getAccountOrFail(payload.id);
+        const updatedLicenses =
+          await this.accountLicenseService.applyLicensePolicy(account.id);
+        await this.licenseService.saveAll(updatedLicenses);
+      },
+      payload.task
     );
-    const channel: Channel = context.getChannelRef();
-    const originalMsg = context.getMessage() as Message;
-
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
-
-    try {
-      const account = await this.accountService.getAccountOrFail(payload.id);
-      const updatedLicenses =
-        await this.accountLicenseService.applyLicensePolicy(account.id);
-      await this.licenseService.saveAll(updatedLicenses);
-
-      const message = `Finished resetting license for account with id ${payload.id}.`;
-      this.logger.verbose?.(message, LogContext.AUTH_POLICY);
-      this.taskService.updateTaskResults(payload.task, message);
-      channel.ack(originalMsg);
-    } catch (error: any) {
-      if (retryCount >= MAX_RETRIES) {
-        const message = `Resetting license for account with id ${payload.id} failed! Max retries reached. Rejecting message.`;
-        this.logger.error(message, error?.stack, LogContext.AUTH);
-        this.taskService.updateTaskErrors(payload.task, message);
-
-        channel.reject(originalMsg, false); // Reject and don't requeue
-      } else {
-        this.logger.warn(
-          `Processing  license reset for account with id ${
-            payload.id
-          } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
-          LogContext.AUTH
-        );
-        channel.publish('', this.authResetQueue, originalMsg.content, {
-          headers: { [RETRY_HEADER]: retryCount + 1 },
-          persistent: true, // Make the message durable
-        });
-        channel.ack(originalMsg); // Acknowledge the original message
-      }
-    }
   }
 
   @EventPattern(RESET_EVENT_TYPE.LICENSE_RESET_ORGANIZATION, Transport.RMQ)
@@ -164,182 +173,48 @@ export class AuthResetController {
     @Payload() payload: AuthResetEventPayload,
     @Ctx() context: RmqContext
   ) {
-    this.logger.verbose?.(
-      `Starting reset of license for organization with id ${payload.id}.`,
-      LogContext.AUTH_POLICY
-    );
-    const channel: Channel = context.getChannelRef();
-    const originalMsg = context.getMessage() as Message;
-
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
-
-    try {
-      const organization =
-        await this.organizationLookupService.getOrganizationByIdOrFail(
-          payload.id
-        );
-      const updatedLicenses =
-        await this.organizationLicenseService.applyLicensePolicy(
-          organization.id
-        );
-      await this.licenseService.saveAll(updatedLicenses);
-
-      const message = `Finished resetting license for organization with id ${payload.id}.`;
-      this.logger.verbose?.(message, LogContext.AUTH_POLICY);
-      this.taskService.updateTaskResults(payload.task, message);
-      channel.ack(originalMsg);
-    } catch (error: any) {
-      if (retryCount >= MAX_RETRIES) {
-        const message = `Resetting license for organization with id ${payload.id} failed! Max retries reached. Rejecting message.`;
-        this.logger.error(message, error?.stack, LogContext.AUTH);
-        this.taskService.updateTaskErrors(payload.task, message);
-
-        channel.reject(originalMsg, false); // Reject and don't requeue
-      } else {
-        this.logger.warn(
-          `Processing  license reset for organization with id ${
+    await this.handleReset(
+      context,
+      `license for organization with id ${payload.id}`,
+      async () => {
+        const organization =
+          await this.organizationLookupService.getOrganizationByIdOrFail(
             payload.id
-          } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
-          LogContext.AUTH
-        );
-        channel.publish('', this.authResetQueue, originalMsg.content, {
-          headers: { [RETRY_HEADER]: retryCount + 1 },
-          persistent: true, // Make the message durable
-        });
-        channel.ack(originalMsg); // Acknowledge the original message
-      }
-    }
+          );
+        const updatedLicenses =
+          await this.organizationLicenseService.applyLicensePolicy(
+            organization.id
+          );
+        await this.licenseService.saveAll(updatedLicenses);
+      },
+      payload.task
+    );
   }
 
   @EventPattern(RESET_EVENT_TYPE.AUTHORIZATION_RESET_PLATFORM, Transport.RMQ)
   public async authResetPlatform(@Ctx() context: RmqContext) {
-    this.logger.verbose?.(
-      'Starting reset of authorization for platform',
-      LogContext.AUTH_POLICY
-    );
-    const channel: Channel = context.getChannelRef();
-    const originalMsg = context.getMessage() as Message;
-
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
-
-    try {
+    await this.handleReset(context, 'authorization for platform', async () => {
       const authorizations =
         await this.platformAuthorizationService.applyAuthorizationPolicy();
       await this.authorizationPolicyService.saveAll(authorizations);
-      this.logger.verbose?.(
-        'Finished resetting authorization for platform.',
-        LogContext.AUTH_POLICY
-      );
-      channel.ack(originalMsg);
-    } catch (error: any) {
-      if (retryCount >= MAX_RETRIES) {
-        this.logger.error(
-          'Resetting authorization for platform failed! Max retries reached. Rejecting message.',
-          error?.stack,
-          LogContext.AUTH
-        );
-        channel.reject(originalMsg, false); // Reject and don't requeue
-      } else {
-        this.logger.warn(
-          `Processing  authorization reset for platform failed. Retrying (${
-            retryCount + 1
-          }/${MAX_RETRIES})`,
-          LogContext.AUTH
-        );
-        channel.publish('', this.authResetQueue, originalMsg.content, {
-          headers: { [RETRY_HEADER]: retryCount + 1 },
-          persistent: true, // Make the message durable
-        });
-        channel.ack(originalMsg); // Acknowledge the original message
-      }
-    }
+    });
   }
 
   @EventPattern(RESET_EVENT_TYPE.LICENSE_RESET_PLATFORM, Transport.RMQ)
   public async licenseResetPlatform(@Ctx() context: RmqContext) {
-    this.logger.verbose?.(
-      'Starting reset of license for platform',
-      LogContext.AUTH_POLICY
-    );
-    const channel: Channel = context.getChannelRef();
-    const originalMsg = context.getMessage() as Message;
-
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
-
-    try {
+    await this.handleReset(context, 'license for platform', async () => {
       const licenses = await this.platformLicenseService.applyLicensePolicy();
       await this.licenseService.saveAll(licenses);
-      this.logger.verbose?.(
-        'Finished resetting license for platform.',
-        LogContext.AUTH_POLICY
-      );
-      channel.ack(originalMsg);
-    } catch (error: any) {
-      if (retryCount >= MAX_RETRIES) {
-        this.logger.error(
-          'Resetting license for platform failed! Max retries reached. Rejecting message.',
-          error?.stack,
-          LogContext.AUTH
-        );
-        channel.reject(originalMsg, false); // Reject and don't requeue
-      } else {
-        this.logger.warn(
-          `Processing license reset for platform failed. Retrying (${
-            retryCount + 1
-          }/${MAX_RETRIES})`,
-          LogContext.AUTH
-        );
-        channel.publish('', this.authResetQueue, originalMsg.content, {
-          headers: { [RETRY_HEADER]: retryCount + 1 },
-          persistent: true, // Make the message durable
-        });
-        channel.ack(originalMsg); // Acknowledge the original message
-      }
-    }
+    });
   }
 
   @EventPattern(RESET_EVENT_TYPE.AUTHORIZATION_RESET_AI_SERVER, Transport.RMQ)
   public async authResetAiServer(@Ctx() context: RmqContext) {
-    this.logger.verbose?.(
-      'Starting reset of authorization for AI Server',
-      LogContext.AUTH_POLICY
-    );
-    const channel: Channel = context.getChannelRef();
-    const originalMsg = context.getMessage() as Message;
-
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
-
-    try {
+    await this.handleReset(context, 'authorization for AI Server', async () => {
       const authorizations =
         await this.aiServerAuthorizationService.applyAuthorizationPolicy();
       await this.authorizationPolicyService.saveAll(authorizations);
-      this.logger.verbose?.(
-        'Finished resetting authorization for AI Server.',
-        LogContext.AUTH_POLICY
-      );
-      channel.ack(originalMsg);
-    } catch (error: any) {
-      if (retryCount >= MAX_RETRIES) {
-        this.logger.error(
-          'Resetting authorization for AI Server failed! Max retries reached. Rejecting message.',
-          error?.stack,
-          LogContext.AUTH
-        );
-        channel.reject(originalMsg, false); // Reject and don't requeue
-      } else {
-        this.logger.warn(
-          `Processing  authorization reset for AI Server failed. Retrying (${
-            retryCount + 1
-          }/${MAX_RETRIES})`,
-          LogContext.AUTH
-        );
-        channel.publish('', this.authResetQueue, originalMsg.content, {
-          headers: { [RETRY_HEADER]: retryCount + 1 },
-          persistent: true, // Make the message durable
-        });
-        channel.ack(originalMsg); // Acknowledge the original message
-      }
-    }
+    });
   }
 
   @EventPattern(RESET_EVENT_TYPE.AUTHORIZATION_RESET_USER, Transport.RMQ)
@@ -347,49 +222,17 @@ export class AuthResetController {
     @Payload() payload: AuthResetEventPayload,
     @Ctx() context: RmqContext
   ) {
-    this.logger.verbose?.(
-      `Starting reset of authorization for user with id ${payload.id}.`,
-      LogContext.AUTH_POLICY
+    await this.handleReset(
+      context,
+      `authorization for user with id ${payload.id}`,
+      async () => {
+        const user = await this.userService.getUserByIdOrFail(payload.id);
+        const authorizations =
+          await this.userAuthorizationService.applyAuthorizationPolicy(user.id);
+        await this.authorizationPolicyService.saveAll(authorizations);
+      },
+      payload.task
     );
-    const channel: Channel = context.getChannelRef();
-    const originalMsg = context.getMessage() as Message;
-
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
-
-    try {
-      const user = await this.userService.getUserByIdOrFail(payload.id);
-      const authorizations =
-        await this.userAuthorizationService.applyAuthorizationPolicy(user.id);
-      await this.authorizationPolicyService.saveAll(authorizations);
-
-      channel.ack(originalMsg);
-
-      const message = `Finished resetting authorization for user with id ${payload.id}.`;
-      this.logger.verbose?.(message, LogContext.AUTH_POLICY);
-
-      this.taskService.updateTaskResults(payload.task, message);
-    } catch (error: any) {
-      if (retryCount >= MAX_RETRIES) {
-        channel.reject(originalMsg, false); // Reject and don't requeue
-
-        const message = `Resetting authorization for user with id ${payload.id} failed! Max retries reached. Rejecting message.`;
-        this.logger.error(message, error?.stack, LogContext.AUTH);
-
-        this.taskService.updateTaskErrors(payload.task, message);
-      } else {
-        this.logger.warn(
-          `Processing  authorization reset for user with id ${
-            payload.id
-          } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
-          LogContext.AUTH
-        );
-        channel.publish('', this.authResetQueue, originalMsg.content, {
-          headers: { [RETRY_HEADER]: retryCount + 1 },
-          persistent: true, // Make the message durable
-        });
-        channel.ack(originalMsg); // Acknowledge the original message
-      }
-    }
   }
 
   @EventPattern(
@@ -400,51 +243,19 @@ export class AuthResetController {
     @Payload() payload: AuthResetEventPayload,
     @Ctx() context: RmqContext
   ) {
-    this.logger.verbose?.(
-      `Starting reset of authorization for organization with id ${payload.id}.`,
-      LogContext.AUTH_POLICY
+    await this.handleReset(
+      context,
+      `authorization for organization with id ${payload.id}`,
+      async () => {
+        const organization =
+          await this.organizationService.getOrganizationOrFail(payload.id);
+        const authorizations =
+          await this.organizationAuthorizationService.applyAuthorizationPolicy(
+            organization
+          );
+        await this.authorizationPolicyService.saveAll(authorizations);
+      },
+      payload.task
     );
-    const channel: Channel = context.getChannelRef();
-    const originalMsg = context.getMessage() as Message;
-
-    const retryCount = originalMsg.properties.headers?.[RETRY_HEADER] ?? 0;
-
-    try {
-      const organization = await this.organizationService.getOrganizationOrFail(
-        payload.id
-      );
-      const authorizations =
-        await this.organizationAuthorizationService.applyAuthorizationPolicy(
-          organization
-        );
-      await this.authorizationPolicyService.saveAll(authorizations);
-      channel.ack(originalMsg);
-
-      const message = `Finished resetting authorization for organization with id ${payload.id}.`;
-      this.logger.verbose?.(message, LogContext.AUTH_POLICY);
-
-      this.taskService.updateTaskResults(payload.task, message);
-    } catch (error: any) {
-      if (retryCount >= MAX_RETRIES) {
-        channel.reject(originalMsg, false); // Reject and don't requeue
-
-        const message = `Resetting authorization for organization with id ${payload.id} failed! Max retries reached. Rejecting message.`;
-        this.logger.error(message, error?.stack, LogContext.AUTH);
-
-        this.taskService.updateTaskErrors(payload.task, message);
-      } else {
-        this.logger.warn(
-          `Processing  authorization reset for organization with id ${
-            payload.id
-          } failed. Retrying (${retryCount + 1}/${MAX_RETRIES})`,
-          LogContext.AUTH
-        );
-        channel.publish('', this.authResetQueue, originalMsg.content, {
-          headers: { [RETRY_HEADER]: retryCount + 1 },
-          persistent: true, // Make the message durable
-        });
-        channel.ack(originalMsg); // Acknowledge the original message
-      }
-    }
   }
 }

--- a/src/services/auth-reset/subscriber/auth-reset.subscriber.module.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.subscriber.module.ts
@@ -10,6 +10,7 @@ import { PlatformModule } from '@platform/platform/platform.module';
 import { AiServerModule } from '@services/ai-server/ai-server/ai.server.module';
 import { TaskModule } from '@services/task/task.module';
 import { AuthResetController } from './auth-reset.controller';
+import { AuthResetWorkerState } from './auth-reset.worker-state.service';
 
 @Global()
 @Module({
@@ -26,5 +27,9 @@ import { AuthResetController } from './auth-reset.controller';
     LicenseModule,
   ],
   controllers: [AuthResetController],
+  // Exported (and @Global) so main.worker.ts can resolve it via app.get() to
+  // drive the SIGTERM drain.
+  providers: [AuthResetWorkerState],
+  exports: [AuthResetWorkerState],
 })
 export class AuthResetSubscriberModule {}

--- a/src/services/auth-reset/subscriber/auth-reset.worker-state.service.spec.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.worker-state.service.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { AuthResetWorkerState } from './auth-reset.worker-state.service';
+
+describe('AuthResetWorkerState', () => {
+  it('tracks the in-flight count and never goes negative', () => {
+    const state = new AuthResetWorkerState();
+    expect(state.activeCount).toBe(0);
+
+    state.begin();
+    expect(state.activeCount).toBe(1);
+
+    state.end();
+    expect(state.activeCount).toBe(0);
+
+    // Extra end() (defensive) must not underflow.
+    state.end();
+    expect(state.activeCount).toBe(0);
+  });
+
+  it('waitForIdle resolves true immediately when nothing is in flight', async () => {
+    const state = new AuthResetWorkerState();
+    await expect(state.waitForIdle(1000)).resolves.toBe(true);
+  });
+
+  it('waitForIdle resolves false when a job is still in flight at the deadline', async () => {
+    const state = new AuthResetWorkerState();
+    state.begin();
+    // Short timeout, short poll — job never ends, so it must time out to false.
+    await expect(state.waitForIdle(30, 5)).resolves.toBe(false);
+  });
+
+  it('waitForIdle resolves true once the in-flight job ends', async () => {
+    const state = new AuthResetWorkerState();
+    state.begin();
+
+    const pending = state.waitForIdle(1000, 5);
+    // End the job on the next macrotask; waitForIdle should then observe idle.
+    setTimeout(() => state.end(), 10);
+
+    await expect(pending).resolves.toBe(true);
+  });
+});

--- a/src/services/auth-reset/subscriber/auth-reset.worker-state.service.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.worker-state.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Tracks how many auth/license reset jobs are actively being processed by this
+ * worker pod, so the SIGTERM handler in `main.worker.ts` can wait for the
+ * in-flight reset to finish before closing the app.
+ *
+ * With `prefetchCount: 1` (see main.worker.ts) the count is only ever 0 or 1,
+ * but a counter keeps the contract correct if prefetch is ever raised.
+ */
+@Injectable()
+export class AuthResetWorkerState {
+  private inFlight = 0;
+
+  /** Call at the start of a reset handler (before any await). */
+  public begin(): void {
+    this.inFlight++;
+  }
+
+  /** Call once the reset has been acked/rejected, always in a `finally`. */
+  public end(): void {
+    if (this.inFlight > 0) {
+      this.inFlight--;
+    }
+  }
+
+  public get activeCount(): number {
+    return this.inFlight;
+  }
+
+  /**
+   * Resolves when no reset is in flight, or when `timeoutMs` elapses —
+   * whichever comes first. Returns `true` if it drained cleanly, `false` on
+   * timeout (caller then lets the broker requeue the unacked message on close).
+   */
+  public async waitForIdle(timeoutMs: number, pollMs = 100): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.inFlight > 0) {
+      if (Date.now() >= deadline) {
+        return false;
+      }
+      await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
## What

The dedicated auth-reset worker (`AUTH_RESET_WORKER=true` → `main.worker.ts`) now **drains gracefully on SIGTERM** instead of relying on Nest's `enableShutdownHooks()`, whose `app.close()` ripped the RMQ channel out from under any reset that was mid-flight — the unacked message was requeued and the partial work redone from scratch on scale-up.

## How

On `SIGTERM`/`SIGINT` the worker now runs an explicit three-step drain:

1. **Stop taking new jobs** — `DrainableRmqServer.stopConsuming()` issues an AMQP `basic.cancel` (via `ChannelWrapper.cancelAll()`). The broker stops delivering new resets to this pod, but the channel stays **open** so an in-flight reset can still ack.
2. **Wait for the active reset** — `AuthResetWorkerState.waitForIdle()` blocks until the in-flight job finishes and acks (count is 0 or 1 given `prefetchCount: 1`), bounded by `AUTH_RESET_DRAIN_TIMEOUT_SECONDS` (default 55s).
3. **Close** — `app.close()` + `process.exit(0)`. Any message still unacked at the timeout is requeued by the broker; handlers are idempotent and carry an `x-retry-count` header, so no work is lost.

Because `prefetchCount: 1` caps in-flight work at one job, cancelling the consumer at the broker means a shutting-down pod touches **zero** new messages — no requeue churn even with hundreds queued.

### Also

- Collapsed the 8 near-identical controller handlers into a shared `handleReset()` shell that wires the drain tracking and uniformizes the previously inconsistent ack ordering (~340 lines lighter).
- Added a unit spec for `AuthResetWorkerState` (counter + `waitForIdle` timeout/drain behaviour).

## Ops requirement ⚠️

`AUTH_RESET_DRAIN_TIMEOUT_SECONDS` **must be set a few seconds below** the worker deployment's `terminationGracePeriodSeconds` (K8s cannot expose that value to the container, so the two are matched by hand in the manifest). If the timeout meets or exceeds the grace period, SIGKILL fires mid-drain and `app.close()` never runs. Unset → 55s, so pair with a grace period ≥ ~60s.

## Testing

- `AuthResetWorkerState` unit spec (4 tests) ✅
- Full existing suite green (auth-reset controller spec unchanged in behaviour) ✅
- `tsc --noEmit` + Biome clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful draining for the auth reset worker so it stops receiving new messages before shutting down.
  * Added in-flight job tracking to wait for active work to finish during shutdown.

* **Bug Fixes**
  * Improved message handling with consistent retry, acknowledgement, and rejection behavior.
  * Reduced duplicate processing logic across reset handlers.

* **Tests**
  * Added coverage for worker drain timing and in-flight job tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->