### PR TITLE
SubSpaces callout

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -287,6 +287,7 @@ enum CalloutFramingType {
   MEMO
   NONE
   POLL
+  SPACES
   WHITEBOARD
 }
 
@@ -1904,6 +1905,10 @@ type CalloutFraming {
   poll: Poll
   """The Profile for framing the associated Callout."""
   profile: Profile!
+  """
+  The host space's subspaces for a SPACES framing, ordered pinned-first then the space's sortOrder/displayName. Returns the existing Space type (no new item type). No server-side pagination/search: the client name-searches and paginates client-side over this set. Empty for non-SPACES framings, for a callout not attached to a space, or for a host with no subspaces.
+  """
+  subspaces: [Space!]!
   """
   The type of the Callout Framing, the additional content attached to this callout
   """

--- a/src/common/enums/callout.framing.type.ts
+++ b/src/common/enums/callout.framing.type.ts
@@ -9,6 +9,7 @@ export enum CalloutFramingType {
   POLL = 'poll',
   COLLABORA_DOCUMENT = 'collabora_document',
   CONTRIBUTORS = 'contributors',
+  SPACES = 'spaces',
 }
 
 registerEnumType(CalloutFramingType, {

--- a/src/core/bootstrap/platform-template-definitions/default-templates/bootstrap.template.space.content.space.l0.spaces.spec.ts
+++ b/src/core/bootstrap/platform-template-definitions/default-templates/bootstrap.template.space.content.space.l0.spaces.spec.ts
@@ -1,0 +1,47 @@
+import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
+import {
+  bootstrapTemplateSpaceContentSpaceL0,
+  FlowState,
+} from './bootstrap.template.space.content.space.l0';
+
+// Structural verification for the SPACES callout on the platform default L0
+// space template (workspace#013-spaces-collection-callout, US1 T008a / US3 T012).
+// The callout must serialize its framing TYPE ONLY — config-free, with no
+// hardcoded subspace IDs — so a space created from this template gets a SPACES
+// callout that self-populates from the NEW space's own subspaces.
+describe('bootstrapTemplateSpaceContentSpaceL0 — SPACES callout', () => {
+  const spacesCallout =
+    bootstrapTemplateSpaceContentSpaceL0.collaborationData?.calloutsSetData?.calloutsData?.find(
+      c => c.framing?.type === CalloutFramingType.SPACES
+    );
+
+  it('includes a SPACES callout on the default L0 template', () => {
+    expect(spacesCallout).toBeDefined();
+  });
+
+  it('is classified onto the Subspaces flow-state tab', () => {
+    const flowStateTagset = spacesCallout?.classification?.tagsets?.find(
+      t => t.name === TagsetReservedName.FLOW_STATE
+    );
+    expect(flowStateTagset?.tags).toContain(FlowState.SUBSPACES);
+  });
+
+  it('renders first on the Subspaces tab (sortOrder 1)', () => {
+    expect(spacesCallout?.sortOrder).toBe(1);
+  });
+
+  it('uses the "Subspaces" framing profile displayName (preserve the block name)', () => {
+    expect(spacesCallout?.framing?.profile?.displayName).toBe('Subspaces');
+  });
+
+  it('is CONFIG-FREE — no settings block, no subspace IDs serialized', () => {
+    // The whole point of 013: nothing but the framing type (and profile name)
+    // serializes. No contributors config, no counts, no view, and — critically —
+    // no hardcoded subspace IDs, so instantiation self-populates.
+    expect((spacesCallout as any)?.settings).toBeUndefined();
+    const serialized = JSON.stringify(spacesCallout);
+    expect(serialized).not.toContain('contributors');
+    expect(serialized).not.toContain('defaultView');
+  });
+});

--- a/src/core/bootstrap/platform-template-definitions/default-templates/bootstrap.template.space.content.space.l0.ts
+++ b/src/core/bootstrap/platform-template-definitions/default-templates/bootstrap.template.space.content.space.l0.ts
@@ -108,6 +108,34 @@ export const bootstrapTemplateSpaceContentSpaceL0: CreateTemplateContentSpaceInp
               },
             },
           },
+          // Spaces-collection callout on the Subspaces tab, replacing the
+          // removed hard-coded subspaces block
+          // (workspace#013-spaces-collection-callout, US3/FR-013). It is
+          // CONFIG-FREE (no settings block) — contrast the CONTRIBUTORS callout
+          // above — and its framing profile displayName is deliberately
+          // "Subspaces" (preserve the block name, FR-004g). `sortOrder: 1`
+          // renders it first on the Subspaces tab. Spaces created from this
+          // default template inherit it via the normal template clone path;
+          // existing environments get the same callout backfilled by the
+          // BackfillSpacesCalloutL0Subspaces migration.
+          {
+            nameID: 'subspaces',
+            sortOrder: 1,
+            classification: {
+              tagsets: [
+                {
+                  name: TagsetReservedName.FLOW_STATE,
+                  tags: [FlowState.SUBSPACES],
+                },
+              ],
+            },
+            framing: {
+              type: CalloutFramingType.SPACES,
+              profile: {
+                displayName: 'Subspaces',
+              },
+            },
+          },
         ],
       },
     },

--- a/src/domain/collaboration/callout-framing/callout.framing.contributors.validation.spec.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.contributors.validation.spec.ts
@@ -138,4 +138,30 @@ describe('CalloutFramingService.validateAndNormalizeContributorsSettings', () =>
       ContributorCollectionView.LIST
     );
   });
+
+  // 013: a SPACES framing is config-free. Any contributors config on it is
+  // rejected (workspace#013-spaces-collection-callout, FR-004b); a bare
+  // (config-free) SPACES framing validates unchanged.
+  it('rejects contributors settings on a SPACES framing (config-free, FR-004b)', () => {
+    expect(() =>
+      service.validateAndNormalizeContributorsSettings(
+        CalloutFramingType.SPACES,
+        framing({
+          contributorTypes: [ActorType.USER],
+          defaultContributorType: ActorType.USER,
+          defaultView: ContributorCollectionView.LIST,
+        })
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('accepts a config-free SPACES framing unchanged (FR-004b)', () => {
+    const settings = framing(undefined);
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.SPACES,
+      settings
+    );
+    expect(result.contributors).toBeUndefined();
+    expect(result).toBe(settings);
+  });
 });

--- a/src/domain/collaboration/callout-framing/callout.framing.module.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.module.ts
@@ -3,6 +3,7 @@ import { CollaboraDocumentModule } from '@domain/collaboration/collabora-documen
 import { ContributorCollectionModule } from '@domain/collaboration/contributor-collection/contributor.collection.module';
 import { LinkModule } from '@domain/collaboration/link/link.module';
 import { PollModule } from '@domain/collaboration/poll/poll.module';
+import { SpaceCollectionModule } from '@domain/collaboration/space-collection/space.collection.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { MediaGalleryModule } from '@domain/common/media-gallery/media.gallery.module';
 import { MemoModule } from '@domain/common/memo';
@@ -33,6 +34,7 @@ import { CalloutFramingAuthorizationService } from './callout.framing.service.au
     PollModule,
     CollaboraDocumentModule,
     ContributorCollectionModule,
+    SpaceCollectionModule,
     TypeOrmModule.forFeature([CalloutFraming]),
   ],
   providers: [

--- a/src/domain/collaboration/callout-framing/callout.framing.resolver.fields.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.resolver.fields.ts
@@ -1,4 +1,5 @@
 import { ActorType } from '@common/enums/actor.type';
+import { CalloutFramingType } from '@common/enums/callout.framing.type';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { ProfileLoaderCreator } from '@core/dataloader/creators';
 import { Loader } from '@core/dataloader/decorators';
@@ -9,10 +10,12 @@ import { IContributorCollectionCounts } from '@domain/collaboration/contributor-
 import { IContributorCollectionItem } from '@domain/collaboration/contributor-collection/dto/contributor.collection.item';
 import { ILink } from '@domain/collaboration/link/link.interface';
 import { IPoll } from '@domain/collaboration/poll/poll.interface';
+import { SpaceCollectionService } from '@domain/collaboration/space-collection/space.collection.service';
 import { IMediaGallery } from '@domain/common/media-gallery/media.gallery.interface';
 import { IMemo } from '@domain/common/memo/types';
 import { IProfile } from '@domain/common/profile/profile.interface';
 import { IWhiteboard } from '@domain/common/whiteboard/types';
+import { ISpace } from '@domain/space/space/space.interface';
 import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { CurrentActor } from '@src/common/decorators';
 import { CalloutFraming } from './callout.framing.entity';
@@ -23,7 +26,8 @@ import { CalloutFramingService } from './callout.framing.service';
 export class CalloutFramingResolverFields {
   constructor(
     private calloutFramingService: CalloutFramingService,
-    private contributorCollectionService: ContributorCollectionService
+    private contributorCollectionService: ContributorCollectionService,
+    private spaceCollectionService: SpaceCollectionService
   ) {}
 
   @ResolveField('profile', () => IProfile, {
@@ -134,5 +138,27 @@ export class CalloutFramingResolverFields {
       callout,
       actorContext
     );
+  }
+
+  @ResolveField('subspaces', () => [ISpace], {
+    nullable: false,
+    description:
+      "The host space's subspaces for a SPACES framing, ordered pinned-first then the space's sortOrder/displayName. Returns the existing Space type (no new item type). No server-side pagination/search: the client name-searches and paginates client-side over this set. Empty for non-SPACES framings, for a callout not attached to a space, or for a host with no subspaces.",
+  })
+  async subspaces(
+    @Parent() calloutFraming: ICalloutFraming
+  ): Promise<ISpace[]> {
+    // Config-free + host-space-generic (workspace#013-spaces-collection-callout,
+    // US1/US2). Only SPACES framings expose a collection; every other framing
+    // resolves to an empty list (mirrors the conditional `contributors` field).
+    if (calloutFraming.type !== CalloutFramingType.SPACES) {
+      return [];
+    }
+    const callout =
+      await this.calloutFramingService.getParentCallout(calloutFraming);
+    if (!callout) {
+      return [];
+    }
+    return this.spaceCollectionService.getSubspaces(callout);
   }
 }

--- a/src/domain/collaboration/callout-framing/callout.framing.service.spec.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.spec.ts
@@ -896,6 +896,48 @@ describe('CalloutFramingService', () => {
       );
     });
 
+    // 013: a SPACES framing has a FIXED kind — it can never be switched to
+    // another framing type (workspace#013-spaces-collection-callout, FR-005/FR-006).
+    it('should reject switching a SPACES framing to another type (fixed kind, FR-005/FR-006)', async () => {
+      const framing = {
+        id: 'framing-1',
+        type: CalloutFramingType.SPACES,
+        profile: { id: 'profile-1' },
+      } as any;
+      const updateData = {
+        type: CalloutFramingType.CONTRIBUTORS,
+      } as any;
+
+      await expect(
+        service.updateCalloutFraming(
+          framing,
+          updateData,
+          storageAggregator,
+          false
+        )
+      ).rejects.toThrow(ValidationException);
+    });
+
+    it('should allow a no-op SPACES → SPACES type update (fixed kind is idempotent)', async () => {
+      const framing = {
+        id: 'framing-1',
+        type: CalloutFramingType.SPACES,
+        profile: { id: 'profile-1' },
+      } as any;
+      const updateData = {
+        type: CalloutFramingType.SPACES,
+      } as any;
+
+      const result = await service.updateCalloutFraming(
+        framing,
+        updateData,
+        storageAggregator,
+        false
+      );
+
+      expect(result.type).toBe(CalloutFramingType.SPACES);
+    });
+
     it('should create new link when framing type is LINK but no existing link', async () => {
       const framing = {
         id: 'framing-1',

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -440,6 +440,16 @@ export class CalloutFramingService {
       const oldType = calloutFraming.type;
       const newType = calloutFramingData.type;
 
+      // Fixed kind (workspace#013-spaces-collection-callout, FR-005/FR-006):
+      // a SPACES framing can never be switched to another framing type (and
+      // never offers a map/view option — it carries no config at all).
+      if (oldType === CalloutFramingType.SPACES && newType !== oldType) {
+        throw new ValidationException(
+          'A SPACES callout framing has a fixed kind and cannot be changed to another framing type.',
+          LogContext.COLLABORATION
+        );
+      }
+
       // Validate framing type transitions for callout templates
       if (
         isParentCalloutTemplate &&
@@ -707,6 +717,11 @@ export class CalloutFramingService {
           LogContext.COLLABORATION
         );
       }
+      // A SPACES framing is deliberately CONFIG-FREE
+      // (workspace#013-spaces-collection-callout, FR-004b): it carries no
+      // framing settings block (no contributors object, no counts, no view/map).
+      // The check above already rejects any `contributors` payload on a SPACES
+      // callout; nothing else needs to be persisted for SPACES.
       return framingSettings;
     }
 

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
@@ -475,4 +475,142 @@ describe('CalloutsSetResolverMutations', () => {
       ).not.toHaveBeenCalled();
     });
   });
+
+  // 013 admin-only / collaboration-only guards for SPACES framing
+  // (workspace#013-spaces-collection-callout, FR-004a / FR-004d / FR-004e). T008.
+  describe('SPACES framing guards', () => {
+    const setupBaseMocks = (calloutsSet: any) => {
+      vi.mocked(calloutsSetService.getCalloutsSetOrFail).mockResolvedValue(
+        calloutsSet
+      );
+    };
+
+    it('rejects SPACES on a non-COLLABORATION (knowledge base) callouts set', async () => {
+      const calloutsSet = {
+        id: 'cs-kb',
+        type: CalloutsSetType.KNOWLEDGE_BASE,
+        authorization: { id: 'auth-kb' },
+      } as any;
+      setupBaseMocks(calloutsSet);
+      // CREATE_CALLOUT passes; the type check rejects before any CREATE check.
+      vi.mocked(authorizationService.grantAccessOrFail).mockReturnValue(
+        undefined as any
+      );
+
+      const actorContext = { actorID: 'user-1' } as any;
+
+      await expect(
+        resolver.createCalloutOnCalloutsSet(actorContext, {
+          calloutsSetID: 'cs-kb',
+          framing: { type: CalloutFramingType.SPACES },
+        } as any)
+      ).rejects.toThrow(ValidationException);
+
+      expect(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).not.toHaveBeenCalled();
+    });
+
+    it('requires the CREATE (admin) privilege for SPACES even with member create-callout rights', async () => {
+      const calloutsSet = {
+        id: 'cs-collab',
+        type: CalloutsSetType.COLLABORATION,
+        authorization: { id: 'auth-collab' },
+      } as any;
+      setupBaseMocks(calloutsSet);
+
+      // First call (CREATE_CALLOUT) succeeds, second call (CREATE admin) throws.
+      vi.mocked(authorizationService.grantAccessOrFail)
+        .mockImplementationOnce(() => undefined as any)
+        .mockImplementationOnce(() => {
+          throw new ValidationException('forbidden', 'collaboration' as any);
+        });
+
+      const actorContext = { actorID: 'member-1' } as any;
+
+      await expect(
+        resolver.createCalloutOnCalloutsSet(actorContext, {
+          calloutsSetID: 'cs-collab',
+          framing: { type: CalloutFramingType.SPACES },
+        } as any)
+      ).rejects.toThrow();
+
+      // The second authorization assertion was for the admin CREATE privilege.
+      expect(authorizationService.grantAccessOrFail).toHaveBeenCalledWith(
+        actorContext,
+        calloutsSet.authorization,
+        AuthorizationPrivilege.CREATE,
+        expect.any(String)
+      );
+      expect(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).not.toHaveBeenCalled();
+    });
+
+    it('lets an admin create a SPACES callout with NO space-level restriction (host-space-generic, FR-004e)', async () => {
+      // The resolver imposes no space.level guard: an admin (CREATE granted)
+      // may create a SPACES callout on any COLLABORATION callouts set — L0 or
+      // L1 — and it lists that host space's subspaces. Both CREATE_CALLOUT and
+      // the admin CREATE assertions pass; creation proceeds.
+      const calloutsSet = {
+        id: 'cs-l1',
+        type: CalloutsSetType.COLLABORATION,
+        authorization: { id: 'auth-l1' },
+      } as any;
+      const callout = {
+        id: 'callout-spaces',
+        nameID: 'subspaces',
+        framing: { type: CalloutFramingType.SPACES },
+        settings: { visibility: CalloutVisibility.DRAFT },
+      } as any;
+      setupBaseMocks(calloutsSet);
+      vi.mocked(authorizationService.grantAccessOrFail).mockReturnValue(
+        undefined as any
+      );
+      vi.mocked(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).mockResolvedValue(callout);
+      vi.mocked(calloutService.save).mockResolvedValue(callout);
+      vi.mocked(calloutService.getStorageBucket).mockResolvedValue({
+        id: 'sb-1',
+      } as any);
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(callout);
+      vi.mocked(
+        calloutAuthorizationService.applyAuthorizationPolicy
+      ).mockResolvedValue([]);
+      const temporaryStorageService = (resolver as any).temporaryStorageService;
+      vi.mocked(
+        temporaryStorageService.moveTemporaryDocuments
+      ).mockResolvedValue(undefined);
+      const roomResolverService = (resolver as any).roomResolverService;
+      vi.mocked(
+        roomResolverService.getRoleSetAndSettingsForCollaborationCalloutsSet
+      ).mockResolvedValue({
+        roleSet: { id: 'rs-1' },
+        platformRolesAccess: { roles: [] },
+        spaceSettings: {},
+      });
+      const communityResolverService = (resolver as any)
+        .communityResolverService;
+      vi.mocked(
+        communityResolverService.getLevelZeroSpaceIdForCalloutsSet
+      ).mockResolvedValue('space-1');
+
+      const actorContext = { actorID: 'admin-1' } as any;
+
+      await resolver.createCalloutOnCalloutsSet(actorContext, {
+        calloutsSetID: 'cs-l1',
+        framing: { type: CalloutFramingType.SPACES },
+      } as any);
+
+      // Creation proceeded — no level guard rejected it.
+      expect(calloutsSetService.createCalloutOnCalloutsSet).toHaveBeenCalled();
+      expect(authorizationService.grantAccessOrFail).toHaveBeenCalledWith(
+        actorContext,
+        calloutsSet.authorization,
+        AuthorizationPrivilege.CREATE,
+        expect.any(String)
+      );
+    });
+  });
 });

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
@@ -31,6 +31,7 @@ import { ICallout } from '../callout/callout.interface';
 import { CalloutService } from '../callout/callout.service';
 import { CalloutAuthorizationService } from '../callout/callout.service.authorization';
 import { CollaborationLicenseService } from '../collaboration/collaboration.service.license';
+import { ICalloutsSet } from './callouts.set.interface';
 import { CalloutsSetService } from './callouts.set.service';
 import { CreateCalloutOnCalloutsSetInput } from './dto/callouts.set.dto.create.callout';
 import { UpdateCalloutsSortOrderInput } from './dto/callouts.set.dto.update.callouts.sort.order';
@@ -76,45 +77,21 @@ export class CalloutsSetResolverMutations {
       `create callout on callouts Set: ${calloutsSet.id}`
     );
 
-    // CONTRIBUTORS framing is admin-only and collaboration-only (FR-004a/FR-004f, R5):
-    //  - require CREATE (space admin) on the CalloutsSet even when
-    //    allowMembersToCreateCallouts maps CREATE_CALLOUT to CONTRIBUTE.
-    //  - reject on non-COLLABORATION CalloutsSets (e.g. VC knowledge bases).
-    if (calloutData.framing?.type === CalloutFramingType.CONTRIBUTORS) {
-      if (calloutsSet.type !== CalloutsSetType.COLLABORATION) {
-        throw new ValidationException(
-          'CONTRIBUTORS framing is only available on COLLABORATION callouts sets.',
-          LogContext.COLLABORATION
-        );
-      }
-      this.authorizationService.grantAccessOrFail(
+    // CONTRIBUTORS and SPACES framings are admin-only and collaboration-only
+    // (FR-004a/FR-004d/FR-004f, R5): reject on non-COLLABORATION callouts sets and
+    // require CREATE (space admin) even when allowMembersToCreateCallouts maps
+    // CREATE_CALLOUT to CONTRIBUTE. SPACES is NOT level-restricted — an admin may
+    // create it on any space (L0 or L1); only AUTOMATIC provisioning is L0-only
+    // (FR-004e). Shared guard keeps the two in sync as restricted framings grow.
+    const restrictedFramingType = calloutData.framing?.type;
+    if (
+      restrictedFramingType === CalloutFramingType.CONTRIBUTORS ||
+      restrictedFramingType === CalloutFramingType.SPACES
+    ) {
+      this.assertAdminOnlyCollaborationFraming(
         actorContext,
-        calloutsSet.authorization,
-        AuthorizationPrivilege.CREATE,
-        `create CONTRIBUTORS callout (admin-only) on callouts Set: ${calloutsSet.id}`
-      );
-    }
-
-    // SPACES framing is admin-only and collaboration-only, mirroring CONTRIBUTORS
-    // (workspace#013-spaces-collection-callout, FR-004a/FR-004d):
-    //  - require CREATE (space admin) even when allowMembersToCreateCallouts is on.
-    //  - reject on non-COLLABORATION CalloutsSets (VC knowledge bases).
-    //  - NOT level-restricted: an admin may create a SPACES callout on any space
-    //    (L0 or L1); it lists the host space's subspaces. Only AUTOMATIC
-    //    provisioning (migration + default template) is L0-only (FR-004e). There
-    //    is deliberately no create-time space.level guard here.
-    if (calloutData.framing?.type === CalloutFramingType.SPACES) {
-      if (calloutsSet.type !== CalloutsSetType.COLLABORATION) {
-        throw new ValidationException(
-          'SPACES framing is only available on COLLABORATION callouts sets.',
-          LogContext.COLLABORATION
-        );
-      }
-      this.authorizationService.grantAccessOrFail(
-        actorContext,
-        calloutsSet.authorization,
-        AuthorizationPrivilege.CREATE,
-        `create SPACES callout (admin-only) on callouts Set: ${calloutsSet.id}`
+        calloutsSet,
+        restrictedFramingType
       );
     }
 
@@ -302,6 +279,33 @@ export class CalloutsSetResolverMutations {
     return this.calloutsSetService.updateCalloutsSortOrder(
       calloutsSet,
       sortOrderData
+    );
+  }
+
+  /**
+   * Shared admin-only + collaboration-only guard for the "collection" framings
+   * (CONTRIBUTORS and SPACES), FR-004a/FR-004d/FR-004f (R5): reject on
+   * non-COLLABORATION callouts sets, and require CREATE (space admin) even when
+   * allowMembersToCreateCallouts maps CREATE_CALLOUT to CONTRIBUTE. Neither is
+   * level-restricted. Extracted so the two guards cannot drift out of sync.
+   */
+  private assertAdminOnlyCollaborationFraming(
+    actorContext: ActorContext,
+    calloutsSet: ICalloutsSet,
+    framingType: CalloutFramingType
+  ): void {
+    const label = framingType.toUpperCase();
+    if (calloutsSet.type !== CalloutsSetType.COLLABORATION) {
+      throw new ValidationException(
+        `${label} framing is only available on COLLABORATION callouts sets.`,
+        LogContext.COLLABORATION
+      );
+    }
+    this.authorizationService.grantAccessOrFail(
+      actorContext,
+      calloutsSet.authorization,
+      AuthorizationPrivilege.CREATE,
+      `create ${label} callout (admin-only) on callouts Set: ${calloutsSet.id}`
     );
   }
 }

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
@@ -95,6 +95,29 @@ export class CalloutsSetResolverMutations {
       );
     }
 
+    // SPACES framing is admin-only and collaboration-only, mirroring CONTRIBUTORS
+    // (workspace#013-spaces-collection-callout, FR-004a/FR-004d):
+    //  - require CREATE (space admin) even when allowMembersToCreateCallouts is on.
+    //  - reject on non-COLLABORATION CalloutsSets (VC knowledge bases).
+    //  - NOT level-restricted: an admin may create a SPACES callout on any space
+    //    (L0 or L1); it lists the host space's subspaces. Only AUTOMATIC
+    //    provisioning (migration + default template) is L0-only (FR-004e). There
+    //    is deliberately no create-time space.level guard here.
+    if (calloutData.framing?.type === CalloutFramingType.SPACES) {
+      if (calloutsSet.type !== CalloutsSetType.COLLABORATION) {
+        throw new ValidationException(
+          'SPACES framing is only available on COLLABORATION callouts sets.',
+          LogContext.COLLABORATION
+        );
+      }
+      this.authorizationService.grantAccessOrFail(
+        actorContext,
+        calloutsSet.authorization,
+        AuthorizationPrivilege.CREATE,
+        `create SPACES callout (admin-only) on callouts Set: ${calloutsSet.id}`
+      );
+    }
+
     // Office Docs entitlement gate (FR-001/FR-004/FR-009): block introduction of a
     // Collabora Document — in framing form, contribution-allowed form, or via attached
     // contributions — when the owning Collaboration lacks SPACE_FLAG_OFFICE_DOCUMENTS.
@@ -201,12 +224,13 @@ export class CalloutsSetResolverMutations {
 
     if (calloutsSet.type === CalloutsSetType.COLLABORATION) {
       if (callout.settings.visibility === CalloutVisibility.PUBLISHED) {
-        // A CONTRIBUTORS callout is a passive display that accepts no
+        // A CONTRIBUTORS or SPACES callout is a passive display that accepts no
         // contributions and never emits a callout-published notification
-        // (FR-004e), regardless of any sendNotification flag.
-        const isContributorsFraming =
-          callout.framing?.type === CalloutFramingType.CONTRIBUTORS;
-        if (calloutData.sendNotification && !isContributorsFraming) {
+        // (008 FR-004e / 013 FR-004c), regardless of any sendNotification flag.
+        const isCollectionFraming =
+          callout.framing?.type === CalloutFramingType.CONTRIBUTORS ||
+          callout.framing?.type === CalloutFramingType.SPACES;
+        if (calloutData.sendNotification && !isCollectionFraming) {
           const notificationInput: NotificationInputCalloutPublished = {
             triggeredBy: actorContext.actorID,
             callout: callout,

--- a/src/domain/collaboration/space-collection/space.collection.module.ts
+++ b/src/domain/collaboration/space-collection/space.collection.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
+import { SpaceCollectionService } from './space.collection.service';
+
+// NOTE: deliberately does NOT import SpaceModule — that closes a module cycle
+// (CalloutFramingModule → SpaceCollectionModule → SpaceModule → … →
+// CalloutModule → CalloutFramingModule). The host space + its subspaces are
+// resolved via the cycle-free CommunityResolverService (EntityResolverModule),
+// and subspace ordering is a pure helper shared with SpaceService.getSubspaces.
+@Module({
+  imports: [EntityResolverModule],
+  providers: [SpaceCollectionService],
+  exports: [SpaceCollectionService],
+})
+export class SpaceCollectionModule {}

--- a/src/domain/collaboration/space-collection/space.collection.service.spec.ts
+++ b/src/domain/collaboration/space-collection/space.collection.service.spec.ts
@@ -1,0 +1,80 @@
+import { ICallout } from '@domain/collaboration/callout/callout.interface';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
+import { SpaceCollectionService } from './space.collection.service';
+
+// Covers the SPACES callout collection (workspace#013-spaces-collection-callout,
+// US1/US2): host-space resolution, pinned-first ordering, and empty results.
+describe('SpaceCollectionService', () => {
+  let service: SpaceCollectionService;
+  let communityResolver: CommunityResolverService;
+
+  const callout = { id: 'callout-1' } as ICallout;
+
+  const subspace = (
+    id: string,
+    sortOrder: number,
+    displayName: string,
+    pinned = false
+  ): any => ({
+    id,
+    sortOrder,
+    pinned,
+    about: { profile: { displayName } },
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SpaceCollectionService,
+        {
+          provide: CommunityResolverService,
+          useValue: {
+            getSpaceWithSubspacesFromCollaborationCallout: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SpaceCollectionService);
+    communityResolver = module.get(CommunityResolverService);
+  });
+
+  it('returns the host space subspaces pinned-first, then by sortOrder/displayName', async () => {
+    vi.mocked(
+      communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+    ).mockResolvedValue({
+      id: 'host-space',
+      subspaces: [
+        subspace('a', 30, 'Alpha'),
+        subspace('b', 10, 'Bravo'),
+        subspace('c', 20, 'Charlie', true), // pinned
+      ],
+    } as any);
+
+    const result = await service.getSubspaces(callout);
+
+    expect(result.map(s => s.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('returns an empty list when the callout is not attached to a space', async () => {
+    vi.mocked(
+      communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+    ).mockResolvedValue(null);
+
+    const result = await service.getSubspaces(callout);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when the host space has no subspaces', async () => {
+    vi.mocked(
+      communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+    ).mockResolvedValue({ id: 'host-space', subspaces: [] } as any);
+
+    const result = await service.getSubspaces(callout);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/domain/collaboration/space-collection/space.collection.service.ts
+++ b/src/domain/collaboration/space-collection/space.collection.service.ts
@@ -1,0 +1,53 @@
+import { ICallout } from '@domain/collaboration/callout/callout.interface';
+import { ISpace } from '@domain/space/space/space.interface';
+import { orderSubspaces } from '@domain/space/space/subspace.ordering';
+import { Injectable } from '@nestjs/common';
+import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
+
+/**
+ * Computes the subspace collection for a SPACES callout
+ * (workspace#013-spaces-collection-callout, US1/US2).
+ *
+ * Deliberately MUCH smaller than the contributors collection (008): a subspace
+ * is already an `ISpace` (an `Actor` with `ActorType.SPACE`), so there is no new
+ * item type, no counts, no config — the service just resolves the host space
+ * from the callout and returns its direct subspaces, ordered pinned-first via
+ * the shared `orderSubspaces` helper (the single ordering source, FR-007/R2).
+ *
+ * The returned `ISpace[]` is subject to the platform's existing subspace read
+ * authorization: each `Space` returned is authorized per-field by the standard
+ * space field-resolver auth (READ privilege) downstream — no new visibility
+ * semantics are introduced here (FR-010). This matches the existing
+ * `Space.subspaces` field, which likewise returns `getSubspaces` and relies on
+ * per-space authorization for the fields the client selects.
+ *
+ * NOTE: like 008's collection service, this module intentionally does NOT import
+ * SpaceModule (which would close a module cycle
+ * CalloutFramingModule → SpaceCollectionModule → SpaceModule → … →
+ * CalloutModule → CalloutFramingModule). The host space + subspaces are resolved
+ * via the cycle-free CommunityResolverService (EntityResolverModule), and the
+ * ordering is a pure helper shared with SpaceService.getSubspaces.
+ */
+@Injectable()
+export class SpaceCollectionService {
+  constructor(
+    private readonly communityResolverService: CommunityResolverService
+  ) {}
+
+  /**
+   * The host space's direct subspaces for a SPACES callout, ordered
+   * pinned-first then sortOrder then displayName. Host-space-generic (works on
+   * L0 or L1). Empty when the callout is not attached to a space (template /
+   * knowledge base) or the host has no subspaces.
+   */
+  public async getSubspaces(callout: ICallout): Promise<ISpace[]> {
+    const hostSpace =
+      await this.communityResolverService.getSpaceWithSubspacesFromCollaborationCallout(
+        callout.id
+      );
+    if (!hostSpace || !hostSpace.subspaces) {
+      return [];
+    }
+    return orderSubspaces(hostSpace.subspaces);
+  }
+}

--- a/src/domain/space/space/space.service.ts
+++ b/src/domain/space/space/space.service.ts
@@ -94,6 +94,7 @@ import { Space } from './space.entity';
 import { ISpace } from './space.interface';
 import { ISpaceSubscription } from './space.license.subscription.interface';
 import { SpacePlatformRolesAccessService } from './space.service.platform.roles.access';
+import { orderSubspaces } from './subspace.ordering';
 
 const EXPLORE_SPACES_LIMIT = 30;
 const EXPLORE_SPACES_ACTIVITY_DAYS_OLD = 30;
@@ -1114,20 +1115,15 @@ export class SpaceService {
       args?.shuffle
     );
 
-    // Sort the subspaces based on sortOrder, with displayName as tiebreaker
-    // Skip sorting when shuffle is requested to preserve randomization
+    // Order the subspaces PINNED-first, then by sortOrder, then displayName
+    // (case-insensitive) — the single ordering source shared with the SPACES
+    // callout collection (workspace#013-spaces-collection-callout, FR-007 / R2).
+    // Skip ordering when shuffle is requested to preserve randomization.
     if (args?.shuffle) {
       return limitAndShuffled;
     }
 
-    return limitAndShuffled.sort((a, b) => {
-      if (a.sortOrder !== b.sortOrder) {
-        return a.sortOrder - b.sortOrder;
-      }
-      return a.about.profile.displayName
-        .toLowerCase()
-        .localeCompare(b.about.profile.displayName.toLowerCase());
-    });
+    return orderSubspaces(limitAndShuffled);
   }
 
   public async updateSubspacesSortOrder(

--- a/src/domain/space/space/subspace.ordering.spec.ts
+++ b/src/domain/space/space/subspace.ordering.spec.ts
@@ -1,0 +1,73 @@
+import { ISpace } from './space.interface';
+import { orderSubspaces } from './subspace.ordering';
+
+// Covers the single subspace-ordering source shared by SpaceService.getSubspaces
+// and the SPACES callout collection (workspace#013-spaces-collection-callout,
+// FR-007 / SC-003). Pure logic, no DB.
+describe('orderSubspaces', () => {
+  const subspace = (
+    id: string,
+    sortOrder: number,
+    displayName: string,
+    pinned = false
+  ): ISpace =>
+    ({
+      id,
+      sortOrder,
+      pinned,
+      about: { profile: { displayName } },
+    }) as unknown as ISpace;
+
+  it('orders pinned subspaces first, then by sortOrder, then displayName', () => {
+    const input = [
+      subspace('a', 30, 'Alpha'),
+      subspace('b', 10, 'Bravo'),
+      subspace('c', 20, 'Charlie', true), // pinned
+      subspace('d', 5, 'Delta', true), // pinned
+    ];
+
+    const ordered = orderSubspaces(input);
+
+    // Pinned first (ordered among themselves by sortOrder: d=5 before c=20),
+    // then the unpinned by sortOrder (b=10 before a=30).
+    expect(ordered.map(s => s.id)).toEqual(['d', 'c', 'b', 'a']);
+  });
+
+  it('breaks sortOrder ties by displayName (case-insensitive)', () => {
+    const input = [
+      subspace('a', 10, 'bravo'),
+      subspace('b', 10, 'Alpha'),
+      subspace('c', 10, 'Charlie'),
+    ];
+
+    const ordered = orderSubspaces(input);
+
+    expect(ordered.map(s => s.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('does NOT mutate the input subspaces sortOrder/pinned (FR-016)', () => {
+    const input = [
+      subspace('a', 30, 'Alpha'),
+      subspace('b', 10, 'Bravo', true),
+    ];
+    const snapshot = input.map(s => ({
+      id: s.id,
+      sortOrder: s.sortOrder,
+      pinned: s.pinned,
+    }));
+
+    orderSubspaces(input);
+
+    expect(
+      input.map(s => ({ id: s.id, sortOrder: s.sortOrder, pinned: s.pinned }))
+    ).toEqual(snapshot);
+  });
+
+  it('returns a new array (does not sort in place)', () => {
+    const input = [subspace('a', 20, 'Alpha'), subspace('b', 10, 'Bravo')];
+    const ordered = orderSubspaces(input);
+    expect(ordered).not.toBe(input);
+    // Original order preserved on the input reference.
+    expect(input.map(s => s.id)).toEqual(['a', 'b']);
+  });
+});

--- a/src/domain/space/space/subspace.ordering.ts
+++ b/src/domain/space/space/subspace.ordering.ts
@@ -1,0 +1,36 @@
+import { ISpace } from './space.interface';
+
+/**
+ * Single source of truth for subspace ordering
+ * (workspace#013-spaces-collection-callout, FR-007 / research R2).
+ *
+ * Orders subspaces:
+ *   1. PINNED-first (pinned before unpinned),
+ *   2. then `sortOrder` ascending,
+ *   3. then `displayName` (case-insensitive) as a stable tiebreaker.
+ *
+ * Both `SpaceService.getSubspaces` (the `subspaces` field) and the SPACES
+ * callout collection (`CalloutFraming.subspaces`) order through this helper so
+ * they always agree — the callout preserves the exact order/pins of the static
+ * Subspaces block it replaces, and no consumer mutates any subspace
+ * `sortOrder`/`pinned` state (FR-016). Returns a new sorted array; the input is
+ * not mutated in place beyond `Array.prototype.sort` on a shallow copy.
+ */
+export const orderSubspaces = <T extends ISpace>(subspaces: T[]): T[] => {
+  return [...subspaces].sort((a, b) => {
+    // Pinned subspaces first.
+    const aPinned = a.pinned ? 1 : 0;
+    const bPinned = b.pinned ? 1 : 0;
+    if (aPinned !== bPinned) {
+      return bPinned - aPinned;
+    }
+    // Then by sortOrder ascending.
+    if (a.sortOrder !== b.sortOrder) {
+      return a.sortOrder - b.sortOrder;
+    }
+    // Then alphabetically (case-insensitive) as a tiebreaker.
+    return (a.about?.profile?.displayName ?? '')
+      .toLowerCase()
+      .localeCompare((b.about?.profile?.displayName ?? '').toLowerCase());
+  });
+};

--- a/src/migrations/1783329479325-BackfillSpacesCalloutL0Subspaces.ts
+++ b/src/migrations/1783329479325-BackfillSpacesCalloutL0Subspaces.ts
@@ -30,8 +30,10 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
  * orphan comments room / emit publish info on edit). This folds in the fix that
  * 008 needed a separate follow-up migration for; here the backfill has not
  * shipped, so it is corrected inline. The platform default L0 space template is
- * seeded by the template branch of this same loop (its level is already 0 and it
- * has a `welcome` callout, so the sibling-callout lookups resolve) — no separate
+ * seeded by the template branch of this same loop (its level is already 0; its
+ * flow-state tagsetTemplate is resolved DIRECTLY via callouts_set.tagsetTemplateSetId
+ * — robust on sparse templates — and its storage aggregator from a sibling
+ * callout's framing bucket, which the `welcome` callout supplies) — no separate
  * platform-default seed migration is needed.
  *
  * Template content spaces have no storageAggregatorId column; the callout's
@@ -155,6 +157,7 @@ export class BackfillSpacesCalloutL0Subspaces1783329479325
           SELECT
             cs.id AS callouts_set_id,
             s."storageAggregatorId" AS storage_aggregator_id,
+            cs."tagsetTemplateSetId" AS tagset_template_set_id,
             false AS is_template
           FROM space s
           JOIN collaboration c ON c.id = s."collaborationId"
@@ -181,27 +184,26 @@ export class BackfillSpacesCalloutL0Subspaces1783329479325
                WHERE co2."calloutsSetId" = cs.id
                  AND sb2."storageAggregatorId" IS NOT NULL
                LIMIT 1) AS storage_aggregator_id,
+            cs."tagsetTemplateSetId" AS tagset_template_set_id,
             true AS is_template
           FROM template_content_space tcs
           JOIN collaboration c ON c.id = tcs."collaborationId"
           JOIN callouts_set cs ON cs.id = c."calloutsSetId"
           WHERE tcs.level = 0
         LOOP
-          -- The new flow-state tagset MUST reference the space's flow-state
-          -- tagsetTemplate (one per calloutsSet) so the client can resolve
-          -- classification.flowState.allowedValues. Reuse the template already
-          -- used by this calloutsSet's other callouts.
-          SELECT ts."tagsetTemplateId" INTO flow_state_template_id
-            FROM callout co2
-            JOIN callout_framing cf2 ON cf2.id = co2."framingId"
-            JOIN classification cl2 ON cl2.id = co2."classificationId"
-            JOIN tagset ts ON ts."classificationId" = cl2.id
-            WHERE co2."calloutsSetId" = rec.callouts_set_id
-              AND ts.name = 'flow-state'
-              AND ts."tagsetTemplateId" IS NOT NULL
+          -- The new flow-state tagset MUST reference the calloutsSet's flow-state
+          -- tagsetTemplate so the client can resolve classification.flowState.
+          -- allowedValues. Resolve it DIRECTLY off callouts_set.tagsetTemplateSetId
+          -- (not via a sibling callout — that lookup starves on sparse template
+          -- callouts sets), matching the contributors migrations (008 fix
+          -- 1782998815506 + BackfillContributorsCalloutL0Templates).
+          SELECT tt.id, tt."allowedValues"
+            INTO flow_state_template_id, allowed_values
+            FROM tagset_template tt
+            WHERE tt."tagsetTemplateSetId" = rec.tagset_template_set_id
+              AND tt.name = 'flow-state'
             LIMIT 1;
-          -- Without the flow-state template we cannot place a tab; skip
-          -- (does not happen for L0 spaces, which always have flow-tab callouts).
+          -- Without the flow-state template we cannot place a tab; skip.
           IF flow_state_template_id IS NULL THEN
             CONTINUE;
           END IF;
@@ -210,9 +212,6 @@ export class BackfillSpacesCalloutL0Subspaces1783329479325
           -- 'Subspaces'): the flow-state tab order is the tagsetTemplate's
           -- ordered comma-separated allowedValues, so the third tab is the third
           -- element. This is robust to a renamed / localized third tab.
-          SELECT tt."allowedValues" INTO allowed_values
-            FROM tagset_template tt
-            WHERE tt.id = flow_state_template_id;
           third_tab_name := split_part(COALESCE(allowed_values, ''), ',', 3);
           -- No third tab (fewer than three flow states) → nothing to target; skip.
           IF third_tab_name IS NULL OR third_tab_name = '' THEN

--- a/src/migrations/1783329479325-BackfillSpacesCalloutL0Subspaces.ts
+++ b/src/migrations/1783329479325-BackfillSpacesCalloutL0Subspaces.ts
@@ -1,0 +1,456 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * One-time data migration (workspace#013-spaces-collection-callout, US3).
+ *
+ * Backfills exactly one PUBLISHED SPACES callout into the FIRST position of the
+ * THIRD (Subspaces) flow-state tab of:
+ *   - every L0 space (space.level = 0), and
+ *   - every L0 space content template (template_content_space.level = 0 — ALL of
+ *     them, not just the platform default, so every L0 space template is
+ *     consistent), so new spaces created from a template inherit the callout
+ *     (the clone path copies the framing type).
+ * The third tab is resolved BY POSITION — the third entry of the flow-state
+ * tagsetTemplate's ordered `allowedValues` — regardless of its displayName, so a
+ * renamed / localized "Subspaces" tab is still targeted correctly. Subspaces and
+ * subspace content templates (level != 0) are UNTOUCHED, and no subspace
+ * sortOrder / pinned value is ever modified (FR-015 / FR-016).
+ *
+ * Contrast with the 008 contributors backfill: a SPACES callout is CONFIG-FREE.
+ * There is no framing settings block (no contributors object, no counts, no
+ * view); the callout `settings` carry only the standard visibility/contribution
+ * defaults, and the framing type alone drives behaviour. No hardcoded subspace
+ * IDs are stored — the callout self-populates from the host space's subspaces at
+ * read time.
+ *
+ * `isTemplate` is set per source: rows inserted into a LIVE L0 space get
+ * `isTemplate = false`; rows inserted into an L0 space content template get
+ * `isTemplate = true` (the app forces this for callouts created inside a
+ * template — a false template callout is treated as LIVE and would create an
+ * orphan comments room / emit publish info on edit). This folds in the fix that
+ * 008 needed a separate follow-up migration for; here the backfill has not
+ * shipped, so it is corrected inline. The platform default L0 space template is
+ * seeded by the template branch of this same loop (its level is already 0 and it
+ * has a `welcome` callout, so the sibling-callout lookups resolve) — no separate
+ * platform-default seed migration is needed.
+ *
+ * Template content spaces have no storageAggregatorId column; the callout's
+ * storage bucket reuses the aggregator already bound to a sibling callout's
+ * framing storage bucket in the same calloutsSet.
+ *
+ * Placement: the callout is given a `sortOrder` strictly BELOW the minimum of
+ * the callouts already in that third tab (NOT MAX+10), so it renders FIRST within
+ * the tab (where the hard-coded subspaces block used to render). Negative
+ * sortOrders are idiomatic in this codebase (create-at-front = MIN - 10).
+ *
+ * ONE-TIME / NO RESURRECTION: this is a standard TypeORM migration recorded in
+ * the migrations table — it runs ONCE at rollout and is never re-scheduled. It
+ * therefore does NOT re-provision a space after the fact, and a deliberately
+ * deleted default is NOT resurrected (FR-017 / SC-013).
+ *
+ * Idempotency / re-run (safe to run repeatedly, incl. on environments where an
+ * earlier version of this migration already ran) — a no-op safety net, not
+ * recurring behaviour:
+ *   - If the third tab's FIRST callout is already a SPACES callout → skip.
+ *   - Else, if a prior run of THIS migration left a default-shape SPACES callout
+ *     anywhere in the calloutsSet (e.g. tagged a since-renamed tab) → MOVE it
+ *     into the third tab at first position (retag + reorder) instead of
+ *     inserting a duplicate.
+ *   - Else, if the third tab already holds someone else's SPACES callout → skip.
+ *   - Else → insert a fresh one at first position.
+ *
+ * The migration is SILENT — it inserts rows directly, bypassing the mutation's
+ * notification / activity / publish adapters, so it emits no notifications,
+ * activity-log entries, or emails (FR-019).
+ *
+ * ⚠️ REQUIRED POST-STEP (rollout runbook, FR-020): the inserted callouts carry
+ * EMPTY authorization policies (credentialRules '[]'). They are therefore
+ * unreadable — and invisible in the Subspaces tab — until an authorization reset
+ * recomputes them. After running this migration you MUST run the platform
+ * authorization reset (GraphQL `mutation { authorizationPolicyResetAll }` as a
+ * global admin, or the equivalent per-space reset) so the engine grants the
+ * standard space/collaboration read rules. Without this step the backfill
+ * appears to have done nothing. Sequence:
+ *   migrate → authorizationPolicyResetAll → (then the client block-removal release).
+ *
+ * Per target space it inserts the minimal valid graph the running app resolves
+ * without throwing (008 R8 learnings):
+ *   authorization_policy x7 (callout, callout_framing, profile, storage_bucket,
+ *     classification, flow-state tagset, default tagset) — empty rule arrays;
+ *     the authorization reset (post-step above) repopulates them.
+ *   storage_bucket (REQUIRED: CalloutService.getStorageBucket throws if absent),
+ *     bound to the space's storage aggregator.
+ *   location, profile (type 'callout-framing', displayName 'Subspaces') + its
+ *     DEFAULT freeform tagset (REQUIRED: ProfileResolverFields.tagset throws
+ *     ENTITY_NOT_FOUND without it).
+ *   callout_framing (type 'spaces').
+ *   classification + flow-state tagset (tags = the third tab's displayName,
+ *     type 'select-one'), linked to the calloutsSet's flow-state tagsetTemplate
+ *     (REQUIRED: classification.flowState.allowedValues throws without it).
+ *   callout_contribution_defaults (kept for the update/delete paths).
+ *   callout (PUBLISHED; settings mirror DefaultCalloutSettings — CONFIG-FREE
+ *     framing, no contributors block).
+ * No comments Room is created: the framing is a passive display, every
+ * read/auth path tolerates a null commentsId, and a SQL-inserted room would
+ * have no Matrix backing.
+ *
+ * Validate with `.scripts/migrations/run_validate_migration.sh` against a DB copy
+ * before release.
+ */
+export class BackfillSpacesCalloutL0Subspaces1783329479325
+  implements MigrationInterface
+{
+  name = 'BackfillSpacesCalloutL0Subspaces1783329479325';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      DECLARE
+        rec RECORD;
+        new_callout_id uuid;
+        new_callout_auth_id uuid;
+        new_framing_id uuid;
+        new_framing_auth_id uuid;
+        new_profile_id uuid;
+        new_profile_auth_id uuid;
+        new_bucket_id uuid;
+        new_bucket_auth_id uuid;
+        new_location_id uuid;
+        new_classification_id uuid;
+        new_classification_auth_id uuid;
+        new_tagset_id uuid;
+        new_tagset_auth_id uuid;
+        new_default_tagset_id uuid;
+        new_default_tagset_auth_id uuid;
+        flow_state_template_id uuid;
+        allowed_values TEXT;
+        third_tab_name TEXT;
+        first_is_spaces boolean;
+        existing_callout_id uuid;
+        existing_flowtag_id uuid;
+        new_contrib_defaults_id uuid;
+        new_name_id varchar(36);
+        next_sort_order int;
+        default_mime_types TEXT := 'application/pdf,image/jpg,image/jpeg,image/x-png,image/png,image/gif,image/webp,image/svg+xml,image/avif';
+        default_max_file_size INT := 15728640;
+        default_geo_location JSONB := '{"isValid": false}'::jsonb;
+        -- CONFIG-FREE: no framing.contributors block. Standard callout defaults
+        -- only. The framing type alone ('spaces') drives behaviour.
+        spaces_settings JSONB := jsonb_build_object(
+          'framing', jsonb_build_object(
+            'commentsEnabled', true
+          ),
+          'contribution', jsonb_build_object(
+            'enabled', false,
+            'canAddContributions', 'members',
+            'allowedTypes', jsonb_build_array(),
+            'commentsEnabled', true
+          ),
+          'visibility', 'published'
+        );
+      BEGIN
+        FOR rec IN
+          -- Live L0 spaces: storage aggregator taken directly from the space.
+          -- is_template = false → a live-space callout.
+          SELECT
+            cs.id AS callouts_set_id,
+            s."storageAggregatorId" AS storage_aggregator_id,
+            false AS is_template
+          FROM space s
+          JOIN collaboration c ON c.id = s."collaborationId"
+          JOIN callouts_set cs ON cs.id = c."calloutsSetId"
+          WHERE s.level = 0
+            AND s."storageAggregatorId" IS NOT NULL
+          UNION ALL
+          -- L0 space content templates: template_content_space has NO
+          -- storageAggregatorId column, so reuse the storage aggregator already
+          -- bound to a sibling callout's framing storage bucket in the same
+          -- calloutsSet. Adding the callout here makes new spaces created from
+          -- the template inherit it (the clone path copies the framing type).
+          -- is_template = true → a template callout: it MUST be inserted with
+          -- callout.isTemplate = true (the app forces this for callouts created
+          -- inside a template; a false template callout is treated as LIVE and
+          -- would create an orphan comments room / emit publish info on edit).
+          SELECT
+            cs.id AS callouts_set_id,
+            (SELECT sb2."storageAggregatorId"
+               FROM callout co2
+               JOIN callout_framing cf2 ON cf2.id = co2."framingId"
+               JOIN profile p2 ON p2.id = cf2."profileId"
+               JOIN storage_bucket sb2 ON sb2.id = p2."storageBucketId"
+               WHERE co2."calloutsSetId" = cs.id
+                 AND sb2."storageAggregatorId" IS NOT NULL
+               LIMIT 1) AS storage_aggregator_id,
+            true AS is_template
+          FROM template_content_space tcs
+          JOIN collaboration c ON c.id = tcs."collaborationId"
+          JOIN callouts_set cs ON cs.id = c."calloutsSetId"
+          WHERE tcs.level = 0
+        LOOP
+          -- The new flow-state tagset MUST reference the space's flow-state
+          -- tagsetTemplate (one per calloutsSet) so the client can resolve
+          -- classification.flowState.allowedValues. Reuse the template already
+          -- used by this calloutsSet's other callouts.
+          SELECT ts."tagsetTemplateId" INTO flow_state_template_id
+            FROM callout co2
+            JOIN callout_framing cf2 ON cf2.id = co2."framingId"
+            JOIN classification cl2 ON cl2.id = co2."classificationId"
+            JOIN tagset ts ON ts."classificationId" = cl2.id
+            WHERE co2."calloutsSetId" = rec.callouts_set_id
+              AND ts.name = 'flow-state'
+              AND ts."tagsetTemplateId" IS NOT NULL
+            LIMIT 1;
+          -- Without the flow-state template we cannot place a tab; skip
+          -- (does not happen for L0 spaces, which always have flow-tab callouts).
+          IF flow_state_template_id IS NULL THEN
+            CONTINUE;
+          END IF;
+
+          -- Resolve the THIRD tab BY POSITION (not by the literal name
+          -- 'Subspaces'): the flow-state tab order is the tagsetTemplate's
+          -- ordered comma-separated allowedValues, so the third tab is the third
+          -- element. This is robust to a renamed / localized third tab.
+          SELECT tt."allowedValues" INTO allowed_values
+            FROM tagset_template tt
+            WHERE tt.id = flow_state_template_id;
+          third_tab_name := split_part(COALESCE(allowed_values, ''), ',', 3);
+          -- No third tab (fewer than three flow states) → nothing to target; skip.
+          IF third_tab_name IS NULL OR third_tab_name = '' THEN
+            CONTINUE;
+          END IF;
+
+          -- Idempotency (1/2): if the third tab's FIRST callout is already a
+          -- spaces callout, it is already placed correctly → skip. This is the
+          -- re-run no-op for environments already migrated by THIS version.
+          first_is_spaces := NULL;
+          SELECT (cf.type = 'spaces')
+            INTO first_is_spaces
+            FROM callout co
+            JOIN callout_framing cf ON cf.id = co."framingId"
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND third_tab_name = ANY(string_to_array(t.tags, ','))
+            ORDER BY co."sortOrder" ASC
+            LIMIT 1;
+          IF first_is_spaces IS TRUE THEN
+            CONTINUE;
+          END IF;
+
+          -- FIRST position within the third tab: sortOrder strictly below the
+          -- minimum of the callouts already in that tab. Empty tab → -10.
+          SELECT COALESCE(MIN(co."sortOrder"), 0) - 10
+            INTO next_sort_order
+            FROM callout co
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND third_tab_name = ANY(string_to_array(t.tags, ','));
+
+          -- Re-run repositioning: if a prior run of THIS migration already left a
+          -- default-shape spaces callout in this calloutsSet (tagged a
+          -- since-renamed tab), MOVE it into the third tab at first position
+          -- rather than inserting a duplicate. Matched by the migration's own
+          -- default shape (generated nameID, PUBLISHED but no publisher, no
+          -- comments room) so user-created spaces callouts are never touched.
+          existing_callout_id := NULL;
+          existing_flowtag_id := NULL;
+          SELECT co.id, t.id
+            INTO existing_callout_id, existing_flowtag_id
+            FROM callout co
+            JOIN callout_framing cf ON cf.id = co."framingId"
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND cf.type = 'spaces'
+              AND co."nameID" LIKE 'subspaces-%'
+              AND co."publishedBy" IS NULL
+              AND co."commentsId" IS NULL
+            ORDER BY co."sortOrder" ASC
+            LIMIT 1;
+          IF existing_callout_id IS NOT NULL THEN
+            UPDATE tagset
+              SET tags = third_tab_name, "updatedDate" = NOW()
+              WHERE id = existing_flowtag_id;
+            UPDATE callout
+              SET "sortOrder" = next_sort_order, "updatedDate" = NOW()
+              WHERE id = existing_callout_id;
+            CONTINUE;
+          END IF;
+
+          -- Idempotency (2/2): don't duplicate a spaces callout a user may
+          -- already have placed elsewhere in the third tab (not at first, and
+          -- not default-shape, so not repositioned above).
+          IF EXISTS (
+            SELECT 1
+            FROM callout co
+            JOIN callout_framing cf ON cf.id = co."framingId"
+            JOIN classification cl ON cl.id = co."classificationId"
+            JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+            WHERE co."calloutsSetId" = rec.callouts_set_id
+              AND cf.type = 'spaces'
+              AND third_tab_name = ANY(string_to_array(t.tags, ','))
+          ) THEN
+            CONTINUE;
+          END IF;
+
+          -- A fresh insert needs a storage aggregator to bind the callout's
+          -- framing storage bucket. Live L0 spaces always have one; an L0
+          -- template with no storage-bearing sibling callout (degenerate) is
+          -- skipped. The reposition path above needs no aggregator.
+          IF rec.storage_aggregator_id IS NULL THEN
+            CONTINUE;
+          END IF;
+
+          new_callout_id          := gen_random_uuid();
+          new_callout_auth_id     := gen_random_uuid();
+          new_framing_id          := gen_random_uuid();
+          new_framing_auth_id     := gen_random_uuid();
+          new_profile_id          := gen_random_uuid();
+          new_profile_auth_id     := gen_random_uuid();
+          new_bucket_id           := gen_random_uuid();
+          new_bucket_auth_id      := gen_random_uuid();
+          new_location_id         := gen_random_uuid();
+          new_classification_id   := gen_random_uuid();
+          new_classification_auth_id := gen_random_uuid();
+          new_tagset_id           := gen_random_uuid();
+          new_tagset_auth_id      := gen_random_uuid();
+          new_default_tagset_id      := gen_random_uuid();
+          new_default_tagset_auth_id := gen_random_uuid();
+          new_contrib_defaults_id := gen_random_uuid();
+          new_name_id := 'subspaces-' || left(replace(gen_random_uuid()::text, '-', ''), 8);
+
+          INSERT INTO authorization_policy (id,"createdDate","updatedDate",version,"credentialRules","privilegeRules",type) VALUES
+            (new_callout_auth_id,        NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'callout'),
+            (new_framing_auth_id,        NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'callout-framing'),
+            (new_profile_auth_id,        NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'profile'),
+            (new_bucket_auth_id,         NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'storage-bucket'),
+            (new_classification_auth_id, NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'classification'),
+            (new_tagset_auth_id,         NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'tagset'),
+            (new_default_tagset_auth_id, NOW(),NOW(),1,'[]'::jsonb,'[]'::jsonb,'tagset');
+
+          INSERT INTO storage_bucket (id,"createdDate","updatedDate",version,"allowedMimeTypes","maxFileSize","authorizationId","storageAggregatorId")
+          VALUES (new_bucket_id,NOW(),NOW(),1,default_mime_types,default_max_file_size,new_bucket_auth_id,rec.storage_aggregator_id);
+
+          INSERT INTO location (id,"createdDate","updatedDate",version,"geoLocation")
+          VALUES (new_location_id,NOW(),NOW(),1,default_geo_location);
+
+          -- Framing profile displayName is deliberately 'Subspaces' (preserve the
+          -- block name, FR-004g) — NOT 'Spaces'.
+          INSERT INTO profile (id,"createdDate","updatedDate",version,"displayName",type,"authorizationId","locationId","storageBucketId")
+          VALUES (new_profile_id,NOW(),NOW(),1,'Subspaces','callout-framing',new_profile_auth_id,new_location_id,new_bucket_id);
+
+          INSERT INTO callout_framing (id,"createdDate","updatedDate",version,type,"authorizationId","profileId")
+          VALUES (new_framing_id,NOW(),NOW(),1,'spaces',new_framing_auth_id,new_profile_id);
+
+          -- DEFAULT freeform tagset on the framing profile. Every callout profile
+          -- has one; ProfileResolverFields.tagset throws ENTITY_NOT_FOUND without it.
+          INSERT INTO tagset (id,"createdDate","updatedDate",version,name,type,tags,"authorizationId","profileId")
+          VALUES (new_default_tagset_id,NOW(),NOW(),1,'default','freeform','',new_default_tagset_auth_id,new_profile_id);
+
+          INSERT INTO classification (id,"createdDate","updatedDate",version,"authorizationId")
+          VALUES (new_classification_id,NOW(),NOW(),1,new_classification_auth_id);
+
+          -- Flow-state classification tagset, tagged with the THIRD tab's
+          -- displayName (resolved by position above) and linked to the
+          -- calloutsSet's flow-state tagsetTemplate so
+          -- classification.flowState.allowedValues resolves.
+          INSERT INTO tagset (id,"createdDate","updatedDate",version,name,type,tags,"authorizationId","classificationId","tagsetTemplateId")
+          VALUES (new_tagset_id,NOW(),NOW(),1,'flow-state','select-one',third_tab_name,new_tagset_auth_id,new_classification_id,flow_state_template_id);
+
+          INSERT INTO callout_contribution_defaults (id,"createdDate","updatedDate",version)
+          VALUES (new_contrib_defaults_id,NOW(),NOW(),1);
+
+          INSERT INTO callout
+            (id,"createdDate","updatedDate",version,"nameID","isTemplate",settings,"sortOrder","publishedBy","publishedDate",
+             "authorizationId","framingId","classificationId","contributionDefaultsId","commentsId","calloutsSetId")
+          VALUES
+            (new_callout_id,NOW(),NOW(),1,new_name_id,rec.is_template,spaces_settings,next_sort_order,NULL,NOW(),
+             new_callout_auth_id,new_framing_id,new_classification_id,new_contrib_defaults_id,NULL,rec.callouts_set_id);
+        END LOOP;
+      END $$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Targeted reversal: remove only the PUBLISHED SPACES callouts in L0 spaces
+    // and L0 space content templates that still carry the exact default shape
+    // this migration produced (generated 'subspaces-%' nameID, published but no
+    // publisher, no comments room) — so user-created spaces callouts are never
+    // deleted. Subspace content templates (level != 0) are never targeted by
+    // up(), so they are never touched here either. Children are deleted
+    // explicitly; deleting the classification cascades its flow-state tagset, and
+    // the profile's DEFAULT tagset is removed before the profile
+    // (tagset.profileId FK).
+    await queryRunner.query(`
+      DO $$
+      DECLARE
+        rec RECORD;
+      BEGIN
+        FOR rec IN
+          SELECT
+            co.id AS callout_id,
+            co."authorizationId" AS callout_auth_id,
+            cf.id AS framing_id,
+            cf."authorizationId" AS framing_auth_id,
+            p.id AS profile_id,
+            p."authorizationId" AS profile_auth_id,
+            p."locationId" AS location_id,
+            sb.id AS bucket_id,
+            sb."authorizationId" AS bucket_auth_id,
+            cl.id AS classification_id,
+            cl."authorizationId" AS classification_auth_id,
+            t."authorizationId" AS tagset_auth_id,
+            dt.id AS default_tagset_id,
+            dt."authorizationId" AS default_tagset_auth_id,
+            cd.id AS contrib_defaults_id
+          FROM (
+            -- Reverse both sources the up() targets: L0 live spaces and L0
+            -- space content templates.
+            SELECT c."calloutsSetId" AS callouts_set_id
+            FROM space s
+            JOIN collaboration c ON c.id = s."collaborationId"
+            WHERE s.level = 0
+            UNION ALL
+            SELECT c."calloutsSetId"
+            FROM template_content_space tcs
+            JOIN collaboration c ON c.id = tcs."collaborationId"
+            WHERE tcs.level = 0
+          ) src
+          JOIN callout co ON co."calloutsSetId" = src.callouts_set_id
+          JOIN callout_framing cf ON cf.id = co."framingId"
+          JOIN profile p ON p.id = cf."profileId"
+          LEFT JOIN storage_bucket sb ON sb.id = p."storageBucketId"
+          JOIN classification cl ON cl.id = co."classificationId"
+          JOIN tagset t ON t."classificationId" = cl.id AND t.name = 'flow-state'
+          LEFT JOIN tagset dt ON dt."profileId" = p.id AND dt.name = 'default'
+          LEFT JOIN callout_contribution_defaults cd ON cd.id = co."contributionDefaultsId"
+          WHERE cf.type = 'spaces'
+            AND co."nameID" LIKE 'subspaces-%'
+            AND co.settings->>'visibility' = 'published'
+            AND co."commentsId" IS NULL
+            -- A user-published callout always records a publisher; this migration
+            -- leaves publishedBy NULL on a PUBLISHED callout (an anomaly only it
+            -- creates). This guard prevents deleting legitimate user-created
+            -- spaces callouts that otherwise match the default shape.
+            AND co."publishedBy" IS NULL
+        LOOP
+          DELETE FROM callout WHERE id = rec.callout_id;
+          DELETE FROM callout_framing WHERE id = rec.framing_id;
+          -- Delete the profile's DEFAULT tagset before the profile (tagset.profileId FK).
+          IF rec.default_tagset_id IS NOT NULL THEN DELETE FROM tagset WHERE id = rec.default_tagset_id; END IF;
+          DELETE FROM profile WHERE id = rec.profile_id;
+          IF rec.bucket_id IS NOT NULL THEN DELETE FROM storage_bucket WHERE id = rec.bucket_id; END IF;
+          IF rec.location_id IS NOT NULL THEN DELETE FROM location WHERE id = rec.location_id; END IF;
+          DELETE FROM classification WHERE id = rec.classification_id; -- cascades its flow-state tagset
+          IF rec.contrib_defaults_id IS NOT NULL THEN DELETE FROM callout_contribution_defaults WHERE id = rec.contrib_defaults_id; END IF;
+          DELETE FROM authorization_policy WHERE id IN (
+            rec.callout_auth_id, rec.framing_auth_id, rec.profile_auth_id,
+            rec.bucket_auth_id, rec.classification_auth_id, rec.tagset_auth_id,
+            rec.default_tagset_auth_id
+          );
+        END LOOP;
+      END $$;
+    `);
+  }
+}

--- a/src/services/infrastructure/entity-resolver/community.resolver.service.ts
+++ b/src/services/infrastructure/entity-resolver/community.resolver.service.ts
@@ -256,6 +256,39 @@ export class CommunityResolverService {
     return community;
   }
 
+  /**
+   * Resolve callout → CalloutsSet → Collaboration → Space (the HOST space) for a
+   * collaboration callout, loading the host space's direct subspaces and their
+   * profiles (workspace#013-spaces-collection-callout). Host-space-generic:
+   * works on any level (L0 or L1) — it returns whatever the host space's
+   * subspaces relation contains (empty for a leaf). Returns null when the
+   * callout is not attached to a space (e.g. a template / knowledge-base
+   * callout), so the SPACES collection resolves to an empty list there.
+   */
+  public async getSpaceWithSubspacesFromCollaborationCallout(
+    calloutId: string
+  ): Promise<Space | null> {
+    const space = await this.entityManager.findOne(Space, {
+      where: {
+        collaboration: {
+          calloutsSet: {
+            callouts: {
+              id: calloutId,
+            },
+          },
+        },
+      },
+      relations: {
+        subspaces: {
+          about: {
+            profile: true,
+          },
+        },
+      },
+    });
+    return space ?? null;
+  }
+
   public async getCommunityFromWhiteboardOrFail(
     whiteboardId: string
   ): Promise<ICommunity> {


### PR DESCRIPTION
## Subspaces callout — server slice

Adds the **`SPACES` callout framing type** — an admin-only callout that renders a space's **subspaces** as a self-populating collection, replacing the hard-coded subspaces block on the L0 Subspaces tab. The deferred counterpart to the shipped Contributors callout (008).

**Cross-repo:** workspace spec [`013-spaces-collection-callout`](https://github.com/alkem-io/agents-hq/tree/013-spaces-collection-callout/specs/013-spaces-collection-callout) · client PR alkem-io/client-web#9981 · tracking story alkem-io/client-web#9931 · epic alkem-io/alkemio#1541 · ADR [0002](https://github.com/alkem-io/agents-hq/blob/013-spaces-collection-callout/docs/decisions/0002-spaces-collection-callout-contract.md)

### Design highlights
- **No new object types** — a subspace is already an `Actor` (`Space` = `ActorType.SPACE`), so `CalloutFraming.subspaces` returns the **existing `Space`/`ISpace`** type (client selects the `SubspaceCard` fields). No `SpaceCollectionItem`, no counts DTO — much smaller than 008 (which needed a projection only because contributors span three actor types).
- **Config-free** framing — no settings JSONB, no counts, no view/map; the framing type alone drives behaviour.
- **Order & pins owned by the space** — a single shared `orderSubspaces` helper (pinned-first → `sortOrder` → `displayName`) used by both `framing.subspaces` and `SpaceService.getSubspaces`, closing the gap where `getSubspaces` previously ignored `pinned`. Never mutates subspace `sortOrder`/`pinned`.
- **Admin-only + collaboration-only** create guard (shared with CONTRIBUTORS via a small helper); **fixed kind** (can't switch a SPACES callout to another framing, never a map). **Not** level-restricted for manual creation (works on L0 or L1); only auto-provisioning is L0-only.
- Reuses existing subspace read authorization — no new visibility semantics.

### Rollout / provisioning
- **Bootstrap**: the platform default L0 space template (`bootstrapTemplateSpaceContentSpaceL0`, `PLATFORM_SPACE`) carries a "Subspaces" callout on the 3rd (Subspaces) flow-state tab.
- **One migration** `BackfillSpacesCalloutL0Subspaces` — backfills every existing **L0 space** and **every L0 space content template** (all of them) on top of the 3rd tab, published + silent + idempotent; `isTemplate` set per source (live `false` / template `true`); never touches sub-L0 or subspace `sortOrder`/`pinned`. **Runbook:** callouts are inserted with empty authorization → run an authorization reset afterward to make them readable.

### Schema
Additive only — `CalloutFramingType.SPACES` enum value + `CalloutFraming.subspaces: [Space!]!`. No breaking changes; no relational schema migration (the backfill only creates rows).

### Testing / gates
`pnpm build`, `pnpm lint` (tsc + Biome) green; Vitest suites for the ordering helper, the collection service, the create guards (incl. admin-can-create-on-L1), config-free/fixed-kind, and the bootstrap template. Migration validated structurally; run `.scripts/migrations/run_validate_migration.sh` against a DB copy before release.

**Ships before** the client PR (client codegen consumes this schema).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `SPACES` callout framing with a Subspaces view.
  * Exposed a `subspaces` field in the API to return the host space’s subspaces for `SPACES` framings.
* **Bug Fixes**
  * Enforced `SPACES` framing to remain config-free and prevented changing `SPACES` to other framing types.
  * Added admin-only and collaboration-only create checks for `SPACES`.
  * Improved pinned-first subspace ordering for consistent display.
* **Tests**
  * Expanded coverage for `SPACES` behavior, framing updates, and subspace ordering.
* **Chores**
  * Backfilled existing L0 spaces with the new Subspaces callout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->