### PR TITLE
fix(oidc): retry issuer discovery with backoff instead of crash-looping

### DIFF
--- a/src/core/auth/oidc/oidc.service.ts
+++ b/src/core/auth/oidc/oidc.service.ts
@@ -12,6 +12,21 @@ import { Client, Issuer } from 'openid-client';
 // - public client: token_endpoint_auth_method=none
 // - PKCE-S256 mandatory (controller sets code_challenge_method=S256)
 // - nonce always present (controller sets nonce)
+
+// Discovery retry policy. `Issuer.discover` does a single HTTP GET with
+// openid-client's default 3500 ms timeout; a bare `await` there crash-loops the
+// whole process whenever the identity chain (Hydra + traefik) is slow to settle
+// after a restart wave — e.g. right after a test-env DB reset scales Hydra back
+// up (test-suites#555). Retry with capped exponential backoff so a transient
+// unavailability delays boot instead of killing it; only a persistently
+// unreachable issuer (all attempts exhausted) is fatal.
+const DISCOVERY_MAX_ATTEMPTS = 10;
+const DISCOVERY_BASE_DELAY_MS = 1000;
+const DISCOVERY_MAX_DELAY_MS = 15000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
 @Injectable()
 export class OidcService implements OnModuleInit {
   private issuer?: Issuer<Client>;
@@ -30,7 +45,7 @@ export class OidcService implements OnModuleInit {
         infer: true,
       });
 
-    this.issuer = await Issuer.discover(issuer_url);
+    this.issuer = await this.discoverWithRetry(issuer_url);
     this.client = new this.issuer.Client({
       client_id: web_client_id,
       redirect_uris: [web_redirect_uri],
@@ -39,6 +54,36 @@ export class OidcService implements OnModuleInit {
     });
     const log: LoggerService = this.logger ?? new Logger(OidcService.name);
     log.log?.(`OIDC Issuer discovered at ${issuer_url}`, OidcService.name);
+  }
+
+  private async discoverWithRetry(issuerUrl: string): Promise<Issuer<Client>> {
+    const log: LoggerService = this.logger ?? new Logger(OidcService.name);
+    for (let attempt = 1; attempt <= DISCOVERY_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await Issuer.discover(issuerUrl);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (attempt === DISCOVERY_MAX_ATTEMPTS) {
+          log.error?.(
+            `OIDC issuer discovery failed after ${attempt} attempts against ${issuerUrl}: ${message}`,
+            error instanceof Error ? error.stack : undefined,
+            OidcService.name
+          );
+          throw error;
+        }
+        const delay = Math.min(
+          DISCOVERY_BASE_DELAY_MS * 2 ** (attempt - 1),
+          DISCOVERY_MAX_DELAY_MS
+        );
+        log.warn?.(
+          `OIDC issuer discovery attempt ${attempt}/${DISCOVERY_MAX_ATTEMPTS} against ${issuerUrl} failed (${message}); retrying in ${delay}ms`,
+          OidcService.name
+        );
+        await sleep(delay);
+      }
+    }
+    // Unreachable: the loop either returns or throws on the final attempt.
+    throw new Error('OIDC issuer discovery exhausted all attempts');
   }
 
   getIssuer(): Issuer<Client> {


### PR DESCRIPTION
## Why

`OidcService.onModuleInit` did a single `Issuer.discover()` (openid-client default 3500 ms timeout) and let any rejection propagate — **crash-looping the whole process** whenever the identity chain (Hydra + traefik) is slow to settle after a restart wave.

Observed repeatedly on `k8s-hetzner-test`: right after the test-env DB reset scales Hydra back up, the server boots before Hydra serves `/.well-known/openid-configuration`, `Issuer.discover` times out, and the pod CrashLoopBackOffs until Hydra happens to be ready. It self-heals after ~3 restarts, but the e2e job meanwhile hammers a dead endpoint (481 `ECONNRESET` failures in run 28944454812).

## What

Wrap discovery in a capped exponential backoff (`10` attempts, `1s → 15s`) so a transient unavailability **delays** boot instead of killing it. Only a persistently unreachable issuer (all attempts exhausted) is fatal. Each retry logs a warning; the final failure logs an error with the stack before rethrowing.

This is the server-side half of alkem-io/test-suites#555; the reset-pipeline half (readiness gate + hydra-maester client restoration) is a separate test-suites PR.

## Notes

- No config surface added — retry constants are module-local with an explanatory comment. Happy to promote them to `alkemio.yml` if preferred.
- Fixes the crash-loop in **every** environment, not just test — any slow identity-chain start (node cold start, Hydra rollout) previously risked the same crash.

Refs alkem-io/test-suites#555

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC sign-in reliability by retrying issuer discovery during app startup.
  * Added capped backoff between attempts and clearer logging when discovery fails.
  * Helps avoid startup failures caused by temporary identity provider outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->