### PR TITLE
chore(dev-compose): add assistant-service + bump whiteboard-collaboration to v0.12.0

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -504,7 +504,9 @@ services:
   whiteboard-collaboration:
     container_name: alkemio_dev_whiteboard_collaboration
     hostname: whiteboard-collaboration
-    image: alkemio/whiteboard-collaboration-service:v0.11.0
+    # External scene updates (Option A: merge external writes as a collaborator)
+    # shipped in v0.12.0 (2026-06-29), superseding the earlier livepush-local build.
+    image: alkemio/whiteboard-collaboration-service:v0.12.0
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -520,6 +522,40 @@ services:
       - alkemio_dev_net
     ports:
       - 4002
+
+  # Web-Client AI Assistant (workspace#004-web-ai-assistant). The MCP host runs in
+  # the server, started from source on the host (:4000) — reached via host.docker.internal.
+  # Secrets (ASSISTANT_LLM_API_KEY = Mistral key, ASSISTANT_MCP_API_KEY = virtual-assistant
+  # mcp_api_key) come from the compose env — merge assistant-service/.env via a second
+  # --env-file, or add them to .env.docker.
+  assistant-service:
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    container_name: alkemio_dev_assistant_service
+    hostname: assistant-service
+    # Token-budget metering (app/budget/*) landed on develop and shipped in the
+    # published v0.1.3 image (2026-07-02), superseding the local-develop build.
+    image: alkemio/assistant-service:v0.1.3
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/assistant
+      - REDIS_URL=redis://redis:6379
+      - MCP_URL=http://host.docker.internal:4000/rest/mcp
+      - ASSISTANT_LLM_PROVIDER=mistral
+      - ASSISTANT_LLM_MODEL=mistral-large-latest
+      - ASSISTANT_LLM_API_KEY=${ASSISTANT_LLM_API_KEY}
+      - ASSISTANT_MCP_API_KEY=${ASSISTANT_MCP_API_KEY}
+      - ASSISTANT_CORS_ORIGIN=http://localhost:3001
+      - ASSISTANT_PORT=4006
+    restart: always
+    networks:
+      - alkemio_dev_net
+    ports:
+      - 4006:4006
 
   file-service:
     extra_hosts:


### PR DESCRIPTION
## What

Two changes to the local dev stack (`quickstart-services.yml`), both switching to **released images** — no local builds required anymore:

- **whiteboard-collaboration-service `v0.11.0` → `v0.12.0`** — external scene updates (Option A: merge external writes as a collaborator) shipped in [v0.12.0](https://github.com/alkem-io/whiteboard-collaboration-service/releases/tag/v0.12.0) (2026-06-29).
- **Add `assistant-service` `v0.1.3`** (workspace#004-web-ai-assistant) to the compose — previously it only lived in k8s/dev-orchestration, so it was missing from the local stack. Wired the standard dev way: MCP host reached on `host.docker.internal:4000/rest/mcp` (server runs from host source), Mistral provider, token-budget metering (`app/budget/*`, shipped in [v0.1.3](https://github.com/alkem-io/assistant-service/releases/tag/v0.1.3)), port `4006`.

## Why

Both features have landed and been released, so the local `livepush-local` / `local-develop` image overrides several of us were carrying can be dropped. This makes `assistant-service` a first-class part of the dev stack.

## Notes

- Secrets are `${...}` env references only (`ASSISTANT_LLM_API_KEY`, `ASSISTANT_MCP_API_KEY`) — supplied via `.env.docker` or a second `--env-file`. No secrets or local paths committed.
- Uses the existing shared `postgres` (`assistant` DB, already alembic-migrated) + `redis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new assistant service for the Web-Client AI Assistant workspace, including local port setup, AI model configuration, and browser access support.
* **Bug Fixes**
  * Updated the whiteboard collaboration service to a newer version for improved reliability and compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->