### PR TITLE
fix(oidc): never crash the server on issuer discovery failure

### DIFF
--- a/src/core/auth/oidc/oidc.service.spec.ts
+++ b/src/core/auth/oidc/oidc.service.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OidcService } from './oidc.service';
+
+// Control issuer discovery by mocking openid-client's static `Issuer.discover`.
+const { discoverMock } = vi.hoisted(() => ({ discoverMock: vi.fn() }));
+vi.mock('openid-client', () => ({
+  Issuer: { discover: discoverMock },
+}));
+
+const OIDC_CONFIG = {
+  issuer_url: 'https://identity.test-alkem.io/',
+  web_client_id: 'alkemio-web',
+  web_redirect_uri: 'https://test-alkem.io/auth/callback',
+};
+
+const makeService = (): OidcService => {
+  const configService = { get: vi.fn().mockReturnValue(OIDC_CONFIG) } as any;
+  const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+  return new OidcService(configService, logger);
+};
+
+// A discovered issuer exposes a `Client` constructor; `new issuer.Client(...)`
+// must yield the resolved client instance (a real class, so the constructor's
+// object return is honoured exactly like openid-client's).
+const makeFakeIssuer = () => {
+  const client = { id: 'fake-client' };
+  return {
+    metadata: { issuer: OIDC_CONFIG.issuer_url },
+    Client: class {
+      constructor() {
+        return client;
+      }
+    },
+    resolvedClient: client,
+  } as any;
+};
+
+// The failure the live crash was caused by (openid-client RPError).
+const DISCOVERY_ERROR = new Error('outgoing request timed out after 3500ms');
+
+// Drive fake timers forward in backoff-sized rounds, flushing the discovery
+// promise chain each round, until the client is ready (or we give up).
+const settleDiscovery = async (service: OidcService): Promise<boolean> => {
+  for (let round = 0; round < 40; round++) {
+    try {
+      service.getClient();
+      return true;
+    } catch {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+  }
+  return false;
+};
+
+describe('OidcService — boot resilience', () => {
+  beforeEach(() => {
+    discoverMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Leave the never-resolving background retry parked on a cleared fake timer.
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('does not throw on boot when issuer discovery fails, and reports not-ready', async () => {
+    discoverMock.mockRejectedValue(DISCOVERY_ERROR);
+    const service = makeService();
+
+    // onModuleInit is fire-and-forget: it must return synchronously without
+    // throwing (a boot-fatal discovery previously crashed the whole process).
+    expect(() => service.onModuleInit()).not.toThrow();
+
+    // Let the first (failing) discovery attempt settle.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The server is up; interactive-login accessors surface a clear
+    // "not yet initialised" error instead of exposing an undefined client.
+    expect(() => service.getClient()).toThrow(/not yet initialised/);
+    expect(() => service.getIssuer()).toThrow(/not yet initialised/);
+    expect(discoverMock).toHaveBeenCalled();
+  });
+
+  it('self-heals: resolves the client once discovery succeeds on a later attempt', async () => {
+    const fakeIssuer = makeFakeIssuer();
+    discoverMock
+      .mockRejectedValueOnce(DISCOVERY_ERROR) // first attempt fails
+      .mockResolvedValue(fakeIssuer); // retry succeeds
+
+    const service = makeService();
+    service.onModuleInit();
+
+    expect(await settleDiscovery(service)).toBe(true);
+    expect(service.getClient()).toBe(fakeIssuer.resolvedClient);
+    expect(service.getIssuer()).toBe(fakeIssuer);
+    expect(discoverMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('discovers on the first attempt with no retry when the issuer is reachable', async () => {
+    const fakeIssuer = makeFakeIssuer();
+    discoverMock.mockResolvedValue(fakeIssuer);
+
+    const service = makeService();
+    service.onModuleInit();
+
+    expect(await settleDiscovery(service)).toBe(true);
+    expect(service.getClient()).toBe(fakeIssuer.resolvedClient);
+    expect(discoverMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/auth/oidc/oidc.service.spec.ts
+++ b/src/core/auth/oidc/oidc.service.spec.ts
@@ -19,19 +19,20 @@ const makeService = (): OidcService => {
   return new OidcService(configService, logger);
 };
 
-// A discovered issuer exposes a `Client` constructor; `new issuer.Client(...)`
-// must yield the resolved client instance (a real class, so the constructor's
-// object return is honoured exactly like openid-client's).
+// A discovered issuer exposes a `Client` constructor; the service does
+// `new issuer.Client(opts)`. Use a real class (records its construction opts) so
+// the resolved client is a genuine instance.
 const makeFakeIssuer = () => {
-  const client = { id: 'fake-client' };
+  const constructedWith: unknown[] = [];
+  class FakeClient {
+    constructor(opts: unknown) {
+      constructedWith.push(opts);
+    }
+  }
   return {
     metadata: { issuer: OIDC_CONFIG.issuer_url },
-    Client: class {
-      constructor() {
-        return client;
-      }
-    },
-    resolvedClient: client,
+    Client: FakeClient,
+    constructedWith,
   } as any;
 };
 
@@ -92,8 +93,11 @@ describe('OidcService — boot resilience', () => {
     service.onModuleInit();
 
     expect(await settleDiscovery(service)).toBe(true);
-    expect(service.getClient()).toBe(fakeIssuer.resolvedClient);
+    expect(service.getClient()).toBeInstanceOf(fakeIssuer.Client);
     expect(service.getIssuer()).toBe(fakeIssuer);
+    expect(fakeIssuer.constructedWith[0]).toMatchObject({
+      client_id: OIDC_CONFIG.web_client_id,
+    });
     expect(discoverMock).toHaveBeenCalledTimes(2);
   });
 
@@ -105,7 +109,7 @@ describe('OidcService — boot resilience', () => {
     service.onModuleInit();
 
     expect(await settleDiscovery(service)).toBe(true);
-    expect(service.getClient()).toBe(fakeIssuer.resolvedClient);
+    expect(service.getClient()).toBeInstanceOf(fakeIssuer.Client);
     expect(discoverMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/auth/oidc/oidc.service.spec.ts
+++ b/src/core/auth/oidc/oidc.service.spec.ts
@@ -112,4 +112,23 @@ describe('OidcService — boot resilience', () => {
     expect(service.getClient()).toBeInstanceOf(fakeIssuer.Client);
     expect(discoverMock).toHaveBeenCalledTimes(1);
   });
+
+  it('runs discovery only once — the guard blocks overlapping and post-success rounds', async () => {
+    const fakeIssuer = makeFakeIssuer();
+    discoverMock.mockResolvedValue(fakeIssuer);
+    const service = makeService();
+
+    // Two near-simultaneous inits: the second must short-circuit on
+    // `discovering` while the first round is still in flight.
+    service.onModuleInit();
+    service.onModuleInit();
+    expect(await settleDiscovery(service)).toBe(true);
+
+    // A later init, after discovery has completed, must short-circuit on
+    // `this.client`.
+    service.onModuleInit();
+    await settleDiscovery(service);
+
+    expect(discoverMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/core/auth/oidc/oidc.service.ts
+++ b/src/core/auth/oidc/oidc.service.ts
@@ -5,21 +5,23 @@ import type { AlkemioConfig } from '@src/types';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Client, Issuer } from 'openid-client';
 
-// openid-client RP wiring. Issuer discovery happens once at module init
-// against `identity.authentication.providers.oidc.issuer_url`; the resolved
-// Client is exposed via getClient() for the controller (login/callback/refresh).
+// openid-client RP wiring. Issuer discovery is kicked off (in the background)
+// at module init against `identity.authentication.providers.oidc.issuer_url`;
+// the resolved Client is exposed via getClient() for the controller
+// (login/callback/refresh), the only consumer of OIDC discovery.
 //
 // - public client: token_endpoint_auth_method=none
 // - PKCE-S256 mandatory (controller sets code_challenge_method=S256)
 // - nonce always present (controller sets nonce)
 
 // Discovery retry policy. `Issuer.discover` does a single HTTP GET with
-// openid-client's default 3500 ms timeout; a bare `await` there crash-loops the
-// whole process whenever the identity chain (Hydra + traefik) is slow to settle
-// after a restart wave — e.g. right after a test-env DB reset scales Hydra back
-// up (test-suites#555). Retry with capped exponential backoff so a transient
-// unavailability delays boot instead of killing it; only a persistently
-// unreachable issuer (all attempts exhausted) is fatal.
+// openid-client's default 3500 ms timeout. Discovery runs in the background and
+// is NEVER boot-fatal: onModuleInit returns immediately and initDiscovery()
+// retries with capped exponential backoff, then keeps retrying in rounds until
+// the issuer is reachable. So a slow/unavailable identity chain (Hydra +
+// traefik settling after a restart wave — test-suites#555/#563) delays only
+// interactive OIDC login, never the whole server. These constants bound one
+// round of attempts.
 const DISCOVERY_MAX_ATTEMPTS = 10;
 const DISCOVERY_BASE_DELAY_MS = 1000;
 const DISCOVERY_MAX_DELAY_MS = 15000;
@@ -39,21 +41,62 @@ export class OidcService implements OnModuleInit {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  async onModuleInit(): Promise<void> {
+  private discovering = false;
+
+  onModuleInit(): void {
+    // Fire-and-forget: OIDC discovery must NEVER be boot-fatal. It is only used
+    // by the interactive login controller (oidc.controller.ts) — token
+    // validation and non-interactive-login do not touch it — so the server must
+    // boot and serve everything else even while the identity chain (Hydra +
+    // traefik) is still settling. A boot-fatal discovery previously crashed the
+    // process (unhandled rejection, exit 1) whenever discovery outlasted its 10
+    // retry attempts, e.g. during a restart wave, and cascaded a whole nightly
+    // (test-suites#563).
+    void this.initDiscovery();
+  }
+
+  // Background, self-healing discovery. Retries rounds indefinitely so the
+  // issuer becoming reachable later heals OIDC without a process restart. Never
+  // rejects, so it cannot crash the process.
+  private async initDiscovery(): Promise<void> {
+    if (this.client || this.discovering) {
+      return;
+    }
+    this.discovering = true;
+    const log: LoggerService = this.logger ?? new Logger(OidcService.name);
     const { issuer_url, web_client_id, web_redirect_uri } =
       this.configService.get('identity.authentication.providers.oidc', {
         infer: true,
       });
-
-    this.issuer = await this.discoverWithRetry(issuer_url);
-    this.client = new this.issuer.Client({
-      client_id: web_client_id,
-      redirect_uris: [web_redirect_uri],
-      token_endpoint_auth_method: 'none',
-      response_types: ['code'],
-    });
-    const log: LoggerService = this.logger ?? new Logger(OidcService.name);
-    log.log?.(`OIDC Issuer discovered at ${issuer_url}`, OidcService.name);
+    try {
+      for (;;) {
+        try {
+          this.issuer = await this.discoverWithRetry(issuer_url);
+          this.client = new this.issuer.Client({
+            client_id: web_client_id,
+            redirect_uris: [web_redirect_uri],
+            token_endpoint_auth_method: 'none',
+            response_types: ['code'],
+          });
+          log.log?.(
+            `OIDC Issuer discovered at ${issuer_url}`,
+            OidcService.name
+          );
+          return;
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          log.error?.(
+            `OIDC issuer discovery failed against ${issuer_url}; the server is running WITHOUT interactive OIDC login and will keep retrying every ${DISCOVERY_MAX_DELAY_MS}ms. ${message}`,
+            error instanceof Error ? error.stack : undefined,
+            OidcService.name
+          );
+          await sleep(DISCOVERY_MAX_DELAY_MS);
+        }
+      }
+    } finally {
+      this.discovering = false;
+    }
   }
 
   private async discoverWithRetry(issuerUrl: string): Promise<Issuer<Client>> {
@@ -89,7 +132,7 @@ export class OidcService implements OnModuleInit {
   getIssuer(): Issuer<Client> {
     if (!this.issuer) {
       throw new Error(
-        'OIDC issuer not initialised — onModuleInit did not complete'
+        'OIDC issuer not yet initialised — discovery has not completed (the identity provider may be temporarily unavailable); retry shortly'
       );
     }
     return this.issuer;
@@ -98,7 +141,7 @@ export class OidcService implements OnModuleInit {
   getClient(): Client {
     if (!this.client) {
       throw new Error(
-        'OIDC client not initialised — onModuleInit did not complete'
+        'OIDC client not yet initialised — discovery has not completed (the identity provider may be temporarily unavailable); retry shortly'
       );
     }
     return this.client;


### PR DESCRIPTION
## Why

`OidcService.onModuleInit` awaits `discoverWithRetry` (added in #6241), which — after its 10 attempts (~90s of capped backoff) — **`throw`s**. That throw escapes `onModuleInit` as an **unhandled promise rejection and kills the process (exit 1)**. So when the identity chain (Hydra + traefik) is slow to settle during a deploy/restart wave and discovery outlasts the retry budget, the **whole server crashes on boot**.

On **2026-07-12** this happened on a fresh test deploy: the server crashed at boot (OIDC discovery to `identity.test-alkem.io` timed out 10×), and the disruption cascaded ~**50 nightly suites** (`Space ID is required` setup failures) — see the test-suites#563 investigation. #6241 turned crash-*looping* into a single crash-after-90s, but a boot-fatal discovery remained.

## What

OIDC discovery is used **only** by the interactive login controller (`oidc.controller.ts`) — `getClient()`/`getIssuer()`/`getPreAuthSigningKey()` have no other callers. Token validation and non-interactive-login don't touch it. So a failed discovery must **not** be boot-fatal.

- `onModuleInit` is now synchronous and **fire-and-forget**: `void this.initDiscovery()`. The server boots immediately and serves everything (incl. token validation) regardless of identity readiness.
- `initDiscovery()` runs `discoverWithRetry` in **rounds, indefinitely**, with a 15s gap between rounds. It **never rejects**, so it can't crash the process, and OIDC **self-heals** once the issuer is reachable — no restart needed.
- `getClient()`/`getIssuer()` throw a clear *"not yet initialised — retry shortly"* for interactive-login requests that land before discovery completes (instead of the whole API being down).

This is also the correct **production** behaviour: a transient identity blip should degrade interactive login briefly, not take the API offline.

## Testing

- Biome clean; no `OidcService` spec exists to update, and no spec references `onModuleInit`/`discoverWithRetry`.
- Logic verified by inspection: boot no longer awaits discovery; the background loop catches `discoverWithRetry`'s throw and retries; success sets issuer+client and logs.

> Local `tsc` flags `Cannot find module 'openid-client'` — a pre-existing artifact of an incomplete local install (that import is unchanged); CI has deps.

Refs: #6241, test-suites#563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC discovery now runs in the background and retries continuously until the identity provider becomes reachable.
  * Startup is no longer blocked or treated as failed due to slow or unavailable OIDC discovery.
  * Discovery guards prevent overlapping runs, and error messages now indicate discovery hasn’t finished yet.
* **Tests**
  * Added Vitest coverage for resilient startup, background retry/self-healing behavior, and correct discovery invocation and error states (using fake timers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->