### PR TITLE
fix(mcp): create_whiteboard_in_space accepts a top-level space nameID, not only a UUID

### DIFF
--- a/src/domain/space/space.lookup/space.lookup.service.spec.ts
+++ b/src/domain/space/space.lookup/space.lookup.service.spec.ts
@@ -107,6 +107,56 @@ describe('SpaceLookupService', () => {
     });
   });
 
+  describe('getSpaceByIdOrNameIdOrFail', () => {
+    const SPACE_UUID = 'e0e2e08f-04cc-40dc-b40c-089b6cc27689';
+
+    it('routes a UUID to getSpaceOrFail (any level)', async () => {
+      const mockSpace = { id: SPACE_UUID } as ISpace;
+      entityManager.findOne.mockResolvedValue(mockSpace);
+      const byNameId = vi.spyOn(spaceRepository, 'findOne');
+
+      const result = await service.getSpaceByIdOrNameIdOrFail(SPACE_UUID);
+
+      expect(result).toBe(mockSpace);
+      expect(byNameId).not.toHaveBeenCalled();
+    });
+
+    it('routes a non-UUID to getSpaceByNameIdOrFail (top-level nameID)', async () => {
+      const mockSpace = { id: SPACE_UUID, nameID: 'my-space' } as ISpace;
+      const byNameId = vi
+        .spyOn(spaceRepository, 'findOne')
+        .mockResolvedValue(mockSpace as Space);
+
+      const result = await service.getSpaceByIdOrNameIdOrFail('my-space');
+
+      expect(result).toBe(mockSpace);
+      expect(byNameId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ nameID: 'my-space' }),
+        })
+      );
+      expect(entityManager.findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSpaceByNameIdOrFail where-clause safety', () => {
+    it('caller options can never clobber the nameID + L0 filter', async () => {
+      const byNameId = vi
+        .spyOn(spaceRepository, 'findOne')
+        .mockResolvedValue({ id: 'space-1' } as Space);
+
+      await service.getSpaceByNameIdOrFail('my-space', {
+        where: { visibility: 'demo' },
+      } as any);
+
+      const arg = byNameId.mock.calls[0][0] as any;
+      // The caller's where is merged, not replacing the guard.
+      expect(arg.where.nameID).toBe('my-space');
+      expect(arg.where.level).toBeDefined();
+      expect(arg.where.visibility).toBe('demo');
+    });
+  });
+
   describe('spacesExist', () => {
     it('should return true when called with empty array', async () => {
       const result = await service.spacesExist([]);

--- a/src/domain/space/space.lookup/space.lookup.service.ts
+++ b/src/domain/space/space.lookup/space.lookup.service.ts
@@ -8,6 +8,7 @@ import { IActor } from '@domain/actor/actor/actor.interface';
 import { ICollaboration } from '@domain/collaboration/collaboration/collaboration.interface';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { isUUID } from 'class-validator';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import {
   EntityManager,
@@ -74,22 +75,42 @@ export class SpaceLookupService {
     spaceNameID: string,
     options?: FindOneOptions<Space>
   ): Promise<ISpace> {
+    // Spread options FIRST so a caller-supplied where can never clobber the
+    // nameID + L0 filter (getSpace uses the same safe order).
     const space = await this.spaceRepository.findOne({
+      ...options,
       where: {
+        ...options?.where,
         nameID: spaceNameID,
         level: SpaceLevel.L0,
       },
-      ...options,
     });
     if (!space) {
-      if (!space)
-        throw new EntityNotFoundException(
-          'L0 Space not found',
-          LogContext.SPACES,
-          { spaceNameID }
-        );
+      throw new EntityNotFoundException(
+        'L0 Space not found',
+        LogContext.SPACES,
+        { spaceNameID }
+      );
     }
     return space;
+  }
+
+  /**
+   * Resolve a space by UUID (any level) or, when the input is not a UUID, by
+   * TOP-LEVEL space nameID (the URL slug). Subspace nameIDs are only unique
+   * within their L0 space, so a bare slug can only address an L0 space —
+   * subspaces require the UUID. This is the single home of the id-or-nameID
+   * policy; model-facing MCP tools should call this rather than re-deriving
+   * the branch.
+   */
+  public async getSpaceByIdOrNameIdOrFail(
+    spaceIdOrNameId: string,
+    options?: FindOneOptions<Space>
+  ): Promise<ISpace> {
+    if (isUUID(spaceIdOrNameId)) {
+      return this.getSpaceOrFail(spaceIdOrNameId, options);
+    }
+    return this.getSpaceByNameIdOrFail(spaceIdOrNameId, options);
   }
 
   public async getSubspaceByNameIdInLevelZeroSpace(
@@ -98,12 +119,13 @@ export class SpaceLookupService {
     options?: FindOneOptions<Space>
   ): Promise<ISpace | null> {
     const subspace = await this.spaceRepository.findOne({
+      ...options,
       where: {
+        ...options?.where,
         nameID: subspaceNameID,
         levelZeroSpaceID: levelZeroSpaceID,
         level: Not(SpaceLevel.L0),
       },
-      ...options,
     });
 
     return subspace;

--- a/src/services/mcp-server/tools/contributions-analyze.tool.ts
+++ b/src/services/mcp-server/tools/contributions-analyze.tool.ts
@@ -4,6 +4,7 @@ import { CalloutContributionType } from '@common/enums/callout.contribution.type
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { CalloutContribution } from '@domain/collaboration/callout-contribution/callout.contribution.entity';
+import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
@@ -76,6 +77,7 @@ export class ContributionsAnalyzeTool implements McpTool {
     @InjectEntityManager('default')
     private readonly entityManager: EntityManager,
     private readonly authorizationService: AuthorizationService,
+    private readonly spaceLookupService: SpaceLookupService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
   ) {}
@@ -94,7 +96,8 @@ export class ContributionsAnalyzeTool implements McpTool {
             type: 'string',
             description:
               'Scope of analysis: "my_contributions" for your contributions, ' +
-              '"callout:{id}" for a specific callout, "space:{id}" for all contributions in a space',
+              '"callout:{id}" for a specific callout, "space:{id}" for all contributions in a space ' +
+              '(a space/subspace UUID, or a top-level space nameID / URL slug)',
           },
           analysisType: {
             type: 'string',
@@ -141,6 +144,22 @@ export class ContributionsAnalyzeTool implements McpTool {
       return this.errorResult(
         'Invalid scope format. Use "my_contributions", "callout:{id}", or "space:{id}"'
       );
+    }
+
+    // Resolve the space scope's id-or-nameID to a UUID (the lookup service
+    // owns the policy) — a slug matched raw against space.id would silently
+    // return an empty set instead of an error.
+    if (scope.type === 'space') {
+      try {
+        const space = await this.spaceLookupService.getSpaceByIdOrNameIdOrFail(
+          scope.spaceId
+        );
+        scope.spaceId = space.id;
+      } catch {
+        return this.errorResult(
+          `Space not found: ${scope.spaceId}. Pass a space/subspace UUID, or a top-level space nameID (URL slug); subspaces require the UUID.`
+        );
+      }
     }
 
     this.logger.verbose?.(

--- a/src/services/mcp-server/tools/create-whiteboard-in-space.tool.spec.ts
+++ b/src/services/mcp-server/tools/create-whiteboard-in-space.tool.spec.ts
@@ -1,0 +1,116 @@
+import { ActorContext } from '@core/actor-context/actor.context';
+import { vi } from 'vitest';
+import { CreateWhiteboardInSpaceTool } from './create-whiteboard-in-space.tool';
+
+/**
+ * Space resolution for `create_whiteboard_in_space`: a UUID resolves any
+ * space/subspace by id, anything else is treated as a TOP-LEVEL space nameID
+ * (the URL slug) — the id the model most often has at hand. Found live: the
+ * model passed a space's slug and the tool refused it as "not found" even
+ * though its own description said "resolve it from a name".
+ */
+describe('create_whiteboard_in_space — space id/nameID resolution', () => {
+  const SPACE_UUID = 'e0e2e08f-04cc-40dc-b40c-089b6cc27689';
+  const CALLOUTS_SET_ID = 'callouts-set-1';
+
+  const actor = (): ActorContext =>
+    Object.assign(new ActorContext(), {
+      actorID: 'user-1',
+      isAnonymous: false,
+      credentials: [],
+    });
+
+  const buildTool = () => {
+    const space = {
+      id: SPACE_UUID,
+      collaboration: { calloutsSet: { id: CALLOUTS_SET_ID } },
+    };
+    const spaceLookupService = {
+      getSpaceOrFail: vi.fn().mockResolvedValue(space),
+      getSpaceByNameIdOrFail: vi.fn().mockResolvedValue(space),
+    };
+    const calloutsSetResolverMutations = {
+      createCalloutOnCalloutsSet: vi
+        .fn()
+        .mockResolvedValue({ id: 'callout-1' }),
+    };
+    const calloutRepository = {
+      findOne: vi.fn().mockResolvedValue(null),
+    };
+    const urlGeneratorService = {
+      getWhiteboardUrlPath: vi.fn(),
+    };
+    const logger = { verbose: vi.fn(), warn: vi.fn() };
+
+    const tool = new CreateWhiteboardInSpaceTool(
+      calloutsSetResolverMutations as any,
+      spaceLookupService as any,
+      calloutRepository as any,
+      {} as any, // templateService — unused without fromTemplateId
+      {} as any, // authorizationService — unused without fromTemplateId
+      urlGeneratorService as any,
+      logger as any
+    );
+    return { tool, spaceLookupService, calloutsSetResolverMutations };
+  };
+
+  it('resolves a UUID via getSpaceOrFail (any level)', async () => {
+    const { tool, spaceLookupService, calloutsSetResolverMutations } =
+      buildTool();
+
+    const result = await tool.execute(
+      { spaceId: SPACE_UUID, displayName: 'Test board' },
+      actor()
+    );
+
+    expect(spaceLookupService.getSpaceOrFail).toHaveBeenCalledWith(
+      SPACE_UUID,
+      expect.objectContaining({ relations: expect.anything() })
+    );
+    expect(spaceLookupService.getSpaceByNameIdOrFail).not.toHaveBeenCalled();
+    expect(result.isError).toBeUndefined();
+    expect(
+      calloutsSetResolverMutations.createCalloutOnCalloutsSet
+    ).toHaveBeenCalled();
+  });
+
+  it('resolves a non-UUID as a top-level space nameID (URL slug)', async () => {
+    const { tool, spaceLookupService, calloutsSetResolverMutations } =
+      buildTool();
+
+    const result = await tool.execute(
+      { spaceId: 'zimbabve', displayName: 'Test board' },
+      actor()
+    );
+
+    expect(spaceLookupService.getSpaceByNameIdOrFail).toHaveBeenCalledWith(
+      'zimbabve',
+      expect.objectContaining({ relations: expect.anything() })
+    );
+    expect(spaceLookupService.getSpaceOrFail).not.toHaveBeenCalled();
+    expect(result.isError).toBeUndefined();
+    expect(
+      calloutsSetResolverMutations.createCalloutOnCalloutsSet
+    ).toHaveBeenCalled();
+  });
+
+  it('returns a guidance error when neither resolution finds the space', async () => {
+    const { tool, spaceLookupService, calloutsSetResolverMutations } =
+      buildTool();
+    spaceLookupService.getSpaceByNameIdOrFail.mockRejectedValue(
+      new Error('L0 Space not found')
+    );
+
+    const result = await tool.execute(
+      { spaceId: 'no-such-space', displayName: 'Test board' },
+      actor()
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Space not found: no-such-space');
+    expect(result.content[0].text).toContain('nameID');
+    expect(
+      calloutsSetResolverMutations.createCalloutOnCalloutsSet
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/mcp-server/tools/create-whiteboard-in-space.tool.spec.ts
+++ b/src/services/mcp-server/tools/create-whiteboard-in-space.tool.spec.ts
@@ -3,11 +3,12 @@ import { vi } from 'vitest';
 import { CreateWhiteboardInSpaceTool } from './create-whiteboard-in-space.tool';
 
 /**
- * Space resolution for `create_whiteboard_in_space`: a UUID resolves any
- * space/subspace by id, anything else is treated as a TOP-LEVEL space nameID
- * (the URL slug) — the id the model most often has at hand. Found live: the
- * model passed a space's slug and the tool refused it as "not found" even
- * though its own description said "resolve it from a name".
+ * Space resolution for `create_whiteboard_in_space` delegates to
+ * `SpaceLookupService.getSpaceByIdOrNameIdOrFail` — UUID resolves any
+ * space/subspace, anything else a TOP-LEVEL space nameID (URL slug); routing
+ * itself is covered by space.lookup.service.spec.ts. Found live: the model
+ * passed a space's slug and the tool refused it as "not found" even though
+ * its own description said "resolve it from a name".
  */
 describe('create_whiteboard_in_space — space id/nameID resolution', () => {
   const SPACE_UUID = 'e0e2e08f-04cc-40dc-b40c-089b6cc27689';
@@ -26,8 +27,7 @@ describe('create_whiteboard_in_space — space id/nameID resolution', () => {
       collaboration: { calloutsSet: { id: CALLOUTS_SET_ID } },
     };
     const spaceLookupService = {
-      getSpaceOrFail: vi.fn().mockResolvedValue(space),
-      getSpaceByNameIdOrFail: vi.fn().mockResolvedValue(space),
+      getSpaceByIdOrNameIdOrFail: vi.fn().mockResolvedValue(space),
     };
     const calloutsSetResolverMutations = {
       createCalloutOnCalloutsSet: vi
@@ -54,50 +54,33 @@ describe('create_whiteboard_in_space — space id/nameID resolution', () => {
     return { tool, spaceLookupService, calloutsSetResolverMutations };
   };
 
-  it('resolves a UUID via getSpaceOrFail (any level)', async () => {
+  it('resolves the spaceId (UUID or slug alike) via the shared id-or-nameID resolver', async () => {
     const { tool, spaceLookupService, calloutsSetResolverMutations } =
       buildTool();
 
-    const result = await tool.execute(
-      { spaceId: SPACE_UUID, displayName: 'Test board' },
-      actor()
-    );
+    for (const spaceId of [SPACE_UUID, 'zimbabve']) {
+      const result = await tool.execute(
+        { spaceId, displayName: 'Test board' },
+        actor()
+      );
 
-    expect(spaceLookupService.getSpaceOrFail).toHaveBeenCalledWith(
-      SPACE_UUID,
-      expect.objectContaining({ relations: expect.anything() })
-    );
-    expect(spaceLookupService.getSpaceByNameIdOrFail).not.toHaveBeenCalled();
-    expect(result.isError).toBeUndefined();
+      expect(
+        spaceLookupService.getSpaceByIdOrNameIdOrFail
+      ).toHaveBeenCalledWith(
+        spaceId,
+        expect.objectContaining({ relations: expect.anything() })
+      );
+      expect(result.isError).toBeUndefined();
+    }
     expect(
       calloutsSetResolverMutations.createCalloutOnCalloutsSet
-    ).toHaveBeenCalled();
-  });
-
-  it('resolves a non-UUID as a top-level space nameID (URL slug)', async () => {
-    const { tool, spaceLookupService, calloutsSetResolverMutations } =
-      buildTool();
-
-    const result = await tool.execute(
-      { spaceId: 'zimbabve', displayName: 'Test board' },
-      actor()
-    );
-
-    expect(spaceLookupService.getSpaceByNameIdOrFail).toHaveBeenCalledWith(
-      'zimbabve',
-      expect.objectContaining({ relations: expect.anything() })
-    );
-    expect(spaceLookupService.getSpaceOrFail).not.toHaveBeenCalled();
-    expect(result.isError).toBeUndefined();
-    expect(
-      calloutsSetResolverMutations.createCalloutOnCalloutsSet
-    ).toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(2);
   });
 
   it('returns a guidance error when neither resolution finds the space', async () => {
     const { tool, spaceLookupService, calloutsSetResolverMutations } =
       buildTool();
-    spaceLookupService.getSpaceByNameIdOrFail.mockRejectedValue(
+    spaceLookupService.getSpaceByIdOrNameIdOrFail.mockRejectedValue(
       new Error('L0 Space not found')
     );
 

--- a/src/services/mcp-server/tools/create-whiteboard-in-space.tool.ts
+++ b/src/services/mcp-server/tools/create-whiteboard-in-space.tool.ts
@@ -12,7 +12,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { UrlGeneratorService } from '@services/infrastructure/url-generator/url.generator.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Repository } from 'typeorm';
-import { validate as uuidValidate } from 'uuid';
 import { McpTool, McpToolDefinition, McpToolResult } from '../dto/mcp.types';
 import { resolveTemplateScene } from './whiteboard-template-scene';
 
@@ -154,17 +153,15 @@ export class CreateWhiteboardInSpaceTool implements McpTool {
     }
 
     // Resolve the space/subspace -> its Collaboration -> CalloutsSet (where
-    // callouts are created). A UUID resolves any level; anything else is
-    // treated as a top-level space nameID (the URL slug) — the id the model
-    // most often has at hand (listings/URLs carry the slug, not the UUID).
+    // callouts are created). The lookup service owns the id-or-nameID policy:
+    // a UUID resolves any level; anything else is a top-level space nameID
+    // (the URL slug) — the id the model most often has at hand.
     let calloutsSetId: string | undefined;
     try {
-      const relations = { collaboration: { calloutsSet: true } } as const;
-      const space = uuidValidate(spaceId)
-        ? await this.spaceLookupService.getSpaceOrFail(spaceId, { relations })
-        : await this.spaceLookupService.getSpaceByNameIdOrFail(spaceId, {
-            relations,
-          });
+      const space = await this.spaceLookupService.getSpaceByIdOrNameIdOrFail(
+        spaceId,
+        { relations: { collaboration: { calloutsSet: true } } }
+      );
       calloutsSetId = space.collaboration?.calloutsSet?.id;
     } catch {
       return this.errorResult(

--- a/src/services/mcp-server/tools/create-whiteboard-in-space.tool.ts
+++ b/src/services/mcp-server/tools/create-whiteboard-in-space.tool.ts
@@ -12,6 +12,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { UrlGeneratorService } from '@services/infrastructure/url-generator/url.generator.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Repository } from 'typeorm';
+import { validate as uuidValidate } from 'uuid';
 import { McpTool, McpToolDefinition, McpToolResult } from '../dto/mcp.types';
 import { resolveTemplateScene } from './whiteboard-template-scene';
 
@@ -66,8 +67,9 @@ export class CreateWhiteboardInSpaceTool implements McpTool {
         'NOT have a specific callout that already accepts whiteboard contributions — it creates the ' +
         'hosting callout for you, so "create a whiteboard in space X" works even when no suitable ' +
         'callout exists. (To add a whiteboard to an EXISTING callout that accepts contributions, use ' +
-        'create_whiteboard instead.) Provide the space/subspace id (resolve it from a name via ' +
-        'search_content / list_whiteboards). To start FROM A TEMPLATE, set "fromTemplateId" — the ' +
+        'create_whiteboard instead.) Provide the space UUID (resolve it from a name via ' +
+        'search_content), or a TOP-LEVEL space nameID / URL slug; a SUBSPACE requires its UUID. ' +
+        'To start FROM A TEMPLATE, set "fromTemplateId" — the ' +
         'server fills the board with the template scene by reference, so do NOT generate or paste the ' +
         'scene yourself. Otherwise set "content" to a full Excalidraw scene JSON string, or omit both ' +
         'for a blank board. Provide at most one of "fromTemplateId" or "content". Requires ' +
@@ -78,7 +80,9 @@ export class CreateWhiteboardInSpaceTool implements McpTool {
           spaceId: {
             type: 'string',
             description:
-              'The ID of the space OR subspace to create the whiteboard in (its CalloutsSet hosts the new callout).',
+              'The space to create the whiteboard in (its CalloutsSet hosts the new callout): a space ' +
+              'or subspace UUID, or a top-level space nameID (the URL slug, e.g. "my-space" from ' +
+              'https://…/my-space). Subspaces can only be addressed by UUID.',
           },
           displayName: {
             type: 'string',
@@ -150,15 +154,22 @@ export class CreateWhiteboardInSpaceTool implements McpTool {
     }
 
     // Resolve the space/subspace -> its Collaboration -> CalloutsSet (where
-    // callouts are created). getSpaceOrFail works for any level by id.
+    // callouts are created). A UUID resolves any level; anything else is
+    // treated as a top-level space nameID (the URL slug) — the id the model
+    // most often has at hand (listings/URLs carry the slug, not the UUID).
     let calloutsSetId: string | undefined;
     try {
-      const space = await this.spaceLookupService.getSpaceOrFail(spaceId, {
-        relations: { collaboration: { calloutsSet: true } },
-      });
+      const relations = { collaboration: { calloutsSet: true } } as const;
+      const space = uuidValidate(spaceId)
+        ? await this.spaceLookupService.getSpaceOrFail(spaceId, { relations })
+        : await this.spaceLookupService.getSpaceByNameIdOrFail(spaceId, {
+            relations,
+          });
       calloutsSetId = space.collaboration?.calloutsSet?.id;
     } catch {
-      return this.errorResult(`Space not found: ${spaceId}`);
+      return this.errorResult(
+        `Space not found: ${spaceId}. Pass a space/subspace UUID, or a top-level space nameID (URL slug); subspaces require the UUID.`
+      );
     }
     if (!calloutsSetId) {
       return this.errorResult(


### PR DESCRIPTION
## Problem

Live on acceptance (2026-07-02): a user asked the assistant to create a whiteboard in their space, approved the confirmation, and got

> I couldn't complete that action — Space not found: zimbabve. I haven't made any changes.

`zimbabve` is the space's **real nameID** (and displayName — typo is in the data). The model passed it because that's the only space identifier it can obtain:

- `list_whiteboards` declares `context.spaceId` in its result shape but **never populates it**; the items carry the whiteboard URL, whose path segment is the space *slug*.
- The tool's own description says *"resolve the space id from a name via search_content / list_whiteboards"* — yet `execute()` resolved via `getSpaceOrFail`, which is **UUID-only**.

So the happy path documented in the tool description was impossible with a slug, and the failure surfaced only *after* user approval.

## Fix

- `uuidValidate(spaceId)` → `getSpaceOrFail` (any level, unchanged behavior for UUIDs).
- Otherwise → `getSpaceByNameIdOrFail` (top-level space nameID — unambiguous; subspace nameIDs are not globally unique, so subspaces still require the UUID).
- Input schema + description now state exactly what's accepted; the not-found error tells the model what to pass instead of dead-ending.

Authorization is untouched — resolution only finds the CalloutsSet; `createCalloutOnCalloutsSet` still enforces `CREATE_CALLOUT` on the same path as GraphQL.

## Testing

- New spec: UUID → `getSpaceOrFail`; slug → `getSpaceByNameIdOrFail`; unresolvable → guidance error, no mutation call.
- MCP suite: 18 files / **149 passed**; biome + tsc clean.

## Review pass (applied in-PR)

A multi-agent review of this PR surfaced and fixed here:
- **Shared resolver**: the id-or-nameID policy now lives in `SpaceLookupService.getSpaceByIdOrNameIdOrFail` (using `isUUID` from class-validator, the codebase convention) instead of an inline branch in one tool.
- **`analyze_contributions` had the same bug, silently**: a slug in `scope: "space:{id}"` was matched raw against `space.id` and returned an *empty result set with no error*. It now resolves through the shared method and errors with guidance.
- **Hardened `getSpaceByNameIdOrFail` / `getSubspaceByNameIdInLevelZeroSpace`**: `...options` was spread after `where`, letting a caller-supplied `where` clobber the nameID/level guard — now merged safely (same order as `getSpace`).

## Follow-up (not this PR)

`list_whiteboards` should populate the declared `context.spaceId` so the model can use UUIDs directly — tracked as part of the assistant hardening epics (alkem-io/alkemio#1948–#1952 scope area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Space references now accept either a UUID or a top-level space slug in more places.
  * Whiteboard creation and contribution analysis now provide clearer guidance on how to enter space identifiers.

* **Bug Fixes**
  * Improved space lookup safety so required filters can’t be overwritten by extra query options.
  * Fixed space-not-found handling to return a consistent, clearer error message.
  * Subspace lookups now preserve the correct level and parent-space constraints.

* **Tests**
  * Added coverage for UUID vs slug handling and lookup guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->