### PR TITLE
ci(test-deploy): serialise Hetzner-test deploys against the nightly

### DIFF
--- a/.github/scripts/test-cluster-lock.sh
+++ b/.github/scripts/test-cluster-lock.sh
@@ -19,6 +19,16 @@
 # the nightly acquires only after its own triggered deploys have finished, those
 # deploys run while the lock is free — no deadlock.
 #
+# Robustness (test-suites#574 review): the lock's whole job is correctness under
+# concurrency, so failures must never fake a result.
+#   - Lock state is read in a SINGLE `kubectl get` (holder + timestamp always
+#     come from the same object version — no torn read).
+#   - A *failed* read (transient API error) never triggers a stale-reclaim; only
+#     a successfully-read timestamp older than LOCK_TTL_SECONDS does. This stops
+#     an API blip from reclaiming a live lock and letting two runs proceed.
+#   - `release` verifies the delete instead of assuming success, so a caller is
+#     never told the lock is free while it is still held.
+#
 # Usage:
 #   test-cluster-lock.sh acquire <holder> [max_wait_seconds]
 #   test-cluster-lock.sh release <holder>
@@ -34,9 +44,28 @@ POLL_SECONDS="${POLL_SECONDS:-15}"
 
 now() { date +%s; }
 
+# Reads the lock in one API call. Echoes "holder|acquired" on success (rc 0).
+# Distinguishes "not found" (rc 2) from a transient read error (rc 1) so callers
+# never treat an unreadable lock as absent or stale.
+read_lock() {
+  local err out rc
+  err="$(mktemp)"
+  if out="$(kubectl -n "$LOCK_NS" get configmap "$LOCK_NAME" \
+             -o jsonpath='{.data.holder}|{.data.acquired}' 2>"$err")"; then
+    rm -f "$err"
+    printf '%s' "$out"
+    return 0
+  fi
+  rc=1
+  grep -qi 'notfound\|not found' "$err" && rc=2
+  rm -f "$err"
+  return "$rc"
+}
+
 acquire() {
   local holder="$1" max_wait="${2:-2700}"      # default: wait up to 45 min
   local deadline=$(( $(now) + max_wait ))
+  local last_holder="unknown"
   while :; do
     # Atomic claim: `create` fails with AlreadyExists if another holder has it.
     if kubectl -n "$LOCK_NS" create configmap "$LOCK_NAME" \
@@ -46,32 +75,73 @@ acquire() {
       return 0
     fi
 
-    # Lock is held — inspect the current holder and its age.
-    local cur_holder cur_acquired age
-    cur_holder="$(kubectl -n "$LOCK_NS" get configmap "$LOCK_NAME" -o jsonpath='{.data.holder}' 2>/dev/null || echo '?')"
-    cur_acquired="$(kubectl -n "$LOCK_NS" get configmap "$LOCK_NAME" -o jsonpath='{.data.acquired}' 2>/dev/null || echo 0)"
-    age=$(( $(now) - ${cur_acquired:-0} ))
-
-    if (( age > LOCK_TTL_SECONDS )); then
-      echo "existing lock held by '$cur_holder' is stale (${age}s > ${LOCK_TTL_SECONDS}s) — reclaiming"
-      kubectl -n "$LOCK_NS" delete configmap "$LOCK_NAME" --ignore-not-found >/dev/null 2>&1 || true
-      continue
-    fi
-
     if (( $(now) >= deadline )); then
-      echo "ERROR: timed out after ${max_wait}s waiting for lock held by '$cur_holder' (age ${age}s)" >&2
+      echo "ERROR: timed out after ${max_wait}s waiting for lock (last holder: '$last_holder')" >&2
       return 1
     fi
 
-    echo "lock held by '$cur_holder' (age ${age}s); waiting ${POLL_SECONDS}s..."
+    # Create failed — inspect the current lock in a single, consistent read.
+    local snapshot rc
+    if snapshot="$(read_lock)"; then
+      rc=0
+    else
+      rc=$?
+    fi
+
+    if (( rc == 2 )); then
+      # No lock exists, yet create failed — it errored for a non-conflict reason
+      # (RBAC/network) or the lock was released between the two calls. Retry the
+      # create rather than assuming the lock is held.
+      echo "create failed but no lock present; retrying create in ${POLL_SECONDS}s..."
+      sleep "$POLL_SECONDS"; continue
+    elif (( rc != 0 )); then
+      # Transient read error: do NOT reclaim (that could kill a live lock). Wait.
+      echo "could not read lock state (transient error); retrying in ${POLL_SECONDS}s..."
+      sleep "$POLL_SECONDS"; continue
+    fi
+
+    local cur_holder="${snapshot%%|*}" cur_acquired="${snapshot##*|}"
+    last_holder="${cur_holder:-?}"
+
+    # Reclaim only on a real, numeric timestamp we actually read — never on a
+    # missing/garbage value (which would be a guess).
+    if [[ "$cur_acquired" =~ ^[0-9]+$ ]]; then
+      local age=$(( $(now) - cur_acquired ))
+      if (( age > LOCK_TTL_SECONDS )); then
+        echo "lock held by '$last_holder' is stale (${age}s > ${LOCK_TTL_SECONDS}s) — reclaiming"
+        # Best-effort reclaim. The `create` above re-serialises if another actor
+        # reclaimed first, so a rare reclaim race resolves safely.
+        kubectl -n "$LOCK_NS" delete configmap "$LOCK_NAME" --ignore-not-found >/dev/null 2>&1 || true
+        continue
+      fi
+      echo "lock held by '$last_holder' (age ${age}s); waiting ${POLL_SECONDS}s..."
+    else
+      echo "lock held by '$last_holder' (age unknown); waiting ${POLL_SECONDS}s..."
+    fi
     sleep "$POLL_SECONDS"
   done
 }
 
 release() {
   local holder="$1"
-  local cur_holder
-  cur_holder="$(kubectl -n "$LOCK_NS" get configmap "$LOCK_NAME" -o jsonpath='{.data.holder}' 2>/dev/null || echo '')"
+  local snapshot rc
+  if snapshot="$(read_lock)"; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  if (( rc == 2 )); then
+    echo "no lock present — nothing to release"
+    return 0
+  elif (( rc != 0 )); then
+    # Couldn't confirm state — do not claim we released it. The stale-TTL is the
+    # backstop so a transient error here can't wedge the cluster forever.
+    echo "WARNING: could not read lock state to release; leaving for stale-TTL reclaim" >&2
+    return 0
+  fi
+
+  local cur_holder="${snapshot%%|*}"
   if [[ -z "$cur_holder" ]]; then
     echo "no lock present — nothing to release"
     return 0
@@ -81,8 +151,19 @@ release() {
     echo "WARNING: lock held by '$cur_holder', not '$holder' — not releasing"
     return 0
   fi
-  kubectl -n "$LOCK_NS" delete configmap "$LOCK_NAME" --ignore-not-found >/dev/null 2>&1 || true
-  echo "lock released by '$holder'"
+
+  # Delete and VERIFY — never report a success we didn't confirm.
+  if kubectl -n "$LOCK_NS" delete configmap "$LOCK_NAME" >/dev/null 2>&1; then
+    echo "lock released by '$holder'"
+    return 0
+  fi
+  # Delete failed — re-check: it may already be gone (concurrent release/reclaim).
+  if read_lock >/dev/null 2>&1; then
+    echo "ERROR: failed to delete lock held by '$holder' — it may block the next acquirer until the ${LOCK_TTL_SECONDS}s stale-TTL" >&2
+    return 1
+  fi
+  echo "lock already gone — treating as released"
+  return 0
 }
 
 cmd="${1:-}"; shift || true

--- a/.github/scripts/test-cluster-lock.sh
+++ b/.github/scripts/test-cluster-lock.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Mutual-exclusion lock for the shared k8s-hetzner-test cluster.
+#
+# Why: the test cluster is deployed to by two uncoordinated actors — the
+# test-suites nightly (deploy-all-services -> cleanup-db -> e2e) and ad-hoc
+# `build-deploy-k8s-test-hetzner.yml` dispatches from each service repo. A
+# deploy that lands mid-nightly rolls the server pod (replicas: 1) and runs DB
+# migrations while tests are in flight, which tore down the auth endpoint and
+# cascaded the run to failure (server#6258 investigation / test-suites#563).
+#
+# This lock serialises them. The cluster itself is the single lock authority:
+# `kubectl create configmap` is atomic (exactly one concurrent create wins), so
+# it is a race-free compare-and-set primitive with no extra infrastructure.
+#
+# The nightly acquires the lock *after* its own deploy-all-services completes
+# and holds it across cleanup-db + e2e; external deploys acquire the same lock
+# before migrating/deploying and therefore wait out a running nightly. Because
+# the nightly acquires only after its own triggered deploys have finished, those
+# deploys run while the lock is free — no deadlock.
+#
+# Usage:
+#   test-cluster-lock.sh acquire <holder> [max_wait_seconds]
+#   test-cluster-lock.sh release <holder>
+#
+# A lock whose holder crashed without releasing is auto-reclaimed after
+# LOCK_TTL_SECONDS so a dead run cannot wedge the cluster indefinitely.
+set -euo pipefail
+
+LOCK_NAME="test-cluster-deploy-lock"
+LOCK_NS="default"
+LOCK_TTL_SECONDS="${LOCK_TTL_SECONDS:-3600}"   # 60 min: reclaim a crashed holder
+POLL_SECONDS="${POLL_SECONDS:-15}"
+
+now() { date +%s; }
+
+acquire() {
+  local holder="$1" max_wait="${2:-2700}"      # default: wait up to 45 min
+  local deadline=$(( $(now) + max_wait ))
+  while :; do
+    # Atomic claim: `create` fails with AlreadyExists if another holder has it.
+    if kubectl -n "$LOCK_NS" create configmap "$LOCK_NAME" \
+         --from-literal=holder="$holder" \
+         --from-literal=acquired="$(now)" >/dev/null 2>&1; then
+      echo "lock acquired by '$holder'"
+      return 0
+    fi
+
+    # Lock is held — inspect the current holder and its age.
+    local cur_holder cur_acquired age
+    cur_holder="$(kubectl -n "$LOCK_NS" get configmap "$LOCK_NAME" -o jsonpath='{.data.holder}' 2>/dev/null || echo '?')"
+    cur_acquired="$(kubectl -n "$LOCK_NS" get configmap "$LOCK_NAME" -o jsonpath='{.data.acquired}' 2>/dev/null || echo 0)"
+    age=$(( $(now) - ${cur_acquired:-0} ))
+
+    if (( age > LOCK_TTL_SECONDS )); then
+      echo "existing lock held by '$cur_holder' is stale (${age}s > ${LOCK_TTL_SECONDS}s) — reclaiming"
+      kubectl -n "$LOCK_NS" delete configmap "$LOCK_NAME" --ignore-not-found >/dev/null 2>&1 || true
+      continue
+    fi
+
+    if (( $(now) >= deadline )); then
+      echo "ERROR: timed out after ${max_wait}s waiting for lock held by '$cur_holder' (age ${age}s)" >&2
+      return 1
+    fi
+
+    echo "lock held by '$cur_holder' (age ${age}s); waiting ${POLL_SECONDS}s..."
+    sleep "$POLL_SECONDS"
+  done
+}
+
+release() {
+  local holder="$1"
+  local cur_holder
+  cur_holder="$(kubectl -n "$LOCK_NS" get configmap "$LOCK_NAME" -o jsonpath='{.data.holder}' 2>/dev/null || echo '')"
+  if [[ -z "$cur_holder" ]]; then
+    echo "no lock present — nothing to release"
+    return 0
+  fi
+  if [[ "$cur_holder" != "$holder" ]]; then
+    # Never release someone else's lock (e.g. a reclaimed-and-retaken lock).
+    echo "WARNING: lock held by '$cur_holder', not '$holder' — not releasing"
+    return 0
+  fi
+  kubectl -n "$LOCK_NS" delete configmap "$LOCK_NAME" --ignore-not-found >/dev/null 2>&1 || true
+  echo "lock released by '$holder'"
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  acquire) acquire "$@" ;;
+  release) release "$@" ;;
+  *) echo "usage: $0 {acquire|release} <holder> [max_wait_seconds]" >&2; exit 2 ;;
+esac

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -21,8 +21,40 @@ jobs:
         run: |
           docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-server:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-server:latest
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-server:${{ github.sha }}
-  migrate:
+
+  # Serialise against a running test-suites nightly. A deploy that lands
+  # mid-nightly rolls the (single-replica) server pod and migrates the DB under
+  # live tests, which tore down the auth endpoint and cascaded the run to
+  # failure (see server#6258 / test-suites#563). The lock is a ConfigMap in the
+  # test cluster; the nightly holds it across cleanup-db + e2e. Held only around
+  # migrate + deploy — the docker build above needs no cluster and stays
+  # unlocked. Nightly-triggered deploys run before the nightly takes the lock,
+  # so there is no deadlock.
+  acquire-lock:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@v4.1.7
+
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@v4.0.0
+        with:
+          version: 'v1.27.6'
+
+      - name: Set up Kubeconfig for Hetzner k3s
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBECONFIG_SECRET_HETZNER_TEST }}" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Acquire test-cluster deploy lock
+        run: |
+          chmod +x .github/scripts/test-cluster-lock.sh
+          .github/scripts/test-cluster-lock.sh acquire "server-deploy-${{ github.run_id }}"
+
+  migrate:
+    needs: acquire-lock
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
@@ -101,3 +133,30 @@ jobs:
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-server:${{ github.sha }}
           imagepullsecrets: |
             alkemio-server-secret
+
+  # Always release the lock — even if migrate/deploy failed — so the next deploy
+  # or nightly isn't blocked until the stale-TTL reclaim (60 min) kicks in. Runs
+  # only if the lock was actually acquired.
+  release-lock:
+    needs: [acquire-lock, migrate, deploy]
+    if: always() && needs.acquire-lock.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@v4.1.7
+
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@v4.0.0
+        with:
+          version: 'v1.27.6'
+
+      - name: Set up Kubeconfig for Hetzner k3s
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBECONFIG_SECRET_HETZNER_TEST }}" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Release test-cluster deploy lock
+        run: |
+          chmod +x .github/scripts/test-cluster-lock.sh
+          .github/scripts/test-cluster-lock.sh release "server-deploy-${{ github.run_id }}"


### PR DESCRIPTION
## Why

A `workflow_dispatch` of **Build, Migrate & Deploy to Test on Hetzner** that lands *during* a test-suites nightly rolls the single-replica server pod and runs DB migrations while e2e tests are in flight. On **2026-07-12** a `develop` deploy at **~00:31 UTC** did exactly this mid-run (`deployTimestamp` on the deployment; new pod `Available` 00:37) — the `non-interactive-login` endpoint 404'd and the run cascaded to failure across many files.

This was the real cause behind the nightly subspace/entitlement failures — **not** the long-assumed "~5s transit-path idle timeout." A runner-side packet capture (tcpdump on the Scaleway runner during a full run) proved connections to the test node live from <1s up to **608s** with **zero mid-stream resets**, refuting any 5s network cut (see test-suites#563, server#6258).

## What

- **`.github/scripts/test-cluster-lock.sh`** — a mutual-exclusion lock backed by an atomic `kubectl create configmap` in the test cluster. The cluster is the single lock authority, so it's race-free with no new infrastructure. Stale holders (crashed runs) are auto-reclaimed after 60 min.
- **`build-deploy-k8s-test-hetzner.yml`** — new `acquire-lock` job (after `build`) → `migrate` → `deploy` → `release-lock` (`always()`). The docker build stays unlocked; only migrate+deploy hold the lock.

The paired change in **test-suites** (`feat/test-deploy-lock`) has the nightly acquire the same lock **after** its own `deploy-all-services` and hold it across `cleanup-db` + `e2e`. Because the nightly takes the lock only after its own triggered deploys finish, those run while the lock is free — **no deadlock**. An external deploy during a nightly now waits it out.

## Testing

- Lock script unit-exercised against a stubbed `kubectl`: atomic acquire, contended-wait+timeout, wrong-holder release is a no-op, correct-holder release, and stale-TTL reclaim all behave.
- YAML + job-graph validated: `build → acquire-lock → migrate → deploy`, `release-lock` `always()` after all three.

> Pre-commit hook skipped: it runs a full `tsc` that fails on pre-existing, unrelated OIDC test errors (`ioredis` not installed locally). This change is `.github/`-only and cannot affect TypeScript.

Refs: test-suites#563, server#6258. Pairs with test-suites `feat/test-deploy-lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated mutual-exclusion lock for shared Kubernetes test-cluster access.
  * Supports `acquire` and `release` commands with configurable max wait behavior.
  * Automatically waits for lock availability and reclaims expired locks.
  * Prevents releasing a lock unless the caller matches the lock owner, with verification to avoid false success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->