### PR TITLE
fix(019): restore flat dist/main.js emit — server CrashLoopBackOff on dev

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,18 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "vitest.config.ts"]
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "scripts",
+    ".build",
+    "specs",
+    "docs",
+    "**/*spec.ts",
+    "vitest.config.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "outDir": "./dist",
     "removeComments": true,
     "strict": true,
-    "rootDir": ".",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Hotfix — server down on dev (CrashLoopBackOff)

The TS7 upgrade (#6249) normalized tsconfig `baseUrl` → `rootDir: "."`. Because `scripts/` is part of the program, `nest build` then emitted **`dist/src/main.js`** (nested) instead of `dist/main.js`. The Dockerfile CMD `node dist/main.js` → `MODULE_NOT_FOUND` → **CrashLoopBackOff** on the dev Hetzner cluster right after deploy.

**Why it slipped through:** the `docker build` gate builds the image but never runs the entrypoint, and forge live-verification booted the server via `start:dev` (ts-node), not the built `dist`.

**Fix:** scope the production build (`tsconfig.build.json`, used by `nest build`) to `src` via `rootDir: ./src` + include/exclude → flat `dist/main.js`, and keep `scripts/` out of the runtime image. Removed the now-unneeded `rootDir: "."` from the base tsconfig (native typecheck is `--noEmit`, unaffected).

**Verified:** `pnpm build`, `docker build`, and `docker run … ls dist/main.js` all green; `typecheck:native` still passes.

workspace#019-typescript-7-upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to include the intended source files.
  * Refined exclusions so tests, documentation, generated output, and configuration files are omitted from production builds.
  * Simplified shared TypeScript configuration while keeping build-specific settings explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->