### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -4864,6 +4864,10 @@ type Mutation {
   Reorder Poll options. Requires UPDATE privilege. The provided list must contain exactly the same option IDs as the current poll options.
   """
   reorderPollOptions(optionData: ReorderPollOptionsInput!): Poll!
+  """
+  Replace the backing file of an existing CollaboraDocument in place, preserving its identity. Requires UPDATE on the document. The replacement must be an allowed OfficeDocs format, within the size cap, and the SAME document type as the current file. Refused while the document is being edited.
+  """
+  replaceCollaboraDocument(file: Upload!, replaceData: ReplaceCollaboraDocumentInput!): CollaboraDocument!
   """Resets the interaction with the VC by recreating the room."""
   resetConversationVc(input: ConversationVcResetInput!): Conversation!
   """Reset all license plans on Accounts"""
@@ -6466,6 +6470,15 @@ input RemoveUserGroupMemberInput {
 input ReorderPollOptionsInput {
   optionIDs: [UUID!]!
   pollID: UUID!
+}
+
+input ReplaceCollaboraDocumentInput {
+  """The ID of the CollaboraDocument whose backing file is being replaced."""
+  ID: UUID!
+  """
+  Optional title chosen in the replace dialog (defaults to the incoming file title). ACCEPTED FOR FORWARD-COMPATIBILITY BUT NOT APPLIED in this feature: the stored display name is left unchanged. Persisting a rename is owned by feature 016-officedocs-rename-ux (FR-009 / FR-015). Present so reviewers do not read the unused field as a bug.
+  """
+  displayName: String
 }
 
 input RevokeAuthorizationCredentialInput {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size:   309476 bytes
Snapshot md5: fb4d8ae2dd5557aaff1c85b1cfe4c981

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for replacing a Collabora document’s file while keeping the same document record.
  * Introduced a new replacement request option that accepts the document ID and an optional display name for compatibility.
* **Bug Fixes**
  * Replacement is restricted to allowed Office document formats and matching document types.
  * The operation is blocked while a document is actively being edited.
  * Update access is required before a document can be replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->