### PR TITLE
feat/021 - Flow state settings 

### DIFF
--- a/.scripts/migrations/verify_021_backfill.sh
+++ b/.scripts/migrations/verify_021_backfill.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Data-level verification for the 021 per-flow-state layout backfill (US4-AS1..AS4).
+#
+# Why this exists rather than `pnpm run migration:validate`: that harness needs an
+# operator-supplied reference_schema.sql + reference_CSVs/ that are not in the repo, and
+# neither it nor compare_sql_tables.sh sets `set -e` or ever exits non-zero — so it reports
+# success unconditionally. A gate that cannot fail is not a gate.
+#
+# This script builds a scratch database, seeds the exact row shapes US4 names, runs the
+# migration's UP statements against them, and ASSERTS on the resulting rows. It exits
+# non-zero on any failed assertion.
+#
+# Usage: ./.scripts/migrations/verify_021_backfill.sh
+# Requires: the dev postgres container running (pnpm run start:services).
+
+set -euo pipefail
+
+CONTAINER="${POSTGRES_CONTAINER:-alkemio_dev_postgres}"
+PGUSER="${POSTGRES_USER:-synapse}"
+DB="alkemio_021_verify"
+
+psql_db() { docker exec -i "$CONTAINER" psql -U "$PGUSER" -d "$DB" -v ON_ERROR_STOP=1 "$@"; }
+
+failures=0
+assert_eq() { # <description> <actual> <expected>
+  if [ "$2" = "$3" ]; then
+    echo "  PASS  $1 (= $3)"
+  else
+    echo "  FAIL  $1 — expected '$3', got '$2'"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "==> Creating scratch database $DB"
+docker exec -i "$CONTAINER" psql -U "$PGUSER" -d postgres -v ON_ERROR_STOP=1 \
+  -c "DROP DATABASE IF EXISTS $DB;" -c "CREATE DATABASE $DB;" >/dev/null
+
+echo "==> Seeding the row shapes from US4 (minimal schema — only what the migration touches)"
+psql_db >/dev/null <<'SQL'
+CREATE TABLE collaboration ("id" uuid PRIMARY KEY, "innovationFlowId" uuid);
+CREATE TABLE space ("id" uuid PRIMARY KEY, "collaborationId" uuid, "settings" jsonb);
+CREATE TABLE template_content_space ("id" uuid PRIMARY KEY, "collaborationId" uuid, "settings" jsonb);
+CREATE TABLE innovation_flow_state (
+  "id" text PRIMARY KEY, "innovationFlowId" uuid, "displayName" text, "settings" jsonb NOT NULL
+);
+
+-- flow ids
+-- f1 space=collapsed | f2 space=expanded | f3 space with no layout key
+-- f4 template=collapsed | f5 orphaned (no owner) | f6 space=collapsed w/ admin value already set
+-- f7 space with an out-of-enum legacy value
+INSERT INTO collaboration VALUES
+  ('00000000-0000-0000-0000-0000000000c1','00000000-0000-0000-0000-0000000000f1'),
+  ('00000000-0000-0000-0000-0000000000c2','00000000-0000-0000-0000-0000000000f2'),
+  ('00000000-0000-0000-0000-0000000000c3','00000000-0000-0000-0000-0000000000f3'),
+  ('00000000-0000-0000-0000-0000000000c4','00000000-0000-0000-0000-0000000000f4'),
+  ('00000000-0000-0000-0000-0000000000c6','00000000-0000-0000-0000-0000000000f6'),
+  ('00000000-0000-0000-0000-0000000000c7','00000000-0000-0000-0000-0000000000f7');
+
+INSERT INTO space VALUES
+  ('00000000-0000-0000-0000-0000000000a1','00000000-0000-0000-0000-0000000000c1','{"layout":{"calloutDescriptionDisplayMode":"collapsed"}}'),
+  ('00000000-0000-0000-0000-0000000000a2','00000000-0000-0000-0000-0000000000c2','{"layout":{"calloutDescriptionDisplayMode":"expanded"}}'),
+  ('00000000-0000-0000-0000-0000000000a3','00000000-0000-0000-0000-0000000000c3','{"privacy":{"mode":"public"}}'),
+  ('00000000-0000-0000-0000-0000000000a6','00000000-0000-0000-0000-0000000000c6','{"layout":{"calloutDescriptionDisplayMode":"collapsed"}}'),
+  ('00000000-0000-0000-0000-0000000000a7','00000000-0000-0000-0000-0000000000c7','{"layout":{"calloutDescriptionDisplayMode":"COLLAPSED_LEGACY"}}');
+
+-- the template content space is the M1 case: it carries its OWN collapsed layout
+INSERT INTO template_content_space VALUES
+  ('00000000-0000-0000-0000-0000000000b4','00000000-0000-0000-0000-0000000000c4','{"layout":{"calloutDescriptionDisplayMode":"collapsed"}}');
+
+INSERT INTO innovation_flow_state VALUES
+  ('s-space-collapsed','00000000-0000-0000-0000-0000000000f1','Home','{"allowNewCallouts":true,"visible":true}'),
+  ('s-space-expanded' ,'00000000-0000-0000-0000-0000000000f2','Home','{"allowNewCallouts":true,"visible":true}'),
+  ('s-space-nolayout' ,'00000000-0000-0000-0000-0000000000f3','Home','{"allowNewCallouts":true,"visible":true}'),
+  ('s-template'       ,'00000000-0000-0000-0000-0000000000f4','Home','{"allowNewCallouts":true,"visible":true}'),
+  ('s-orphan'         ,'00000000-0000-0000-0000-0000000000f5','Home','{"allowNewCallouts":true,"visible":true}'),
+  -- US4-AS4: an admin already chose expanded on a collapsed space; the backfill must not touch it
+  ('s-admin-preset'   ,'00000000-0000-0000-0000-0000000000f6','Home','{"allowNewCallouts":true,"visible":true,"descriptionDisplayMode":"expanded","showPublishDetails":false}'),
+  ('s-legacy-value'   ,'00000000-0000-0000-0000-0000000000f7','Home','{"allowNewCallouts":true,"visible":true}');
+SQL
+
+# The migration's UP statements, kept in sync with
+# src/migrations/1783600000000-BackfillInnovationFlowStateLayout.ts
+run_migration() {
+psql_db >/dev/null <<'SQL'
+UPDATE innovation_flow_state ifs
+SET settings = jsonb_set(ifs.settings, '{descriptionDisplayMode}',
+  to_jsonb(CASE WHEN s.settings->'layout'->>'calloutDescriptionDisplayMode' IN ('expanded','collapsed')
+                THEN s.settings->'layout'->>'calloutDescriptionDisplayMode' ELSE 'expanded' END), true)
+FROM collaboration c JOIN space s ON s."collaborationId" = c.id
+WHERE ifs."innovationFlowId" = c."innovationFlowId"
+  AND ifs.settings -> 'descriptionDisplayMode' IS NULL;
+
+UPDATE innovation_flow_state ifs
+SET settings = jsonb_set(ifs.settings, '{descriptionDisplayMode}',
+  to_jsonb(CASE WHEN tcs.settings->'layout'->>'calloutDescriptionDisplayMode' IN ('expanded','collapsed')
+                THEN tcs.settings->'layout'->>'calloutDescriptionDisplayMode' ELSE 'expanded' END), true)
+FROM collaboration c JOIN template_content_space tcs ON tcs."collaborationId" = c.id
+WHERE ifs."innovationFlowId" = c."innovationFlowId"
+  AND ifs.settings -> 'descriptionDisplayMode' IS NULL;
+
+UPDATE innovation_flow_state
+SET settings = jsonb_set(settings, '{descriptionDisplayMode}', '"expanded"'::jsonb, true)
+WHERE settings -> 'descriptionDisplayMode' IS NULL;
+
+UPDATE innovation_flow_state
+SET settings = jsonb_set(settings, '{showPublishDetails}', 'true'::jsonb, true)
+WHERE settings -> 'showPublishDetails' IS NULL;
+SQL
+}
+
+get() { psql_db -tAc "SELECT settings->>'$2' FROM innovation_flow_state WHERE id='$1';" | tr -d '[:space:]'; }
+
+echo
+echo "==> BEFORE (no row carries the new keys)"
+psql_db -c "SELECT id, settings->>'descriptionDisplayMode' AS ddm, settings->>'showPublishDetails' AS spd FROM innovation_flow_state ORDER BY id;"
+
+echo "==> Running migration UP (first run)"
+run_migration
+
+echo
+echo "==> AFTER first run"
+psql_db -c "SELECT id, settings->>'descriptionDisplayMode' AS ddm, settings->>'showPublishDetails' AS spd FROM innovation_flow_state ORDER BY id;"
+
+echo
+echo "==> Assertions"
+assert_eq "US4-AS1  space Collapsed  -> collapsed"            "$(get s-space-collapsed descriptionDisplayMode)" "collapsed"
+assert_eq "US4-AS2  space Expanded   -> expanded"             "$(get s-space-expanded  descriptionDisplayMode)" "expanded"
+assert_eq "US4-AS2  space no layout  -> expanded (default)"   "$(get s-space-nolayout  descriptionDisplayMode)" "expanded"
+assert_eq "M1       template Collapsed -> collapsed (NOT reset to expanded)" \
+                                                              "$(get s-template        descriptionDisplayMode)" "collapsed"
+assert_eq "US4-AS3  orphaned flow    -> expanded (default)"   "$(get s-orphan          descriptionDisplayMode)" "expanded"
+assert_eq "m6       out-of-enum legacy value -> expanded"     "$(get s-legacy-value    descriptionDisplayMode)" "expanded"
+assert_eq "FR-002   showPublishDetails defaults to true"      "$(get s-space-collapsed showPublishDetails)"     "true"
+assert_eq "US4-AS4  admin preset value survives"              "$(get s-admin-preset    descriptionDisplayMode)" "expanded"
+assert_eq "US4-AS4  admin preset showPublishDetails survives" "$(get s-admin-preset    showPublishDetails)"     "false"
+
+echo
+echo "==> Idempotency: capturing state, re-running, diffing (US4-AS4)"
+before_hash=$(psql_db -tAc "SELECT md5(string_agg(id || settings::text, '|' ORDER BY id)) FROM innovation_flow_state;")
+run_migration
+after_hash=$(psql_db -tAc "SELECT md5(string_agg(id || settings::text, '|' ORDER BY id)) FROM innovation_flow_state;")
+assert_eq "second run changes zero rows" "$after_hash" "$before_hash"
+
+echo
+echo "==> Dropping scratch database"
+docker exec -i "$CONTAINER" psql -U "$PGUSER" -d postgres -c "DROP DATABASE IF EXISTS $DB;" >/dev/null
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "RESULT: $failures assertion(s) FAILED"
+  exit 1
+fi
+echo "RESULT: all assertions passed"

--- a/schema.graphql
+++ b/schema.graphql
@@ -2546,6 +2546,14 @@ type CreateInnovationFlowStateSettingsData {
   """The flag to set."""
   allowNewCallouts: Boolean!
   """
+  Optional. How Post descriptions in this State are displayed in the feed: expanded or collapsed. Defaults to EXPANDED when omitted.
+  """
+  descriptionDisplayMode: CalloutDescriptionDisplayMode
+  """
+  Optional. Whether Posts in this State show publish details in the feed. Defaults to true when omitted.
+  """
+  showPublishDetails: Boolean
+  """
   Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted.
   """
   visible: Boolean
@@ -3107,6 +3115,14 @@ type InnovationFlowState {
 type InnovationFlowStateSettings {
   """Whether new callouts can be added to this State."""
   allowNewCallouts: Boolean!
+  """
+  How Post descriptions in this State are displayed in the feed: expanded or collapsed. Default expanded.
+  """
+  descriptionDisplayMode: CalloutDescriptionDisplayMode!
+  """
+  Whether Posts in this State show publish details (publisher, publish date, avatar) in the feed. Presentation only — does not restrict access to publisher data. Default true.
+  """
+  showPublishDetails: Boolean!
   """
   Whether this State/phase is shown in the member-facing navigation. Default true. UI-affordance only: it does NOT gate access to the phase content.
   """
@@ -6089,7 +6105,7 @@ type SpaceSettingsCollaboration {
 
 type SpaceSettingsLayout {
   """The default display mode for callout descriptions in this Space."""
-  calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode!
+  calloutDescriptionDisplayMode: CalloutDescriptionDisplayMode! @deprecated(reason: "REMOVE_AFTER=2026-10-31 | superseded by InnovationFlowStateSettings.descriptionDisplayMode")
 }
 
 type SpaceSettingsMembership {
@@ -7621,6 +7637,14 @@ input CreateInnovationFlowStateSettingsInput {
   """The flag to set."""
   allowNewCallouts: Boolean!
   """
+  Optional. How Post descriptions in this State are displayed in the feed: expanded or collapsed. Defaults to EXPANDED when omitted.
+  """
+  descriptionDisplayMode: CalloutDescriptionDisplayMode
+  """
+  Optional. Whether Posts in this State show publish details in the feed. Defaults to true when omitted.
+  """
+  showPublishDetails: Boolean
+  """
   Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted.
   """
   visible: Boolean
@@ -9008,6 +9032,14 @@ input UpdateInnovationFlowStateSettingsInput {
   Optional. Sets whether new callouts can be added to this State; omission leaves the stored value unchanged.
   """
   allowNewCallouts: Boolean
+  """
+  Optional. Sets how Post descriptions in this State are displayed in the feed; omission leaves the stored value unchanged.
+  """
+  descriptionDisplayMode: CalloutDescriptionDisplayMode
+  """
+  Optional. Sets whether Posts in this State show publish details (publisher, publish date, avatar) in the feed; omission leaves the stored value unchanged.
+  """
+  showPublishDetails: Boolean
   """
   Optional. Sets whether the phase is shown in member-facing navigation; omission leaves the stored value unchanged.
   """

--- a/schema.graphql
+++ b/schema.graphql
@@ -9018,10 +9018,14 @@ input UpdateInnovationFlowInput {
 }
 
 input UpdateInnovationFlowStateInput {
-  """The explanation text to clarify the State."""
+  """
+  Optional. The explanation text to clarify the State; omission leaves the stored value unchanged.
+  """
   description: Markdown
-  """The display name for the State"""
-  displayName: String!
+  """
+  Optional. The display name for the State; omission leaves the stored value unchanged.
+  """
+  displayName: String
   """ID of the Innovation Flow"""
   innovationFlowStateID: UUID!
   settings: UpdateInnovationFlowStateSettingsInput

--- a/src/domain/collaboration/innovation-flow-state-settings/dto/innovation.flow.state.settings.dto.create.ts
+++ b/src/domain/collaboration/innovation-flow-state-settings/dto/innovation.flow.state.settings.dto.create.ts
@@ -1,3 +1,4 @@
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 
 @InputType()
@@ -15,4 +16,18 @@ export class CreateInnovationFlowStateSettingsInput {
       'Optional. Whether the phase is shown in member-facing navigation. Defaults to true when omitted.',
   })
   visible?: boolean;
+
+  @Field(() => CalloutDescriptionDisplayMode, {
+    nullable: true,
+    description:
+      'Optional. How Post descriptions in this State are displayed in the feed: expanded or collapsed. Defaults to EXPANDED when omitted.',
+  })
+  descriptionDisplayMode?: CalloutDescriptionDisplayMode;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Optional. Whether Posts in this State show publish details in the feed. Defaults to true when omitted.',
+  })
+  showPublishDetails?: boolean;
 }

--- a/src/domain/collaboration/innovation-flow-state-settings/dto/innovation.flow.state.settings.dto.update.ts
+++ b/src/domain/collaboration/innovation-flow-state-settings/dto/innovation.flow.state.settings.dto.update.ts
@@ -1,3 +1,4 @@
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
 import { Field, InputType } from '@nestjs/graphql';
 
 @InputType()
@@ -15,4 +16,18 @@ export class UpdateInnovationFlowStateSettingsInput {
       'Optional. Sets whether the phase is shown in member-facing navigation; omission leaves the stored value unchanged.',
   })
   visible?: boolean;
+
+  @Field(() => CalloutDescriptionDisplayMode, {
+    nullable: true,
+    description:
+      'Optional. Sets how Post descriptions in this State are displayed in the feed; omission leaves the stored value unchanged.',
+  })
+  descriptionDisplayMode?: CalloutDescriptionDisplayMode;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Optional. Sets whether Posts in this State show publish details (publisher, publish date, avatar) in the feed; omission leaves the stored value unchanged.',
+  })
+  showPublishDetails?: boolean;
 }

--- a/src/domain/collaboration/innovation-flow-state-settings/innovation.flow.settings.interface.ts
+++ b/src/domain/collaboration/innovation-flow-state-settings/innovation.flow.settings.interface.ts
@@ -1,3 +1,4 @@
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
 import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType('InnovationFlowStateSettings')
@@ -14,4 +15,18 @@ export abstract class IInnovationFlowStateSettings {
       'Whether this State/phase is shown in the member-facing navigation. Default true. UI-affordance only: it does NOT gate access to the phase content.',
   })
   visible!: boolean;
+
+  @Field(() => CalloutDescriptionDisplayMode, {
+    nullable: false,
+    description:
+      'How Post descriptions in this State are displayed in the feed: expanded or collapsed. Default expanded.',
+  })
+  descriptionDisplayMode!: CalloutDescriptionDisplayMode;
+
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      'Whether Posts in this State show publish details (publisher, publish date, avatar) in the feed. Presentation only — does not restrict access to publisher data. Default true.',
+  })
+  showPublishDetails!: boolean;
 }

--- a/src/domain/collaboration/innovation-flow-state/dto/innovation.flow.state.dto.update.ts
+++ b/src/domain/collaboration/innovation-flow-state/dto/innovation.flow.state.dto.update.ts
@@ -15,15 +15,17 @@ export class UpdateInnovationFlowStateInput {
   innovationFlowStateID!: string;
 
   @Field(() => String, {
-    nullable: false,
-    description: 'The display name for the State',
+    nullable: true,
+    description:
+      'Optional. The display name for the State; omission leaves the stored value unchanged.',
   })
   @MaxLength(SMALL_TEXT_LENGTH)
-  displayName!: string;
+  displayName?: string;
 
   @Field(() => Markdown, {
     nullable: true,
-    description: 'The explanation text to clarify the State.',
+    description:
+      'Optional. The explanation text to clarify the State; omission leaves the stored value unchanged.',
   })
   @MaxLength(LONG_TEXT_LENGTH)
   description?: string;

--- a/src/domain/collaboration/innovation-flow-state/dto/innovation.flow.state.dto.update.ts
+++ b/src/domain/collaboration/innovation-flow-state/dto/innovation.flow.state.dto.update.ts
@@ -4,7 +4,7 @@ import { Markdown } from '@domain/common/scalars/scalar.markdown';
 import { Field, InputType } from '@nestjs/graphql';
 import { LONG_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@src/common/constants';
 import { Type } from 'class-transformer';
-import { MaxLength, ValidateNested } from 'class-validator';
+import { IsOptional, MaxLength, ValidateNested } from 'class-validator';
 
 @InputType()
 export class UpdateInnovationFlowStateInput {
@@ -19,6 +19,7 @@ export class UpdateInnovationFlowStateInput {
     description:
       'Optional. The display name for the State; omission leaves the stored value unchanged.',
   })
+  @IsOptional()
   @MaxLength(SMALL_TEXT_LENGTH)
   displayName?: string;
 
@@ -27,6 +28,7 @@ export class UpdateInnovationFlowStateInput {
     description:
       'Optional. The explanation text to clarify the State; omission leaves the stored value unchanged.',
   })
+  @IsOptional()
   @MaxLength(LONG_TEXT_LENGTH)
   description?: string;
 

--- a/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.spec.ts
+++ b/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.spec.ts
@@ -252,13 +252,13 @@ describe('InnovationFlowStateService', () => {
       expect(state.settings.visible).toBe(false);
     });
 
-    it('should preserve stored descriptionDisplayMode/showPublishDetails when sent as explicit null (never overwrite a NonNull field)', async () => {
+    it('should preserve every stored settings field when sent as explicit null (never overwrite a NonNull field)', async () => {
       const state = {
         id: 'state-1',
         displayName: 'Name',
         description: '',
         settings: {
-          allowNewCallouts: true,
+          allowNewCallouts: false,
           visible: true,
           descriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
           showPublishDetails: false,
@@ -273,6 +273,7 @@ describe('InnovationFlowStateService', () => {
       await service.update(state, {
         displayName: 'Name',
         settings: {
+          allowNewCallouts: null,
           descriptionDisplayMode: null,
           showPublishDetails: null,
           visible: null,
@@ -284,6 +285,9 @@ describe('InnovationFlowStateService', () => {
       );
       expect(state.settings.showPublishDetails).toBe(false);
       expect(state.settings.visible).toBe(true);
+      // allowNewCallouts is Boolean! on the output type: an explicit null must never be
+      // persisted, or every subsequent read of this state fails NonNull serialization.
+      expect(state.settings.allowNewCallouts).toBe(false);
     });
 
     it('should preserve stored settings.allowNewCallouts when omitted from the update', async () => {
@@ -325,7 +329,10 @@ describe('InnovationFlowStateService', () => {
       expect(state.settings.visible).toBe(false);
     });
 
-    it('should default description to empty string when undefined', async () => {
+    // FR-013: displayName/description are partial updates too. A client editing only
+    // `settings` omits them, and omission must preserve — previously `description ?? ''`
+    // wiped the stored description whenever it was not re-sent.
+    it('should preserve the stored description when omitted from the update (FR-013)', async () => {
       const state = {
         id: 'state-1',
         displayName: 'Name',
@@ -340,7 +347,45 @@ describe('InnovationFlowStateService', () => {
         description: undefined,
       } as any);
 
+      expect(state.description).toBe('Old');
+    });
+
+    it('should clear the description when an explicit empty string is sent', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Name',
+        description: 'Old',
+        settings: { allowNewCallouts: true },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      await service.update(state, {
+        displayName: 'Name',
+        description: '',
+      } as any);
+
       expect(state.description).toBe('');
+    });
+
+    it('should preserve the stored displayName when omitted from the update (FR-013)', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Original',
+        description: 'Desc',
+        settings: { allowNewCallouts: true },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      // A settings-only edit must not clobber a concurrent rename it never saw.
+      await service.update(state, {
+        settings: { showPublishDetails: false },
+      } as any);
+
+      expect(state.displayName).toBe('Original');
+      expect(state.description).toBe('Desc');
+      expect(state.settings.showPublishDetails).toBe(false);
     });
 
     // FR-001/021: descriptionDisplayMode partial update

--- a/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.spec.ts
+++ b/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.spec.ts
@@ -1,3 +1,4 @@
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
 import { TemplateType } from '@common/enums/template.type';
 import {
   EntityNotFoundException,
@@ -105,6 +106,53 @@ describe('InnovationFlowStateService', () => {
 
       expect(result.sortOrder).toBe(0);
     });
+
+    // FR-001/021: descriptionDisplayMode defaults
+    it('should default settings.descriptionDisplayMode to EXPANDED when not provided (FR-001)', async () => {
+      const stateData = { displayName: 'Draft' };
+
+      const result = await service.createInnovationFlowState(stateData as any);
+
+      expect(result.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.EXPANDED
+      );
+    });
+
+    it('should honor an explicit create-time descriptionDisplayMode=COLLAPSED (FR-001)', async () => {
+      const stateData = {
+        displayName: 'Dense Phase',
+        settings: {
+          allowNewCallouts: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+        },
+      };
+
+      const result = await service.createInnovationFlowState(stateData as any);
+
+      expect(result.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.COLLAPSED
+      );
+    });
+
+    // FR-002/021: showPublishDetails defaults
+    it('should default settings.showPublishDetails to true when not provided (FR-002)', async () => {
+      const stateData = { displayName: 'Draft' };
+
+      const result = await service.createInnovationFlowState(stateData as any);
+
+      expect(result.settings.showPublishDetails).toBe(true);
+    });
+
+    it('should honor an explicit create-time showPublishDetails=false (FR-002)', async () => {
+      const stateData = {
+        displayName: 'Content Block',
+        settings: { allowNewCallouts: true, showPublishDetails: false },
+      };
+
+      const result = await service.createInnovationFlowState(stateData as any);
+
+      expect(result.settings.showPublishDetails).toBe(false);
+    });
   });
 
   describe('update', () => {
@@ -204,6 +252,40 @@ describe('InnovationFlowStateService', () => {
       expect(state.settings.visible).toBe(false);
     });
 
+    it('should preserve stored descriptionDisplayMode/showPublishDetails when sent as explicit null (never overwrite a NonNull field)', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Name',
+        description: '',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+          showPublishDetails: false,
+        },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      // A nullable GraphQL input can arrive as explicit null; the `!= null` guard must
+      // treat it like omission and keep the stored values (so the mutation's own NonNull
+      // response never fails to serialize).
+      await service.update(state, {
+        displayName: 'Name',
+        settings: {
+          descriptionDisplayMode: null,
+          showPublishDetails: null,
+          visible: null,
+        },
+      } as any);
+
+      expect(state.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.COLLAPSED
+      );
+      expect(state.settings.showPublishDetails).toBe(false);
+      expect(state.settings.visible).toBe(true);
+    });
+
     it('should preserve stored settings.allowNewCallouts when omitted from the update', async () => {
       const state = {
         id: 'state-1',
@@ -259,6 +341,132 @@ describe('InnovationFlowStateService', () => {
       } as any);
 
       expect(state.description).toBe('');
+    });
+
+    // FR-001/021: descriptionDisplayMode partial update
+    it('should update descriptionDisplayMode to COLLAPSED when explicitly set (FR-001)', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Name',
+        description: '',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+          showPublishDetails: true,
+        },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      await service.update(state, {
+        displayName: 'Name',
+        settings: {
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+        },
+      } as any);
+
+      expect(state.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.COLLAPSED
+      );
+    });
+
+    it('should preserve stored descriptionDisplayMode when omitted from the update (FR-013)', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Name',
+        description: '',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+          showPublishDetails: true,
+        },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      await service.update(state, {
+        displayName: 'Name',
+        settings: { visible: true },
+      } as any);
+
+      expect(state.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.COLLAPSED
+      );
+    });
+
+    // FR-002/021: showPublishDetails partial update
+    it('should update showPublishDetails to false when explicitly set (FR-002)', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Name',
+        description: '',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+          showPublishDetails: true,
+        },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      await service.update(state, {
+        displayName: 'Name',
+        settings: { showPublishDetails: false },
+      } as any);
+
+      expect(state.settings.showPublishDetails).toBe(false);
+    });
+
+    it('should preserve stored showPublishDetails when omitted from the update (FR-013)', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Name',
+        description: '',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+          showPublishDetails: false,
+        },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      await service.update(state, {
+        displayName: 'Name',
+        settings: { visible: true },
+      } as any);
+
+      expect(state.settings.showPublishDetails).toBe(false);
+    });
+
+    it('should not alter descriptionDisplayMode when only showPublishDetails changes (FR-013)', async () => {
+      const state = {
+        id: 'state-1',
+        displayName: 'Name',
+        description: '',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+          showPublishDetails: true,
+        },
+      } as any;
+
+      vi.mocked(repository.save).mockResolvedValue(state);
+
+      await service.update(state, {
+        displayName: 'Name',
+        settings: { showPublishDetails: false },
+      } as any);
+
+      expect(state.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.COLLAPSED
+      );
+      expect(state.settings.showPublishDetails).toBe(false);
     });
   });
 
@@ -328,6 +536,81 @@ describe('InnovationFlowStateService', () => {
 
       expect(result.settings.visible).toBe(true);
       expect(result.settings.allowNewCallouts).toBe(true);
+    });
+
+    // FR-001/021: descriptionDisplayMode coercion
+    it('should coerce absent descriptionDisplayMode to EXPANDED on read (FR-001)', async () => {
+      const state = {
+        id: 'state-1',
+        settings: { allowNewCallouts: true, visible: true },
+      } as any;
+      vi.mocked(repository.findOne).mockResolvedValue(state);
+
+      const result = await service.getInnovationFlowStateOrFail('state-1');
+
+      expect(result.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.EXPANDED
+      );
+    });
+
+    it('should not overwrite an existing descriptionDisplayMode=COLLAPSED on read (FR-001)', async () => {
+      const state = {
+        id: 'state-1',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.COLLAPSED,
+        },
+      } as any;
+      vi.mocked(repository.findOne).mockResolvedValue(state);
+
+      const result = await service.getInnovationFlowStateOrFail('state-1');
+
+      expect(result.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.COLLAPSED
+      );
+    });
+
+    // FR-002/021: showPublishDetails coercion
+    it('should coerce absent showPublishDetails to true on read (FR-002)', async () => {
+      const state = {
+        id: 'state-1',
+        settings: { allowNewCallouts: true, visible: true },
+      } as any;
+      vi.mocked(repository.findOne).mockResolvedValue(state);
+
+      const result = await service.getInnovationFlowStateOrFail('state-1');
+
+      expect(result.settings.showPublishDetails).toBe(true);
+    });
+
+    it('should not overwrite an existing showPublishDetails=false on read (FR-002)', async () => {
+      const state = {
+        id: 'state-1',
+        settings: {
+          allowNewCallouts: true,
+          visible: true,
+          descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+          showPublishDetails: false,
+        },
+      } as any;
+      vi.mocked(repository.findOne).mockResolvedValue(state);
+
+      const result = await service.getInnovationFlowStateOrFail('state-1');
+
+      expect(result.settings.showPublishDetails).toBe(false);
+    });
+
+    it('should initialize settings with all defaults when settings is entirely absent on read (FR-001/FR-002)', async () => {
+      const state = { id: 'state-1' } as any;
+      vi.mocked(repository.findOne).mockResolvedValue(state);
+
+      const result = await service.getInnovationFlowStateOrFail('state-1');
+
+      expect(result.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.EXPANDED
+      );
+      expect(result.settings.showPublishDetails).toBe(true);
     });
   });
 

--- a/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.ts
@@ -16,6 +16,7 @@ import { CreateInnovationFlowStateInput } from './dto/innovation.flow.state.dto.
 import { UpdateInnovationFlowStateInput } from './dto/innovation.flow.state.dto.update';
 import { InnovationFlowState } from './innovation.flow.state.entity';
 import { IInnovationFlowState } from './innovation.flow.state.interface';
+import { normalizeStateSettings } from './normalize.state.settings';
 
 @Injectable()
 export class InnovationFlowStateService {
@@ -73,13 +74,22 @@ export class InnovationFlowStateService {
     innovationFlowState: IInnovationFlowState,
     updateData: UpdateInnovationFlowStateInput
   ): Promise<IInnovationFlowState> {
-    innovationFlowState.displayName = updateData.displayName;
-    innovationFlowState.description = updateData.description ?? '';
+    // FR-013: every field of this mutation is a non-destructive partial update. Omission
+    // (or an explicit null) preserves the stored value, so a client editing only `settings`
+    // cannot clobber a concurrent rename or description edit it never saw.
+    if (updateData.displayName != null) {
+      innovationFlowState.displayName = updateData.displayName;
+    }
+    // `!= null`, not `?? ''`: omitting `description` must preserve it, not wipe it.
+    // Clearing a description still works — an explicit '' is not null.
+    if (updateData.description != null) {
+      innovationFlowState.description = updateData.description;
+    }
     if (updateData.settings) {
       // Both flags are optional, non-destructive partial updates: an explicit
       // value (including `false`) is honored; omission preserves the stored
       // value.
-      if (updateData.settings.allowNewCallouts !== undefined) {
+      if (updateData.settings.allowNewCallouts != null) {
         innovationFlowState.settings.allowNewCallouts =
           updateData.settings.allowNewCallouts;
       }
@@ -135,29 +145,7 @@ export class InnovationFlowStateService {
         `Unable to find InnovationFlowState with ID: ${innovationFlowStateID}`,
         LogContext.INNOVATION_FLOW
       );
-    // FR-001 / research Decision 2: non-nullable GraphQL fields on settings.
-    // The backfill migration guarantees every persisted row carries them, but
-    // coerce defensively here so any un-backfilled row — or a row with missing
-    // settings — still resolves to a value rather than null (risk R-4).
-    if (!innovationFlowState.settings) {
-      innovationFlowState.settings = {
-        allowNewCallouts: true,
-        visible: true,
-        descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
-        showPublishDetails: true,
-      };
-    } else {
-      innovationFlowState.settings.visible =
-        innovationFlowState.settings.visible ?? true;
-      // FR-001/021: coerce absent descriptionDisplayMode to EXPANDED.
-      innovationFlowState.settings.descriptionDisplayMode =
-        innovationFlowState.settings.descriptionDisplayMode ??
-        CalloutDescriptionDisplayMode.EXPANDED;
-      // FR-002/021: coerce absent showPublishDetails to true.
-      innovationFlowState.settings.showPublishDetails =
-        innovationFlowState.settings.showPublishDetails ?? true;
-    }
-    return innovationFlowState;
+    return normalizeStateSettings(innovationFlowState);
   }
 
   public getStateNames(states: IInnovationFlowState[]): string[] {

--- a/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.ts
+++ b/src/domain/collaboration/innovation-flow-state/innovation.flow.state.service.ts
@@ -1,5 +1,6 @@
 import { LogContext } from '@common/enums';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
 import { TemplateType } from '@common/enums/template.type';
 import {
   EntityNotFoundException,
@@ -41,6 +42,12 @@ export class InnovationFlowStateService {
       // intentionally left untouched (consuming create-time allowNewCallouts is
       // out of scope for story #6138).
       visible: stateData.settings?.visible ?? true,
+      // FR-001/021: descriptionDisplayMode defaults to EXPANDED; honor explicit create-time value.
+      descriptionDisplayMode:
+        stateData.settings?.descriptionDisplayMode ??
+        CalloutDescriptionDisplayMode.EXPANDED,
+      // FR-002/021: showPublishDetails defaults to true; honor explicit create-time value.
+      showPublishDetails: stateData.settings?.showPublishDetails ?? true,
     };
     innovationFlowState.sortOrder = stateData.sortOrder ?? 0;
     innovationFlowState.authorization = new AuthorizationPolicy(
@@ -83,8 +90,22 @@ export class InnovationFlowStateService {
       // UPDATE privilege (see innovation.flow.resolver.mutations.ts); `visible`
       // is a navigation hint only and is never read by authorization or content
       // access logic.
-      if (updateData.settings.visible !== undefined) {
+      // `!= null` (not `!== undefined`): these settings fields are non-nullable, but the
+      // GraphQL inputs are nullable, so a client can send an explicit `null`. Guarding on
+      // `!= null` skips both `undefined` (omitted → preserve) AND `null` (never overwrite a
+      // NonNull field, which would otherwise make the mutation's own response fail to serialize).
+      if (updateData.settings.visible != null) {
         innovationFlowState.settings.visible = updateData.settings.visible;
+      }
+      // FR-001/021: partial update for descriptionDisplayMode — omission/null preserves stored value.
+      if (updateData.settings.descriptionDisplayMode != null) {
+        innovationFlowState.settings.descriptionDisplayMode =
+          updateData.settings.descriptionDisplayMode;
+      }
+      // FR-002/021: partial update for showPublishDetails — omission/null preserves stored value.
+      if (updateData.settings.showPublishDetails != null) {
+        innovationFlowState.settings.showPublishDetails =
+          updateData.settings.showPublishDetails;
       }
     }
 
@@ -114,16 +135,27 @@ export class InnovationFlowStateService {
         `Unable to find InnovationFlowState with ID: ${innovationFlowStateID}`,
         LogContext.INNOVATION_FLOW
       );
-    // FR-001 / research Decision 2: `visible` is a non-nullable GraphQL field.
-    // The backfill migration guarantees every persisted row carries it, but
-    // coerce defensively here (treat absent as visible) so any un-backfilled
-    // row — or, in the worst case, a row with missing settings — still resolves
-    // to a boolean rather than null.
+    // FR-001 / research Decision 2: non-nullable GraphQL fields on settings.
+    // The backfill migration guarantees every persisted row carries them, but
+    // coerce defensively here so any un-backfilled row — or a row with missing
+    // settings — still resolves to a value rather than null (risk R-4).
     if (!innovationFlowState.settings) {
-      innovationFlowState.settings = { allowNewCallouts: true, visible: true };
+      innovationFlowState.settings = {
+        allowNewCallouts: true,
+        visible: true,
+        descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+        showPublishDetails: true,
+      };
     } else {
       innovationFlowState.settings.visible =
         innovationFlowState.settings.visible ?? true;
+      // FR-001/021: coerce absent descriptionDisplayMode to EXPANDED.
+      innovationFlowState.settings.descriptionDisplayMode =
+        innovationFlowState.settings.descriptionDisplayMode ??
+        CalloutDescriptionDisplayMode.EXPANDED;
+      // FR-002/021: coerce absent showPublishDetails to true.
+      innovationFlowState.settings.showPublishDetails =
+        innovationFlowState.settings.showPublishDetails ?? true;
     }
     return innovationFlowState;
   }

--- a/src/domain/collaboration/innovation-flow-state/normalize.state.settings.ts
+++ b/src/domain/collaboration/innovation-flow-state/normalize.state.settings.ts
@@ -1,0 +1,45 @@
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
+import { IInnovationFlowState } from './innovation.flow.state.interface';
+
+/**
+ * FR-001 / research Decision 2 (risk R-4): every field of `InnovationFlowStateSettings` is
+ * NonNull in GraphQL, but the underlying JSONB is only guaranteed to carry them once the
+ * backfill migration (1783600000000) has run. A row missing a key would serialize `null`
+ * into a NonNull field, and because `InnovationFlow.states` is `[InnovationFlowState!]!`
+ * the error propagates up and takes out the whole flow — a 500 on the space page rather
+ * than a graceful default.
+ *
+ * Apply this to EVERY path that hands an InnovationFlowState to the GraphQL layer, not just
+ * the single-state-by-id lookups: the dominant read path (`InnovationFlow.states`) returns
+ * raw TypeORM rows and never touched the old inline coercion. Keeping this as one shared
+ * helper is what removes the (previously undocumented) migrate-before-deploy ordering
+ * constraint.
+ *
+ * Mutates and returns the state so it can be used inline on a mapped array.
+ */
+export const normalizeStateSettings = (
+  state: IInnovationFlowState
+): IInnovationFlowState => {
+  if (!state.settings) {
+    state.settings = {
+      allowNewCallouts: true,
+      visible: true,
+      descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+      showPublishDetails: true,
+    };
+    return state;
+  }
+
+  state.settings.allowNewCallouts = state.settings.allowNewCallouts ?? true;
+  state.settings.visible = state.settings.visible ?? true;
+  state.settings.descriptionDisplayMode =
+    state.settings.descriptionDisplayMode ??
+    CalloutDescriptionDisplayMode.EXPANDED;
+  state.settings.showPublishDetails = state.settings.showPublishDetails ?? true;
+
+  return state;
+};
+
+export const normalizeStatesSettings = (
+  states: IInnovationFlowState[]
+): IInnovationFlowState[] => states.map(normalizeStateSettings);

--- a/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.spec.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.spec.ts
@@ -1,3 +1,4 @@
+import { CalloutDescriptionDisplayMode } from '@common/enums/callout.description.display.mode';
 import { IInnovationFlow } from '@domain/collaboration/innovation-flow/innovation.flow.interface';
 import { InnovationFlowService } from '@domain/collaboration/innovation-flow/innovation.flow.service';
 import { IInnovationFlowState } from '@domain/collaboration/innovation-flow-state/innovation.flow.state.interface';
@@ -72,6 +73,41 @@ describe('InnovationFlowResolverFields', () => {
 
       expect(result).toEqual(serviceStates);
       expect(innovationFlowService.getStates).toHaveBeenCalledWith('flow-1');
+    });
+
+    // Every field of `settings` is NonNull in GraphQL, and `states` is [InnovationFlowState!]!,
+    // so a single un-backfilled row returning null here does not degrade — it errors the whole
+    // flow, and the space page with it. This is the read path that actually serves these fields.
+    it('should coerce settings of an un-backfilled row to defaults rather than serializing null', async () => {
+      const unbackfilled = {
+        id: 's-1',
+        sortOrder: 1,
+        settings: { allowNewCallouts: false },
+      } as unknown as IInnovationFlowState;
+      const flow = makeFlow('flow-1', [unbackfilled]);
+
+      const [state] = await resolver.states(flow);
+
+      expect(state.settings.descriptionDisplayMode).toBe(
+        CalloutDescriptionDisplayMode.EXPANDED
+      );
+      expect(state.settings.showPublishDetails).toBe(true);
+      expect(state.settings.visible).toBe(true);
+      // a stored value must survive the coercion
+      expect(state.settings.allowNewCallouts).toBe(false);
+    });
+
+    it('should coerce a row with no settings object at all', async () => {
+      const flow = makeFlow('flow-1', [makeState('s-1', 1)]);
+
+      const [state] = await resolver.states(flow);
+
+      expect(state.settings).toEqual({
+        allowNewCallouts: true,
+        visible: true,
+        descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+        showPublishDetails: true,
+      });
     });
   });
 

--- a/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.resolver.fields.ts
@@ -8,6 +8,10 @@ import { IProfile } from '@domain/common/profile/profile.interface';
 import { UseGuards } from '@nestjs/common';
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { IInnovationFlowState } from '../innovation-flow-state/innovation.flow.state.interface';
+import {
+  normalizeStateSettings,
+  normalizeStatesSettings,
+} from '../innovation-flow-state/normalize.state.settings';
 import { sortBySortOrder } from '../innovation-flow-state/utils/sortBySortOrder';
 import { InnovationFlow } from './innovation.flow.entity';
 import { IInnovationFlow } from './innovation.flow.interface';
@@ -26,9 +30,14 @@ export class InnovationFlowResolverFields {
   async states(
     @Parent() innovationFlow: IInnovationFlow
   ): Promise<IInnovationFlowState[]> {
-    // If states were eagerly loaded (e.g. from getInnovationFlow), reuse them
+    // If states were eagerly loaded (e.g. from getInnovationFlow), reuse them.
+    // Normalize: these are raw TypeORM rows that never pass through
+    // getInnovationFlowStateOrFail, so an un-backfilled row would serialize null
+    // into the NonNull settings fields and fail the whole [InnovationFlowState!]! list.
     if (innovationFlow.states?.length) {
-      return [...innovationFlow.states].sort(sortBySortOrder);
+      return normalizeStatesSettings(
+        [...innovationFlow.states].sort(sortBySortOrder)
+      );
     }
     return await this.innovationFlowService.getStates(innovationFlow.id);
   }
@@ -47,11 +56,10 @@ export class InnovationFlowResolverFields {
     }
     // If states were eagerly loaded, find currentState from the array
     if (innovationFlow.states?.length) {
-      return (
-        innovationFlow.states.find(
-          s => s.id === innovationFlow.currentStateID
-        ) ?? null
+      const currentState = innovationFlow.states.find(
+        s => s.id === innovationFlow.currentStateID
       );
+      return currentState ? normalizeStateSettings(currentState) : null;
     }
     return await this.innovationFlowService.getCurrentState(
       innovationFlow.currentStateID

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
@@ -140,6 +140,50 @@ describe('InnovationFlowService', () => {
     });
   });
 
+  // Uniqueness was enforced only when a flow was CREATED, so the incremental edit paths
+  // (rename, add state) could produce a flow that creating it from scratch would reject.
+  // Posts join to their phase by display name, so duplicates make that join ambiguous.
+  describe('validateStateDisplayNameIsUnique', () => {
+    const existingStates = [
+      { id: 's-1', displayName: 'Home' },
+      { id: 's-2', displayName: 'Community' },
+    ] as any[];
+
+    it('should throw when adding a name that already exists', () => {
+      expect(() =>
+        service.validateStateDisplayNameIsUnique('Home', existingStates)
+      ).toThrow(ValidationException);
+    });
+
+    it('should throw regardless of casing or surrounding whitespace', () => {
+      expect(() =>
+        service.validateStateDisplayNameIsUnique('  hOmE ', existingStates)
+      ).toThrow(ValidationException);
+    });
+
+    it('should allow a state to keep its own name on rename (self-collision excluded)', () => {
+      expect(() =>
+        service.validateStateDisplayNameIsUnique('Home', existingStates, 's-1')
+      ).not.toThrow();
+    });
+
+    it('should throw when renaming one state onto another state name', () => {
+      expect(() =>
+        service.validateStateDisplayNameIsUnique(
+          'Community',
+          existingStates,
+          's-1'
+        )
+      ).toThrow(ValidationException);
+    });
+
+    it('should allow a genuinely new name', () => {
+      expect(() =>
+        service.validateStateDisplayNameIsUnique('Knowledge', existingStates)
+      ).not.toThrow();
+    });
+  });
+
   describe('getInnovationFlowOrFail', () => {
     it('should return innovation flow when found', async () => {
       const flow = { id: 'flow-1' } as any;

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -30,6 +30,7 @@ import { CreateInnovationFlowStateInput } from '../innovation-flow-state/dto/inn
 import { UpdateInnovationFlowStateInput } from '../innovation-flow-state/dto/innovation.flow.state.dto.update';
 import { IInnovationFlowState } from '../innovation-flow-state/innovation.flow.state.interface';
 import { InnovationFlowStateService } from '../innovation-flow-state/innovation.flow.state.service';
+import { normalizeStatesSettings } from '../innovation-flow-state/normalize.state.settings';
 import { sortBySortOrder } from '../innovation-flow-state/utils/sortBySortOrder';
 import { CreateInnovationFlowInput } from './dto/innovation.flow.dto.create';
 import { DeleteStateOnInnovationFlowInput } from './dto/innovation.flow.dto.state.delete';
@@ -192,12 +193,24 @@ export class InnovationFlowService {
         }
       );
     }
-    // Reject comma-containing names on rename (commas are reserved separators)
-    this.validateStateDisplayNames([stateUpdatedData.displayName]);
+    // displayName is an optional partial update: only validate/rename when supplied.
+    const newDisplayName = stateUpdatedData.displayName;
+    if (newDisplayName != null) {
+      // Reject comma-containing names on rename (commas are reserved separators)
+      this.validateStateDisplayNames([newDisplayName]);
+      // Reject a rename that collides with another state. Posts are joined to their phase
+      // by display name, so duplicates make that join ambiguous: the settings of whichever
+      // phase sorts first would silently apply to both.
+      this.validateStateDisplayNameIsUnique(
+        newDisplayName,
+        states,
+        updatedState.id
+      );
+    }
 
     const renamedState =
-      updatedState.displayName !== stateUpdatedData.displayName
-        ? { old: updatedState.displayName, new: stateUpdatedData.displayName }
+      newDisplayName != null && updatedState.displayName !== newDisplayName
+        ? { old: updatedState.displayName, new: newDisplayName }
         : undefined;
 
     // Update the state with the new data
@@ -458,6 +471,11 @@ export class InnovationFlowService {
         LogContext.INNOVATION_FLOW
       );
     }
+    // Posts join to their phase by display name, so a duplicate makes that join ambiguous.
+    this.validateStateDisplayNameIsUnique(
+      stateData.displayName,
+      innovationFlow.states
+    );
     if (innovationFlow.states.length >= maximumNumberOfStates) {
       throw new ValidationException(
         `Innovation Flow can have a maximum of ${maximumNumberOfStates} states; provided: ${innovationFlow.states.length}`,
@@ -618,7 +636,11 @@ export class InnovationFlowService {
         );
       }
     }
-    const stateNames = states.map(state => state.displayName);
+    // On an update input, an omitted displayName means "leave unchanged", so it carries no
+    // name to validate. Creation inputs always carry one.
+    const stateNames = states
+      .map(state => state.displayName)
+      .filter((displayName): displayName is string => displayName != null);
     const uniqueStateNames = new Set(stateNames);
     if (uniqueStateNames.size !== stateNames.length) {
       throw new ValidationException(
@@ -646,6 +668,42 @@ export class InnovationFlowService {
       throw new ValidationException(
         `Invalid characters found on flow state: ${stateNames}`,
         LogContext.INNOVATION_FLOW
+      );
+    }
+  }
+
+  /**
+   * Rejects a state display name that collides with an existing state in the same flow.
+   *
+   * `validateInnovationFlowDefinition` enforces uniqueness when a flow is created, but the
+   * incremental edit paths (rename, add state) bypassed it — so a flow could be edited into
+   * a state that creating it from scratch would have rejected.
+   *
+   * Uniqueness is load-bearing, not cosmetic: a post resolves its presentation settings by
+   * joining its flow-state classification on the phase *display name* (there is no stable
+   * phase id in the classification). Two phases sharing a name make that join ambiguous.
+   *
+   * Comparison is case-insensitive and trims surrounding whitespace, matching the
+   * collision check the client applies when adding a phase.
+   *
+   * @param excludeStateID the state being renamed, so it does not collide with itself
+   */
+  public validateStateDisplayNameIsUnique(
+    displayName: string,
+    existingStates: IInnovationFlowState[],
+    excludeStateID?: string
+  ) {
+    const normalized = displayName.trim().toLowerCase();
+    const collides = existingStates.some(
+      state =>
+        state.id !== excludeStateID &&
+        state.displayName?.trim().toLowerCase() === normalized
+    );
+    if (collides) {
+      throw new ValidationException(
+        'A state with this display name already exists in the Innovation Flow',
+        LogContext.INNOVATION_FLOW,
+        { displayName }
       );
     }
   }
@@ -770,8 +828,11 @@ export class InnovationFlowService {
       );
     }
 
-    // sort the states by sortOrder
-    return [...innovationFlow.states].sort(sortBySortOrder);
+    // sort the states by sortOrder, and normalize settings: these are raw TypeORM rows,
+    // so an un-backfilled row would serialize null into the NonNull settings fields.
+    return normalizeStatesSettings(
+      [...innovationFlow.states].sort(sortBySortOrder)
+    );
   }
 
   public async getCurrentState(
@@ -856,7 +917,8 @@ export class InnovationFlowService {
 
     await this.innovationFlowStateService.saveAll(modifiedStates);
 
-    return statesInOrder;
+    // This mutation returns [IInnovationFlowState!]! straight from the raw rows.
+    return normalizeStatesSettings(statesInOrder);
   }
 
   private async getCollaborationByInnovationFlowId(innovationFlowId: string) {

--- a/src/domain/space/space.settings/space.settings.layout.interface.ts
+++ b/src/domain/space/space.settings/space.settings.layout.interface.ts
@@ -7,6 +7,8 @@ export abstract class ISpaceSettingsLayout {
     nullable: false,
     description:
       'The default display mode for callout descriptions in this Space.',
+    deprecationReason:
+      'REMOVE_AFTER=2026-10-31 | superseded by InnovationFlowStateSettings.descriptionDisplayMode',
   })
   calloutDescriptionDisplayMode!: CalloutDescriptionDisplayMode;
 }

--- a/src/domain/space/space/space.service.spec.ts
+++ b/src/domain/space/space/space.service.spec.ts
@@ -2066,6 +2066,8 @@ const getSubspacesMock = (
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),
@@ -2077,6 +2079,8 @@ const getSubspacesMock = (
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),
@@ -2088,6 +2092,8 @@ const getSubspacesMock = (
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),
@@ -2099,6 +2105,8 @@ const getSubspacesMock = (
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),
@@ -2218,6 +2226,8 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),
@@ -2229,6 +2239,8 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),
@@ -2240,6 +2252,8 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),
@@ -2251,6 +2265,8 @@ const getSubsubspacesMock = (subsubspaceId: string, count: number): Space[] => {
               settings: {
                 allowNewCallouts: true,
                 visible: true,
+                descriptionDisplayMode: CalloutDescriptionDisplayMode.EXPANDED,
+                showPublishDetails: true,
               },
               sortOrder: 1,
               ...getEntityMock<InnovationFlowState>(),

--- a/src/migrations/1783600000000-BackfillInnovationFlowStateLayout.ts
+++ b/src/migrations/1783600000000-BackfillInnovationFlowStateLayout.ts
@@ -4,18 +4,30 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * Backfills per-phase presentation settings (feature 021-flow-state-post-layout,
  * FR-009) into the JSONB `settings` of every `innovation_flow_state` row.
  *
- * Two-branch approach (data-model.md §Migration):
+ * Three-branch approach:
  *
  *   Branch A — space-owned states:
  *     Join path: space → space."collaborationId" → collaboration."innovationFlowId"
  *                       → innovation_flow_state."innovationFlowId"
- *     Value: COALESCE(space.settings->'layout'->>'calloutDescriptionDisplayMode', 'expanded')
+ *     Value: the owning space's layout.calloutDescriptionDisplayMode.
  *     Covers ALL space levels (L0/L1/L2 — FR-009/FR-017).
  *
- *   Branch B — remaining states (template-owned, orphaned):
+ *   Branch A2 — template-owned states:
+ *     `template_content_space` also owns a collaboration, and carries its own
+ *     `settings.layout.calloutDescriptionDisplayMode`. Without this branch those states
+ *     fall through to Branch B and are blanket-set to 'expanded', discarding the template's
+ *     real value — and `InputCreatorService` copies state settings verbatim when a template
+ *     is applied, so every space created from that template would silently render Expanded
+ *     even though the admin saved it as Collapsed. Must run BEFORE Branch B.
+ *
+ *   Branch B — remaining states (orphaned: reachable from no space and no template):
  *     Set `descriptionDisplayMode` to 'expanded' where still absent.
  *
  *   All states: set `showPublishDetails` to true where absent.
+ *
+ * The source value is allow-listed (CASE ... IN ('expanded','collapsed')) rather than copied
+ * verbatim: it lands in a NonNull GraphQL enum, so any legacy or hand-edited out-of-enum
+ * string would break the tab query for every viewer of that space.
  *
  * Idempotent: every statement is guarded `settings -> '<key>' IS NULL` so
  * re-running is a no-op and admin-chosen values are never overwritten (US4-AS4).
@@ -33,19 +45,31 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class BackfillInnovationFlowStateLayout1783600000000
   implements MigrationInterface
 {
+  name = 'BackfillInnovationFlowStateLayout1783600000000';
+
   public async up(queryRunner: QueryRunner): Promise<void> {
+    const [{ count: before }] = await queryRunner.query(`
+      SELECT COUNT(*) AS count FROM innovation_flow_state
+      WHERE settings -> 'descriptionDisplayMode' IS NULL
+    `);
+    console.log(
+      `[Migration] BackfillInnovationFlowStateLayout: ${before} flow state(s) require descriptionDisplayMode backfill`
+    );
+
     // Branch A: space-owned states — copy the owning space's calloutDescriptionDisplayMode.
-    // The COALESCE handles spaces whose layout block predates the enum (defaults 'expanded').
+    // The CASE allow-lists the value (defaults 'expanded' for absent/legacy/out-of-enum).
     await queryRunner.query(`
       UPDATE innovation_flow_state ifs
       SET settings = jsonb_set(
         ifs.settings,
         '{descriptionDisplayMode}',
         to_jsonb(
-          COALESCE(
-            s.settings->'layout'->>'calloutDescriptionDisplayMode',
-            'expanded'
-          )
+          CASE
+            WHEN s.settings->'layout'->>'calloutDescriptionDisplayMode'
+              IN ('expanded', 'collapsed')
+            THEN s.settings->'layout'->>'calloutDescriptionDisplayMode'
+            ELSE 'expanded'
+          END
         ),
         true
       )
@@ -55,7 +79,30 @@ export class BackfillInnovationFlowStateLayout1783600000000
         AND ifs.settings -> 'descriptionDisplayMode' IS NULL
     `);
 
-    // Branch B: remaining states (template-owned or orphaned) not reached by branch A.
+    // Branch A2: template-owned states — copy the owning template content space's value.
+    // MUST run before Branch B, or these rows get the blanket 'expanded' default instead.
+    await queryRunner.query(`
+      UPDATE innovation_flow_state ifs
+      SET settings = jsonb_set(
+        ifs.settings,
+        '{descriptionDisplayMode}',
+        to_jsonb(
+          CASE
+            WHEN tcs.settings->'layout'->>'calloutDescriptionDisplayMode'
+              IN ('expanded', 'collapsed')
+            THEN tcs.settings->'layout'->>'calloutDescriptionDisplayMode'
+            ELSE 'expanded'
+          END
+        ),
+        true
+      )
+      FROM collaboration c
+      JOIN template_content_space tcs ON tcs."collaborationId" = c.id
+      WHERE ifs."innovationFlowId" = c."innovationFlowId"
+        AND ifs.settings -> 'descriptionDisplayMode' IS NULL
+    `);
+
+    // Branch B: remaining states (orphaned) not reached by branch A or A2.
     await queryRunner.query(`
       UPDATE innovation_flow_state
       SET settings = jsonb_set(settings, '{descriptionDisplayMode}', '"expanded"'::jsonb, true)
@@ -68,12 +115,33 @@ export class BackfillInnovationFlowStateLayout1783600000000
       SET settings = jsonb_set(settings, '{showPublishDetails}', 'true'::jsonb, true)
       WHERE settings -> 'showPublishDetails' IS NULL
     `);
+
+    // Verify: the failure mode of this migration is silently backfilling nothing, so assert
+    // that no row is left without a key or carrying an out-of-enum descriptionDisplayMode.
+    const [{ count: residual }] = await queryRunner.query(`
+      SELECT COUNT(*) AS count FROM innovation_flow_state
+      WHERE settings -> 'descriptionDisplayMode' IS NULL
+         OR settings -> 'showPublishDetails' IS NULL
+         OR settings ->> 'descriptionDisplayMode' NOT IN ('expanded', 'collapsed')
+    `);
+    if (Number(residual) > 0) {
+      console.warn(
+        `[Migration] WARNING BackfillInnovationFlowStateLayout: ${residual} flow state(s) still missing or carrying an invalid descriptionDisplayMode/showPublishDetails after backfill — investigate before proceeding`
+      );
+    } else {
+      console.log(
+        '[Migration] BackfillInnovationFlowStateLayout: verification passed — 0 flow states missing per-phase layout settings'
+      );
+    }
   }
 
   // Intentional no-op — see the "Rollback note" above. The two JSONB keys are additive and
   // ignored by pre-feature code; stripping them here would delete admin edits made after the
   // migration ran. Leaving them in place is the non-destructive choice.
   public async down(_queryRunner: QueryRunner): Promise<void> {
+    console.log(
+      '[Migration] BackfillInnovationFlowStateLayout: down() is an intentional no-op — the additive JSONB keys are left in place'
+    );
     return;
   }
 }

--- a/src/migrations/1783600000000-BackfillInnovationFlowStateLayout.ts
+++ b/src/migrations/1783600000000-BackfillInnovationFlowStateLayout.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Backfills per-phase presentation settings (feature 021-flow-state-post-layout,
+ * FR-009) into the JSONB `settings` of every `innovation_flow_state` row.
+ *
+ * Two-branch approach (data-model.md §Migration):
+ *
+ *   Branch A — space-owned states:
+ *     Join path: space → space."collaborationId" → collaboration."innovationFlowId"
+ *                       → innovation_flow_state."innovationFlowId"
+ *     Value: COALESCE(space.settings->'layout'->>'calloutDescriptionDisplayMode', 'expanded')
+ *     Covers ALL space levels (L0/L1/L2 — FR-009/FR-017).
+ *
+ *   Branch B — remaining states (template-owned, orphaned):
+ *     Set `descriptionDisplayMode` to 'expanded' where still absent.
+ *
+ *   All states: set `showPublishDetails` to true where absent.
+ *
+ * Idempotent: every statement is guarded `settings -> '<key>' IS NULL` so
+ * re-running is a no-op and admin-chosen values are never overwritten (US4-AS4).
+ *
+ * Rollback note: `down()` is an intentional no-op. `descriptionDisplayMode` and
+ * `showPublishDetails` are additive JSONB keys that pre-feature code ignores, and admins
+ * can edit them after this migration runs. Stripping them on rollback would silently
+ * delete those later edits, so we leave the keys in place — rolling the feature back does
+ * not require removing them.
+ *
+ * JSONB stores the lowercase TypeScript enum values ('expanded'/'collapsed')
+ * exactly as the space layout JSONB does — the GraphQL layer serialises them to
+ * the uppercase enum names (EXPANDED/COLLAPSED).
+ */
+export class BackfillInnovationFlowStateLayout1783600000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Branch A: space-owned states — copy the owning space's calloutDescriptionDisplayMode.
+    // The COALESCE handles spaces whose layout block predates the enum (defaults 'expanded').
+    await queryRunner.query(`
+      UPDATE innovation_flow_state ifs
+      SET settings = jsonb_set(
+        ifs.settings,
+        '{descriptionDisplayMode}',
+        to_jsonb(
+          COALESCE(
+            s.settings->'layout'->>'calloutDescriptionDisplayMode',
+            'expanded'
+          )
+        ),
+        true
+      )
+      FROM collaboration c
+      JOIN space s ON s."collaborationId" = c.id
+      WHERE ifs."innovationFlowId" = c."innovationFlowId"
+        AND ifs.settings -> 'descriptionDisplayMode' IS NULL
+    `);
+
+    // Branch B: remaining states (template-owned or orphaned) not reached by branch A.
+    await queryRunner.query(`
+      UPDATE innovation_flow_state
+      SET settings = jsonb_set(settings, '{descriptionDisplayMode}', '"expanded"'::jsonb, true)
+      WHERE settings -> 'descriptionDisplayMode' IS NULL
+    `);
+
+    // All states: default showPublishDetails to true where absent.
+    await queryRunner.query(`
+      UPDATE innovation_flow_state
+      SET settings = jsonb_set(settings, '{showPublishDetails}', 'true'::jsonb, true)
+      WHERE settings -> 'showPublishDetails' IS NULL
+    `);
+  }
+
+  // Intentional no-op — see the "Rollback note" above. The two JSONB keys are additive and
+  // ignored by pre-feature code; stripping them here would delete admin edits made after the
+  // migration ran. Leaving them in place is the non-destructive choice.
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    return;
+  }
+}

--- a/test/integration/flow-state-layout/flow-state-layout-authorization.spec.ts
+++ b/test/integration/flow-state-layout/flow-state-layout-authorization.spec.ts
@@ -365,8 +365,12 @@ describe('flow-state-layout — public-read cascade contract (FR-007, intake Q1)
       flowAuth
     );
     expect(result).toBe(inheritedAuth);
-    // The returned authorization carries the cascaded READ rule from the flow
-    expect(result.credentialRules[0].cascade).toBe(true);
+    // NOTE: deliberately NOT asserting on result.credentialRules here. `inheritParentAuthorization`
+    // is mocked, so those rules are this test's own fixture — asserting `cascade === true` on them
+    // would check the literal declared above against itself and could never fail. What this test
+    // can honestly prove is the delegation: reset(state) → inheritParentAuthorization(reset, flow).
+    // That the cascade actually REACHES a flow state is a live-stack property (FR-007), not a
+    // mockable one.
 
     await stateModule.close();
   });

--- a/test/integration/flow-state-layout/flow-state-layout-authorization.spec.ts
+++ b/test/integration/flow-state-layout/flow-state-layout-authorization.spec.ts
@@ -1,0 +1,500 @@
+/**
+ * Integration tests: flow-state-layout authorization
+ * (feature 021-flow-state-post-layout, FR-003/FR-007, intake ruling Q1)
+ *
+ * Pin the two authorization contracts at the TestingModule level:
+ *
+ *   (a) Public-read cascade: on a PUBLIC-privacy space, the READ privilege
+ *       cascades to the innovation flow and its states (including their
+ *       `settings` scalar fields). We drive SpaceAuthorizationService through a
+ *       real TestingModule and verify that createCredentialRule is called with
+ *       [READ] and that the returned rule has cascade:true — exactly the
+ *       assertion that would fail if someone removed `rule.cascade = true` from
+ *       space.service.authorization.ts:599.
+ *
+ *   (b) Write guard: `updateInnovationFlowState` requires UPDATE on the
+ *       state's authorization policy. We drive InnovationFlowResolverMutations
+ *       directly and assert (i) grantAccessOrFail is invoked with UPDATE, and
+ *       (ii) when grantAccessOrFail throws (actor lacks UPDATE), the mutation
+ *       rejects — confirming the new descriptionDisplayMode / showPublishDetails
+ *       fields are blocked for non-admins.
+ *
+ *   (c) InnovationFlowStateAuthorizationService inherits the parent (flow)
+ *       authorization, which carries the cascade chain from the space — so the
+ *       public-read rule propagates all the way to the state.
+ *
+ * The LIVE anonymous GraphQL probe (FR-007, contract §5) is owned by the
+ * forge verification phase (gql-live track, repos.yaml) — not duplicated here.
+ *
+ * No real DB or HTTP server is used. All interactions are exercised through
+ * NestJS TestingModule with mocked dependencies, following the same pattern
+ * used by innovation.flow.resolver.mutations.spec.ts and
+ * space.service.authorization.spec.ts.
+ */
+
+import { AuthorizationCredential, AuthorizationPrivilege } from '@common/enums';
+import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { CommunityMembershipPolicy } from '@common/enums/community.membership.policy';
+import { RoleName } from '@common/enums/role.name';
+import { SpaceLevel } from '@common/enums/space.level';
+import { SpacePrivacyMode } from '@common/enums/space.privacy.mode';
+import { SpaceSortMode } from '@common/enums/space.sort.mode';
+import { SpaceVisibility } from '@common/enums/space.visibility';
+import { ForbiddenAuthorizationPolicyException } from '@common/exceptions/forbidden.authorization.policy.exception';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { PlatformRolesAccessService } from '@domain/access/platform-roles-access/platform.roles.access.service';
+import { RoleSetService } from '@domain/access/role-set/role.set.service';
+import { CollaborationAuthorizationService } from '@domain/collaboration/collaboration/collaboration.service.authorization';
+import { InnovationFlowResolverMutations } from '@domain/collaboration/innovation-flow/innovation.flow.resolver.mutations';
+import { InnovationFlowService } from '@domain/collaboration/innovation-flow/innovation.flow.service';
+import { InnovationFlowStateService } from '@domain/collaboration/innovation-flow-state/innovation.flow.state.service';
+import { InnovationFlowStateAuthorizationService } from '@domain/collaboration/innovation-flow-state/innovation.flow.state.service.authorization';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { LicenseAuthorizationService } from '@domain/common/license/license.service.authorization';
+import { ProfileAuthorizationService } from '@domain/common/profile/profile.service.authorization';
+import { CommunityAuthorizationService } from '@domain/community/community/community.service.authorization';
+import { SpaceAuthorizationService } from '@domain/space/space/space.service.authorization';
+import { SpaceAboutAuthorizationService } from '@domain/space/space.about/space.about.service.authorization';
+import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
+import { StorageAggregatorAuthorizationService } from '@domain/storage/storage-aggregator/storage.aggregator.service.authorization';
+import { TemplatesManagerAuthorizationService } from '@domain/template/templates-manager/templates.manager.service.authorization';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockCacheManager } from '@test/mocks/cache-manager.mock';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+
+// ---------------------------------------------------------------------------
+// (a) Public-read cascade: PUBLIC space → createCredentialRule called with
+//     [READ] and the returned rule has cascade:true set by the production code
+//     in space.service.authorization.ts:594-599 (extendAuthorizationPolicyLocal).
+// ---------------------------------------------------------------------------
+
+describe('flow-state-layout — public-read cascade contract (FR-007, intake Q1)', () => {
+  let module: TestingModule;
+  let spaceAuthorizationService: SpaceAuthorizationService;
+  let spaceLookupService: SpaceLookupService;
+  let authorizationPolicyService: AuthorizationPolicyService;
+  let platformRolesAccessService: PlatformRolesAccessService;
+  let communityAuthorizationService: CommunityAuthorizationService;
+  let collaborationAuthorizationService: CollaborationAuthorizationService;
+  let storageAggregatorAuthorizationService: StorageAggregatorAuthorizationService;
+  let spaceAboutAuthorizationService: SpaceAboutAuthorizationService;
+  let profileAuthorizationService: ProfileAuthorizationService;
+  let licenseAuthorizationService: LicenseAuthorizationService;
+  let templatesManagerAuthorizationService: TemplatesManagerAuthorizationService;
+
+  const defaultSettings = {
+    privacy: {
+      mode: SpacePrivacyMode.PUBLIC,
+      allowPlatformSupportAsAdmin: false,
+    },
+    membership: {
+      policy: CommunityMembershipPolicy.OPEN,
+      trustedOrganizations: [],
+      allowSubspaceAdminsToInviteMembers: false,
+    },
+    collaboration: {
+      inheritMembershipRights: true,
+      allowMembersToCreateSubspaces: true,
+      allowMembersToCreateCallouts: true,
+      allowEventsFromSubspaces: true,
+      allowMembersToVideoCall: false,
+      allowGuestContributions: false,
+    },
+    sortMode: SpaceSortMode.ALPHABETICAL,
+  };
+
+  const createMockSpace = (
+    privacyMode: SpacePrivacyMode = SpacePrivacyMode.PUBLIC
+  ) => ({
+    id: 'space-1',
+    level: SpaceLevel.L0,
+    visibility: SpaceVisibility.ACTIVE,
+    settings: {
+      ...defaultSettings,
+      privacy: { ...defaultSettings.privacy, mode: privacyMode },
+    },
+    authorization: {
+      id: 'auth-1',
+      credentialRules: [],
+      privilegeRules: [],
+      type: AuthorizationPolicyType.SPACE,
+      parentAuthorizationPolicy: undefined,
+    },
+    community: { id: 'community-1', roleSet: { id: 'roleset-1' } },
+    collaboration: { id: 'collab-1' },
+    about: { id: 'about-1', profile: { id: 'profile-1' } },
+    profile: { id: 'space-profile-1' },
+    storageAggregator: { id: 'storage-1' },
+    templatesManager: { id: 'templates-1' },
+    subspaces: [],
+    license: { id: 'license-1' },
+    account: { id: 'account-1' },
+    platformRolesAccess: {
+      roles: [
+        {
+          roleName: RoleName.MEMBER,
+          grantedPrivileges: [AuthorizationPrivilege.READ],
+        },
+      ],
+    },
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+
+    module = await Test.createTestingModule({
+      providers: [SpaceAuthorizationService, MockWinstonProvider],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    spaceAuthorizationService = module.get(SpaceAuthorizationService);
+    spaceLookupService = module.get(SpaceLookupService);
+    authorizationPolicyService = module.get(AuthorizationPolicyService);
+    platformRolesAccessService = module.get(PlatformRolesAccessService);
+    communityAuthorizationService = module.get(CommunityAuthorizationService);
+    collaborationAuthorizationService = module.get(
+      CollaborationAuthorizationService
+    );
+    storageAggregatorAuthorizationService = module.get(
+      StorageAggregatorAuthorizationService
+    );
+    spaceAboutAuthorizationService = module.get(SpaceAboutAuthorizationService);
+    profileAuthorizationService = module.get(ProfileAuthorizationService);
+    licenseAuthorizationService = module.get(LicenseAuthorizationService);
+    templatesManagerAuthorizationService = module.get(
+      TemplatesManagerAuthorizationService
+    );
+
+    // Base mocks shared between tests — each test may override specific mocks
+    (
+      profileAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
+    (
+      communityAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
+    (
+      storageAggregatorAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
+    (
+      collaborationAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
+    (
+      licenseAuthorizationService.applyAuthorizationPolicy as any
+    ).mockReturnValue([]);
+    (
+      templatesManagerAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
+    (
+      spaceAboutAuthorizationService.applyAuthorizationPolicy as any
+    ).mockResolvedValue([]);
+    (authorizationPolicyService.saveAll as any).mockResolvedValue([]);
+    (
+      authorizationPolicyService.appendPrivilegeAuthorizationRuleMapping as any
+    ).mockImplementation((auth: any) => auth);
+    (
+      authorizationPolicyService.appendCredentialAuthorizationRules as any
+    ).mockImplementation((auth: any) => auth);
+    (platformRolesAccessService.getPrivilegesForRole as any).mockReturnValue(
+      []
+    );
+    (authorizationPolicyService.reset as any).mockImplementation(
+      (auth: any) => auth
+    );
+    (
+      authorizationPolicyService.inheritParentAuthorization as any
+    ).mockImplementation((auth: any) => auth);
+    (authorizationPolicyService.save as any).mockImplementation(
+      async (auth: any) => auth
+    );
+    (
+      authorizationPolicyService.createCredentialRuleUsingTypesOnly as any
+    ).mockReturnValue({
+      cascade: false,
+    });
+  });
+
+  afterEach(() => module.close());
+
+  it('PUBLIC space: createCredentialRule is called with [READ] and the rule has cascade:true — regression for space.service.authorization.ts:594-599', async () => {
+    // This test will FAIL if someone removes `rule.cascade = true` from
+    // extendAuthorizationPolicyLocal or changes the privilege from READ to
+    // READ_ABOUT for the PUBLIC branch — the exact regression FR-007 guards against.
+    const mockSpace = createMockSpace(SpacePrivacyMode.PUBLIC);
+
+    (spaceLookupService.getSpaceOrFail as any).mockResolvedValue(mockSpace);
+    (
+      platformRolesAccessService.getCredentialsForRolesWithAccess as any
+    ).mockReturnValue([
+      { type: AuthorizationCredential.GLOBAL_ADMIN, resourceID: '' },
+    ]);
+    RoleSetService.prototype as any;
+    (module.get(RoleSetService).getCredentialsForRole as any).mockResolvedValue(
+      []
+    );
+    (
+      module.get(RoleSetService).getCredentialsForRoleWithParents as any
+    ).mockResolvedValue([]);
+    (
+      module.get(RoleSetService).getDirectParentCredentialForRole as any
+    ).mockResolvedValue(undefined);
+
+    // Track the rule returned from createCredentialRule so we can observe
+    // whether production code sets cascade:true on it.
+    const capturedRules: any[] = [];
+    (authorizationPolicyService.createCredentialRule as any).mockImplementation(
+      (grantedPrivileges: any, criterias: any, _name: any) => {
+        const rule = { grantedPrivileges, criterias, cascade: false };
+        capturedRules.push(rule);
+        return rule;
+      }
+    );
+
+    await spaceAuthorizationService.applyAuthorizationPolicy('space-1');
+
+    // extendAuthorizationPolicyLocal calls createCredentialRule for the PUBLIC branch
+    // with [AuthorizationPrivilege.READ] and then sets cascade:true on the returned rule.
+    const readRule = capturedRules.find(
+      r =>
+        Array.isArray(r.grantedPrivileges) &&
+        r.grantedPrivileges.includes(AuthorizationPrivilege.READ) &&
+        !r.grantedPrivileges.includes(AuthorizationPrivilege.READ_ABOUT)
+    );
+
+    expect(readRule).toBeDefined();
+    // The production code at line 599 sets rule.cascade = true on this exact object
+    expect(readRule!.cascade).toBe(true);
+  });
+
+  it('PRIVATE space: createCredentialRule is called with [READ_ABOUT] and cascade:false — anonymous access blocked', async () => {
+    // Symmetrical regression guard: if PUBLIC accidentally degrades to READ_ABOUT,
+    // or if PRIVATE accidentally gains cascade:true, one of these two tests fails.
+    const mockSpace = createMockSpace(SpacePrivacyMode.PRIVATE);
+
+    (spaceLookupService.getSpaceOrFail as any).mockResolvedValue(mockSpace);
+    (
+      platformRolesAccessService.getCredentialsForRolesWithAccess as any
+    ).mockReturnValue([
+      { type: AuthorizationCredential.GLOBAL_ADMIN, resourceID: '' },
+    ]);
+    (module.get(RoleSetService).getCredentialsForRole as any).mockResolvedValue(
+      []
+    );
+    (
+      module.get(RoleSetService).getCredentialsForRoleWithParents as any
+    ).mockResolvedValue([]);
+    (
+      module.get(RoleSetService).getDirectParentCredentialForRole as any
+    ).mockResolvedValue(undefined);
+
+    const capturedRules: any[] = [];
+    (authorizationPolicyService.createCredentialRule as any).mockImplementation(
+      (grantedPrivileges: any, criterias: any, _name: any) => {
+        const rule = { grantedPrivileges, criterias, cascade: true };
+        capturedRules.push(rule);
+        return rule;
+      }
+    );
+
+    await spaceAuthorizationService.applyAuthorizationPolicy('space-1');
+
+    // PRIVATE branch calls createCredentialRule with [READ_ABOUT] and sets cascade:false
+    const readAboutRule = capturedRules.find(
+      r =>
+        Array.isArray(r.grantedPrivileges) &&
+        r.grantedPrivileges.includes(AuthorizationPrivilege.READ_ABOUT)
+    );
+
+    expect(readAboutRule).toBeDefined();
+    // Production code at line 609 sets rule.cascade = false for PRIVATE
+    expect(readAboutRule!.cascade).toBe(false);
+    // READ is NOT granted — only READ_ABOUT
+    expect(readAboutRule!.grantedPrivileges).not.toContain(
+      AuthorizationPrivilege.READ
+    );
+  });
+
+  it('InnovationFlowStateAuthorizationService inherits parent authorization via inheritParentAuthorization (cascade propagates)', async () => {
+    // States call inheritParentAuthorization(stateAuth, flowAuth) where flowAuth
+    // already carries the cascaded PUBLIC READ rule from the space. This test pins
+    // that the state auth service uses inheritance (not a fresh policy), preserving
+    // the cascade chain.
+
+    const stateModule = await Test.createTestingModule({
+      providers: [
+        InnovationFlowStateAuthorizationService,
+        MockCacheManager,
+        MockWinstonProvider,
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    const stateAuthService = stateModule.get(
+      InnovationFlowStateAuthorizationService
+    );
+    const policyService = stateModule.get(AuthorizationPolicyService);
+
+    const stateAuth = { id: 'state-auth' } as any;
+    const flowAuth = {
+      id: 'flow-auth',
+      credentialRules: [
+        { cascade: true, grantedPrivileges: [AuthorizationPrivilege.READ] },
+      ],
+    } as any;
+
+    const resetAuth = { id: 'reset-auth' } as any;
+    const inheritedAuth = {
+      id: 'inherited-auth',
+      credentialRules: flowAuth.credentialRules,
+    } as any;
+
+    vi.mocked(policyService.reset).mockReturnValue(resetAuth);
+    vi.mocked(policyService.inheritParentAuthorization).mockReturnValue(
+      inheritedAuth
+    );
+
+    const result = stateAuthService.applyAuthorizationPolicy(
+      { id: 'state-1', authorization: stateAuth } as any,
+      flowAuth
+    );
+
+    expect(policyService.inheritParentAuthorization).toHaveBeenCalledWith(
+      resetAuth,
+      flowAuth
+    );
+    expect(result).toBe(inheritedAuth);
+    // The returned authorization carries the cascaded READ rule from the flow
+    expect(result.credentialRules[0].cascade).toBe(true);
+
+    await stateModule.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) Write guard: settings update requires UPDATE privilege (FR-003)
+//     Drive InnovationFlowResolverMutations directly so that
+//     grantAccessOrFail is asserted against the state's authorization with
+//     AuthorizationPrivilege.UPDATE — mirroring the pattern in
+//     innovation.flow.resolver.mutations.spec.ts:192-238.
+// ---------------------------------------------------------------------------
+
+describe('flow-state-layout — write guard: UPDATE privilege required for settings changes (FR-003)', () => {
+  let resolver: InnovationFlowResolverMutations;
+  let innovationFlowStateService: InnovationFlowStateService;
+  let innovationFlowService: InnovationFlowService;
+  let authorizationService: AuthorizationService;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InnovationFlowResolverMutations,
+        MockCacheManager,
+        MockWinstonProvider,
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    resolver = module.get(InnovationFlowResolverMutations);
+    innovationFlowStateService = module.get(InnovationFlowStateService);
+    innovationFlowService = module.get(InnovationFlowService);
+    authorizationService = module.get(AuthorizationService);
+  });
+
+  it('updateInnovationFlowState: grantAccessOrFail is called with UPDATE on the state authorization (admin path)', async () => {
+    // The new descriptionDisplayMode and showPublishDetails fields are updated
+    // via the existing updateInnovationFlowState mutation, which gates on
+    // UPDATE against the state's own authorization — not the flow's.
+    // This test will fail if the privilege gate is weakened (e.g. changed to
+    // READ or removed) or if the gate moves to a different authorization object.
+
+    const stateAuth = { id: 'state-auth', type: 'INNOVATION_FLOW_STATE' };
+    const flowState = {
+      id: 'state-1',
+      authorization: stateAuth,
+      innovationFlow: { id: 'flow-1' },
+    } as any;
+    const updatedState = {
+      id: 'state-1',
+      displayName: 'Updated',
+      settings: {
+        descriptionDisplayMode: 'COLLAPSED',
+        showPublishDetails: false,
+      },
+    } as any;
+
+    vi.mocked(
+      innovationFlowStateService.getInnovationFlowStateOrFail
+    ).mockResolvedValue(flowState);
+    vi.mocked(
+      innovationFlowService.updateInnovationFlowState
+    ).mockResolvedValue(updatedState);
+
+    const actorContext = { actorID: 'admin-user' } as any;
+
+    const result = await resolver.updateInnovationFlowState(actorContext, {
+      innovationFlowStateID: 'state-1',
+      settings: {
+        descriptionDisplayMode: 'COLLAPSED',
+        showPublishDetails: false,
+      },
+    } as any);
+
+    // The resolver MUST call grantAccessOrFail with UPDATE on the state's auth
+    expect(authorizationService.grantAccessOrFail).toHaveBeenCalledWith(
+      actorContext,
+      stateAuth,
+      AuthorizationPrivilege.UPDATE,
+      expect.any(String)
+    );
+    expect(result).toBe(updatedState);
+  });
+
+  it('updateInnovationFlowState: non-admin actor is denied when grantAccessOrFail throws (FR-003)', async () => {
+    // When a non-admin calls updateInnovationFlowState (including updates to the
+    // new descriptionDisplayMode / showPublishDetails fields), the UPDATE privilege
+    // check must throw and the mutation must not proceed.
+    //
+    // This test will fail if the grantAccessOrFail call is removed or bypassed,
+    // letting unauthorized updates through.
+
+    const stateAuth = { id: 'state-auth', type: 'INNOVATION_FLOW_STATE' };
+    const flowState = {
+      id: 'state-1',
+      authorization: stateAuth,
+      innovationFlow: { id: 'flow-1' },
+    } as any;
+
+    vi.mocked(
+      innovationFlowStateService.getInnovationFlowStateOrFail
+    ).mockResolvedValue(flowState);
+
+    // Simulate what AuthorizationService throws when privilege is denied
+    vi.mocked(authorizationService.grantAccessOrFail).mockImplementation(() => {
+      throw new ForbiddenAuthorizationPolicyException(
+        'not allowed',
+        AuthorizationPrivilege.UPDATE,
+        stateAuth.id,
+        'non-admin-user'
+      );
+    });
+
+    const actorContext = { actorID: 'non-admin-user' } as any;
+
+    await expect(
+      resolver.updateInnovationFlowState(actorContext, {
+        innovationFlowStateID: 'state-1',
+        settings: { descriptionDisplayMode: 'COLLAPSED' },
+      } as any)
+    ).rejects.toBeInstanceOf(ForbiddenAuthorizationPolicyException);
+
+    // The update service must NOT have been called after a denied gate
+    expect(
+      innovationFlowService.updateInnovationFlowState
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/test/integration/flow-state-layout/flow-state-layout-migration.spec.ts
+++ b/test/integration/flow-state-layout/flow-state-layout-migration.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Integration tests: BackfillInnovationFlowStateLayout migration
+ * (feature 021-flow-state-post-layout, FR-009)
+ *
+ * These tests verify the SQL structure of the three UP statements:
+ *   1. Branch A (space-owned states via JOIN) only touches rows where
+ *      `descriptionDisplayMode` is absent.
+ *   2. Branch B (remaining states) only touches rows where
+ *      `descriptionDisplayMode` is still absent after branch A.
+ *   3. All-states pass sets `showPublishDetails` only where absent.
+ *
+ * All assertions are SQL-string structural — the real-database stack is not
+ * available in CI unit mode, consistent with the callout-collapse precedent.
+ * Use the live migration:validate harness for full DB coverage (US4-AS1..AS5).
+ */
+
+import { BackfillInnovationFlowStateLayout1783600000000 } from '@src/migrations/1783600000000-BackfillInnovationFlowStateLayout';
+
+describe('BackfillInnovationFlowStateLayout migration', () => {
+  const migration = new BackfillInnovationFlowStateLayout1783600000000();
+
+  it('migration class implements MigrationInterface (has up and down methods)', () => {
+    expect(typeof migration.up).toBe('function');
+    expect(typeof migration.down).toBe('function');
+  });
+
+  // -------------------------------------------------------------------------
+  // UP — Branch A (space-owned via JOIN)
+  // -------------------------------------------------------------------------
+
+  it('Branch A UP query joins space → collaboration → innovation_flow_state and guards descriptionDisplayMode absent', async () => {
+    const queriedSql: string[] = [];
+    const mockQueryRunner = {
+      query: (sql: string) => {
+        queriedSql.push(sql);
+        return Promise.resolve(undefined);
+      },
+    } as any;
+
+    await migration.up(mockQueryRunner);
+
+    // Branch A is the first query
+    const branchA = queriedSql[0];
+    expect(branchA).toContain('collaboration');
+    expect(branchA).toContain('space');
+    expect(branchA).toContain('innovationFlowId');
+    expect(branchA).toContain(`'descriptionDisplayMode'`);
+    expect(branchA).toContain(`IS NULL`);
+    expect(branchA).toContain('descriptionDisplayMode');
+    // Value comes from space settings with COALESCE fallback
+    expect(branchA).toContain('calloutDescriptionDisplayMode');
+    expect(branchA).toContain('COALESCE');
+    expect(branchA).toContain("'expanded'");
+  });
+
+  it('Branch A UP is idempotent: WHERE guards only rows where descriptionDisplayMode is absent (US4-AS4)', async () => {
+    const queriedSql: string[] = [];
+    const mockQueryRunner = {
+      query: (sql: string) => {
+        queriedSql.push(sql);
+        return Promise.resolve(undefined);
+      },
+    } as any;
+
+    await migration.up(mockQueryRunner);
+
+    // The WHERE clause must contain IS NULL guard so a second run skips already-set rows
+    const branchA = queriedSql[0];
+    expect(branchA).toMatch(/descriptionDisplayMode.*IS NULL/s);
+  });
+
+  // -------------------------------------------------------------------------
+  // UP — Branch B (remaining states)
+  // -------------------------------------------------------------------------
+
+  it('Branch B UP only touches rows where descriptionDisplayMode is still absent (US4-AS3)', async () => {
+    const queriedSql: string[] = [];
+    const mockQueryRunner = {
+      query: (sql: string) => {
+        queriedSql.push(sql);
+        return Promise.resolve(undefined);
+      },
+    } as any;
+
+    await migration.up(mockQueryRunner);
+
+    const branchB = queriedSql[1];
+    expect(branchB).toContain(`'descriptionDisplayMode'`);
+    expect(branchB).toContain(`IS NULL`);
+    expect(branchB).toContain('"expanded"');
+  });
+
+  // -------------------------------------------------------------------------
+  // UP — showPublishDetails (all states)
+  // -------------------------------------------------------------------------
+
+  it('showPublishDetails UP only touches rows where the key is absent and sets true (FR-002)', async () => {
+    const queriedSql: string[] = [];
+    const mockQueryRunner = {
+      query: (sql: string) => {
+        queriedSql.push(sql);
+        return Promise.resolve(undefined);
+      },
+    } as any;
+
+    await migration.up(mockQueryRunner);
+
+    const showPublishQuery = queriedSql[2];
+    expect(showPublishQuery).toContain(`'showPublishDetails'`);
+    expect(showPublishQuery).toContain(`IS NULL`);
+    expect(showPublishQuery).toContain('true');
+  });
+
+  it('up() executes exactly 3 queries (branch A, branch B, showPublishDetails)', async () => {
+    let callCount = 0;
+    const mockQueryRunner = {
+      query: () => {
+        callCount++;
+        return Promise.resolve(undefined);
+      },
+    } as any;
+
+    await migration.up(mockQueryRunner);
+
+    expect(callCount).toBe(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // DOWN
+  // -------------------------------------------------------------------------
+
+  it('down() is a non-destructive no-op — it never strips the additive keys (data safety)', async () => {
+    // The keys are additive and editable after the migration; rolling back must NOT delete
+    // admin edits, so down() issues no UPDATE/strip queries.
+    const queriedSql: string[] = [];
+    const mockQueryRunner = {
+      query: (sql: string) => {
+        queriedSql.push(sql);
+        return Promise.resolve(undefined);
+      },
+    } as any;
+
+    await expect(migration.down(mockQueryRunner)).resolves.not.toThrow();
+    expect(queriedSql).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Re-run structural guard (US4-AS4)
+  //
+  // NOTE: these unit tests use a mock QueryRunner and therefore verify the SQL is
+  // *structurally* guarded (every UP statement carries a `settings -> '<key>' IS NULL`
+  // WHERE clause — see the Branch A/B/showPublishDetails tests above), which is what makes
+  // a re-run a no-op. RUNTIME idempotency against real rows is verified live by the
+  // migration validation harness (`pnpm run migration:validate`) — a mock cannot prove it.
+  // -------------------------------------------------------------------------
+
+  it('up() re-run issues the same guarded statements (structural idempotency; runtime proven by migration:validate)', async () => {
+    let callCount = 0;
+    const mockQueryRunner = {
+      query: () => {
+        callCount++;
+        return Promise.resolve(undefined);
+      },
+    } as any;
+
+    await migration.up(mockQueryRunner);
+    await migration.up(mockQueryRunner);
+
+    // 3 guarded statements per run × 2 runs = 6
+    expect(callCount).toBe(6);
+  });
+});

--- a/test/integration/flow-state-layout/flow-state-layout-migration.spec.ts
+++ b/test/integration/flow-state-layout/flow-state-layout-migration.spec.ts
@@ -2,19 +2,40 @@
  * Integration tests: BackfillInnovationFlowStateLayout migration
  * (feature 021-flow-state-post-layout, FR-009)
  *
- * These tests verify the SQL structure of the three UP statements:
- *   1. Branch A (space-owned states via JOIN) only touches rows where
- *      `descriptionDisplayMode` is absent.
- *   2. Branch B (remaining states) only touches rows where
- *      `descriptionDisplayMode` is still absent after branch A.
- *   3. All-states pass sets `showPublishDetails` only where absent.
+ * SCOPE AND LIMITS — read before adding assertions here.
  *
- * All assertions are SQL-string structural — the real-database stack is not
- * available in CI unit mode, consistent with the callout-collapse precedent.
- * Use the live migration:validate harness for full DB coverage (US4-AS1..AS5).
+ * These tests use a mock QueryRunner and assert on the SQL *text*. That is enough to pin
+ * structural properties that are cheap to break and expensive to lose:
+ *   - each UPDATE carries its `settings -> '<key>' IS NULL` guard (what makes a re-run a no-op)
+ *   - the source value is allow-listed rather than copied verbatim into a NonNull enum
+ *   - branch ORDER: the space and template branches must both precede the blanket-'expanded'
+ *     branch, or they can never match anything and the migration silently defaults everything
+ *
+ * It is NOT enough to prove the migration does the right thing to real rows — a substring
+ * assertion passes for a wrong JOIN column just as happily as a right one. Data-level
+ * behaviour (US4-AS1..AS4) is proven against a seeded PostgreSQL by
+ * `.scripts/migrations/verify_021_backfill.sh`; see that script's output for the evidence.
  */
 
 import { BackfillInnovationFlowStateLayout1783600000000 } from '@src/migrations/1783600000000-BackfillInnovationFlowStateLayout';
+
+/** Mock runner: SELECT COUNT(*) probes must return a rows array, UPDATEs return nothing. */
+const createMockQueryRunner = () => {
+  const queriedSql: string[] = [];
+  return {
+    queriedSql,
+    runner: {
+      query: (sql: string) => {
+        queriedSql.push(sql);
+        return Promise.resolve([{ count: '0' }]);
+      },
+    } as any,
+  };
+};
+
+/** The UPDATE statements, in execution order, with the COUNT(*) probes filtered out. */
+const updatesFrom = (queriedSql: string[]) =>
+  queriedSql.filter(sql => sql.includes('UPDATE'));
 
 describe('BackfillInnovationFlowStateLayout migration', () => {
   const migration = new BackfillInnovationFlowStateLayout1783600000000();
@@ -28,101 +49,108 @@ describe('BackfillInnovationFlowStateLayout migration', () => {
   // UP — Branch A (space-owned via JOIN)
   // -------------------------------------------------------------------------
 
-  it('Branch A UP query joins space → collaboration → innovation_flow_state and guards descriptionDisplayMode absent', async () => {
-    const queriedSql: string[] = [];
-    const mockQueryRunner = {
-      query: (sql: string) => {
-        queriedSql.push(sql);
-        return Promise.resolve(undefined);
-      },
-    } as any;
+  it('Branch A joins space → collaboration → innovation_flow_state and guards descriptionDisplayMode absent', async () => {
+    const { runner, queriedSql } = createMockQueryRunner();
 
-    await migration.up(mockQueryRunner);
+    await migration.up(runner);
 
-    // Branch A is the first query
-    const branchA = queriedSql[0];
-    expect(branchA).toContain('collaboration');
-    expect(branchA).toContain('space');
-    expect(branchA).toContain('innovationFlowId');
-    expect(branchA).toContain(`'descriptionDisplayMode'`);
-    expect(branchA).toContain(`IS NULL`);
-    expect(branchA).toContain('descriptionDisplayMode');
-    // Value comes from space settings with COALESCE fallback
+    const [branchA] = updatesFrom(queriedSql);
+    expect(branchA).toContain('JOIN space s ON s."collaborationId" = c.id');
+    expect(branchA).toContain('ifs."innovationFlowId" = c."innovationFlowId"');
     expect(branchA).toContain('calloutDescriptionDisplayMode');
-    expect(branchA).toContain('COALESCE');
-    expect(branchA).toContain("'expanded'");
-  });
-
-  it('Branch A UP is idempotent: WHERE guards only rows where descriptionDisplayMode is absent (US4-AS4)', async () => {
-    const queriedSql: string[] = [];
-    const mockQueryRunner = {
-      query: (sql: string) => {
-        queriedSql.push(sql);
-        return Promise.resolve(undefined);
-      },
-    } as any;
-
-    await migration.up(mockQueryRunner);
-
-    // The WHERE clause must contain IS NULL guard so a second run skips already-set rows
-    const branchA = queriedSql[0];
     expect(branchA).toMatch(/descriptionDisplayMode.*IS NULL/s);
   });
 
   // -------------------------------------------------------------------------
-  // UP — Branch B (remaining states)
+  // UP — Branch A2 (template-owned via JOIN) — M1
   // -------------------------------------------------------------------------
 
-  it('Branch B UP only touches rows where descriptionDisplayMode is still absent (US4-AS3)', async () => {
-    const queriedSql: string[] = [];
-    const mockQueryRunner = {
-      query: (sql: string) => {
-        queriedSql.push(sql);
-        return Promise.resolve(undefined);
-      },
-    } as any;
+  it('Branch A2 copies the template content space layout instead of defaulting it away (M1)', async () => {
+    const { runner, queriedSql } = createMockQueryRunner();
 
-    await migration.up(mockQueryRunner);
+    await migration.up(runner);
 
-    const branchB = queriedSql[1];
+    const branchA2 = updatesFrom(queriedSql)[1];
+    expect(branchA2).toContain(
+      'JOIN template_content_space tcs ON tcs."collaborationId" = c.id'
+    );
+    expect(branchA2).toContain(
+      "tcs.settings->'layout'->>'calloutDescriptionDisplayMode'"
+    );
+    expect(branchA2).toMatch(/descriptionDisplayMode.*IS NULL/s);
+  });
+
+  it('the space and template branches both run BEFORE the blanket-expanded branch, or they could never match', async () => {
+    const { runner, queriedSql } = createMockQueryRunner();
+
+    await migration.up(runner);
+
+    const updates = updatesFrom(queriedSql);
+    const spaceBranch = updates.findIndex(sql => sql.includes('JOIN space'));
+    const templateBranch = updates.findIndex(sql =>
+      sql.includes('JOIN template_content_space')
+    );
+    const blanketBranch = updates.findIndex(sql =>
+      sql.includes(`'"expanded"'::jsonb`)
+    );
+
+    expect(spaceBranch).toBeGreaterThanOrEqual(0);
+    expect(templateBranch).toBeGreaterThanOrEqual(0);
+    expect(blanketBranch).toBeGreaterThan(spaceBranch);
+    expect(blanketBranch).toBeGreaterThan(templateBranch);
+  });
+
+  it('allow-lists the copied value rather than trusting the stored string (m6)', async () => {
+    const { runner, queriedSql } = createMockQueryRunner();
+
+    await migration.up(runner);
+
+    // Both JOIN branches feed a NonNull GraphQL enum; an out-of-enum legacy value would
+    // break the tab query for every viewer of that space.
+    for (const branch of updatesFrom(queriedSql).filter(sql =>
+      sql.includes('JOIN')
+    )) {
+      expect(branch).toContain("IN ('expanded', 'collapsed')");
+      expect(branch).toContain("ELSE 'expanded'");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // UP — Branch B + showPublishDetails
+  // -------------------------------------------------------------------------
+
+  it('Branch B only touches rows where descriptionDisplayMode is still absent (US4-AS3)', async () => {
+    const { runner, queriedSql } = createMockQueryRunner();
+
+    await migration.up(runner);
+
+    const branchB = updatesFrom(queriedSql)[2];
     expect(branchB).toContain(`'descriptionDisplayMode'`);
-    expect(branchB).toContain(`IS NULL`);
+    expect(branchB).toContain('IS NULL');
     expect(branchB).toContain('"expanded"');
   });
 
-  // -------------------------------------------------------------------------
-  // UP — showPublishDetails (all states)
-  // -------------------------------------------------------------------------
+  it('showPublishDetails only touches rows where the key is absent and sets true (FR-002)', async () => {
+    const { runner, queriedSql } = createMockQueryRunner();
 
-  it('showPublishDetails UP only touches rows where the key is absent and sets true (FR-002)', async () => {
-    const queriedSql: string[] = [];
-    const mockQueryRunner = {
-      query: (sql: string) => {
-        queriedSql.push(sql);
-        return Promise.resolve(undefined);
-      },
-    } as any;
+    await migration.up(runner);
 
-    await migration.up(mockQueryRunner);
-
-    const showPublishQuery = queriedSql[2];
+    const showPublishQuery = updatesFrom(queriedSql)[3];
     expect(showPublishQuery).toContain(`'showPublishDetails'`);
-    expect(showPublishQuery).toContain(`IS NULL`);
+    expect(showPublishQuery).toContain('IS NULL');
     expect(showPublishQuery).toContain('true');
   });
 
-  it('up() executes exactly 3 queries (branch A, branch B, showPublishDetails)', async () => {
-    let callCount = 0;
-    const mockQueryRunner = {
-      query: () => {
-        callCount++;
-        return Promise.resolve(undefined);
-      },
-    } as any;
+  it('every UPDATE is guarded so a re-run is a no-op (structural idempotency, US4-AS4)', async () => {
+    const { runner, queriedSql } = createMockQueryRunner();
 
-    await migration.up(mockQueryRunner);
+    await migration.up(runner);
 
-    expect(callCount).toBe(3);
+    const updates = updatesFrom(queriedSql);
+    expect(updates).toHaveLength(4);
+    for (const sql of updates) {
+      expect(sql).toContain('IS NULL');
+    }
   });
 
   // -------------------------------------------------------------------------
@@ -132,41 +160,9 @@ describe('BackfillInnovationFlowStateLayout migration', () => {
   it('down() is a non-destructive no-op — it never strips the additive keys (data safety)', async () => {
     // The keys are additive and editable after the migration; rolling back must NOT delete
     // admin edits, so down() issues no UPDATE/strip queries.
-    const queriedSql: string[] = [];
-    const mockQueryRunner = {
-      query: (sql: string) => {
-        queriedSql.push(sql);
-        return Promise.resolve(undefined);
-      },
-    } as any;
+    const { runner, queriedSql } = createMockQueryRunner();
 
-    await expect(migration.down(mockQueryRunner)).resolves.not.toThrow();
+    await expect(migration.down(runner)).resolves.not.toThrow();
     expect(queriedSql).toHaveLength(0);
-  });
-
-  // -------------------------------------------------------------------------
-  // Re-run structural guard (US4-AS4)
-  //
-  // NOTE: these unit tests use a mock QueryRunner and therefore verify the SQL is
-  // *structurally* guarded (every UP statement carries a `settings -> '<key>' IS NULL`
-  // WHERE clause — see the Branch A/B/showPublishDetails tests above), which is what makes
-  // a re-run a no-op. RUNTIME idempotency against real rows is verified live by the
-  // migration validation harness (`pnpm run migration:validate`) — a mock cannot prove it.
-  // -------------------------------------------------------------------------
-
-  it('up() re-run issues the same guarded statements (structural idempotency; runtime proven by migration:validate)', async () => {
-    let callCount = 0;
-    const mockQueryRunner = {
-      query: () => {
-        callCount++;
-        return Promise.resolve(undefined);
-      },
-    } as any;
-
-    await migration.up(mockQueryRunner);
-    await migration.up(mockQueryRunner);
-
-    // 3 guarded statements per run × 2 runs = 6
-    expect(callCount).toBe(6);
   });
 });


### PR DESCRIPTION
feat(021): per-flow-state post layout settings — server wave 1 Adds descriptionDisplayMode and showPublishDetails to InnovationFlowStateSettings JSONB (workspace#021-flow-state-post-layout, FR-001/FR-002/FR-003/FR-007/FR-008/FR-009).

- Extends IInnovationFlowStateSettings, UpdateInnovationFlowStateSettingsInput, and CreateInnovationFlowStateSettingsInput with two new optional fields; partial-update semantics mirror the existing visible precedent (omission preserves stored value, no spread that drops keys, FR-013)
- Extends InnovationFlowStateService at create defaults, update merge, and getOrFail coercion (defensive absent-key coercion to defaults, risk R-4)
- Deprecates space.settings.layout.calloutDescriptionDisplayMode with REMOVE_AFTER=2026-10-31 (expand-then-contract, FR-008)
- Idempotent two-branch backfill migration (1783600000000): Branch A joins space to collaboration to innovation_flow_state copying space callout display mode; Branch B defaults remaining states to expanded; all states default showPublishDetails to true (FR-009/US4-AS1..AS5)
- Regenerates schema.graphql (additive + one deprecation, no breaking changes)
- Adds unit tests for new settings at all three service extension points
- Adds migration SQL-structural tests and authorization cascade contract tests
- Updates space.service.spec.ts settings fixtures with new required fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-innovation-flow-state controls for callout description **expanded vs collapsed**.
  - Added a per-state toggle to **show/hide publish details**.
- **Behavior Changes**
  - Omitting (or explicitly nulling) settings **preserves existing values**.
  - Missing settings are defaulted to **expanded** and **publish details enabled** when read.
  - **Display name** and **description** updates are now optional (omission leaves values unchanged).
- **Bug Fixes / Reliability**
  - Added a migration to backfill defaults for existing records, with idempotency validation.
- **Deprecation**
  - Deprecated the legacy space-level callout description setting (removal scheduled **2026-10-31**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->