### PR TITLE
feat(017-combined-subspace-application): combined Subspace application — shared ancestor-chain grant, APPLY exposure, actor-relative reachability

### DIFF
--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -6,6 +6,8 @@ export const CREDENTIAL_RULE_SUBSPACE_PARENT_MEMBER_APPLY =
   'credentialRule-subspaceParentMemberApply';
 export const CREDENTIAL_RULE_SUBSPACE_NON_MEMBER_APPLY =
   'credentialRule-subspaceNonMemberApply';
+export const CREDENTIAL_RULE_SUBSPACE_ANCESTOR_MEMBER_APPLY =
+  'credentialRule-subspaceAncestorMemberApply';
 export const CREDENTIAL_RULE_SPACE_ADMIN_DELETE_SUBSPACE =
   'credentialRule-SpaceAdminDeleteSubspace';
 export const CREDENTIAL_RULE_SPACE_ADMINS = 'credentialRule-spaceAdmins';

--- a/src/common/constants/authorization/credential.rule.constants.ts
+++ b/src/common/constants/authorization/credential.rule.constants.ts
@@ -4,6 +4,8 @@ export const CREDENTIAL_RULE_SUBSPACE_PARENT_MEMBER_JOIN =
   'credentialRule-subspaceParentMemberJoin';
 export const CREDENTIAL_RULE_SUBSPACE_PARENT_MEMBER_APPLY =
   'credentialRule-subspaceParentMemberApply';
+export const CREDENTIAL_RULE_SUBSPACE_NON_MEMBER_APPLY =
+  'credentialRule-subspaceNonMemberApply';
 export const CREDENTIAL_RULE_SPACE_ADMIN_DELETE_SUBSPACE =
   'credentialRule-SpaceAdminDeleteSubspace';
 export const CREDENTIAL_RULE_SPACE_ADMINS = 'credentialRule-spaceAdmins';

--- a/src/domain/access/application/application.service.lifecycle.spec.ts
+++ b/src/domain/access/application/application.service.lifecycle.spec.ts
@@ -4,7 +4,11 @@ import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { type Mock } from 'vitest';
-import { ApplicationLifecycleService } from './application.service.lifecycle';
+import {
+  ApplicationLifecycleService,
+  ApplicationLifecycleState,
+  applicationLifecycleMachine,
+} from './application.service.lifecycle';
 
 describe('ApplicationLifecycleService', () => {
   let service: ApplicationLifecycleService;
@@ -83,6 +87,22 @@ describe('ApplicationLifecycleService', () => {
       const result = service.isFinalState(mockLifecycle);
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('applicationLifecycleMachine definition', () => {
+    it('allows REJECT from `approving` so a failed approval (e.g. FR-015 combined-flow authorisation revoked) is not stranded', () => {
+      const approving = (applicationLifecycleMachine.states as any)[
+        ApplicationLifecycleState.APPROVING
+      ];
+      expect(approving.on.APPROVED.target).toBe(
+        ApplicationLifecycleState.APPROVED
+      );
+      expect(approving.on.REJECT).toBeDefined();
+      expect(approving.on.REJECT.target).toBe(
+        ApplicationLifecycleState.REJECTED
+      );
+      expect(approving.on.REJECT.guard).toBe('hasUpdatePrivilege');
     });
   });
 });

--- a/src/domain/access/application/application.service.lifecycle.ts
+++ b/src/domain/access/application/application.service.lifecycle.ts
@@ -75,6 +75,15 @@ export const applicationLifecycleMachine: ILifecycleDefinition = {
           guard: 'hasGrantPrivilege',
           target: ApplicationLifecycleState.APPROVED,
         },
+        // Escape hatch: the membership grant can fail after entering
+        // `approving` (e.g. the combined-flow authorisation was revoked
+        // between submission and approval — FR-015). Without a transition out
+        // the application would be stranded here, since retrying APPROVED just
+        // re-fails the grant. Allow an admin to REJECT such an application.
+        REJECT: {
+          guard: 'hasUpdatePrivilege',
+          target: ApplicationLifecycleState.REJECTED,
+        },
       },
     },
     approved: {

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.spec.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.spec.ts
@@ -192,6 +192,12 @@ describe('RoleSetResolverMutationsMembership', () => {
         undefined
       );
       (roleSetService.isInRole as Mock).mockResolvedValue(false);
+      // Feature 017: a non-parent-member is only allowed to apply when the
+      // combined-flow preconditions hold; here they do not, so the original
+      // "join the parent first" exception must still fire.
+      (
+        roleSetService.isCombinedApplicationGrantAuthorised as Mock
+      ).mockResolvedValue(false);
 
       await expect(
         resolver.applyForEntryRoleOnRoleSet(actorContext, {
@@ -199,6 +205,46 @@ describe('RoleSetResolverMutationsMembership', () => {
           questions: [],
         } as any)
       ).rejects.toThrow(RoleSetMembershipException);
+    });
+
+    it('should allow a non-parent-member to apply when the combined Subspace flow is authorised', async () => {
+      const actorContext = { actorID: 'user-1' } as any;
+      const parentRoleSet = { id: 'parent-rs' } as any;
+      const mockRoleSet = {
+        id: 'rs-1',
+        type: RoleSetType.SPACE,
+        authorization: { id: 'auth-1' },
+        parentRoleSet,
+      } as any;
+      const mockApplication = { id: 'app-1' } as any;
+
+      (roleSetService.getRoleSetOrFail as Mock).mockResolvedValue(mockRoleSet);
+      (authorizationService.grantAccessOrFail as Mock).mockReturnValue(
+        undefined
+      );
+      // Not a member of the parent...
+      (roleSetService.isInRole as Mock).mockResolvedValue(false);
+      // ...but the combined Subspace application flow is authorised.
+      (
+        roleSetService.isCombinedApplicationGrantAuthorised as Mock
+      ).mockResolvedValue(true);
+      (roleSetService.createApplication as Mock).mockResolvedValue(
+        mockApplication
+      );
+      (applicationService.save as Mock).mockResolvedValue(mockApplication);
+      (applicationService.getApplicationOrFail as Mock).mockResolvedValue(
+        mockApplication
+      );
+      (
+        roleSetAuthorizationService.applyAuthorizationPolicyOnInvitationsApplications as Mock
+      ).mockResolvedValue([]);
+
+      const result = await resolver.applyForEntryRoleOnRoleSet(actorContext, {
+        roleSetID: 'rs-1',
+        questions: [],
+      } as any);
+
+      expect(result).toBe(mockApplication);
     });
   });
 

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -201,10 +201,21 @@ export class RoleSetResolverMutationsMembership {
         RoleName.MEMBER
       );
       if (!userIsMemberInParent) {
-        throw new RoleSetMembershipException(
-          `Unable to apply for Community (${roleSet.id}): user is not a member of the parent Community`,
-          LogContext.COMMUNITY
-        );
+        // Feature 017 — combined Subspace application: a non-parent-member may
+        // apply directly IFF the combined-flow preconditions hold (parent chain
+        // PUBLIC + the ancestor Spaces' `allowSubspaceAdminsToInviteMembers`
+        // enabled). On approval they are registered in the Subspace AND every
+        // missing ancestor. Otherwise today's "join the parent first" still fires.
+        const combinedApplicationAllowed =
+          await this.roleSetService.isCombinedApplicationGrantAuthorised(
+            roleSet
+          );
+        if (!combinedApplicationAllowed) {
+          throw new RoleSetMembershipException(
+            `Unable to apply for Community (${roleSet.id}): user is not a member of the parent Community`,
+            LogContext.COMMUNITY
+          );
+        }
       }
     }
 

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -202,13 +202,17 @@ export class RoleSetResolverMutationsMembership {
       );
       if (!userIsMemberInParent) {
         // Feature 017 — combined Subspace application: a non-parent-member may
-        // apply directly IFF the combined-flow preconditions hold (parent chain
-        // PUBLIC + the ancestor Spaces' `allowSubspaceAdminsToInviteMembers`
-        // enabled). On approval they are registered in the Subspace AND every
-        // missing ancestor. Otherwise today's "join the parent first" still fires.
+        // apply directly IFF the combined-flow preconditions hold for THIS
+        // applicant (actor-relative reachability, ADR 0001 — ancestors they
+        // already belong to impose no requirements; every ancestor they would
+        // be granted into must be PUBLIC with
+        // `allowSubspaceAdminsToInviteMembers` enabled). On approval they are
+        // registered in the Subspace AND every missing ancestor. Otherwise
+        // today's "join the parent first" still fires.
         const combinedApplicationAllowed =
           await this.roleSetService.isCombinedApplicationGrantAuthorised(
-            roleSet
+            roleSet,
+            actorContext.actorID
           );
         if (!combinedApplicationAllowed) {
           throw new RoleSetMembershipException(

--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -1852,12 +1852,9 @@ describe('RoleSetService', () => {
         'space-sub',
         'space-subsub',
       ]);
-      (spaceLookupService.getSpaceOrFail as Mock).mockImplementation(
-        async (spaceID: string) => ({
-          id: spaceID,
-          community: { roleSet: { id: `rs-of-${spaceID}` } },
-        })
-      );
+      (
+        communityResolverService.getRoleSetIdForSpace as Mock
+      ).mockImplementation(async (spaceID: string) => `rs-of-${spaceID}`);
 
       const inAppNotificationService = (service as any)
         .inAppNotificationService;
@@ -1897,6 +1894,80 @@ describe('RoleSetService', () => {
       expect(
         roleSetCacheService.cleanActorMembershipCache
       ).toHaveBeenCalledWith('actor-1', 'rs-parent');
+    });
+
+    it('a descendant deleted mid-cascade does not abort the remaining descendants’ revocations (best-effort cache resolution)', async () => {
+      const roleSet = {
+        id: 'rs-parent',
+        type: RoleSetType.SPACE,
+        roles: [
+          {
+            name: RoleName.MEMBER,
+            credential: { type: 'space-member', resourceID: 'space-parent' },
+            userPolicy: { minimum: -1, maximum: -1 },
+            organizationPolicy: { minimum: -1, maximum: -1 },
+            virtualContributorPolicy: { minimum: -1, maximum: -1 },
+          },
+        ],
+      } as any;
+
+      (actorLookupService.getActorTypeByIdOrFail as Mock).mockResolvedValue(
+        'user'
+      );
+      (actorService.revokeCredential as Mock).mockResolvedValue(undefined);
+      vi.spyOn(service, 'getParentRoleSet').mockResolvedValue(undefined);
+
+      const communityResolverService = (service as any)
+        .communityResolverService;
+      (
+        communityResolverService.getCommunicationForRoleSet as Mock
+      ).mockResolvedValue({ id: 'comm-1' });
+      (
+        communityResolverService.getSpaceForRoleSetOrFail as Mock
+      ).mockResolvedValue({ id: 'space-parent' });
+      // First descendant was deleted concurrently — resolves to undefined
+      // (non-throwing); the second still resolves.
+      (communityResolverService.getRoleSetIdForSpace as Mock)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce('rs-of-space-subsub');
+
+      const communityCommunicationService = (service as any)
+        .communityCommunicationService;
+      (
+        communityCommunicationService.removeMemberFromCommunication as Mock
+      ).mockResolvedValue(undefined);
+
+      const spaceLookupService = (service as any).spaceLookupService;
+      (spaceLookupService.getAllDescendantSpaceIDs as Mock).mockResolvedValue([
+        'space-sub',
+        'space-subsub',
+      ]);
+
+      const inAppNotificationService = (service as any)
+        .inAppNotificationService;
+      (
+        inAppNotificationService.deleteAllForReceiverInSpace as Mock
+      ).mockResolvedValue(undefined);
+      (
+        inAppNotificationService.deleteAllForReceiverInSpaces as Mock
+      ).mockResolvedValue(undefined);
+      (roleSetCacheService.cleanActorMembershipCache as Mock).mockResolvedValue(
+        undefined
+      );
+
+      await expect(
+        service.removeActorFromRole(roleSet, RoleName.MEMBER, 'actor-1', false)
+      ).resolves.toBe('actor-1');
+
+      // Both descendants' credentials were still revoked...
+      expect(actorService.revokeCredential).toHaveBeenCalledWith('actor-1', {
+        type: AuthorizationCredential.SPACE_MEMBER,
+        resourceID: 'space-subsub',
+      });
+      // ...and the surviving descendant's cache was cleaned.
+      expect(
+        roleSetCacheService.cleanActorMembershipCache
+      ).toHaveBeenCalledWith('actor-1', 'rs-of-space-subsub');
     });
   });
 

--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -1,4 +1,5 @@
 import { ActorType } from '@common/enums/actor.type';
+import { AuthorizationCredential } from '@common/enums/authorization.credential';
 import { CommunityMembershipPolicy } from '@common/enums/community.membership.policy';
 import { CommunityMembershipStatus } from '@common/enums/community.membership.status';
 import { RoleName } from '@common/enums/role.name';
@@ -1809,6 +1810,94 @@ describe('RoleSetService', () => {
         roleSetCacheService.cleanActorMembershipCache
       ).toHaveBeenCalledWith('actor-1', 'rs-1');
     });
+
+    it('should clean the membership cache of every descendant role-set when removing MEMBER from a SPACE (cascade)', async () => {
+      const roleSet = {
+        id: 'rs-parent',
+        type: RoleSetType.SPACE,
+        roles: [
+          {
+            name: RoleName.MEMBER,
+            credential: { type: 'space-member', resourceID: 'space-parent' },
+            userPolicy: { minimum: -1, maximum: -1 },
+            organizationPolicy: { minimum: -1, maximum: -1 },
+            virtualContributorPolicy: { minimum: -1, maximum: -1 },
+          },
+        ],
+      } as any;
+
+      (actorLookupService.getActorTypeByIdOrFail as Mock).mockResolvedValue(
+        'user'
+      );
+      (actorService.revokeCredential as Mock).mockResolvedValue(undefined);
+      vi.spyOn(service, 'getParentRoleSet').mockResolvedValue(undefined);
+
+      const communityResolverService = (service as any)
+        .communityResolverService;
+      (
+        communityResolverService.getCommunicationForRoleSet as Mock
+      ).mockResolvedValue({ id: 'comm-1' });
+      (
+        communityResolverService.getSpaceForRoleSetOrFail as Mock
+      ).mockResolvedValue({ id: 'space-parent' });
+
+      const communityCommunicationService = (service as any)
+        .communityCommunicationService;
+      (
+        communityCommunicationService.removeMemberFromCommunication as Mock
+      ).mockResolvedValue(undefined);
+
+      const spaceLookupService = (service as any).spaceLookupService;
+      (spaceLookupService.getAllDescendantSpaceIDs as Mock).mockResolvedValue([
+        'space-sub',
+        'space-subsub',
+      ]);
+      (spaceLookupService.getSpaceOrFail as Mock).mockImplementation(
+        async (spaceID: string) => ({
+          id: spaceID,
+          community: { roleSet: { id: `rs-of-${spaceID}` } },
+        })
+      );
+
+      const inAppNotificationService = (service as any)
+        .inAppNotificationService;
+      (
+        inAppNotificationService.deleteAllForReceiverInSpace as Mock
+      ).mockResolvedValue(undefined);
+      (
+        inAppNotificationService.deleteAllForReceiverInSpaces as Mock
+      ).mockResolvedValue(undefined);
+
+      (roleSetCacheService.cleanActorMembershipCache as Mock).mockResolvedValue(
+        undefined
+      );
+
+      const result = await service.removeActorFromRole(
+        roleSet,
+        RoleName.MEMBER,
+        'actor-1',
+        false
+      );
+
+      expect(result).toBe('actor-1');
+      // Descendant credentials revoked (4 credential types per descendant space)
+      expect(actorService.revokeCredential).toHaveBeenCalledWith('actor-1', {
+        type: AuthorizationCredential.SPACE_MEMBER,
+        resourceID: 'space-sub',
+      });
+      // Cache cleaned for the target role-set AND each descendant's role-set —
+      // a stale descendant isMember entry would otherwise block a later
+      // re-application with ROLE_SET_ALREADY_MEMBER.
+      expect(
+        roleSetCacheService.cleanActorMembershipCache
+      ).toHaveBeenCalledWith('actor-1', 'rs-of-space-sub');
+      expect(
+        roleSetCacheService.cleanActorMembershipCache
+      ).toHaveBeenCalledWith('actor-1', 'rs-of-space-subsub');
+      expect(
+        roleSetCacheService.cleanActorMembershipCache
+      ).toHaveBeenCalledWith('actor-1', 'rs-parent');
+    });
   });
 
   describe('acceptInvitationToRoleSet', () => {
@@ -2642,6 +2731,22 @@ describe('RoleSetService', () => {
       await expect(
         service.isCombinedApplicationGrantAuthorised(target)
       ).resolves.toBe(false);
+    });
+
+    it('(FR-002) returns true when the target itself is PRIVATE but every ancestor is PUBLIC with the setting enabled — reachability is defined over the ancestors only', async () => {
+      const root = spaceRoleSet('root');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PUBLIC, true),
+        target: settings(SpacePrivacyMode.PRIVATE, true), // private target — not part of the gate
+      });
+      await expect(
+        service.isCombinedApplicationGrantAuthorised(target)
+      ).resolves.toBe(true);
     });
 
     it('(US3) returns false when an intermediate ancestor is PRIVATE', async () => {

--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -2419,7 +2419,7 @@ describe('RoleSetService', () => {
       const grantSpy = vi
         .spyOn(service as any, 'grantRoleCredential')
         .mockResolvedValue(undefined);
-      vi.spyOn(service as any, 'applyMemberGrantSideEffects').mockResolvedValue(
+      vi.spyOn(service as any, 'applyRoleGrantSideEffects').mockResolvedValue(
         undefined
       );
       passthroughTransaction();
@@ -2449,7 +2449,7 @@ describe('RoleSetService', () => {
       const grantSpy = vi
         .spyOn(service as any, 'grantRoleCredential')
         .mockResolvedValue(undefined);
-      vi.spyOn(service as any, 'applyMemberGrantSideEffects').mockResolvedValue(
+      vi.spyOn(service as any, 'applyRoleGrantSideEffects').mockResolvedValue(
         undefined
       );
       passthroughTransaction();
@@ -2486,7 +2486,7 @@ describe('RoleSetService', () => {
         .spyOn(service as any, 'grantRoleCredential')
         .mockResolvedValue(undefined);
       const sideEffectsSpy = vi
-        .spyOn(service as any, 'applyMemberGrantSideEffects')
+        .spyOn(service as any, 'applyRoleGrantSideEffects')
         .mockResolvedValue(undefined);
       const transaction = passthroughTransaction();
 
@@ -2505,7 +2505,7 @@ describe('RoleSetService', () => {
       );
       // One post-commit side-effect dispatch per Space joined, events triggered.
       expect(sideEffectsSpy).toHaveBeenCalledTimes(3);
-      expect(sideEffectsSpy.mock.calls.every((c: any[]) => c[4] === true)).toBe(
+      expect(sideEffectsSpy.mock.calls.every((c: any[]) => c[5] === true)).toBe(
         true
       );
     });
@@ -2533,7 +2533,7 @@ describe('RoleSetService', () => {
         }
       );
       const sideEffectsSpy = vi
-        .spyOn(service as any, 'applyMemberGrantSideEffects')
+        .spyOn(service as any, 'applyRoleGrantSideEffects')
         .mockResolvedValue(undefined);
       passthroughTransaction();
 
@@ -2558,6 +2558,14 @@ describe('RoleSetService', () => {
         service,
         'isCombinedApplicationGrantAuthorised'
       ).mockResolvedValue(false);
+      // The applicant IS a member of the parent — today's rule can proceed.
+      vi.spyOn(
+        service as any,
+        'isActorMemberInParentRoleSet'
+      ).mockResolvedValue({
+        parentRoleSet: { id: 'parent' },
+        isMember: true,
+      });
       const chainSpy = vi.spyOn(service, 'getRoleSetAncestorChain');
       const grantSpy = vi
         .spyOn(service as any, 'grantRoleCredential')
@@ -2586,6 +2594,78 @@ describe('RoleSetService', () => {
         expect.anything(),
         true
       );
+    });
+
+    it('(US3/FR-015) fails with an actionable RoleSetMembershipException when authorisation was revoked AND the applicant is not a parent member', async () => {
+      const target = spaceRoleSet('target');
+      vi.spyOn(
+        service,
+        'isCombinedApplicationGrantAuthorised'
+      ).mockResolvedValue(false);
+      // Non-parent-member applicant — today's rule cannot grant the target;
+      // fail clearly instead of assignActorToRole's opaque ValidationException
+      // (the application stays in `approving`, which now supports REJECT).
+      vi.spyOn(
+        service as any,
+        'isActorMemberInParentRoleSet'
+      ).mockResolvedValue({
+        parentRoleSet: { id: 'parent' },
+        isMember: false,
+      });
+      const assignSpy = vi
+        .spyOn(service, 'assignActorToRole')
+        .mockResolvedValue('user-1');
+
+      await expect(
+        service.ensureMemberOfRoleSetAndAncestors(
+          target,
+          'user-1',
+          { actorID: 'user-1' } as any,
+          { source: 'application' }
+        )
+      ).rejects.toThrow(RoleSetMembershipException);
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it('post-commit side-effect failure on one Space does NOT skip the remaining Spaces’ dispatches nor fail the flow (credentials already committed)', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      vi.spyOn(service, 'isMember').mockResolvedValue(false);
+      vi.spyOn(
+        service,
+        'isCombinedApplicationGrantAuthorised'
+      ).mockResolvedValue(true);
+      vi.spyOn(service as any, 'grantRoleCredential').mockResolvedValue(
+        undefined
+      );
+      passthroughTransaction();
+      const sideEffects = vi
+        .spyOn(service as any, 'applyRoleGrantSideEffects')
+        .mockRejectedValueOnce(new Error('matrix hiccup on root'))
+        .mockResolvedValue(undefined);
+
+      await expect(
+        service.ensureMemberOfRoleSetAndAncestors(
+          target,
+          'user-1',
+          { actorID: 'user-1' } as any,
+          { source: 'application' }
+        )
+      ).resolves.toBeUndefined();
+
+      // All three Spaces got their dispatch attempt, in chain order.
+      expect(sideEffects).toHaveBeenCalledTimes(3);
+      expect(sideEffects.mock.calls.map(c => (c[0] as any).id)).toEqual([
+        'root',
+        'mid',
+        'target',
+      ]);
     });
 
     it('(FR-021) notification/event parity: application and invitation emit the SAME per-Space dispatch, one per Space joined', async () => {
@@ -2676,11 +2756,8 @@ describe('RoleSetService', () => {
       const communityResolverService = (service as any)
         .communityResolverService;
       (
-        communityResolverService.getSpaceForRoleSetOrFail as Mock
-      ).mockImplementation(async (roleSetID: string) => ({
-        id: `space-${roleSetID}`,
-        settings: byId[roleSetID],
-      }));
+        communityResolverService.getSpaceSettingsForRoleSet as Mock
+      ).mockImplementation(async (roleSetID: string) => byId[roleSetID]);
     };
 
     it('returns false for a non-SPACE role-set', async () => {
@@ -2874,11 +2951,8 @@ describe('RoleSetService', () => {
       const communityResolverService = (service as any)
         .communityResolverService;
       (
-        communityResolverService.getSpaceForRoleSetOrFail as Mock
-      ).mockImplementation(async (roleSetID: string) => ({
-        id: `space-${roleSetID}`,
-        settings: byId[roleSetID],
-      }));
+        communityResolverService.getSpaceSettingsForRoleSet as Mock
+      ).mockImplementation(async (roleSetID: string) => byId[roleSetID]);
     };
 
     it('returns globalRegistered when every ancestor is PUBLIC + opted in', async () => {

--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -2767,5 +2767,213 @@ describe('RoleSetService', () => {
         service.isCombinedApplicationGrantAuthorised(target)
       ).resolves.toBe(false);
     });
+
+    describe('actor-relative reachability (ADR 0001 — explicit scope decision 2026-07-07)', () => {
+      const mockActorMemberships = (memberOf: string[]) => {
+        vi.spyOn(service, 'isMember').mockImplementation(
+          async (_actorID: string, rs: IRoleSet) => memberOf.includes(rs.id)
+        );
+      };
+
+      it('returns true for an actor who is a member of the PRIVATE root when everything below is public + opted in', async () => {
+        const root = spaceRoleSet('root');
+        const mid = spaceRoleSet('mid');
+        const target = spaceRoleSet('target');
+        vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+          root,
+          mid,
+          target,
+        ]);
+        mockSpaceSettings({
+          root: settings(SpacePrivacyMode.PRIVATE, true), // private — but owned
+          mid: settings(SpacePrivacyMode.PUBLIC, true),
+          target: settings(SpacePrivacyMode.PUBLIC, true),
+        });
+        mockActorMemberships(['root']);
+        await expect(
+          service.isCombinedApplicationGrantAuthorised(target, 'actor-1')
+        ).resolves.toBe(true);
+      });
+
+      it('setting is only required on ancestors actually being granted — an owned ancestor with the setting OFF does not block', async () => {
+        const root = spaceRoleSet('root');
+        const mid = spaceRoleSet('mid');
+        const target = spaceRoleSet('target');
+        vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+          root,
+          mid,
+          target,
+        ]);
+        mockSpaceSettings({
+          root: settings(SpacePrivacyMode.PRIVATE, false), // owned — setting irrelevant
+          mid: settings(SpacePrivacyMode.PUBLIC, true),
+          target: settings(SpacePrivacyMode.PUBLIC, true),
+        });
+        mockActorMemberships(['root']);
+        await expect(
+          service.isCombinedApplicationGrantAuthorised(target, 'actor-1')
+        ).resolves.toBe(true);
+      });
+
+      it('returns false for an actor who is NOT a member of the PRIVATE root (generic non-member outcome unchanged)', async () => {
+        const root = spaceRoleSet('root');
+        const mid = spaceRoleSet('mid');
+        const target = spaceRoleSet('target');
+        vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+          root,
+          mid,
+          target,
+        ]);
+        mockSpaceSettings({
+          root: settings(SpacePrivacyMode.PRIVATE, true),
+          mid: settings(SpacePrivacyMode.PUBLIC, true),
+          target: settings(SpacePrivacyMode.PUBLIC, true),
+        });
+        mockActorMemberships([]);
+        await expect(
+          service.isCombinedApplicationGrantAuthorised(target, 'actor-1')
+        ).resolves.toBe(false);
+      });
+
+      it('returns false when a NON-owned ancestor below the owned one is private', async () => {
+        const root = spaceRoleSet('root');
+        const mid = spaceRoleSet('mid');
+        const target = spaceRoleSet('target');
+        vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+          root,
+          mid,
+          target,
+        ]);
+        mockSpaceSettings({
+          root: settings(SpacePrivacyMode.PRIVATE, true), // owned
+          mid: settings(SpacePrivacyMode.PRIVATE, true), // not owned + private
+          target: settings(SpacePrivacyMode.PUBLIC, true),
+        });
+        mockActorMemberships(['root']);
+        await expect(
+          service.isCombinedApplicationGrantAuthorised(target, 'actor-1')
+        ).resolves.toBe(false);
+      });
+    });
+  });
+
+  describe('getCombinedApplicationEligibleCriteria (feature 017 — APPLY exposure)', () => {
+    const spaceRoleSet = (id: string): IRoleSet =>
+      ({ id, type: RoleSetType.SPACE }) as unknown as IRoleSet;
+
+    const settings = (mode: SpacePrivacyMode, allow: boolean) =>
+      ({
+        privacy: { mode },
+        membership: {
+          policy: CommunityMembershipPolicy.APPLICATIONS,
+          allowSubspaceAdminsToInviteMembers: allow,
+        },
+      }) as any;
+
+    const mockSpaceSettings = (byId: Record<string, any>) => {
+      const communityResolverService = (service as any)
+        .communityResolverService;
+      (
+        communityResolverService.getSpaceForRoleSetOrFail as Mock
+      ).mockImplementation(async (roleSetID: string) => ({
+        id: `space-${roleSetID}`,
+        settings: byId[roleSetID],
+      }));
+    };
+
+    it('returns globalRegistered when every ancestor is PUBLIC + opted in', async () => {
+      const root = spaceRoleSet('root');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PUBLIC, true),
+        target: settings(SpacePrivacyMode.PRIVATE, true), // target privacy irrelevant
+      });
+      await expect(
+        service.getCombinedApplicationEligibleCriteria(target)
+      ).resolves.toEqual({ kind: 'globalRegistered' });
+    });
+
+    it('returns the deepest private ancestor MEMBER credential when everything below it is public + opted in', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PRIVATE, true), // deepest (only) private ancestor
+        mid: settings(SpacePrivacyMode.PUBLIC, true),
+        target: settings(SpacePrivacyMode.PUBLIC, true),
+      });
+      const rootMemberCredential = {
+        type: 'space-member',
+        resourceID: 'space-root',
+      } as any;
+      vi.spyOn(service, 'getCredentialDefinitionForRole').mockResolvedValue(
+        rootMemberCredential
+      );
+      await expect(
+        service.getCombinedApplicationEligibleCriteria(target)
+      ).resolves.toEqual({
+        kind: 'credential',
+        credential: rootMemberCredential,
+      });
+      expect(service.getCredentialDefinitionForRole).toHaveBeenCalledWith(
+        root,
+        RoleName.MEMBER
+      );
+    });
+
+    it('returns undefined when the deepest private ancestor is the direct parent (covered by the parent-member rule)', async () => {
+      const root = spaceRoleSet('root');
+      const parent = spaceRoleSet('parent');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        parent,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PUBLIC, true),
+        parent: settings(SpacePrivacyMode.PRIVATE, true), // private direct parent
+        target: settings(SpacePrivacyMode.PUBLIC, true),
+      });
+      await expect(
+        service.getCombinedApplicationEligibleCriteria(target)
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns undefined when an ancestor below the deepest private one is not opted in', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PRIVATE, true),
+        mid: settings(SpacePrivacyMode.PUBLIC, false), // setting OFF on granted ancestor
+        target: settings(SpacePrivacyMode.PUBLIC, true),
+      });
+      await expect(
+        service.getCombinedApplicationEligibleCriteria(target)
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns undefined for an L0 Space', async () => {
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([target]);
+      await expect(
+        service.getCombinedApplicationEligibleCriteria(target)
+      ).resolves.toBeUndefined();
+    });
   });
 });

--- a/src/domain/access/role-set/role.set.service.spec.ts
+++ b/src/domain/access/role-set/role.set.service.spec.ts
@@ -1,6 +1,9 @@
+import { ActorType } from '@common/enums/actor.type';
+import { CommunityMembershipPolicy } from '@common/enums/community.membership.policy';
 import { CommunityMembershipStatus } from '@common/enums/community.membership.status';
 import { RoleName } from '@common/enums/role.name';
 import { RoleSetType } from '@common/enums/role.set.type';
+import { SpacePrivacyMode } from '@common/enums/space.privacy.mode';
 import {
   EntityNotFoundException,
   EntityNotInitializedException,
@@ -2289,6 +2292,375 @@ describe('RoleSetService', () => {
       expect(
         platformInvitationService.deletePlatformInvitation
       ).toHaveBeenCalledWith({ ID: 'plat-1' });
+    });
+  });
+
+  // Feature 017 — Combined Subspace application. Shared ancestor-chain grant
+  // (FR-006/FR-017/FR-020) + approval-time re-evaluation gate (FR-015) +
+  // notification/event parity (FR-021).
+  describe('ensureMemberOfRoleSetAndAncestors (shared grant — feature 017)', () => {
+    const spaceRoleSet = (id: string): IRoleSet =>
+      ({ id, type: RoleSetType.SPACE }) as unknown as IRoleSet;
+
+    const passthroughTransaction = () => {
+      const transaction = vi.fn(async (cb: any) => cb({} as any));
+      (roleSetRepository as any).manager = { transaction };
+      return transaction;
+    };
+
+    beforeEach(() => {
+      (actorLookupService.getActorTypeByIdOrFail as Mock).mockResolvedValue(
+        ActorType.USER
+      );
+    });
+
+    it('(a) grants only the MISSING ancestors — already-member ancestors are skipped (FR-006)', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      // Already a member of root, missing mid + target.
+      vi.spyOn(service, 'isMember').mockImplementation(
+        async (_actorID: string, rs: IRoleSet) => rs.id === 'root'
+      );
+      const grantSpy = vi
+        .spyOn(service as any, 'grantRoleCredential')
+        .mockResolvedValue(undefined);
+      vi.spyOn(service as any, 'applyMemberGrantSideEffects').mockResolvedValue(
+        undefined
+      );
+      passthroughTransaction();
+
+      await service.ensureMemberOfRoleSetAndAncestors(
+        target,
+        'user-1',
+        { actorID: 'user-1' } as any,
+        { source: 'invitation', invitedToParent: true }
+      );
+
+      const grantedIds = grantSpy.mock.calls.map((c: any[]) => c[0].id);
+      expect(grantedIds).toEqual(['mid', 'target']);
+      expect(grantedIds).not.toContain('root');
+    });
+
+    it('(b) grants the chain TOP-DOWN (root first) so the parent invariant holds', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      vi.spyOn(service, 'isMember').mockResolvedValue(false);
+      const grantSpy = vi
+        .spyOn(service as any, 'grantRoleCredential')
+        .mockResolvedValue(undefined);
+      vi.spyOn(service as any, 'applyMemberGrantSideEffects').mockResolvedValue(
+        undefined
+      );
+      passthroughTransaction();
+
+      await service.ensureMemberOfRoleSetAndAncestors(
+        target,
+        'user-1',
+        { actorID: 'user-1' } as any,
+        { source: 'invitation', invitedToParent: true }
+      );
+
+      expect(grantSpy.mock.calls.map((c: any[]) => c[0].id)).toEqual([
+        'root',
+        'mid',
+        'target',
+      ]);
+    });
+
+    it('(c) full 3-level chain grant for a non-member application, all inside one transaction (FR-006/FR-020)', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      vi.spyOn(
+        service,
+        'isCombinedApplicationGrantAuthorised'
+      ).mockResolvedValue(true);
+      vi.spyOn(service, 'isMember').mockResolvedValue(false);
+      const grantSpy = vi
+        .spyOn(service as any, 'grantRoleCredential')
+        .mockResolvedValue(undefined);
+      const sideEffectsSpy = vi
+        .spyOn(service as any, 'applyMemberGrantSideEffects')
+        .mockResolvedValue(undefined);
+      const transaction = passthroughTransaction();
+
+      await service.ensureMemberOfRoleSetAndAncestors(
+        target,
+        'user-1',
+        { actorID: 'user-1' } as any,
+        { source: 'application' }
+      );
+
+      expect(transaction).toHaveBeenCalledTimes(1);
+      expect(grantSpy).toHaveBeenCalledTimes(3);
+      // The credential write is threaded with the transactional EntityManager.
+      expect(grantSpy.mock.calls.every((c: any[]) => c[4] !== undefined)).toBe(
+        true
+      );
+      // One post-commit side-effect dispatch per Space joined, events triggered.
+      expect(sideEffectsSpy).toHaveBeenCalledTimes(3);
+      expect(sideEffectsSpy.mock.calls.every((c: any[]) => c[4] === true)).toBe(
+        true
+      );
+    });
+
+    it('(d) rolls back atomically on a mid-chain failure — no partial side-effects, error propagates (FR-020)', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      vi.spyOn(
+        service,
+        'isCombinedApplicationGrantAuthorised'
+      ).mockResolvedValue(true);
+      vi.spyOn(service, 'isMember').mockResolvedValue(false);
+      vi.spyOn(service as any, 'grantRoleCredential').mockImplementation(
+        async (...args: unknown[]) => {
+          const rs = args[0] as IRoleSet;
+          if (rs.id === 'mid') {
+            throw new Error('grant failed mid-chain');
+          }
+        }
+      );
+      const sideEffectsSpy = vi
+        .spyOn(service as any, 'applyMemberGrantSideEffects')
+        .mockResolvedValue(undefined);
+      passthroughTransaction();
+
+      await expect(
+        service.ensureMemberOfRoleSetAndAncestors(
+          target,
+          'user-1',
+          { actorID: 'user-1' } as any,
+          { source: 'application' }
+        )
+      ).rejects.toThrow('grant failed mid-chain');
+
+      // Post-commit side-effects (events/notifications) must NOT run when the
+      // transaction failed — no membership is announced for a rolled-back grant.
+      expect(sideEffectsSpy).not.toHaveBeenCalled();
+    });
+
+    it('(US3/FR-015) withholds ancestor grants and falls back to today’s single-target rule when authorisation was revoked at approval time', async () => {
+      const target = spaceRoleSet('target');
+      // Combined authorisation no longer holds at approval time.
+      vi.spyOn(
+        service,
+        'isCombinedApplicationGrantAuthorised'
+      ).mockResolvedValue(false);
+      const chainSpy = vi.spyOn(service, 'getRoleSetAncestorChain');
+      const grantSpy = vi
+        .spyOn(service as any, 'grantRoleCredential')
+        .mockResolvedValue(undefined);
+      const assignSpy = vi
+        .spyOn(service, 'assignActorToRole')
+        .mockResolvedValue('user-1');
+      const transaction = passthroughTransaction();
+
+      await service.ensureMemberOfRoleSetAndAncestors(
+        target,
+        'user-1',
+        { actorID: 'user-1' } as any,
+        { source: 'application' }
+      );
+
+      // No ancestor walk, no atomic ancestor grants...
+      expect(chainSpy).not.toHaveBeenCalled();
+      expect(grantSpy).not.toHaveBeenCalled();
+      expect(transaction).not.toHaveBeenCalled();
+      // ...the target grant follows today's rules (parent-membership enforced).
+      expect(assignSpy).toHaveBeenCalledWith(
+        target,
+        RoleName.MEMBER,
+        'user-1',
+        expect.anything(),
+        true
+      );
+    });
+
+    it('(FR-021) notification/event parity: application and invitation emit the SAME per-Space dispatch, one per Space joined', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      const setupChain = () => {
+        vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+          root,
+          mid,
+          target,
+        ]);
+        vi.spyOn(service, 'isMember').mockResolvedValue(false);
+        vi.spyOn(
+          service,
+          'isCombinedApplicationGrantAuthorised'
+        ).mockResolvedValue(true);
+        vi.spyOn(service as any, 'grantRoleCredential').mockResolvedValue(
+          undefined
+        );
+        passthroughTransaction();
+        // actorAddedToRole is the single per-Space membership-event dispatch
+        // point shared by both flows.
+        return vi
+          .spyOn(service as any, 'actorAddedToRole')
+          .mockResolvedValue(undefined);
+      };
+
+      const applicationDispatch = setupChain();
+      await service.ensureMemberOfRoleSetAndAncestors(
+        target,
+        'user-1',
+        { actorID: 'user-1' } as any,
+        { source: 'application' }
+      );
+      const applicationCalls = applicationDispatch.mock.calls.map(
+        (c: any[]) => ({
+          roleSetId: c[2].id,
+          triggerEvents: c[5],
+        })
+      );
+
+      vi.restoreAllMocks();
+      (actorLookupService.getActorTypeByIdOrFail as Mock).mockResolvedValue(
+        ActorType.USER
+      );
+
+      const invitationDispatch = setupChain();
+      await service.ensureMemberOfRoleSetAndAncestors(
+        target,
+        'user-1',
+        { actorID: 'user-1' } as any,
+        { source: 'invitation', invitedToParent: true }
+      );
+      const invitationCalls = invitationDispatch.mock.calls.map((c: any[]) => ({
+        roleSetId: c[2].id,
+        triggerEvents: c[5],
+      }));
+
+      // Same number of dispatches (one per Space joined), same Spaces, same
+      // trigger flag — no new, aggregated, or suppressed events.
+      expect(applicationCalls).toEqual([
+        { roleSetId: 'root', triggerEvents: true },
+        { roleSetId: 'mid', triggerEvents: true },
+        { roleSetId: 'target', triggerEvents: true },
+      ]);
+      expect(invitationCalls).toEqual(applicationCalls);
+    });
+  });
+
+  // Feature 017 — the combined-flow authorisation predicate. Drives BOTH the
+  // client-facing APPLY privilege exposure (T009) and the approval-time gate
+  // (T013), so the setting (US2/FR-003/FR-014) and privacy (US3) govern both.
+  describe('isCombinedApplicationGrantAuthorised (feature 017)', () => {
+    const spaceRoleSet = (id: string): IRoleSet =>
+      ({ id, type: RoleSetType.SPACE }) as unknown as IRoleSet;
+
+    const settings = (mode: SpacePrivacyMode, allow: boolean) =>
+      ({
+        privacy: { mode },
+        membership: {
+          policy: CommunityMembershipPolicy.APPLICATIONS,
+          allowSubspaceAdminsToInviteMembers: allow,
+        },
+      }) as any;
+
+    const mockSpaceSettings = (byId: Record<string, any>) => {
+      const communityResolverService = (service as any)
+        .communityResolverService;
+      (
+        communityResolverService.getSpaceForRoleSetOrFail as Mock
+      ).mockImplementation(async (roleSetID: string) => ({
+        id: `space-${roleSetID}`,
+        settings: byId[roleSetID],
+      }));
+    };
+
+    it('returns false for a non-SPACE role-set', async () => {
+      const orgRoleSet = {
+        id: 'org',
+        type: RoleSetType.ORGANIZATION,
+      } as unknown as IRoleSet;
+      await expect(
+        service.isCombinedApplicationGrantAuthorised(orgRoleSet)
+      ).resolves.toBe(false);
+    });
+
+    it('returns false for an L0 Space (no ancestors — combined flow N/A)', async () => {
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([target]);
+      await expect(
+        service.isCombinedApplicationGrantAuthorised(target)
+      ).resolves.toBe(false);
+    });
+
+    it('returns true when the whole chain is PUBLIC and every ancestor has the setting enabled', async () => {
+      const root = spaceRoleSet('root');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PUBLIC, true),
+        target: settings(SpacePrivacyMode.PUBLIC, true),
+      });
+      await expect(
+        service.isCombinedApplicationGrantAuthorised(target)
+      ).resolves.toBe(true);
+    });
+
+    it('(US2/FR-003) returns false when the parent setting is disabled', async () => {
+      const root = spaceRoleSet('root');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PUBLIC, false), // setting OFF
+        target: settings(SpacePrivacyMode.PUBLIC, true),
+      });
+      await expect(
+        service.isCombinedApplicationGrantAuthorised(target)
+      ).resolves.toBe(false);
+    });
+
+    it('(US3) returns false when an intermediate ancestor is PRIVATE', async () => {
+      const root = spaceRoleSet('root');
+      const mid = spaceRoleSet('mid');
+      const target = spaceRoleSet('target');
+      vi.spyOn(service, 'getRoleSetAncestorChain').mockResolvedValue([
+        root,
+        mid,
+        target,
+      ]);
+      mockSpaceSettings({
+        root: settings(SpacePrivacyMode.PUBLIC, true),
+        mid: settings(SpacePrivacyMode.PRIVATE, true), // private intermediate
+        target: settings(SpacePrivacyMode.PUBLIC, true),
+      });
+      await expect(
+        service.isCombinedApplicationGrantAuthorised(target)
+      ).resolves.toBe(false);
     });
   });
 });

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -737,17 +737,7 @@ export class RoleSetService {
     // 4. Assign role credential
     await this.grantRoleCredential(roleSet, roleType, actorID, actorType);
 
-    // 5. Clear caches (applies to all actors)
-    await this.roleSetCacheService.deleteOpenApplicationFromCache(
-      actorID,
-      roleSet.id
-    );
-    await this.roleSetCacheService.deleteOpenInvitationFromCache(
-      actorID,
-      roleSet.id
-    );
-
-    // 6. Handle implicit roles (for ALL actor types - any actor can be admin!)
+    // 5. Handle implicit roles (for ALL actor types - any actor can be admin!)
     switch (roleSet.type) {
       case RoleSetType.SPACE: {
         if (roleType === RoleName.ADMIN && parentRoleSet) {
@@ -792,27 +782,17 @@ export class RoleSetService {
       }
     }
 
-    // 7. Post-assignment processing (unified for all actors)
-    await this.actorAddedToRole(
-      actorID,
-      actorType,
+    // 6. Post-assignment side-effects (cache clears + community events /
+    // notifications / Matrix membership + type-specific extensions) — one
+    // shared sequence with the ancestor-chain grant path (FR-021).
+    await this.applyRoleGrantSideEffects(
       roleSet,
       roleType,
+      actorID,
+      actorType,
       actorContext,
       triggerNewMemberEvents
     );
-
-    // 8. Type-specific extensions (can be moved to events later)
-    if (
-      actorType === ActorType.VIRTUAL_CONTRIBUTOR &&
-      roleSet.type === RoleSetType.SPACE
-    ) {
-      const space =
-        await this.communityResolverService.getSpaceForRoleSetOrFail(
-          roleSet.id
-        );
-      void this.aiServerAdapter.ensureContextIsLoaded(space.id);
-    }
 
     return actorID;
   }
@@ -2021,18 +2001,50 @@ export class RoleSetService {
 
         // POST-COMMIT (outside the transaction): membership events /
         // notifications / Matrix room membership / caches, one dispatch per
-        // Space joined (FR-021 — parity with the invitation path).
+        // Space joined (FR-021 — parity with the invitation path). The
+        // credentials are already committed, so these dispatches are
+        // best-effort: a failure on one Space is logged and MUST NOT skip the
+        // remaining Spaces' dispatches nor fail the whole flow — throwing
+        // here would leave the caller's lifecycle out of sync with the
+        // committed membership state.
         for (const grantedRoleSet of toGrant) {
-          await this.applyMemberGrantSideEffects(
-            grantedRoleSet,
-            actorID,
-            actorType,
-            actorContext,
-            true
-          );
+          try {
+            await this.applyRoleGrantSideEffects(
+              grantedRoleSet,
+              RoleName.MEMBER,
+              actorID,
+              actorType,
+              actorContext,
+              true
+            );
+          } catch (e: any) {
+            this.logger.error(
+              `Post-commit member-grant side-effects failed for roleSet ${grantedRoleSet.id}, actor ${actorID}: ${e}`,
+              e?.stack,
+              LogContext.COMMUNITY
+            );
+          }
         }
       }
     } else {
+      if (opts.source === 'application') {
+        // FR-015: the combined-flow authorisation was revoked between
+        // submission and approval — ancestor grants are withheld. When the
+        // applicant is a member of the immediate parent the target grant
+        // still follows today's rules below; otherwise fail with an
+        // actionable error instead of assignActorToRole's opaque parent-
+        // membership ValidationException. The application remains in
+        // `approving`, from which an admin can REJECT it (see the
+        // application lifecycle machine).
+        const { isMember: hasMemberRoleInParent } =
+          await this.isActorMemberInParentRoleSet(actorID, targetRoleSet.id);
+        if (!hasMemberRoleInParent) {
+          throw new RoleSetMembershipException(
+            'Application approval not possible: the combined-flow authorisation was revoked after submission (an ancestor Space is no longer public or its setting was disabled) and the applicant is not a member of the parent Space. Reject the application, or restore the ancestor chain and retry.',
+            LogContext.COMMUNITY
+          );
+        }
+      }
       // Not authorised to grant the ancestor chain — grant only the target via
       // the standard path (enforces the parent-membership precondition; today's
       // behaviour). For an application this is the FR-015 safe fallback.
@@ -2237,24 +2249,27 @@ export class RoleSetService {
     if (roleSet.type !== RoleSetType.SPACE) {
       return undefined;
     }
-    const space = await this.communityResolverService.getSpaceForRoleSetOrFail(
-      roleSet.id
-    );
-    return space.settings;
+    // Settings-only read — this runs per-ancestor on hot paths (authorization
+    // resets walk it for every APPLICATIONS subspace), so avoid the full Space
+    // + about.profile hydration of getSpaceForRoleSetOrFail.
+    return this.communityResolverService.getSpaceSettingsForRoleSet(roleSet.id);
   }
 
   /**
-   * The post-commit side-effects of a MEMBER grant, factored out so the shared
-   * ancestor-chain grant reproduces exactly what {@link assignActorToRole} emits
-   * (cache clears + community events/notifications/Matrix membership), one
-   * dispatch per Space joined (FR-021). Ancestor grants are always MEMBER, so the
-   * ADMIN-only implicit-role branch of assignActorToRole never applies here.
+   * The post-grant side-effects of a role grant (cache clears + community
+   * events/notifications/Matrix membership + type-specific extensions) — the
+   * SINGLE owner of this sequence, consumed by both {@link assignActorToRole}
+   * and the shared ancestor-chain grant (one dispatch per Space joined,
+   * FR-021). The implicit-role handling (ADMIN/OWNER credentials) stays in
+   * assignActorToRole — ancestor grants are always MEMBER, so it never applies
+   * to the chain path.
    */
-  private async applyMemberGrantSideEffects(
+  private async applyRoleGrantSideEffects(
     roleSet: IRoleSet,
+    roleType: RoleName,
     actorID: string,
     actorType: ActorType,
-    actorContext: ActorContext,
+    actorContext: ActorContext | undefined,
     triggerNewMemberEvents: boolean
   ): Promise<void> {
     await this.roleSetCacheService.deleteOpenApplicationFromCache(
@@ -2270,7 +2285,7 @@ export class RoleSetService {
       actorID,
       actorType,
       roleSet,
-      RoleName.MEMBER,
+      roleType,
       actorContext,
       triggerNewMemberEvents
     );

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1383,6 +1383,22 @@ export class RoleSetService {
           resourceID: spaceID,
         });
       }
+
+      // Invalidate the cached membership state on the descendant's role-set:
+      // isMember() / membership-status reads are cache-first, so a stale entry
+      // would keep reporting the revoked membership (e.g. blocking a later
+      // re-application with ROLE_SET_ALREADY_MEMBER).
+      const descendantSpace = await this.spaceLookupService.getSpaceOrFail(
+        spaceID,
+        { relations: { community: { roleSet: true } } }
+      );
+      const descendantRoleSetID = descendantSpace.community?.roleSet?.id;
+      if (descendantRoleSetID) {
+        await this.roleSetCacheService.cleanActorMembershipCache(
+          actorID,
+          descendantRoleSetID
+        );
+      }
     }
   }
 
@@ -2091,9 +2107,12 @@ export class RoleSetService {
   /**
    * Re-evaluates (FR-015) whether the combined Subspace-application flow is
    * authorised to grant the ancestor chain for the supplied target role-set:
-   * every Space in the chain (target included, for reachability) is PUBLIC and
-   * every ANCESTOR Space (parent .. root) has `allowSubspaceAdminsToInviteMembers`
-   * enabled. An L0 Space (no parent) is not part of the combined flow.
+   * every ANCESTOR Space (parent .. root) is PUBLIC (FR-002 — reachability is
+   * defined over the ancestors; the target's own privacy is not part of the
+   * gate, since a Space with an application membership policy accepts
+   * applications regardless of its privacy mode) and every ancestor Space has
+   * `allowSubspaceAdminsToInviteMembers` enabled (FR-003). An L0 Space (no
+   * parent) is not part of the combined flow.
    *
    * This same predicate drives the client-facing APPLY privilege exposure so the
    * offered entry point and the actual grant stay consistent (contract §1/§2).
@@ -2105,22 +2124,18 @@ export class RoleSetService {
       return false;
     }
     const chain = await this.getRoleSetAncestorChain(targetRoleSet);
-    const ancestors = chain.slice(0, -1); // parent .. root (excludes target)
+    const ancestors = chain.slice(0, -1); // root .. parent (excludes target)
     if (ancestors.length === 0) {
       return false; // L0 Space — no combined flow
     }
-    // Whole chain must be reachable (public) for a non-member.
-    for (const roleSetInChain of chain) {
-      const settings = await this.getSpaceSettingsForRoleSet(roleSetInChain);
+    // Every ancestor Space must be reachable (public) for a non-member and
+    // must have opted in to admitting members via a descendant application.
+    for (const ancestorRoleSet of ancestors) {
+      const settings = await this.getSpaceSettingsForRoleSet(ancestorRoleSet);
       if (!settings || settings.privacy.mode !== SpacePrivacyMode.PUBLIC) {
         return false;
       }
-    }
-    // Every ancestor Space must have opted in to admitting members via a
-    // descendant application/invitation.
-    for (const ancestorRoleSet of ancestors) {
-      const settings = await this.getSpaceSettingsForRoleSet(ancestorRoleSet);
-      if (!settings?.membership.allowSubspaceAdminsToInviteMembers) {
+      if (!settings.membership.allowSubspaceAdminsToInviteMembers) {
         return false;
       }
     }

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -11,6 +11,7 @@ import { RoleName } from '@common/enums/role.name';
 import { RoleSetRoleImplicit } from '@common/enums/role.set.role.implicit';
 import { RoleSetType } from '@common/enums/role.set.type';
 import { RoleSetUpdateType } from '@common/enums/role.set.update.type';
+import { SpacePrivacyMode } from '@common/enums/space.privacy.mode';
 import {
   EntityNotFoundException,
   EntityNotInitializedException,
@@ -48,13 +49,14 @@ import { UserLookupService } from '@domain/community/user-lookup/user.lookup.ser
 import { IVirtualContributor } from '@domain/community/virtual-contributor/virtual.contributor.interface';
 import { VirtualContributorLookupService } from '@domain/community/virtual-contributor-lookup/virtual.contributor.lookup.service';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
+import { ISpaceSettings } from '@domain/space/space.settings/space.settings.interface';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { InAppNotificationService } from '@platform/in-app-notification/in.app.notification.service';
 import { AiServerAdapter } from '@services/adapters/ai-server-adapter/ai.server.adapter';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, In, Not, Repository } from 'typeorm';
+import { EntityManager, FindOneOptions, In, Not, Repository } from 'typeorm';
 import { IActorRolePolicy } from '../role/actor.role.policy.interface';
 import { IRole } from '../role/role.interface';
 import { RoleService } from '../role/role.service';
@@ -63,6 +65,28 @@ import { RoleSet } from './role.set.entity';
 import { IRoleSet } from './role.set.interface';
 import { RoleSetCacheService } from './role.set.service.cache';
 import { RoleSetEventsService } from './role.set.service.events';
+
+/**
+ * Options for {@link RoleSetService.ensureMemberOfRoleSetAndAncestors}. The
+ * shared grant service is consumed by BOTH the application-approval and the
+ * invitation-accept flows (feature 017 — FR-017); the source-specific
+ * behaviour is expressed through these options.
+ */
+export interface EnsureMemberOfRoleSetAndAncestorsOptions {
+  /** Which lifecycle is invoking the shared grant. */
+  source: 'application' | 'invitation';
+  /**
+   * Invitation only: whether the invitee should also be granted membership of
+   * the ancestor chain (mirrors `Invitation.invitedToParent`). For the
+   * application source ancestor-granting is decided by re-evaluating the
+   * combined-flow authorisation at approval time (FR-015), not by this flag.
+   */
+  invitedToParent?: boolean;
+  /** Invitation only: extra roles to (best-effort) grant on the target role-set. */
+  extraRoles?: RoleName[];
+  /** Invitation only (SPACE target): remove the SPACE_MEMBER_INVITEE credential. */
+  removeSpaceInviteeCredential?: boolean;
+}
 
 @Injectable()
 export class RoleSetService {
@@ -819,62 +843,28 @@ export class RoleSetService {
         );
       }
 
-      if (invitation.invitedToParent) {
-        if (!roleSet.parentRoleSet) {
-          throw new EntityNotInitializedException(
-            `Unable to load parent community when flag to add is set: ${invitation.id}`,
-            LogContext.COMMUNITY
-          );
-        }
-        // Check if the actor is already a member of the parent roleSet
-        const isMemberOfParentRoleSet = await this.isMember(
-          actorID,
-          roleSet.parentRoleSet
+      if (invitation.invitedToParent && !roleSet.parentRoleSet) {
+        throw new EntityNotInitializedException(
+          `Unable to load parent community when flag to add is set: ${invitation.id}`,
+          LogContext.COMMUNITY
         );
-        if (!isMemberOfParentRoleSet) {
-          await this.assignActorToRole(
-            roleSet.parentRoleSet,
-            RoleName.MEMBER,
-            actorID,
-            actorContext,
-            true
-          );
-        }
       }
 
-      await this.assignActorToRole(
+      // Route through the shared grant service (feature 017 — FR-017). Behaviour-
+      // preserving: `invitedToParent` drives ancestor granting (now full-chain,
+      // a superset of the previous single-hop — research R2), `extraRoles` and
+      // the invitee-credential cleanup are carried through unchanged, and the two
+      // XState lifecycle machines stay separate.
+      await this.ensureMemberOfRoleSetAndAncestors(
         roleSet,
-        RoleName.MEMBER,
         actorID,
         actorContext,
-        true
-      );
-
-      // Remove invitee credential for ANY actor type (not just users)
-      if (roleSet.type === RoleSetType.SPACE) {
-        await this.removeSpaceInviteeCredential(actorID, roleSet);
-      }
-
-      for (const extraRole of invitation.extraRoles) {
-        try {
-          await this.assignActorToRole(
-            roleSet,
-            extraRole,
-            actorID,
-            actorContext,
-            false
-          );
-        } catch (e: any) {
-          // Do not throw an exception further as there might not be entitlements to grant the extra role
-          this.logger.warn?.(
-            `Unable to add actor (${actorID}) to extra roles (${invitation.extraRoles}) in community: ${e}`,
-            LogContext.COMMUNITY
-          );
+        {
+          source: 'invitation',
+          invitedToParent: invitation.invitedToParent,
+          extraRoles: invitation.extraRoles,
+          removeSpaceInviteeCredential: true,
         }
-      }
-      await this.roleSetCacheService.deleteOpenInvitationFromCache(
-        actorID,
-        roleSet.id
       );
     } catch (e: any) {
       this.logger.error?.(
@@ -1049,7 +1039,8 @@ export class RoleSetService {
     roleSet: IRoleSet,
     roleType: RoleName,
     actorID: string,
-    actorType: ActorType
+    actorType: ActorType,
+    entityManager?: EntityManager
   ): Promise<void> {
     const roleCredential = await this.getCredentialDefinitionForRole(
       roleSet,
@@ -1061,10 +1052,14 @@ export class RoleSetService {
       RoleSetUpdateType.ASSIGN,
       actorType
     );
-    await this.actorService.grantCredentialOrFail(actorID, {
-      type: roleCredential.type,
-      resourceID: roleCredential.resourceID,
-    });
+    await this.actorService.grantCredentialOrFail(
+      actorID,
+      {
+        type: roleCredential.type,
+        resourceID: roleCredential.resourceID,
+      },
+      entityManager
+    );
   }
 
   private async revokeRoleCredential(
@@ -1925,18 +1920,267 @@ export class RoleSetService {
         LogContext.COMMUNITY
       );
 
-    await this.assignActorToRole(
+    // Route through the shared grant service (feature 017 — FR-017). For a
+    // combined Subspace application the applicant is granted MEMBER on the
+    // target AND every missing public ancestor, atomically (FR-020). The
+    // combined-flow authorisation is re-evaluated here at approval time
+    // (FR-015); if it no longer holds the ancestor grants are withheld and the
+    // target grant follows today's rules.
+    await this.ensureMemberOfRoleSetAndAncestors(
       roleSet,
-      RoleName.MEMBER,
       userID,
       actorContext,
-      true
+      {
+        source: 'application',
+      }
     );
+  }
 
-    await this.roleSetCacheService.deleteOpenApplicationFromCache(
-      userID,
+  /**
+   * Shared membership grant for the application-approval and invitation-accept
+   * flows (feature 017 — FR-017, single owner of the ancestor-chain grant so
+   * there is no duplicated grant logic, SC-007).
+   *
+   * When granting the ancestor chain: walks `parentRoleSet` from the target up
+   * to the L0 root, then grants `RoleName.MEMBER` on every role-set the actor is
+   * NOT already a member of, TOP-DOWN (root first) so the "must be member of the
+   * immediate parent" invariant holds at each step. All credential writes run in
+   * a SINGLE transaction (FR-020, all-or-nothing); event/notification/Matrix and
+   * cache side-effects are sequenced AFTER a successful commit (R6/R7).
+   *
+   * Ancestor granting is authorised by:
+   * - application: re-evaluating the combined-flow authorisation NOW (FR-015) —
+   *   the whole chain still PUBLIC and the ancestor Spaces' setting still enabled;
+   * - invitation: the invitation's `invitedToParent` flag (existing invite
+   *   privilege already checked when the invitation was created).
+   * When ancestor granting is NOT authorised the target is granted via the
+   * standard {@link assignActorToRole} (today's single-hop rules, incl. its
+   * parent-membership precondition) — behaviour-preserving for invitations
+   * (FR-018/SC-008).
+   */
+  public async ensureMemberOfRoleSetAndAncestors(
+    targetRoleSet: IRoleSet,
+    actorID: string,
+    actorContext: ActorContext,
+    opts: EnsureMemberOfRoleSetAndAncestorsOptions
+  ): Promise<void> {
+    const actorType =
+      await this.actorLookupService.getActorTypeByIdOrFail(actorID);
+
+    const grantAncestors =
+      opts.source === 'application'
+        ? await this.isCombinedApplicationGrantAuthorised(targetRoleSet)
+        : opts.invitedToParent === true;
+
+    if (grantAncestors) {
+      // Build the chain root -> target (top-down) and grant MEMBER on every
+      // missing role-set atomically.
+      const chain = await this.getRoleSetAncestorChain(targetRoleSet);
+      const toGrant: IRoleSet[] = [];
+      for (const roleSetInChain of chain) {
+        const alreadyMember = await this.isMember(actorID, roleSetInChain);
+        if (!alreadyMember) {
+          toGrant.push(roleSetInChain);
+        }
+      }
+
+      if (toGrant.length > 0) {
+        // ATOMIC (FR-020): if any grant fails the whole chain rolls back and no
+        // partial ancestry is persisted. The transactional EntityManager is
+        // threaded down to the credential write so the rollback is real.
+        await this.roleSetRepository.manager.transaction(async manager => {
+          for (const roleSetToGrant of toGrant) {
+            await this.grantRoleCredential(
+              roleSetToGrant,
+              RoleName.MEMBER,
+              actorID,
+              actorType,
+              manager
+            );
+          }
+        });
+
+        // POST-COMMIT (outside the transaction): membership events /
+        // notifications / Matrix room membership / caches, one dispatch per
+        // Space joined (FR-021 — parity with the invitation path).
+        for (const grantedRoleSet of toGrant) {
+          await this.applyMemberGrantSideEffects(
+            grantedRoleSet,
+            actorID,
+            actorType,
+            actorContext,
+            true
+          );
+        }
+      }
+    } else {
+      // Not authorised to grant the ancestor chain — grant only the target via
+      // the standard path (enforces the parent-membership precondition; today's
+      // behaviour). For an application this is the FR-015 safe fallback.
+      await this.assignActorToRole(
+        targetRoleSet,
+        RoleName.MEMBER,
+        actorID,
+        actorContext,
+        true
+      );
+    }
+
+    // Invitation-only post-steps (behaviour-preserving; outside the transaction
+    // exactly as today — best-effort, non-atomic).
+    if (
+      opts.removeSpaceInviteeCredential &&
+      targetRoleSet.type === RoleSetType.SPACE
+    ) {
+      await this.removeSpaceInviteeCredential(actorID, targetRoleSet);
+    }
+    for (const extraRole of opts.extraRoles ?? []) {
+      try {
+        await this.assignActorToRole(
+          targetRoleSet,
+          extraRole,
+          actorID,
+          actorContext,
+          false
+        );
+      } catch (e: any) {
+        // Do not throw further as there might not be entitlements to grant the
+        // extra role (behaviour-preserving with the previous invitation flow).
+        this.logger.warn?.(
+          `Unable to add actor (${actorID}) to extra roles (${opts.extraRoles}) in community: ${e}`,
+          LogContext.COMMUNITY
+        );
+      }
+    }
+
+    // Source-specific cache tail (mirrors the original callers).
+    if (opts.source === 'application') {
+      await this.roleSetCacheService.deleteOpenApplicationFromCache(
+        actorID,
+        targetRoleSet.id
+      );
+    } else {
+      await this.roleSetCacheService.deleteOpenInvitationFromCache(
+        actorID,
+        targetRoleSet.id
+      );
+    }
+  }
+
+  /**
+   * Walk `parentRoleSet` from the supplied role-set up to the L0 root and return
+   * the chain TOP-DOWN (root first ... target last). Single-hop `getParentRoleSet`
+   * is looped (typ. depth <= 3). Guards against cycles.
+   */
+  public async getRoleSetAncestorChain(roleSet: IRoleSet): Promise<IRoleSet[]> {
+    const chain: IRoleSet[] = [roleSet];
+    const seen = new Set<string>([roleSet.id]);
+    let current: IRoleSet | undefined = roleSet;
+    while (current) {
+      const parent = await this.getParentRoleSet(current);
+      if (!parent || seen.has(parent.id)) {
+        break;
+      }
+      chain.push(parent);
+      seen.add(parent.id);
+      current = parent;
+    }
+    return chain.reverse();
+  }
+
+  /**
+   * Re-evaluates (FR-015) whether the combined Subspace-application flow is
+   * authorised to grant the ancestor chain for the supplied target role-set:
+   * every Space in the chain (target included, for reachability) is PUBLIC and
+   * every ANCESTOR Space (parent .. root) has `allowSubspaceAdminsToInviteMembers`
+   * enabled. An L0 Space (no parent) is not part of the combined flow.
+   *
+   * This same predicate drives the client-facing APPLY privilege exposure so the
+   * offered entry point and the actual grant stay consistent (contract §1/§2).
+   */
+  public async isCombinedApplicationGrantAuthorised(
+    targetRoleSet: IRoleSet
+  ): Promise<boolean> {
+    if (targetRoleSet.type !== RoleSetType.SPACE) {
+      return false;
+    }
+    const chain = await this.getRoleSetAncestorChain(targetRoleSet);
+    const ancestors = chain.slice(0, -1); // parent .. root (excludes target)
+    if (ancestors.length === 0) {
+      return false; // L0 Space — no combined flow
+    }
+    // Whole chain must be reachable (public) for a non-member.
+    for (const roleSetInChain of chain) {
+      const settings = await this.getSpaceSettingsForRoleSet(roleSetInChain);
+      if (!settings || settings.privacy.mode !== SpacePrivacyMode.PUBLIC) {
+        return false;
+      }
+    }
+    // Every ancestor Space must have opted in to admitting members via a
+    // descendant application/invitation.
+    for (const ancestorRoleSet of ancestors) {
+      const settings = await this.getSpaceSettingsForRoleSet(ancestorRoleSet);
+      if (!settings?.membership.allowSubspaceAdminsToInviteMembers) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private async getSpaceSettingsForRoleSet(
+    roleSet: IRoleSet
+  ): Promise<ISpaceSettings | undefined> {
+    if (roleSet.type !== RoleSetType.SPACE) {
+      return undefined;
+    }
+    const space = await this.communityResolverService.getSpaceForRoleSetOrFail(
       roleSet.id
     );
+    return space.settings;
+  }
+
+  /**
+   * The post-commit side-effects of a MEMBER grant, factored out so the shared
+   * ancestor-chain grant reproduces exactly what {@link assignActorToRole} emits
+   * (cache clears + community events/notifications/Matrix membership), one
+   * dispatch per Space joined (FR-021). Ancestor grants are always MEMBER, so the
+   * ADMIN-only implicit-role branch of assignActorToRole never applies here.
+   */
+  private async applyMemberGrantSideEffects(
+    roleSet: IRoleSet,
+    actorID: string,
+    actorType: ActorType,
+    actorContext: ActorContext,
+    triggerNewMemberEvents: boolean
+  ): Promise<void> {
+    await this.roleSetCacheService.deleteOpenApplicationFromCache(
+      actorID,
+      roleSet.id
+    );
+    await this.roleSetCacheService.deleteOpenInvitationFromCache(
+      actorID,
+      roleSet.id
+    );
+
+    await this.actorAddedToRole(
+      actorID,
+      actorType,
+      roleSet,
+      RoleName.MEMBER,
+      actorContext,
+      triggerNewMemberEvents
+    );
+
+    if (
+      actorType === ActorType.VIRTUAL_CONTRIBUTOR &&
+      roleSet.type === RoleSetType.SPACE
+    ) {
+      const space =
+        await this.communityResolverService.getSpaceForRoleSetOrFail(
+          roleSet.id
+        );
+      void this.aiServerAdapter.ensureContextIsLoaded(space.id);
+    }
   }
 
   public async isEntryRole(

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1367,12 +1367,11 @@ export class RoleSetService {
       // Invalidate the cached membership state on the descendant's role-set:
       // isMember() / membership-status reads are cache-first, so a stale entry
       // would keep reporting the revoked membership (e.g. blocking a later
-      // re-application with ROLE_SET_ALREADY_MEMBER).
-      const descendantSpace = await this.spaceLookupService.getSpaceOrFail(
-        spaceID,
-        { relations: { community: { roleSet: true } } }
-      );
-      const descendantRoleSetID = descendantSpace.community?.roleSet?.id;
+      // re-application with ROLE_SET_ALREADY_MEMBER). Best-effort resolution —
+      // a descendant deleted between the ID gathering and this loop must not
+      // abort the cascade (later descendants still need their revocations).
+      const descendantRoleSetID =
+        await this.communityResolverService.getRoleSetIdForSpace(spaceID);
       if (descendantRoleSetID) {
         await this.roleSetCacheService.cleanActorMembershipCache(
           actorID,

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1985,7 +1985,10 @@ export class RoleSetService {
 
     const grantAncestors =
       opts.source === 'application'
-        ? await this.isCombinedApplicationGrantAuthorised(targetRoleSet)
+        ? await this.isCombinedApplicationGrantAuthorised(
+            targetRoleSet,
+            actorID
+          )
         : opts.invitedToParent === true;
 
     if (grantAncestors) {
@@ -2106,19 +2109,27 @@ export class RoleSetService {
 
   /**
    * Re-evaluates (FR-015) whether the combined Subspace-application flow is
-   * authorised to grant the ancestor chain for the supplied target role-set:
-   * every ANCESTOR Space (parent .. root) is PUBLIC (FR-002 — reachability is
-   * defined over the ancestors; the target's own privacy is not part of the
-   * gate, since a Space with an application membership policy accepts
-   * applications regardless of its privacy mode) and every ancestor Space has
-   * `allowSubspaceAdminsToInviteMembers` enabled (FR-003). An L0 Space (no
+   * authorised to grant the ancestor chain for the supplied target role-set.
+   *
+   * Reachability is ACTOR-RELATIVE (explicit scope decision, 2026-07-07 — see
+   * ADR 0001): when `actorID` is supplied, ancestors the actor already belongs
+   * to impose NO requirements — they are skipped by the missing-only grant
+   * anyway. Every ancestor the actor would actually be GRANTED into must be
+   * PUBLIC (FR-002) and have `allowSubspaceAdminsToInviteMembers` enabled
+   * (FR-003). The target's own privacy is never part of the gate — a Space
+   * with an application membership policy accepts applications regardless of
+   * its privacy mode. Without `actorID` the check degrades to the generic
+   * non-member reading (every ancestor public + opted in). An L0 Space (no
    * parent) is not part of the combined flow.
    *
-   * This same predicate drives the client-facing APPLY privilege exposure so the
-   * offered entry point and the actual grant stay consistent (contract §1/§2).
+   * The client-facing APPLY privilege exposure is driven by
+   * {@link getCombinedApplicationEligibleCriteria}, the credential-rule
+   * counterpart of this predicate, so the offered entry point and the actual
+   * grant stay consistent (contract §1/§2).
    */
   public async isCombinedApplicationGrantAuthorised(
-    targetRoleSet: IRoleSet
+    targetRoleSet: IRoleSet,
+    actorID?: string
   ): Promise<boolean> {
     if (targetRoleSet.type !== RoleSetType.SPACE) {
       return false;
@@ -2128,9 +2139,15 @@ export class RoleSetService {
     if (ancestors.length === 0) {
       return false; // L0 Space — no combined flow
     }
-    // Every ancestor Space must be reachable (public) for a non-member and
-    // must have opted in to admitting members via a descendant application.
     for (const ancestorRoleSet of ancestors) {
+      // Actor-relative reachability: an ancestor the actor already belongs to
+      // is not granted (missing-only) and imposes no requirements.
+      if (actorID && (await this.isMember(actorID, ancestorRoleSet))) {
+        continue;
+      }
+      // Every ancestor the actor would be granted into must be reachable
+      // (public) and must have opted in to admitting members via a descendant
+      // application.
       const settings = await this.getSpaceSettingsForRoleSet(ancestorRoleSet);
       if (!settings || settings.privacy.mode !== SpacePrivacyMode.PUBLIC) {
         return false;
@@ -2140,6 +2157,78 @@ export class RoleSetService {
       }
     }
     return true;
+  }
+
+  /**
+   * Credential-rule counterpart of {@link isCombinedApplicationGrantAuthorised}
+   * for the authorization-policy APPLY exposure (contract §1). Authorization
+   * policies are static credential rules, so actor-relative reachability is
+   * expressed via the platform invariant `member(Space) ⇒ member(parent)`
+   * (upheld by assignActorToRole, the shared top-down grant, and the removal
+   * cascade): being a member of the DEEPEST PRIVATE ancestor implies membership
+   * of every ancestor above it, so that single membership credential identifies
+   * exactly the population for which every non-owned ancestor is public.
+   *
+   * Returns the criteria for who may be offered APPLY on the target:
+   * - `{ kind: 'globalRegistered' }` — no private ancestor; every ancestor is
+   *   public + opted in (the generic non-member cell).
+   * - `{ kind: 'credential', credential }` — the MEMBER credential of the
+   *   deepest private ancestor; every ancestor BELOW it is public + opted in.
+   *   (Ancestors at/above the deepest private ancestor are owned by that
+   *   population by the invariant, so they impose no requirements.)
+   * - `undefined` — no eligible non-parent-member population (some ancestor
+   *   that would need granting is private or not opted in, the deepest private
+   *   ancestor IS the direct parent — that population is already covered by the
+   *   parent-member APPLY rule — or the target is an L0 Space / non-Space).
+   */
+  public async getCombinedApplicationEligibleCriteria(
+    targetRoleSet: IRoleSet
+  ): Promise<
+    | { kind: 'globalRegistered' }
+    | { kind: 'credential'; credential: ICredentialDefinition }
+    | undefined
+  > {
+    if (targetRoleSet.type !== RoleSetType.SPACE) {
+      return undefined;
+    }
+    const chain = await this.getRoleSetAncestorChain(targetRoleSet);
+    const ancestors = chain.slice(0, -1); // root .. parent (top-down)
+    if (ancestors.length === 0) {
+      return undefined; // L0 Space — no combined flow
+    }
+
+    const ancestorSettings = await Promise.all(
+      ancestors.map(a => this.getSpaceSettingsForRoleSet(a))
+    );
+    let deepestPrivateIndex = -1;
+    for (let i = 0; i < ancestors.length; i++) {
+      if (ancestorSettings[i]?.privacy.mode !== SpacePrivacyMode.PUBLIC) {
+        deepestPrivateIndex = i;
+      }
+    }
+
+    // Every ancestor BELOW the deepest private one would be granted to this
+    // population, so it must be public (guaranteed by deepest-private choice)
+    // and opted in via the setting.
+    for (let i = deepestPrivateIndex + 1; i < ancestors.length; i++) {
+      if (!ancestorSettings[i]?.membership.allowSubspaceAdminsToInviteMembers) {
+        return undefined;
+      }
+    }
+
+    if (deepestPrivateIndex === -1) {
+      return { kind: 'globalRegistered' };
+    }
+    if (deepestPrivateIndex === ancestors.length - 1) {
+      // Deepest private ancestor is the direct parent — parent members are
+      // already offered APPLY by the parent-member rule; nothing to add.
+      return undefined;
+    }
+    const credential = await this.getCredentialDefinitionForRole(
+      ancestors[deepestPrivateIndex],
+      RoleName.MEMBER
+    );
+    return { kind: 'credential', credential };
   }
 
   private async getSpaceSettingsForRoleSet(

--- a/src/domain/actor/actor/actor.module.ts
+++ b/src/domain/actor/actor/actor.module.ts
@@ -1,11 +1,13 @@
 import { ActorContextModule } from '@core/actor-context/actor.context.module';
 import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { RoleSetCacheModule } from '@domain/access/role-set/role.set.service.cache.module';
 import { ActorLookupModule } from '@domain/actor/actor-lookup/actor.lookup.module';
 import { CredentialModule } from '@domain/actor/credential/credential.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
+import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
 import { Actor } from './actor.entity';
 import { ActorFullResolverFields } from './actor.full.resolver.fields';
 import { ActorResolverFields } from './actor.resolver.fields';
@@ -23,6 +25,10 @@ import { ActorAuthorizationService } from './actor.service.authorization';
     AuthorizationModule,
     CredentialModule,
     PlatformAuthorizationPolicyModule,
+    // For the role-set membership-cache invalidation on direct credential
+    // grant/revoke (both are leaf modules — no cycle back into actor).
+    RoleSetCacheModule,
+    EntityResolverModule,
   ],
   providers: [
     ActorService,

--- a/src/domain/actor/actor/actor.resolver.mutations.spec.ts
+++ b/src/domain/actor/actor/actor.resolver.mutations.spec.ts
@@ -1,7 +1,9 @@
 import { CredentialType } from '@common/enums/credential.type';
 import { AuthorizationService } from '@core/authorization/authorization.service';
+import { RoleSetCacheService } from '@domain/access/role-set/role.set.service.cache';
 import { Test } from '@nestjs/testing';
 import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { vi } from 'vitest';
 import { ActorResolverMutations } from './actor.resolver.mutations';
 import { ActorService } from './actor.service';
@@ -11,6 +13,8 @@ describe('ActorResolverMutations', () => {
   let actorService: any;
   let authorizationService: any;
   let platformAuthorizationService: any;
+  let communityResolverService: any;
+  let roleSetCacheService: any;
 
   const mockActorContext = { actorID: 'caller-1' } as any;
   const mockPlatformAuth = { id: 'platform-auth' };
@@ -31,6 +35,14 @@ describe('ActorResolverMutations', () => {
         .mockResolvedValue(mockPlatformAuth),
     };
 
+    communityResolverService = {
+      getRoleSetIdForSpace: vi.fn().mockResolvedValue(undefined),
+    };
+
+    roleSetCacheService = {
+      cleanActorMembershipCache: vi.fn().mockResolvedValue(undefined),
+    };
+
     const module = await Test.createTestingModule({
       providers: [
         ActorResolverMutations,
@@ -40,6 +52,11 @@ describe('ActorResolverMutations', () => {
           provide: PlatformAuthorizationPolicyService,
           useValue: platformAuthorizationService,
         },
+        {
+          provide: CommunityResolverService,
+          useValue: communityResolverService,
+        },
+        { provide: RoleSetCacheService, useValue: roleSetCacheService },
       ],
     }).compile();
 
@@ -100,6 +117,58 @@ describe('ActorResolverMutations', () => {
         resourceID: 'res-1',
       });
       expect(result).toBe(true);
+    });
+  });
+
+  describe('role-set membership cache invalidation (space role credentials)', () => {
+    it('cleans the role-set membership cache when a SPACE_MEMBER credential is revoked', async () => {
+      actorService.revokeCredential.mockResolvedValue(true);
+      communityResolverService.getRoleSetIdForSpace.mockResolvedValue('rs-1');
+
+      await resolver.revokeCredentialFromActor(
+        mockActorContext,
+        'actor-1',
+        CredentialType.SPACE_MEMBER,
+        'space-1'
+      );
+
+      expect(
+        communityResolverService.getRoleSetIdForSpace
+      ).toHaveBeenCalledWith('space-1');
+      expect(
+        roleSetCacheService.cleanActorMembershipCache
+      ).toHaveBeenCalledWith('actor-1', 'rs-1');
+    });
+
+    it('does not touch the cache for non-space credentials', async () => {
+      actorService.revokeCredential.mockResolvedValue(true);
+
+      await resolver.revokeCredentialFromActor(
+        mockActorContext,
+        'actor-1',
+        CredentialType.GLOBAL_ADMIN,
+        'res-1'
+      );
+
+      expect(
+        roleSetCacheService.cleanActorMembershipCache
+      ).not.toHaveBeenCalled();
+    });
+
+    it('never fails the mutation when the cache clean throws (best-effort)', async () => {
+      actorService.revokeCredential.mockResolvedValue(true);
+      communityResolverService.getRoleSetIdForSpace.mockRejectedValue(
+        new Error('lookup down')
+      );
+
+      await expect(
+        resolver.revokeCredentialFromActor(
+          mockActorContext,
+          'actor-1',
+          CredentialType.SPACE_MEMBER,
+          'space-1'
+        )
+      ).resolves.toBe(true);
     });
   });
 });

--- a/src/domain/actor/actor/actor.resolver.mutations.ts
+++ b/src/domain/actor/actor/actor.resolver.mutations.ts
@@ -1,20 +1,40 @@
 import { CurrentActor } from '@common/decorators';
+import { AuthorizationCredential } from '@common/enums/authorization.credential';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { CredentialType } from '@common/enums/credential.type';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
+import { RoleSetCacheService } from '@domain/access/role-set/role.set.service.cache';
 import { ICredential } from '@domain/actor/credential/credential.interface';
 import { UUID } from '@domain/common/scalars';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { ActorService } from './actor.service';
+
+/**
+ * Space role credentials whose direct grant/revoke must invalidate the
+ * role-set membership caches: isMember() / membership-status reads are
+ * cache-first, so a credential mutation without invalidation leaves stale
+ * answers (e.g. a re-application blocked with ROLE_SET_ALREADY_MEMBER after
+ * an admin revoked the membership credential).
+ */
+const SPACE_ROLE_CREDENTIAL_TYPES: CredentialType[] = [
+  AuthorizationCredential.SPACE_MEMBER,
+  AuthorizationCredential.SPACE_ADMIN,
+  AuthorizationCredential.SPACE_LEAD,
+  AuthorizationCredential.SPACE_SUBSPACE_ADMIN,
+  AuthorizationCredential.SPACE_MEMBER_INVITEE,
+];
 
 @Resolver()
 export class ActorResolverMutations {
   constructor(
     private readonly actorService: ActorService,
     private readonly authorizationService: AuthorizationService,
-    private readonly platformAuthorizationService: PlatformAuthorizationPolicyService
+    private readonly platformAuthorizationService: PlatformAuthorizationPolicyService,
+    private readonly communityResolverService: CommunityResolverService,
+    private readonly roleSetCacheService: RoleSetCacheService
   ) {}
 
   @Mutation(() => ICredential, {
@@ -36,10 +56,12 @@ export class ActorResolverMutations {
       'grantCredentialToActor mutation'
     );
 
-    return await this.actorService.grantCredentialOrFail(actorID, {
+    const credential = await this.actorService.grantCredentialOrFail(actorID, {
       type: credentialType,
       resourceID: resourceID ?? '',
     });
+    await this.cleanRoleSetMembershipCache(actorID, credentialType, resourceID);
+    return credential;
   }
 
   @Mutation(() => Boolean, {
@@ -61,9 +83,41 @@ export class ActorResolverMutations {
       'revokeCredentialFromActor mutation'
     );
 
-    return await this.actorService.revokeCredential(actorID, {
+    const revoked = await this.actorService.revokeCredential(actorID, {
       type: credentialType,
       resourceID,
     });
+    await this.cleanRoleSetMembershipCache(actorID, credentialType, resourceID);
+    return revoked;
+  }
+
+  /**
+   * Best-effort role-set membership-cache invalidation after a direct
+   * credential grant/revoke on a Space. Never fails the mutation — the
+   * credential write is the source of truth; cache TTL is the fallback.
+   */
+  private async cleanRoleSetMembershipCache(
+    actorID: string,
+    credentialType: CredentialType,
+    resourceID?: string
+  ): Promise<void> {
+    if (!resourceID) {
+      return;
+    }
+    if (!SPACE_ROLE_CREDENTIAL_TYPES.includes(credentialType)) {
+      return;
+    }
+    try {
+      const roleSetId =
+        await this.communityResolverService.getRoleSetIdForSpace(resourceID);
+      if (roleSetId) {
+        await this.roleSetCacheService.cleanActorMembershipCache(
+          actorID,
+          roleSetId
+        );
+      }
+    } catch {
+      // best-effort only; cache TTL expiry is the fallback
+    }
   }
 }

--- a/src/domain/actor/actor/actor.service.spec.ts
+++ b/src/domain/actor/actor/actor.service.spec.ts
@@ -343,7 +343,8 @@ describe('ActorService', () => {
       expect(actorRepository.findOne).toHaveBeenCalled();
       expect(credentialService.createCredentialForActor).toHaveBeenCalledWith(
         'actor-1',
-        { type: 'admin' }
+        { type: 'admin' },
+        undefined
       );
       expect(cacheManager.del).toHaveBeenCalledWith('@actor:id:actor-1');
       expect(actorContextCacheService.deleteByActorID).toHaveBeenCalledWith(

--- a/src/domain/actor/actor/actor.service.ts
+++ b/src/domain/actor/actor/actor.service.ts
@@ -19,7 +19,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { AlkemioConfig } from '@src/types';
 import { Cache } from 'cache-manager';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, Repository } from 'typeorm';
+import { EntityManager, FindOneOptions, Repository } from 'typeorm';
 import { Actor } from './actor.entity';
 import { IActor } from './actor.interface';
 
@@ -248,15 +248,19 @@ export class ActorService {
    */
   async grantCredentialOrFail(
     actorID: string,
-    credentialData: CreateCredentialInput
+    credentialData: CreateCredentialInput,
+    entityManager?: EntityManager
   ): Promise<ICredential> {
     // Verify actor exists
     await this.getActorOrFail(actorID);
 
-    // Create the credential with the actorID
+    // Create the credential with the actorID. When a transactional
+    // EntityManager is supplied the write participates in that transaction
+    // (feature 017 — atomic ancestor-chain grant, FR-020).
     const credential = await this.credentialService.createCredentialForActor(
       actorID,
-      credentialData
+      credentialData,
+      entityManager
     );
 
     // Invalidate cache since credentials changed

--- a/src/domain/actor/credential/credential.service.ts
+++ b/src/domain/actor/credential/credential.service.ts
@@ -2,7 +2,7 @@ import { LogContext } from '@common/enums';
 import { EntityNotFoundException } from '@common/exceptions';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { Credential } from './credential.entity';
 import { ICredential } from './credential.interface';
 import { CreateCredentialInput } from './dto/credential.dto.create';
@@ -159,14 +159,22 @@ export class CredentialService {
    */
   async createCredentialForActor(
     actorID: string,
-    credentialInput: CreateCredentialInput
+    credentialInput: CreateCredentialInput,
+    entityManager?: EntityManager
   ): Promise<ICredential> {
     const credential = Credential.create({
       ...credentialInput,
       resourceID: credentialInput.resourceID ?? '',
       actorID,
     });
-    await this.credentialRepository.save(credential);
+    // When a transactional EntityManager is supplied the write participates in
+    // that transaction so it can be rolled back atomically (feature 017 —
+    // combined ancestor-chain membership grant, FR-020).
+    if (entityManager) {
+      await entityManager.getRepository(Credential).save(credential);
+    } else {
+      await this.credentialRepository.save(credential);
+    }
     return credential;
   }
 

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -1,6 +1,7 @@
 import {
   CREDENTIAL_RULE_ROLESET_ASSIGN,
   CREDENTIAL_RULE_SPACE_HOST_ASSOCIATES_JOIN,
+  CREDENTIAL_RULE_SUBSPACE_ANCESTOR_MEMBER_APPLY,
   CREDENTIAL_RULE_SUBSPACE_NON_MEMBER_APPLY,
   CREDENTIAL_RULE_SUBSPACE_PARENT_MEMBER_APPLY,
   CREDENTIAL_RULE_SUBSPACE_PARENT_MEMBER_JOIN,
@@ -256,18 +257,22 @@ export class CommunityAuthorizationService {
           spaceMemberCanApply.cascade = false;
           newRules.push(spaceMemberCanApply);
 
-          // Feature 017 — combined Subspace application: when the combined-flow
-          // preconditions hold (whole parent chain PUBLIC + the ancestor Spaces'
-          // `allowSubspaceAdminsToInviteMembers` enabled) also surface
-          // ROLESET_ENTRY_ROLE_APPLY to any registered (non-parent-member) user
-          // that can reach this Subspace. This privilege is the single signal the
-          // client trusts (contract §1); the apply mutation and approval re-check
-          // the same predicate server-side (FR-014/FR-015).
-          const combinedApplicationAllowed =
-            await this.roleSetService.isCombinedApplicationGrantAuthorised(
+          // Feature 017 — combined Subspace application: surface
+          // ROLESET_ENTRY_ROLE_APPLY to the eligible non-parent-member
+          // population. Reachability is actor-relative (ADR 0001): with no
+          // private ancestor the whole registered platform is eligible (every
+          // ancestor public + opted in); with a private ancestor, members of
+          // the DEEPEST private ancestor are eligible when every ancestor
+          // below it is public + opted in (member(Space) ⇒ member(parent), so
+          // that one credential owns everything above). This privilege is the
+          // single signal the client trusts (contract §1); the apply mutation
+          // and approval re-check the actor-aware predicate server-side
+          // (FR-014/FR-015).
+          const eligibleCriteria =
+            await this.roleSetService.getCombinedApplicationEligibleCriteria(
               roleSet
             );
-          if (combinedApplicationAllowed) {
+          if (eligibleCriteria?.kind === 'globalRegistered') {
             const nonMemberCanApply =
               this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
                 [AuthorizationPrivilege.ROLESET_ENTRY_ROLE_APPLY],
@@ -276,6 +281,15 @@ export class CommunityAuthorizationService {
               );
             nonMemberCanApply.cascade = false;
             newRules.push(nonMemberCanApply);
+          } else if (eligibleCriteria?.kind === 'credential') {
+            const ancestorMemberCanApply =
+              this.authorizationPolicyService.createCredentialRule(
+                [AuthorizationPrivilege.ROLESET_ENTRY_ROLE_APPLY],
+                [eligibleCriteria.credential],
+                CREDENTIAL_RULE_SUBSPACE_ANCESTOR_MEMBER_APPLY
+              );
+            ancestorMemberCanApply.cascade = false;
+            newRules.push(ancestorMemberCanApply);
           }
           break;
         }

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -1,6 +1,7 @@
 import {
   CREDENTIAL_RULE_ROLESET_ASSIGN,
   CREDENTIAL_RULE_SPACE_HOST_ASSOCIATES_JOIN,
+  CREDENTIAL_RULE_SUBSPACE_NON_MEMBER_APPLY,
   CREDENTIAL_RULE_SUBSPACE_PARENT_MEMBER_APPLY,
   CREDENTIAL_RULE_SUBSPACE_PARENT_MEMBER_JOIN,
   CREDENTIAL_RULE_TYPES_COMMUNITY_READ_GLOBAL_REGISTERED,
@@ -254,6 +255,28 @@ export class CommunityAuthorizationService {
             );
           spaceMemberCanApply.cascade = false;
           newRules.push(spaceMemberCanApply);
+
+          // Feature 017 — combined Subspace application: when the combined-flow
+          // preconditions hold (whole parent chain PUBLIC + the ancestor Spaces'
+          // `allowSubspaceAdminsToInviteMembers` enabled) also surface
+          // ROLESET_ENTRY_ROLE_APPLY to any registered (non-parent-member) user
+          // that can reach this Subspace. This privilege is the single signal the
+          // client trusts (contract §1); the apply mutation and approval re-check
+          // the same predicate server-side (FR-014/FR-015).
+          const combinedApplicationAllowed =
+            await this.roleSetService.isCombinedApplicationGrantAuthorised(
+              roleSet
+            );
+          if (combinedApplicationAllowed) {
+            const nonMemberCanApply =
+              this.authorizationPolicyService.createCredentialRuleUsingTypesOnly(
+                [AuthorizationPrivilege.ROLESET_ENTRY_ROLE_APPLY],
+                [AuthorizationCredential.GLOBAL_REGISTERED],
+                CREDENTIAL_RULE_SUBSPACE_NON_MEMBER_APPLY
+              );
+            nonMemberCanApply.cascade = false;
+            newRules.push(nonMemberCanApply);
+          }
           break;
         }
         case CommunityMembershipPolicy.OPEN: {

--- a/src/domain/community/community/community.service.authorization.ts
+++ b/src/domain/community/community/community.service.authorization.ts
@@ -212,7 +212,15 @@ export class CommunityAuthorizationService {
       newRules.push(spaceAdminsInvite);
     }
 
-    if (entryRoleAllowed) {
+    if (entryRoleAllowed && !isSubspace) {
+      // L0 only: the blanket GLOBAL_REGISTERED APPLY/JOIN (+ trusted-org JOIN)
+      // rules. On a SUBSPACE these were always false signals — the entry-role
+      // mutations enforce parent membership, so a non-parent-member holding
+      // this privilege got an error instead of an entry point. Since the
+      // client trusts the privilege as the single signal (feature 017,
+      // contract §1), a subspace's exposure comes exclusively from the
+      // subspace branch below (parent-member rule + combined-eligibility
+      // rule), keeping the offered entry point and the actual grant in sync.
       newRules.push(
         ...this.extendRoleSetAuthorizationPolicySpace(spaceSettings)
       );

--- a/src/services/infrastructure/entity-resolver/community.resolver.service.ts
+++ b/src/services/infrastructure/entity-resolver/community.resolver.service.ts
@@ -563,6 +563,43 @@ export class CommunityResolverService {
     return community;
   }
 
+  /**
+   * Lightweight spaceID -> roleSetID resolution (only the join needed for the
+   * lookup, no relation hydration beyond it). Returns undefined when the space
+   * (or its community/role-set) does not exist — for best-effort cache
+   * invalidation, not authorisation.
+   */
+  public async getRoleSetIdForSpace(
+    spaceID: string
+  ): Promise<string | undefined> {
+    const space = await this.entityManager.findOne(Space, {
+      where: { id: spaceID },
+      relations: { community: { roleSet: true } },
+    });
+    return space?.community?.roleSet?.id;
+  }
+
+  /**
+   * Settings-only Space read for a role-set: no relation hydration (unlike
+   * {@link getSpaceForRoleSetOrFail}, which joins about.profile). Used on hot
+   * paths that only gate on `space.settings` — e.g. the combined-application
+   * reachability checks, which run per-ancestor during authorization resets.
+   */
+  public async getSpaceSettingsForRoleSet(
+    roleSetID: string
+  ): Promise<ISpace['settings'] | undefined> {
+    const space = await this.entityManager.findOne(Space, {
+      where: {
+        community: {
+          roleSet: {
+            id: roleSetID,
+          },
+        },
+      },
+    });
+    return space?.settings;
+  }
+
   public async getSpaceForRoleSetOrFail(roleSetID: string): Promise<ISpace> {
     const space = await this.entityManager.findOne(Space, {
       where: {


### PR DESCRIPTION
## Summary

**Lead slice of `workspace#017-combined-subspace-application`** — closes the crux of alkem-io/server#6189: a non-member arriving at a Subspace applies to it directly; on approval they are registered as MEMBER of the Subspace **and every missing ancestor up to the reachable root, atomically**, with no separate parent-Space sign-up. Unblocks the Signalen rollout (~300 first-time users, Oct 7 event).

Contract recorded in workspace ADR [`0001-combined-subspace-application-membership-contract.md`](https://github.com/alkem-io/agents-hq/blob/017-combined-subspace-application/docs/decisions/0001-combined-subspace-application-membership-contract.md) (incl. the two live-verification amendments §7-8).

### Changes

- **Shared grant service** `ensureMemberOfRoleSetAndAncestors` (FR-017/SC-007): walks the ancestor chain to L0, grants MEMBER on every **missing** role-set **top-down**, **all-or-nothing in one DB transaction** (transactional `EntityManager` threaded through `grantRoleCredential → ActorService → CredentialService`; side-effects sequenced after commit). Consumed by **both** `approveApplication` and `acceptInvitationToRoleSet` — the two XState machines stay separate.
- **Apply precondition relaxed** (`applyForEntryRoleOnRoleSet`): a non-parent-member may apply **iff** the combined preconditions hold for *them*; otherwise today's "join the parent first" still throws.
- **APPLY privilege exposure**: eligible non-parent-members get `ROLESET_ENTRY_ROLE_APPLY` on the Subspace role-set — the single signal client-web trusts. With no private ancestor → `GLOBAL_REGISTERED`; with private ancestors → the deepest private ancestor's MEMBER credential (new `CREDENTIAL_RULE_SUBSPACE_ANCESTOR_MEMBER_APPLY`, leaning on the `member(Space) ⇒ member(parent)` invariant).
- **Actor-relative reachability** (explicit scope decision 2026-07-07, ADR §8): gates apply only to ancestors the applicant would be **granted into** — each must be PUBLIC with `allowSubspaceAdminsToInviteMembers` enabled; owned ancestors impose no requirements. The target's own privacy is **not** part of the gate (ADR §7). Re-evaluated at approval time (FR-015).
- **Fix** (pre-existing, surfaced by live testing): `revokeSpaceTreeCredentials` now invalidates the descendants' role-set membership caches on cascade removal — previously a re-application after removal died with `ROLE_SET_ALREADY_MEMBER` from a stale cache-first `isMember()` read.
- **Behaviour-preserving for invitations** (FR-018/SC-008): all 101 pre-existing `role.set.service` tests pass unchanged; `invitedToParent` drives invitation ancestor granting exactly as before (full-chain walk is the intended superset — research R2).

### Verification

- Unit: **7026 passed** (+23 new: shared grant atomicity/rollback, gating, notification parity FR-021, actor-aware predicate, exposure criteria, cascade cache-clean).
- Live (local stack): full test-suites hierarchy-parity matrix **21/21 green** (application 10/10, invitation 10/10, removal-cascade 1/1) + actor-reachability 2/2; manual browser flow verified.

## Schema Contract Checklist (Feature 002)

**No GraphQL schema change** — mutation signatures unchanged (`applyForEntryRoleOnRoleSet`, `eventOnApplication`); behavioural + privilege-surfacing change only. `schema.graphql` untouched.

### Other Notes

- No DB migration, no new entity (membership is credential-based).
- Rollout: **server ships first** — additive & backward compatible (a non-updated client keeps gating on `isParentMember`; the entry point simply stays hidden). No feature flag; gated by the existing per-Space setting.
- Companion PRs: alkem-io/client-web#9986 (UI) + alkem-io/test-suites#551 (parity matrix).

Refs alkem-io/server#6189 · `workspace#017-combined-subspace-application`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced subspace application handling with eligibility-driven apply rules for non-members and ancestor members.
  * Added shared ancestor-chain membership granting for applications and invitations.
* **Bug Fixes**
  * Added an admin “reject” path to prevent applications being stranded during approval.
  * Improved membership cache invalidation so membership cleanup is best-effort and non-blocking.
* **Tests**
  * Expanded coverage for combined-subspace eligibility, ancestor-chain grant/rollback behavior, and cache update scenarios.
* **Chores**
  * Enabled transactional credential writes for coordinated grant operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->