### PR TITLE
Change default calloutDescriptionDisplayMode to Expanded

### DIFF
--- a/specs/043-callout-collapse/data-model.md
+++ b/specs/043-callout-collapse/data-model.md
@@ -22,7 +22,7 @@ New settings sub-object nested within `ISpaceSettings`.
 
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| calloutDescriptionDisplayMode | CalloutDescriptionDisplayMode | Yes | COLLAPSED (new) / EXPANDED (existing) | Default display mode for callout descriptions in this space |
+| calloutDescriptionDisplayMode | CalloutDescriptionDisplayMode | Yes | EXPANDED | Default display mode for callout descriptions in this space |
 
 **Location**: `src/domain/space/space.settings/space.settings.layout.interface.ts`
 
@@ -92,6 +92,7 @@ WHERE "settings" ->> 'layout' IS NOT NULL
 
 | Context | Default Value | Rationale |
 | --- | --- | --- |
-| New space (no template value) | `COLLAPSED` | New spaces benefit from compact layout |
+| New space (no template value) | `EXPANDED` | Callout descriptions visible out-of-the-box; matches platform default templates and runtime fallback |
 | Existing space (migration) | `EXPANDED` | Preserves current behavior |
+| Platform default templates | `EXPANDED` | Set explicitly on the four platform-level default templates so platform-provisioned spaces default to `EXPANDED` |
 | Missing field (runtime fallback) | `EXPANDED` | Defensive default matching pre-feature behavior |

--- a/specs/043-callout-collapse/plan.md
+++ b/specs/043-callout-collapse/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add a new `layout` sub-object to `SpaceSettings` containing a `calloutDescriptionDisplayMode` enum field (`COLLAPSED` | `EXPANDED`). This follows the established sub-object pattern used by `privacy`, `membership`, and `collaboration`. A migration backfills existing spaces with `EXPANDED` (preserving current behavior); new spaces default to `COLLAPSED`. The setting is exposed via GraphQL both through the guarded `settings` resolver and as a public field resolver (no READ privilege required, matching `sortMode` pattern).
+Add a new `layout` sub-object to `SpaceSettings` containing a `calloutDescriptionDisplayMode` enum field (`COLLAPSED` | `EXPANDED`). This follows the established sub-object pattern used by `privacy`, `membership`, and `collaboration`. A migration backfills existing spaces with `EXPANDED` (preserving current behavior); new spaces default to `EXPANDED` (enforced in `SpaceSettingsService.applyCreationDefaults` and by explicitly setting the four platform-level default templates to `EXPANDED` via migration). The setting is exposed via GraphQL both through the guarded `settings` resolver and as a public field resolver (no READ privilege required, matching `sortMode` pattern).
 
 ## Technical Context
 
@@ -319,7 +319,7 @@ FROM "space";
 Expected post-migration result: `missing = 0`.
 
 **Canary rollout plan:**
-1. Deploy the new server image to the **development** environment. Run `migration:run`. Verify via GraphQL Playground that `space.layout.calloutDescriptionDisplayMode` returns `EXPANDED` for existing spaces and `COLLAPSED` for newly created spaces.
+1. Deploy the new server image to the **development** environment. Run `migration:run`. Verify via GraphQL Playground that `space.layout.calloutDescriptionDisplayMode` returns `EXPANDED` for existing spaces and `EXPANDED` for newly created spaces.
 2. Promote to **staging**. Re-run the migration (idempotent; no rows will be updated). Run the integration test suite. Check deployment logs for the `verification passed` line.
 3. Promote to **production**. Monitor the following for 30 minutes post-deploy:
    - Container logs for any `[Migration] WARNING` pattern.

--- a/specs/043-callout-collapse/quickstart.md
+++ b/specs/043-callout-collapse/quickstart.md
@@ -62,7 +62,7 @@ Expected: Returns `COLLAPSED`.
 
 ### 5. Create a new space and verify default
 
-After creating a new space, query its settings. Expected: `calloutDescriptionDisplayMode: COLLAPSED`.
+After creating a new space, query its settings. Expected: `calloutDescriptionDisplayMode: EXPANDED`.
 
 ## Run Tests
 

--- a/specs/043-callout-collapse/research.md
+++ b/specs/043-callout-collapse/research.md
@@ -69,14 +69,14 @@ WHERE "settings" ->> 'layout' IS NULL
 
 ## R6: Default Value for New Spaces
 
-**Decision**: Set `layout.calloutDescriptionDisplayMode = COLLAPSED` during space creation, after template settings are applied.
+**Decision**: Set `layout.calloutDescriptionDisplayMode = EXPANDED` during space creation, after template settings are applied. (Updated 2026-07-06 — originally `COLLAPSED`; see spec Clarifications.)
 
-**Rationale**: Follows the same pattern as `sortMode` default in `space.service.ts`:
+**Rationale**: Follows the same pattern as `sortMode` default in `space.service.ts`, and matches both the runtime resolver fallback and the platform default templates so a new space is `EXPANDED` regardless of which path supplies the value:
 ```typescript
 if (!space.settings.layout?.calloutDescriptionDisplayMode) {
   space.settings.layout = {
     ...space.settings.layout,
-    calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+    calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
   };
 }
 ```

--- a/specs/043-callout-collapse/spec.md
+++ b/specs/043-callout-collapse/spec.md
@@ -26,17 +26,17 @@ As a space administrator, I want to set a space-level callout description displa
 
 ### User Story 2 - Default Display Mode for New Spaces (Priority: P1)
 
-As a platform operator, I want new spaces to default to "Collapsed" callout description display mode, so that new spaces benefit from a compact layout without requiring manual configuration.
+As a platform operator, I want new spaces to default to "Expanded" callout description display mode, so that callout descriptions are visible out-of-the-box without requiring manual configuration.
 
-**Why this priority**: Correct defaults are essential for the feature to work out-of-the-box. New spaces must initialize with the collapsed default.
+**Why this priority**: Correct defaults are essential for the feature to work out-of-the-box. New spaces must initialize with the expanded default.
 
-**Independent Test**: Can be fully tested by creating a new space via the `createSpace` mutation and querying its settings to verify `calloutDescriptionDisplayMode` is `COLLAPSED`.
+**Independent Test**: Can be fully tested by creating a new space via the `createSpace` mutation and querying its settings to verify `calloutDescriptionDisplayMode` is `EXPANDED`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a user creates a new space without specifying `calloutDescriptionDisplayMode`, **When** the space settings are queried, **Then** `calloutDescriptionDisplayMode` is `COLLAPSED`.
-2. **Given** a user creates a new space and explicitly sets `calloutDescriptionDisplayMode: EXPANDED`, **When** the space settings are queried, **Then** `calloutDescriptionDisplayMode` is `EXPANDED`.
-3. **Given** a user creates a new subspace without specifying the display mode, **When** the subspace settings are queried, **Then** `calloutDescriptionDisplayMode` is `COLLAPSED` (independent of parent space setting).
+1. **Given** a user creates a new space without specifying `calloutDescriptionDisplayMode`, **When** the space settings are queried, **Then** `calloutDescriptionDisplayMode` is `EXPANDED`.
+2. **Given** a user creates a new space and explicitly sets `calloutDescriptionDisplayMode: COLLAPSED`, **When** the space settings are queried, **Then** `calloutDescriptionDisplayMode` is `COLLAPSED`.
+3. **Given** a user creates a new subspace without specifying the display mode, **When** the subspace settings are queried, **Then** `calloutDescriptionDisplayMode` is `EXPANDED` (independent of parent space setting).
 
 ---
 
@@ -75,7 +75,7 @@ As a space administrator with subspaces, I want each space and subspace to have 
 
 - What happens if the `layout` object or `calloutDescriptionDisplayMode` field is missing from the JSONB settings? The server falls back to `EXPANDED` to preserve current behavior.
 - What happens if an invalid value is provided for the display mode? The server rejects the mutation with a validation error (enum constraint).
-- What happens when a space is created from a template that has a specific display mode? The template's display mode is inherited during space creation, following existing template-based settings behavior.
+- What happens when a space is created from a template that has a specific display mode? The template's display mode is inherited during space creation, following existing template-based settings behavior. The platform-level default templates carry `EXPANDED`, so platform-provisioned new spaces default to `EXPANDED`.
 
 ## Requirements _(mandatory)_
 
@@ -85,7 +85,7 @@ As a space administrator with subspaces, I want each space and subspace to have 
 - **FR-002**: The `SpaceSettingsLayout` GraphQL type MUST include a `calloutDescriptionDisplayMode` field of enum type `CalloutDescriptionDisplayMode` with values `COLLAPSED` and `EXPANDED`.
 - **FR-003**: The `UpdateSpaceSettingsEntityInput` GraphQL input MUST accept an optional `layout` field of type `UpdateSpaceSettingsLayoutInput`, containing an optional `calloutDescriptionDisplayMode` field.
 - **FR-004**: The `ISpaceSettings` JSONB interface MUST include a `layout` property with nested `calloutDescriptionDisplayMode`, persisted in the existing `settings` JSONB column on the `space` table.
-- **FR-005**: New spaces MUST default to `layout: { calloutDescriptionDisplayMode: COLLAPSED }` when no explicit value is provided during creation.
+- **FR-005**: New spaces MUST default to `layout: { calloutDescriptionDisplayMode: EXPANDED }` when no explicit value is provided during creation. This default is authoritative both in code (`SpaceSettingsService.applyCreationDefaults`) and in the platform-level default space/subspace templates.
 - **FR-006**: A database migration MUST backfill all existing spaces with `layout: { calloutDescriptionDisplayMode: EXPANDED }` in their JSONB settings.
 - **FR-007**: The GraphQL field resolver MUST return `EXPANDED` as the fallback when the `layout` or `calloutDescriptionDisplayMode` field is absent from the stored JSONB (defensive default).
 - **FR-008**: Each space and subspace MUST store its own `layout.calloutDescriptionDisplayMode` independently; no inheritance from parent to child.
@@ -106,11 +106,15 @@ As a space administrator with subspaces, I want each space and subspace to have 
 
 - **SC-001**: Space administrators can update the callout display mode setting via a single GraphQL mutation call.
 - **SC-002**: 100% of existing spaces return `EXPANDED` as their callout display mode after migration, with zero regressions.
-- **SC-003**: 100% of newly created spaces default to `COLLAPSED` without requiring explicit configuration.
+- **SC-003**: 100% of newly created spaces default to `EXPANDED` without requiring explicit configuration.
 - **SC-004**: The display mode setting is independently queryable per space/subspace with no cross-space inheritance.
 - **SC-005**: The migration is fully reversible without data loss in other settings fields.
 
 ## Clarifications
+
+### Session 2026-07-06
+
+- Q: Should the default display mode for newly created spaces be `COLLAPSED` or `EXPANDED`? -> A: `EXPANDED`. The default is flipped from the original `COLLAPSED` to `EXPANDED`. It is enforced both in code (`SpaceSettingsService.applyCreationDefaults`) and by explicitly setting `layout.calloutDescriptionDisplayMode = 'expanded'` on the four platform-level default templates (`platform-space`, `platform-subspace`, `platform-subspace-knowledge`, `platform-space-tutorials`) via migration. Existing spaces are unaffected (already backfilled to `EXPANDED`). The GraphQL schema encodes no default, so `schema.graphql`/`schema-baseline.graphql` remain consistent.
 
 ### Session 2026-03-11
 

--- a/specs/043-callout-collapse/tasks.md
+++ b/specs/043-callout-collapse/tasks.md
@@ -51,15 +51,16 @@
 
 ## Phase 3: User Story 2 — Default Display Mode for New Spaces (Priority: P1)
 
-**Goal**: Newly created spaces default to `COLLAPSED` callout description display mode without requiring explicit configuration.
+**Goal**: Newly created spaces default to `EXPANDED` callout description display mode without requiring explicit configuration.
 
-**Independent Test**: Create a new space via `createSpace` mutation without specifying layout settings, then query `space.settings.layout.calloutDescriptionDisplayMode` and verify it returns `COLLAPSED`.
+**Independent Test**: Create a new space via `createSpace` mutation without specifying layout settings, then query `space.settings.layout.calloutDescriptionDisplayMode` and verify it returns `EXPANDED`.
 
 ### Implementation for User Story 2
 
-- [x] T011 [US2] Add layout default initialization in `createSpace()` in `src/domain/space/space/space.service.ts` — after template settings are applied, set `space.settings.layout = { calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED }` if not already present, following the `sortMode` default pattern
+- [x] T011 [US2] Set the creation default in `SpaceSettingsService.applyCreationDefaults()` (`src/domain/space/space.settings/space.settings.service.ts`) — after template settings are applied, set `calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED` if not already present, following the `sortMode` default pattern
+- [x] T011b [US2] Migration `DefaultPlatformTemplatesCalloutExpanded` — force `layout.calloutDescriptionDisplayMode = 'expanded'` on the four platform-level default templates (`platform-space`, `platform-subspace`, `platform-subspace-knowledge`, `platform-space-tutorials`) so platform-provisioned new spaces default to `EXPANDED` independent of the code fallback
 
-**Checkpoint**: New spaces and subspaces are created with `layout.calloutDescriptionDisplayMode = COLLAPSED`. Verify via creating a space and querying settings.
+**Checkpoint**: New spaces and subspaces are created with `layout.calloutDescriptionDisplayMode = EXPANDED`. Verify via creating a space and querying settings.
 
 ---
 

--- a/src/domain/space/space.settings/space.settings.service.ts
+++ b/src/domain/space/space.settings/space.settings.service.ts
@@ -18,7 +18,7 @@ export class SpaceSettingsService {
     if (!settings.layout?.calloutDescriptionDisplayMode) {
       settings.layout = {
         ...settings.layout,
-        calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+        calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
       };
     }
     return settings;

--- a/src/migrations/1783369909348-DefaultPlatformTemplatesCalloutExpanded.ts
+++ b/src/migrations/1783369909348-DefaultPlatformTemplatesCalloutExpanded.ts
@@ -1,0 +1,120 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Force the platform-level default space/subspace templates to carry
+ * layout.calloutDescriptionDisplayMode = 'expanded'.
+ *
+ * New spaces inherit their settings from these templates first
+ * (SpaceService.createSpace -> templateContentSpace.settings), and only fall
+ * back to the code default in SpaceSettingsService.applyCreationDefaults when
+ * the template does not already specify the value. Setting it explicitly here
+ * makes the EXPANDED default authoritative in the DB for every platform default
+ * template, independent of the code fallback.
+ *
+ * Scope: the four platform-level template_default types. Per-space
+ * 'space-subspace' defaults are intentionally left untouched.
+ */
+export class DefaultPlatformTemplatesCalloutExpanded1783369909348
+  implements MigrationInterface
+{
+  name = 'DefaultPlatformTemplatesCalloutExpanded1783369909348';
+
+  private readonly platformDefaultTypes = [
+    'platform-space',
+    'platform-subspace',
+    'platform-subspace-knowledge',
+    'platform-space-tutorials',
+  ];
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const types = this.platformDefaultTypes;
+
+    const before = await queryRunner.query(
+      `
+      SELECT COUNT(*) AS count
+      FROM "template_content_space" tcs
+      JOIN "template" t ON t."contentSpaceId" = tcs.id
+      JOIN "template_default" td ON td."templateId" = t.id
+      WHERE td.type = ANY($1)
+    `,
+      [types]
+    );
+    console.log(
+      `[Migration] DefaultPlatformTemplatesCalloutExpanded: ${before[0]?.count ?? 0} platform default template content-space(s) targeted`
+    );
+
+    // Force layout.calloutDescriptionDisplayMode = 'expanded'. Ensure the
+    // 'layout' object exists first (it may be missing or JSON null), then set
+    // the nested key with create_missing = true.
+    await queryRunner.query(
+      `
+      UPDATE "template_content_space" AS tcs
+      SET "settings" = jsonb_set(
+        jsonb_set(
+          tcs."settings",
+          '{layout}',
+          CASE
+            WHEN jsonb_typeof(tcs."settings" -> 'layout') = 'object'
+              THEN tcs."settings" -> 'layout'
+            ELSE '{}'::jsonb
+          END,
+          true
+        ),
+        '{layout,calloutDescriptionDisplayMode}',
+        '"expanded"'::jsonb,
+        true
+      )
+      FROM "template" t
+      JOIN "template_default" td ON td."templateId" = t.id
+      WHERE t."contentSpaceId" = tcs.id
+        AND td.type = ANY($1)
+    `,
+      [types]
+    );
+
+    const remaining = await queryRunner.query(
+      `
+      SELECT COUNT(*) AS count
+      FROM "template_content_space" tcs
+      JOIN "template" t ON t."contentSpaceId" = tcs.id
+      JOIN "template_default" td ON td."templateId" = t.id
+      WHERE td.type = ANY($1)
+        AND tcs."settings" -> 'layout' ->> 'calloutDescriptionDisplayMode'
+            IS DISTINCT FROM 'expanded'
+    `,
+      [types]
+    );
+    const notExpanded = parseInt(remaining[0]?.count ?? '0', 10);
+    if (notExpanded > 0) {
+      console.warn(
+        `[Migration] WARNING: DefaultPlatformTemplatesCalloutExpanded: ${notExpanded} platform default template(s) not set to expanded — investigate`
+      );
+    } else {
+      console.log(
+        `[Migration] DefaultPlatformTemplatesCalloutExpanded: verification passed — all targeted templates set to expanded`
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const types = this.platformDefaultTypes;
+
+    // These platform default templates carried no layout key prior to this
+    // migration, so the inverse is to drop the layout key we introduced.
+    await queryRunner.query(
+      `
+      UPDATE "template_content_space" AS tcs
+      SET "settings" = tcs."settings" - 'layout'
+      FROM "template" t
+      JOIN "template_default" td ON td."templateId" = t.id
+      WHERE t."contentSpaceId" = tcs.id
+        AND td.type = ANY($1)
+        AND tcs."settings" -> 'layout' IS NOT NULL
+    `,
+      [types]
+    );
+    console.log(
+      `[Migration] DefaultPlatformTemplatesCalloutExpanded down(): removed layout key from platform default templates`
+    );
+  }
+}

--- a/test/integration/callout-collapse/callout-collapse.spec.ts
+++ b/test/integration/callout-collapse/callout-collapse.spec.ts
@@ -6,7 +6,7 @@
  *      SpaceSettingsService assembled inside a NestJS TestingModule, verifying that
  *      the COLLAPSED / EXPANDED values are persisted and queried back correctly.
  *   2. New-Space defaults – the inline defaulting logic in SpaceService.createSpace()
- *      that seeds COLLAPSED for every new Space record.
+ *      that seeds EXPANDED for every new Space record.
  *   3. Migration idempotency – the AddLayoutSettingsToSpace migration SQL is verified
  *      structurally: the UP query only touches rows where layout is absent, and a
  *      second run produces the same result (idempotent WHERE clause).
@@ -174,7 +174,7 @@ describe('Callout collapse — new Space creation defaults (applyCreationDefault
     await module.close();
   });
 
-  it('space created without calloutDescriptionDisplayMode defaults to COLLAPSED', () => {
+  it('space created without calloutDescriptionDisplayMode defaults to EXPANDED', () => {
     const settings: ISpaceSettings = {
       ...baseSettings(),
       layout: {} as any,
@@ -183,7 +183,7 @@ describe('Callout collapse — new Space creation defaults (applyCreationDefault
     const result = service.applyCreationDefaults(settings);
 
     expect(result.layout.calloutDescriptionDisplayMode).toBe(
-      CalloutDescriptionDisplayMode.COLLAPSED
+      CalloutDescriptionDisplayMode.EXPANDED
     );
   });
 
@@ -203,9 +203,11 @@ describe('Callout collapse — new Space creation defaults (applyCreationDefault
   });
 
   it('settings layout for a new subspace is independent of any parent space value', () => {
+    // Parent explicitly COLLAPSED; the subspace must still take the creation
+    // default (EXPANDED) rather than inheriting the parent's value.
     const parentSettings = baseSettings();
     parentSettings.layout.calloutDescriptionDisplayMode =
-      CalloutDescriptionDisplayMode.EXPANDED;
+      CalloutDescriptionDisplayMode.COLLAPSED;
 
     const subspaceSettings: ISpaceSettings = {
       ...baseSettings(),
@@ -215,11 +217,11 @@ describe('Callout collapse — new Space creation defaults (applyCreationDefault
     const result = service.applyCreationDefaults(subspaceSettings);
 
     expect(result.layout.calloutDescriptionDisplayMode).toBe(
-      CalloutDescriptionDisplayMode.COLLAPSED
+      CalloutDescriptionDisplayMode.EXPANDED
     );
     // Parent unchanged
     expect(parentSettings.layout.calloutDescriptionDisplayMode).toBe(
-      CalloutDescriptionDisplayMode.EXPANDED
+      CalloutDescriptionDisplayMode.COLLAPSED
     );
   });
 

--- a/test/integration/callout-collapse/callout-collapse.spec.ts
+++ b/test/integration/callout-collapse/callout-collapse.spec.ts
@@ -5,7 +5,7 @@
  *   1. The GraphQL mutation path for calloutDescriptionDisplayMode – the
  *      SpaceSettingsService assembled inside a NestJS TestingModule, verifying that
  *      the COLLAPSED / EXPANDED values are persisted and queried back correctly.
- *   2. New-Space defaults – the inline defaulting logic in SpaceService.createSpace()
+ *   2. New-Space defaults – the defaulting logic in SpaceSettingsService.applyCreationDefaults()
  *      that seeds EXPANDED for every new Space record.
  *   3. Migration idempotency – the AddLayoutSettingsToSpace migration SQL is verified
  *      structurally: the UP query only touches rows where layout is absent, and a


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New spaces now default to an expanded callout description display mode.
  * Platform default templates are updated to use the expanded setting consistently.

* **Bug Fixes**
  * Existing spaces and newly created subspaces now follow the expected display behavior.
  * Related defaults and fallback behavior are aligned across setup, migration, and documentation.

* **Documentation**
  * Updated setup, spec, and quickstart guidance to reflect the new default state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->