### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -1272,6 +1272,10 @@ type CalloutFraming {
   """The Profile for framing the associated Callout."""
   profile: Profile!
   """
+  The host space's subspaces for a SPACES framing, ordered pinned-first then the space's sortOrder/displayName. Returns the existing Space type (no new item type). No server-side pagination/search: the client name-searches and paginates client-side over this set. Empty for non-SPACES framings, for a callout not attached to a space, or for a host with no subspaces.
+  """
+  subspaces: [Space!]!
+  """
   The type of the Callout Framing, the additional content attached to this callout
   """
   type: CalloutFramingType!
@@ -1289,6 +1293,7 @@ enum CalloutFramingType {
   MEMO
   NONE
   POLL
+  SPACES
   WHITEBOARD
 }
 


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size:   307346 bytes
Snapshot md5: 2314763fbb0c9e5f57a6fb57feaa7bc1

This PR was generated by the schema-baseline workflow.