### PR TITLE
feat(auth-reset): local docker-compose autoscaler for the reset worker

### DIFF
--- a/.env.docker.local.example
+++ b/.env.docker.local.example
@@ -1,0 +1,27 @@
+# Per-developer LOCAL overrides for the docker stack.
+#
+# Copy this file to `.env.docker.local` (which is gitignored — see the
+# `.env.docker.*` / `!.env.docker.*.example` rules in .gitignore) and put any
+# machine-specific overrides here. `pnpm run start:services` loads it AFTER
+# `.env.docker`, so values here win. Nothing in this file is committed.
+#
+#   cp .env.docker.local.example .env.docker.local
+#
+# ---------------------------------------------------------------------------
+# Auth-reset autoscaler knobs (consumed by docker compose at parse time as
+# ${AUTH_RESET_*:-default} and injected into the auth-reset-scaler sidecar).
+# Uncomment + edit to override the defaults shown.
+# ---------------------------------------------------------------------------
+
+# Max worker replicas the scaler spins up when resets are queued (default 2).
+#AUTH_RESET_MAX_REPLICAS=3
+
+# Seconds between queue-depth polls (default 5).
+#AUTH_RESET_POLL_INTERVAL=5
+
+# Consecutive empty polls before scaling the worker back to 0 (default 3).
+#AUTH_RESET_IDLE_ROUNDS=3
+
+# If you also override COMPOSE_PROJECT_NAME (rare — only if your repo dir isn't
+# `server`), set it here so the scaler targets the right stack.
+#COMPOSE_PROJECT_NAME=server

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/src/main.js",
-    "start:services": "docker compose -f quickstart-services.yml --env-file .env.docker up --build --force-recreate -d",
+    "start:services": "docker compose -f quickstart-services.yml --env-file .env.docker $([ -f .env.docker.local ] && echo --env-file .env.docker.local) up --build --force-recreate -d",
     "start:services:kratos:debug": "docker compose -f quickstart-services.yml -f overlays/kratos-debug.yml --env-file .env.docker up --build --force-recreate -d",
     "start:services:ai": "docker compose -f quickstart-services-ai.yml --env-file .env.docker up --build --force-recreate -d",
     "start:services:ai:scaleway": "docker compose -f quickstart-services-ai.yml --env-file .env.docker.scaleway up --build --force-recreate -d",

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -691,3 +691,90 @@ services:
       - alkemio_dev_net
     ports:
       - 9980
+
+  # Headless auth-reset consumer. Same Alkemio image as the API server; the
+  # AUTH_RESET_WORKER=true env flips main.ts into worker role (binds only the
+  # `alkemio-auth-reset` queue, prefetch=1, no HTTP). The API publisher runs on
+  # the host (`pnpm start:dev`) and emits resets that these containers drain.
+  #
+  # Competing-consumers: scale to N instances that split the queue with no extra
+  # config. Hence NO container_name and NO published port (both would collide
+  # across replicas). profiles: ['auth-reset'] keeps it OUT of a plain `up` — it
+  # boots at 0 and is scaled 0<->N solely by the auth-reset-scaler sidecar below.
+  auth-reset-worker:
+    profiles: ['auth-reset']
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.docker
+    environment:
+      - AUTH_RESET_WORKER=true
+      # Graceful-drain budget on SIGTERM (default 55s). Short locally so
+      # `compose down` / scale-in returns quickly.
+      - AUTH_RESET_DRAIN_TIMEOUT_SECONDS=55
+      # .env.docker maps DATABASE_HOST=postgres and RABBITMQ_HOST=rabbitmq, but
+      # not REDIS_HOST (defaults to localhost in alkemio.yml — right for the host
+      # server via traefik, wrong inside a container). Point it at the service.
+      - REDIS_HOST=redis
+    # No command override: the image's own CMD (`node dist/main.js`) is correct.
+    # In the Docker build only `src` is copied, so tsc's rootDir collapses to
+    # `src` and output flattens to dist/main.js. (A host `nest build` instead
+    # emits dist/src/main.js because tsconfig `include` also pulls in test/,
+    # keeping src/ as a subdir — that layout does NOT exist in the image.)
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    # SIGTERM starts the drain; give it the full budget + margin before SIGKILL.
+    stop_grace_period: 60s
+    restart: unless-stopped
+    networks:
+      - alkemio_dev_net
+
+  # Local KEDA analogue. Starts with the base stack (no profile), watches the
+  # `alkemio-auth-reset` queue via the RabbitMQ mgmt API, and drives the worker
+  # 0<->MAX_REPLICAS through the host Docker socket. Nothing manual: `up` brings
+  # this online, it scales the worker up from zero when resets arrive and back to
+  # zero once the queue drains. COMPOSE_PROFILES=auth-reset lets it manage the
+  # profiled worker; COMPOSE_PROJECT_NAME must match the host stack's project
+  # (compose derives it from the repo dir basename, default `server`) so the
+  # sidecar targets the SAME containers/network instead of forking a new stack.
+  auth-reset-scaler:
+    image: docker:27-cli
+    working_dir: /workspace
+    # RABBITMQ_HOST / RABBITMQ_USER / RABBITMQ_PASSWORD (+ optional
+    # RABBITMQ_AUTH_RESET_QUEUE) come straight from .env.docker; the script
+    # derives the mgmt URL and creds from them. No credentials duplicated here.
+    # .env.docker.local (per-dev, gitignored) layers on top when present.
+    env_file:
+      - path: .env.docker
+        required: true
+      - path: .env.docker.local
+        required: false
+    environment:
+      - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-server}
+      - COMPOSE_PROFILES=auth-reset
+      - COMPOSE_FILE=quickstart-services.yml
+      - ENV_FILE=.env.docker
+      - MAX_REPLICAS=${AUTH_RESET_MAX_REPLICAS:-3}
+      - INTERVAL=${AUTH_RESET_POLL_INTERVAL:-5}
+      - IDLE_ROUNDS=${AUTH_RESET_IDLE_ROUNDS:-3}
+    volumes:
+      # Host Docker socket => the sidecar drives the same daemon the stack runs on.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Repo mount => the compose file, .env.docker, build context, and the
+      # autoscale script are all visible at /workspace.
+      - .:/workspace
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    entrypoint: ['/bin/sh', '-c']
+    command:
+      - 'apk add --no-cache bash jq curl docker-cli-compose >/dev/null && exec bash ./scripts/auth-reset-autoscale.sh'
+    restart: unless-stopped
+    networks:
+      - alkemio_dev_net

--- a/scripts/auth-reset-autoscale.sh
+++ b/scripts/auth-reset-autoscale.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Local KEDA-style autoscaler for the auth-reset worker.
+#
+# Polls the RabbitMQ management API for the depth of the `alkemio-auth-reset`
+# queue and drives `docker compose --scale` up/down:
+#   depth > 0            -> scale up to MAX_REPLICAS
+#   depth == 0 for N     -> scale down to 0 (after IDLE_ROUNDS empty polls)
+#     consecutive polls
+#
+# This is the local analogue of the prod KEDA ScaledObject (queue length
+# trigger, scale-to-zero). Compose has no autoscaler of its own, so we poll.
+#
+# Usage:
+#   scripts/auth-reset-autoscale.sh            # defaults below
+#   MAX_REPLICAS=5 INTERVAL=3 scripts/auth-reset-autoscale.sh
+#
+# Ctrl-C to stop. On exit the worker is left at whatever the last scale was;
+# pass STOP_AT_ZERO=1 to force it to 0 on exit.
+set -euo pipefail
+
+# --- config (override via env) -------------------------------------------------
+COMPOSE_FILE="${COMPOSE_FILE:-quickstart-services.yml}"
+ENV_FILE="${ENV_FILE:-.env.docker}"
+# Per-developer overrides layered on top of ENV_FILE (later --env-file wins),
+# mirroring `start:services`. Loaded only when present, so teammates without one
+# are unaffected. Both files live in the repo mounted at /workspace.
+ENV_FILE_LOCAL="${ENV_FILE_LOCAL:-.env.docker.local}"
+SERVICE="${SERVICE:-auth-reset-worker}"
+QUEUE="${QUEUE:-${RABBITMQ_AUTH_RESET_QUEUE:-alkemio-auth-reset}}"
+VHOST="${VHOST:-/}"                       # default vhost; url-encoded below
+MAX_REPLICAS="${MAX_REPLICAS:-2}"         # the "N" we scale up to
+INTERVAL="${INTERVAL:-5}"                 # seconds between polls
+IDLE_ROUNDS="${IDLE_ROUNDS:-3}"           # empty polls before scaling to 0
+
+# RabbitMQ management API. Creds + host come from .env.docker's RABBITMQ_*
+# (RMQ_* override them if explicitly set, e.g. when running on the host).
+# The mgmt API is a separate port from AMQP (RABBITMQ_PORT=5672), so it is not
+# in .env.docker — default to the conventional 15672.
+RMQ_HOST="${RMQ_HOST:-${RABBITMQ_HOST:-localhost}}"
+RMQ_MGMT_PORT="${RMQ_MGMT_PORT:-15672}"
+RMQ_MGMT="${RMQ_MGMT:-http://$RMQ_HOST:$RMQ_MGMT_PORT}"
+RMQ_USER="${RMQ_USER:-${RABBITMQ_USER:-alkemio-admin}}"
+RMQ_PASS="${RMQ_PASS:-${RABBITMQ_PASSWORD:-alkemio!}}"
+
+# --- deps ----------------------------------------------------------------------
+command -v curl >/dev/null || { echo "need curl" >&2; exit 1; }
+command -v jq   >/dev/null || { echo "need jq" >&2; exit 1; }
+
+# url-encode the vhost ("/" -> "%2F")
+vhost_enc=$(printf '%s' "$VHOST" | jq -sRr @uri)
+
+compose() {
+  local env_args=(--env-file "$ENV_FILE")
+  [[ -f "$ENV_FILE_LOCAL" ]] && env_args+=(--env-file "$ENV_FILE_LOCAL")
+  docker compose -f "$COMPOSE_FILE" "${env_args[@]}" "$@"
+}
+
+current_replicas() { compose ps -q "$SERVICE" 2>/dev/null | grep -c . || true; }
+
+# Echoes "ready unacked". Distinguishes three mgmt-API outcomes:
+#   200 -> real depth
+#   404 -> queue not declared yet (no publisher has emitted / no consumer bound)
+#          => treat as empty "0 0"; this is the normal at-rest state, NOT an error
+#   anything else / no connection -> "-1 -1" (genuinely unreachable: DNS, 401, 5xx)
+queue_depth() {
+  local resp code body
+  # -w appends the status on its own line; no -f so we can inspect 404 vs 200.
+  resp=$(curl -s -u "$RMQ_USER:$RMQ_PASS" -w $'\n%{http_code}' \
+        "$RMQ_MGMT/api/queues/$vhost_enc/$QUEUE" 2>/dev/null) || { echo "-1 -1"; return; }
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  case "$code" in
+    200) echo "$body" | jq -r '"\(.messages_ready // 0) \(.messages_unacknowledged // 0)"' ;;
+    404) echo "0 0" ;;
+    *)   echo "-1 -1" ;;
+  esac
+}
+
+scale_to() {
+  local n="$1"
+  echo "  -> scaling $SERVICE to $n"
+  compose up -d --no-recreate --scale "$SERVICE=$n" >/dev/null 2>&1 || \
+    compose up -d --scale "$SERVICE=$n" "$SERVICE" >/dev/null
+}
+
+cleanup() {
+  if [[ "${STOP_AT_ZERO:-0}" == "1" ]]; then
+    echo; echo "exit: scaling $SERVICE to 0"
+    scale_to 0 || true
+  fi
+  exit 0
+}
+trap cleanup INT TERM
+
+echo "autoscaler: queue=$QUEUE max=$MAX_REPLICAS interval=${INTERVAL}s idle=$IDLE_ROUNDS"
+idle=0
+while true; do
+  read -r ready unacked < <(queue_depth)
+  reps=$(current_replicas)
+
+  if [[ "$ready" == "-1" ]]; then
+    echo "$(date +%T) RabbitMQ unreachable — holding at $reps replica(s)"
+  else
+    total=$((ready + unacked))
+    echo "$(date +%T) ready=$ready unacked=$unacked replicas=$reps"
+
+    if (( ready > 0 )); then
+      # work waiting: ensure we're at MAX. (unacked-only = a worker is busy;
+      # don't add more, prefetch=1 means 1 msg per replica anyway.)
+      idle=0
+      (( reps < MAX_REPLICAS )) && scale_to "$MAX_REPLICAS"
+    elif (( total == 0 )); then
+      # fully drained (nothing ready, nothing in-flight): count down to 0
+      if (( reps > 0 )); then
+        idle=$((idle + 1))
+        (( idle >= IDLE_ROUNDS )) && { scale_to 0; idle=0; }
+      fi
+    else
+      # ready==0 but unacked>0: a worker is finishing a reset. leave it be.
+      idle=0
+    fi
+  fi
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Why

The auth-reset **worker** role (from #6207 / #6217) had no way to run locally. This adds it to the dev stack and autoscales it like prod (KEDA scale-to-zero) — so resets actually get drained on your machine, with zero manual steps.

## How

`quickstart-services.yml` gains two services:
- **`auth-reset-worker`** — the Alkemio image in worker mode. Starts at **0** replicas (competing consumers).
- **`auth-reset-scaler`** — a tiny sidecar that watches the `alkemio-auth-reset` queue and scales the worker `0↔N` via the docker socket. Local stand-in for KEDA.

## How to use

Nothing new to run — it starts with the stack:

```bash
pnpm run start:services      # brings up deps + the scaler (worker at 0)
pnpm start:dev               # host server = the publisher
# trigger authorizationPolicyResetAll -> workers spin up, drain, scale back to 0
```

Tune it per-developer without committing: copy `.env.docker.local.example` → `.env.docker.local` (gitignored) and set any of:

| Env | Default | Meaning |
|-----|---------|---------|
| `AUTH_RESET_MAX_REPLICAS` | `3` | max workers when the queue has resets |
| `AUTH_RESET_POLL_INTERVAL` | `5` | seconds between queue checks |
| `AUTH_RESET_IDLE_ROUNDS` | `3` | empty polls before scaling back to 0 |

Both `start:services` and the scaler load `.env.docker.local` on top of `.env.docker`, so your values win.

## Scope

Local dev tooling only (`quickstart-services.yml`, `package.json`, two new files). No app/source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local autoscaling setup for the auth-reset worker, including a companion service that scales worker replicas based on queue depth.
  * Added optional per-developer Docker environment overrides for customizing scaling behavior and compose project settings.
  * Updated the service start flow to automatically load the local override file when present.
* **Bug Fixes**
  * Improved worker handling so it drains gracefully before scaling down and avoids reducing replicas while work is still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->