### PR TITLE
docs(106): retrospec — MCP space slug resolution (PR #6218)

### DIFF
--- a/specs/106-mcp-space-slug-resolution/quickstart.md
+++ b/specs/106-mcp-space-slug-resolution/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart — MCP space slug resolution (spec 106)
+
+## What it does
+
+Model-facing MCP tools that take a space identifier now accept a **top-level
+space nameID (URL slug)** as well as a UUID; the id-or-nameID policy lives in
+one shared resolver. No config, no env, no schema/migration changes (the MCP
+tool *descriptions* changed — an LLM-facing contract, not a wire contract).
+
+## How to verify
+
+```bash
+# Against a running host with an mcp_ key (session established):
+# 1. Slug create — previously "Space not found":
+tools/call create_whiteboard_in_space {"spaceId":"<top-level-slug>","displayName":"Test"}
+#    → created:true, callout + whiteboard ids, URL.
+# 2. UUID create — unchanged behavior (works for subspaces too).
+# 3. Slug analysis — previously a SILENT EMPTY result:
+tools/call analyze_contributions {"scope":"space:<top-level-slug>"}
+#    → real results; an unresolvable value → explicit guidance error.
+
+# Unit level:
+pnpm vitest run src/services/mcp-server src/domain/space/space.lookup   # 178 passed
+```
+
+## Files changed (PR #6218, merged 9228428d5 → release/65)
+
+| File | Change |
+|------|--------|
+| `src/domain/space/space.lookup/space.lookup.service.ts` | + `getSpaceByIdOrNameIdOrFail` (isUUID dispatch, L0-only slugs); options-merge hardening on both nameID lookups; dead double-check removed |
+| `src/domain/space/space.lookup/space.lookup.service.spec.ts` | routing + where-safety specs |
+| `src/services/mcp-server/tools/create-whiteboard-in-space.tool.ts` | shared resolver; schema/description/error name what's accepted |
+| `src/services/mcp-server/tools/create-whiteboard-in-space.tool.spec.ts` | new — resolution behavior |
+| `src/services/mcp-server/tools/contributions-analyze.tool.ts` | `space:` scope resolves id-or-nameID; explicit error replaces silent-empty |

--- a/specs/106-mcp-space-slug-resolution/research.md
+++ b/specs/106-mcp-space-slug-resolution/research.md
@@ -1,0 +1,60 @@
+# Research — MCP space slug resolution (retrospec)
+
+## D1 — Accept nameIDs in the tool rather than surfacing UUIDs in listings
+
+**Decision**: make `create_whiteboard_in_space` (and `analyze_contributions`)
+resolve top-level nameIDs, instead of first fixing `list_whiteboards` to return
+space UUIDs.
+
+**Rationale**: the identifiers the model actually holds are slugs — whiteboard
+URLs embed them, and profile display names often equal them. Accepting the slug
+fixes every current and future prompt path at the resolution seam; populating
+`context.spaceId` in listings helps only clients that read that field. (Both are
+worth having; the listing fix is tracked in the assistant hardening epics.) The
+incident proved the model behaves correctly given the data it has — the platform
+refused its own identifier.
+
+**Alternative rejected**: *prompt the assistant to always search for the UUID
+first* — prompt-level patches for a contract-level gap; other MCP clients
+(external, #1912/workspace#008) share the same tool surface.
+
+## D2 — nameID resolution is top-level (L0) only
+
+**Decision**: a non-UUID resolves via `getSpaceByNameIdOrFail` (L0-scoped);
+subspaces require their UUID.
+
+**Rationale**: `space` nameIDs have **no global unique index** — uniqueness is
+app-enforced per level-zero scope (see the actor/space migration comments), so
+two parents can each own a subspace `my-challenge`. A bare subspace slug is
+genuinely ambiguous; resolving "first match" would be a correctness bug worse
+than refusal. Verified during review (finding REFUTED as a defect precisely
+because the restriction is deliberate and documented in schema + description +
+error).
+
+## D3 — Policy lives on SpaceLookupService, not in tools
+
+**Decision**: `getSpaceByIdOrNameIdOrFail` on `SpaceLookupService` is the single
+home; tools call it.
+
+**Rationale**: review found the same UUID-only failure in a sibling tool with a
+*silent-empty* failure mode — proof the policy drifts when inlined per-tool.
+`getSpacesById` already resolved the id-or-nameID union for arrays but without
+the L0-only-slug rule, so a new dedicated method (not reuse of `getSpacesById`)
+keeps the level semantics explicit.
+
+**Convention note**: `isUUID` from class-validator (used by user-lookup,
+virtual-contributor-lookup, storage-aggregator resolver) replaces the initial
+`uuid.validate` import — verified behaviorally identical for all realistic
+inputs (nameIDs ≤ 25 chars can never parse as 36-char UUIDs); pure consistency.
+
+## D4 — Options-merge hardening in the same PR
+
+**Decision**: fix `getSpaceByNameIdOrFail` / `getSubspaceByNameIdInLevelZeroSpace`
+to spread caller options **before** the identifying `where` constraints.
+
+**Rationale**: the PR made `getSpaceByNameIdOrFail` a production dependency of a
+model-facing path; review showed a caller-supplied `options.where` would have
+silently replaced the `{nameID, level}` filter (returning an arbitrary space).
+Latent today (the new call passes only `relations`) — but the safe order is what
+the sibling `getSpace` already used, so the inconsistency was a trap with no
+upside.

--- a/specs/106-mcp-space-slug-resolution/spec.md
+++ b/specs/106-mcp-space-slug-resolution/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: MCP tools resolve spaces by nameID (URL slug), not only UUID
+
+**Feature Branch**: `fix/mcp-create-whiteboard-accepts-nameid`
+
+**Created**: 2026-07-03
+
+**Status**: Backfilled (retroactive) — shipped, then spec'd (PR #6218 → `release/65`, merged `9228428d5`)
+
+**Input**: "The assistant asked a user which space to create a whiteboard in, the user answered, the
+user approved the confirmation — and the write failed with `Space not found: zimbabve`. `zimbabve`
+was the space's real nameID: the model passed the only identifier it could obtain (listings and
+whiteboard URLs carry the slug, and `list_whiteboards` returns no space UUID), but the tool resolved
+UUID-only, despite its own description saying 'resolve the space id from a name'."
+
+> **⚠️ Retroactive backfill.** Written **after** the fix shipped (live acceptance failure,
+> 2026-07-02). Single-repo (server only) — one PR, so **not** a workspace vertical spec; the
+> sibling cross-repo work of the same incident window is `workspace#008-external-mcp-access`.
+> Landed on `release/65`; reaches `develop` via the release merge-back.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - "Create a whiteboard in space X" works with the identifier the model has (Priority: P1)
+
+A user asks an MCP client (the assistant) to create a whiteboard in a space they name. The model
+resolves the space from what the platform gave it — usually the URL slug — and the creation
+succeeds. The user never sees a "not found" error for a space that plainly exists.
+
+**Why this priority**: The failure fired **after** the user approved the write — the worst moment:
+trust in the confirmation gate is spent on an error. And the documented happy path ("resolve it from
+a name") was impossible: no tool output carries the space UUID.
+
+**Independent Test**: Call `create_whiteboard_in_space` with a top-level space's nameID (slug) as
+`spaceId` → the whiteboard is created in that space; with the space UUID → identical behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a top-level space with nameID `my-space`, **When** the tool is called with
+   `spaceId: "my-space"`, **Then** the whiteboard-framing callout is created on that space's
+   CalloutsSet.
+2. **Given** a space UUID (any level, including subspaces), **When** the tool is called with it,
+   **Then** behavior is unchanged from before this fix.
+3. **Given** an unresolvable value, **When** the tool is called, **Then** the error names exactly
+   what is accepted (UUID any level; top-level nameID; subspaces require UUID).
+
+---
+
+### User Story 2 - `analyze_contributions` never silently returns an empty set for a slug (Priority: P1)
+
+A model scopes a contribution analysis to a space (`scope: "space:{id}"`) using a slug. It gets
+either real results (slug resolved) or an explicit error naming what's accepted — never a silent
+empty result set that reads as "this space has no contributions".
+
+**Why this priority**: Surfaced by the review of the P1 fix: the same UUID-only matching existed
+here, but **worse** — a slug produced no error at all, just an empty result. A silently-wrong
+analysis is more damaging than a refused one.
+
+**Independent Test**: Call `analyze_contributions` with `scope: "space:<slug>"` of a contributing
+space → results are returned; with an unresolvable value → an explicit guidance error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a top-level space slug in the scope, **When** the analysis runs, **Then** it resolves
+   to the space's UUID and returns that space's contributions.
+2. **Given** an unresolvable scope value, **When** the analysis runs, **Then** an explicit
+   "Space not found … Pass a space/subspace UUID, or a top-level space nameID" error is returned —
+   never an empty success.
+
+---
+
+### User Story 3 - One home for the id-or-nameID policy (Priority: P2)
+
+The next tool (or resolver) that accepts a model-supplied space identifier calls one shared lookup
+method and inherits the policy — UUID any level, nameID top-level-only — instead of re-deriving the
+branch and drifting.
+
+**Why this priority**: Two tools already diverged (one refused slugs, one silently returned
+nothing). Policy drift across a growing MCP tool surface is the root disease; the per-tool fixes
+are symptoms.
+
+**Independent Test**: `SpaceLookupService.getSpaceByIdOrNameIdOrFail` routes a UUID to the by-id
+lookup and anything else to the top-level nameID lookup; both consuming tools call it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a UUID, **When** the shared resolver runs, **Then** it resolves by id (any level) and
+   the nameID path is not consulted.
+2. **Given** a non-UUID, **When** the shared resolver runs, **Then** it resolves as a top-level
+   nameID or throws the standard not-found.
+
+---
+
+### Edge Cases
+
+- **Subspace slugs are deliberately NOT resolvable**: space nameIDs are only unique within their
+  level-zero space (no global unique index — uniqueness is enforced by app logic per L0 scope), so a
+  bare subspace slug is genuinely ambiguous. Subspaces require the UUID; every description/error
+  says so.
+- **A nameID can never collide with a UUID**: nameIDs are `[a-zA-Z0-9-]`, max 25 chars; UUIDs are 36
+  chars — the dispatch is unambiguous.
+- **Caller-supplied lookup options can't weaken the filter**: the nameID lookups merge caller
+  options *before* the `nameID`/`level` constraints, so a passed `where` can never clobber the
+  guard (hardened in the same PR for `getSpaceByNameIdOrFail` and
+  `getSubspaceByNameIdInLevelZeroSpace`).
+- **Authorization unchanged**: resolution only locates the space/CalloutsSet; the mutation path
+  (`createCalloutOnCalloutsSet`) still enforces `CREATE_CALLOUT` exactly as GraphQL does.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `create_whiteboard_in_space` MUST accept a space/subspace UUID **or** a top-level
+  space nameID as `spaceId`, and its schema/description MUST state exactly that.
+- **FR-002**: `analyze_contributions` MUST resolve a `space:{id}` scope through the same policy and
+  MUST return an explicit error (never a silent empty set) when the value is unresolvable.
+- **FR-003**: The id-or-nameID policy MUST live in a single shared lookup method
+  (`SpaceLookupService.getSpaceByIdOrNameIdOrFail`), consumed by every model-facing tool that takes
+  a space identifier.
+- **FR-004**: UUID detection MUST use the codebase-standard validator (`isUUID`, class-validator) —
+  one convention across all id-or-nameID branches.
+- **FR-005**: Not-found errors on model-facing tools MUST name what is accepted so the model can
+  self-correct instead of dead-ending.
+- **FR-006**: nameID lookups MUST be robust to caller-supplied find options (options merged before
+  the identifying `where` constraints).
+
+### Success Criteria
+
+- **SC-001**: The live acceptance failure ("Space not found: zimbabve" after user approval) cannot
+  recur: that exact input now creates the whiteboard.
+- **SC-002**: A slug-scoped `analyze_contributions` returns either real results or an explicit
+  error — 0 silent-empty responses for unresolvable scopes.
+- **SC-003**: Full suite green (178 passed incl. new lookup routing, where-safety, and tool
+  resolution specs); biome + tsc clean.
+
+## Assumptions
+
+- `list_whiteboards` still does not populate its declared `context.spaceId`; slug resolution makes
+  the identifiers the model *does* have work. Populating the UUID is a follow-up (assistant
+  hardening epics #1948–#1952 scope).
+- Making subspace slugs resolvable would require a parent-space parameter or path-based resolution —
+  out of scope; UUID covers subspaces.

--- a/specs/106-mcp-space-slug-resolution/tasks.md
+++ b/specs/106-mcp-space-slug-resolution/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: MCP space slug resolution (retrospec — all complete)
+
+**PR**: #6218 → `release/65` (merged `9228428d5`, 2026-07-03). Two commits: the
+scoped fix, then the review pass (multi-agent /review findings applied pre-merge).
+
+## US1 — create_whiteboard_in_space accepts UUID or top-level nameID
+
+- [X] T001 [US1] Route `spaceId` through the shared resolver in
+  `src/services/mcp-server/tools/create-whiteboard-in-space.tool.ts`
+  (`getSpaceByIdOrNameIdOrFail` with the CalloutsSet relations) (FR-001, FR-003).
+- [X] T002 [US1] Update the tool description + `spaceId` schema description
+  (UUID any level / top-level nameID / subspaces need UUID) and the not-found
+  error to name what's accepted (FR-001, FR-005).
+- [X] T003 [US1] New spec `create-whiteboard-in-space.tool.spec.ts`: UUID and
+  slug both resolve via the shared method; unresolvable → guidance error, no
+  mutation call.
+
+## US2 — analyze_contributions resolves slugs, never silent-empty
+
+- [X] T004 [US2] Inject `SpaceLookupService` into
+  `src/services/mcp-server/tools/contributions-analyze.tool.ts`; resolve the
+  `space:` scope id-or-nameID to the UUID before querying; unresolvable →
+  explicit guidance error (FR-002, FR-005).
+- [X] T005 [US2] Extend the `scope` schema description to state a top-level
+  nameID / URL slug is accepted.
+
+## US3 — one home for the policy
+
+- [X] T006 [US3] Add `SpaceLookupService.getSpaceByIdOrNameIdOrFail` in
+  `src/domain/space/space.lookup/space.lookup.service.ts` — `isUUID`
+  (class-validator, the codebase convention) → `getSpaceOrFail`; else
+  `getSpaceByNameIdOrFail` (L0-only, documented why: subspace nameIDs are not
+  globally unique) (FR-003, FR-004).
+- [X] T007 [US3] Harden `getSpaceByNameIdOrFail` +
+  `getSubspaceByNameIdInLevelZeroSpace`: merge caller options BEFORE the
+  identifying `where` constraints so a caller-supplied `where` can never clobber
+  the nameID/level guard; drop the dead doubled `if (!space)` (FR-006).
+- [X] T008 [US3] Lookup-service specs: UUID→by-id routing, non-UUID→nameID
+  routing, where-clause safety (`space.lookup.service.spec.ts`).
+
+## Exit gates
+
+- [X] G01 `pnpm vitest run src/services/mcp-server src/domain/space/space.lookup`
+  — 178 passed (19 files)
+- [X] G02 biome + `tsc --noEmit` clean
+- [X] G03 Multi-agent `/review` (8 finder angles → 1-vote verify): 2 CONFIRMED +
+  4 PLAUSIBLE findings, all applied pre-merge (US2 and US3 exist because of it)
+- [X] G04 Team-merged to `release/65`; develop receives it via release merge-back


### PR DESCRIPTION
Retroactive spec for alkem-io/server#6218 (merged `9228428d5` → `release/65`; reaches develop via the release merge-back) — the 2026-07-02 acceptance incident where an **approved** whiteboard creation failed with `Space not found: zimbabve` because the model passed the space's real nameID and the tool resolved UUID-only.

Follows the `specs/105-*` retrospec convention: spec.md (3 user stories, FR-001…FR-006) · tasks.md (all [X], incl. the review-pass provenance) · research.md (4 decisions: slug-at-the-seam vs listing UUIDs, L0-only slugs — subspace nameIDs aren't globally unique, shared-resolver home, options-merge hardening) · quickstart.md.

Docs only — no code. Cross-references `workspace#008-external-mcp-access` for the same incident window's vertical work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new quickstart, research notes, spec, and task plan for MCP space identifier handling.
  * MCP tools now document support for top-level space slugs as well as UUIDs.
  * Updated guidance for slug-based creation and analysis, including clearer outcomes when an identifier can’t be resolved.
  * Clarified that subspace slugs are not supported and that resolution behavior is consistent across tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->