### PR TITLE
fix(non-interactive-login): map Kratos 429 to a distinct rate_limited error

### DIFF
--- a/src/core/auth/non-interactive-login/non-interactive-login.audit.ts
+++ b/src/core/auth/non-interactive-login/non-interactive-login.audit.ts
@@ -20,6 +20,7 @@ type NonInteractiveLoginEventType =
   | 'non_interactive_login.bearer_accepted'
   | 'non_interactive_login.bearer_rejected'
   | 'non_interactive_login.credentials_rejected'
+  | 'non_interactive_login.rate_limited'
   | 'non_interactive_login.actor_id_missing'
   | 'non_interactive_login.kratos_unreachable';
 

--- a/src/core/auth/non-interactive-login/non-interactive-login.controller.ts
+++ b/src/core/auth/non-interactive-login/non-interactive-login.controller.ts
@@ -11,6 +11,7 @@ import {
   NonInteractiveLoginActorIdMissingError,
   NonInteractiveLoginInvalidCredentialsError,
   NonInteractiveLoginKratosUnavailableError,
+  NonInteractiveLoginRateLimitedError,
   NonInteractiveLoginService,
 } from './non-interactive-login.service';
 import type {
@@ -39,6 +40,7 @@ import type {
  *                                       email)
  *   404                             — feature disabled
  *   422 message="actor_id_missing"   — identity has no alkemio_actor_id
+ *   429 message="rate_limited"       — Kratos rate-limited the login flow
  *   503 message="kratos_unavailable"
  */
 @Controller('api/auth')
@@ -76,6 +78,9 @@ export class NonInteractiveLoginController {
     } catch (e) {
       if (e instanceof NonInteractiveLoginInvalidCredentialsError) {
         throw new HttpException('invalid_credentials', HttpStatus.UNAUTHORIZED);
+      }
+      if (e instanceof NonInteractiveLoginRateLimitedError) {
+        throw new HttpException('rate_limited', HttpStatus.TOO_MANY_REQUESTS);
       }
       if (e instanceof NonInteractiveLoginActorIdMissingError) {
         throw new HttpException(

--- a/src/core/auth/non-interactive-login/non-interactive-login.service.spec.ts
+++ b/src/core/auth/non-interactive-login/non-interactive-login.service.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `jose` (SignJWT) is only used on the success path, which these error-mapping
+// tests never reach; stub it so the module imports without the real dep.
+vi.mock('jose', () => ({ SignJWT: vi.fn() }));
+
+import {
+  NonInteractiveLoginInvalidCredentialsError,
+  NonInteractiveLoginKratosUnavailableError,
+  NonInteractiveLoginRateLimitedError,
+  NonInteractiveLoginService,
+} from './non-interactive-login.service';
+
+// Maps a Kratos login-flow failure to the right domain error:
+//   429      -> RateLimited      (distinct from a bad password)
+//   other 4xx-> InvalidCredentials
+//   5xx/net  -> KratosUnavailable
+describe('NonInteractiveLoginService — Kratos error mapping', () => {
+  let updateLoginFlow: ReturnType<typeof vi.fn>;
+  let emit: ReturnType<typeof vi.fn>;
+  let service: NonInteractiveLoginService;
+
+  beforeEach(() => {
+    updateLoginFlow = vi.fn();
+    emit = vi.fn();
+    const kratosService = {
+      kratosFrontEndClient: {
+        createNativeLoginFlow: vi
+          .fn()
+          .mockResolvedValue({ data: { id: 'f1' } }),
+        updateLoginFlow,
+      },
+    } as any;
+    const config = { enabled: true, secretKey: Buffer.alloc(32) } as any;
+    const logger = { error: vi.fn(), warn: vi.fn(), log: vi.fn() } as any;
+    service = new NonInteractiveLoginService(
+      kratosService,
+      {} as any, // identityResolveService — not reached on the error path
+      config,
+      { emit } as any,
+      logger
+    );
+  });
+
+  const mintWithKratosStatus = (status: number): Promise<unknown> => {
+    updateLoginFlow.mockRejectedValue({ response: { status } });
+    return service.mint('admin@alkem.io', 'pw');
+  };
+
+  it('maps Kratos 429 to RateLimited (not invalid_credentials)', async () => {
+    await expect(mintWithKratosStatus(429)).rejects.toBeInstanceOf(
+      NonInteractiveLoginRateLimitedError
+    );
+    expect(emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'non_interactive_login.rate_limited',
+        error_code: 'kratos_429',
+      })
+    );
+  });
+
+  it('maps a Kratos 401 to InvalidCredentials', async () => {
+    await expect(mintWithKratosStatus(401)).rejects.toBeInstanceOf(
+      NonInteractiveLoginInvalidCredentialsError
+    );
+  });
+
+  it('maps a Kratos 5xx to KratosUnavailable', async () => {
+    await expect(mintWithKratosStatus(503)).rejects.toBeInstanceOf(
+      NonInteractiveLoginKratosUnavailableError
+    );
+  });
+});

--- a/src/core/auth/non-interactive-login/non-interactive-login.service.ts
+++ b/src/core/auth/non-interactive-login/non-interactive-login.service.ts
@@ -20,6 +20,13 @@ export class NonInteractiveLoginInvalidCredentialsError extends Error {
   }
 }
 
+export class NonInteractiveLoginRateLimitedError extends Error {
+  constructor() {
+    super('rate_limited');
+    this.name = 'NonInteractiveLoginRateLimitedError';
+  }
+}
+
 export class NonInteractiveLoginActorIdMissingError extends Error {
   constructor() {
     super('actor_id_missing');
@@ -117,8 +124,8 @@ export class NonInteractiveLoginService {
   }
 
   // Calls Kratos native login flow with the supplied credentials. Returns
-  // the identity object on success. Maps Kratos 4xx → InvalidCredentials,
-  // 5xx / network errors → KratosUnavailable.
+  // the identity object on success. Maps Kratos 429 → RateLimited, other 4xx →
+  // InvalidCredentials, 5xx / network errors → KratosUnavailable.
   private async loginAgainstKratos(
     email: string,
     password: string,
@@ -164,6 +171,19 @@ export class NonInteractiveLoginService {
       return identity;
     } catch (e) {
       const status = extractHttpStatus(e);
+      if (status === 429) {
+        // Kratos rate-limited the login flow. Distinct from a wrong password so
+        // callers (and audit) can tell "slow down" from "bad credentials" — a
+        // 429 folded into invalid_credentials makes load look like an auth bug
+        // (test-suites#563).
+        this.audit.emit({
+          event_type: 'non_interactive_login.rate_limited',
+          outcome: 'failure',
+          email_hash: emailHash,
+          error_code: 'kratos_429',
+        });
+        throw new NonInteractiveLoginRateLimitedError();
+      }
       if (status !== null && status >= 400 && status < 500) {
         this.audit.emit({
           event_type: 'non_interactive_login.credentials_rejected',

--- a/src/core/auth/oidc/oidc.service.spec.ts
+++ b/src/core/auth/oidc/oidc.service.spec.ts
@@ -46,14 +46,27 @@ const DISCOVERY_ERROR = new Error('outgoing request timed out after 3500ms');
 // many microtask turns the discovery promise chain happened to get — flaky under
 // parallel load.
 //
-// Instead: `advanceTimersByTimeAsync(0)` flushes the discovery promise chain at
-// t=0 (covers the immediate-success path, which schedules no backoff timer), then
-// `runAllTimersAsync` fires every pending/newly-scheduled backoff timer, flushing
-// microtasks between them, until the queue drains (the success path stops
-// scheduling once the client resolves). No polling, no race window.
+// Flush the promise chain explicitly before asking Vitest to run timers. When
+// discovery succeeds immediately there is no timer in the queue, and
+// `advanceTimersByTimeAsync(0)` / `runAllTimersAsync()` are allowed to return
+// without yielding enough microtask turns for both nested awaits
+// (`discoverWithRetry` and `initDiscovery`). That showed up on the macOS CI
+// runner under coverage as all discovery assertions running too early.
+const flushDiscoveryMicrotasks = async (): Promise<void> => {
+  // Two turns are currently sufficient; keep a small cushion so this helper
+  // remains valid if the discovery promise chain gains another async boundary.
+  for (let turn = 0; turn < 5; turn++) {
+    await Promise.resolve();
+  }
+};
+
+// Once the first attempt has either completed or scheduled its retry,
+// `runAllTimersAsync` fires each pending backoff and flushes microtasks between
+// timers until the successful attempt leaves the queue empty.
 const settleDiscovery = async (): Promise<void> => {
-  await vi.advanceTimersByTimeAsync(0);
+  await flushDiscoveryMicrotasks();
   await vi.runAllTimersAsync();
+  await flushDiscoveryMicrotasks();
 };
 
 describe('OidcService — boot resilience', () => {
@@ -76,8 +89,9 @@ describe('OidcService — boot resilience', () => {
     // throwing (a boot-fatal discovery previously crashed the whole process).
     expect(() => service.onModuleInit()).not.toThrow();
 
-    // Let the first (failing) discovery attempt settle.
-    await vi.advanceTimersByTimeAsync(0);
+    // Let the first (failing) discovery attempt settle and park its retry on a
+    // fake timer without advancing into the intentionally endless retry loop.
+    await flushDiscoveryMicrotasks();
 
     // The server is up; interactive-login accessors surface a clear
     // "not yet initialised" error instead of exposing an undefined client.

--- a/src/core/auth/oidc/oidc.service.spec.ts
+++ b/src/core/auth/oidc/oidc.service.spec.ts
@@ -1,11 +1,20 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Issuer } from 'openid-client';
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { OidcService } from './oidc.service';
 
-// Control issuer discovery by mocking openid-client's static `Issuer.discover`.
-const { discoverMock } = vi.hoisted(() => ({ discoverMock: vi.fn() }));
-vi.mock('openid-client', () => ({
-  Issuer: { discover: discoverMock },
-}));
+// Vitest runs this repository with `isolate: false`, so OidcService may already
+// hold the shared openid-client module instance by the time this file loads.
+// Spy on that real shared Issuer instead of installing a late module mock that
+// can leave the service calling one instance while assertions watch another.
+const discoverMock = vi.spyOn(Issuer, 'discover');
 
 const OIDC_CONFIG = {
   issuer_url: 'https://identity.test-alkem.io/',
@@ -79,6 +88,10 @@ describe('OidcService — boot resilience', () => {
     // Leave the never-resolving background retry parked on a cleared fake timer.
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  afterAll(() => {
+    discoverMock.mockRestore();
   });
 
   it('does not throw on boot when issuer discovery fails, and reports not-ready', async () => {


### PR DESCRIPTION
## Why

`loginAgainstKratos` folded **every** Kratos 4xx into `invalid_credentials`:

```ts
if (status !== null && status >= 400 && status < 500) {
  throw new NonInteractiveLoginInvalidCredentialsError();
}
```

So a Kratos login-flow **rate-limit (429)** was reported as a bad password. Under a heavy test run that mints many tokens (the harness ran a full Kratos native login flow per user per file), Kratos rate-limits and the test-suites nightly saw *"Kratos rejected the test-harness credentials"* — a **load** problem masquerading as an **auth** bug. This cost a chunk of the test-suites#563 investigation.

## What

Add `NonInteractiveLoginRateLimitedError` and check 429 **before** the generic 4xx branch:

- **service**: 429 → `RateLimited` (+ a `non_interactive_login.rate_limited` audit event, `error_code: kratos_429`); other 4xx → `InvalidCredentials`; 5xx/network → `KratosUnavailable` (unchanged).
- **controller**: `RateLimited` → **HTTP 429** `rate_limited` (added to the documented response set).

Now a rate-limit is diagnosable — callers can back off instead of chasing a phantom credential problem.

## Testing
- New `non-interactive-login.service.spec.ts`: asserts Kratos 429 → `RateLimitedError` (+ audit event), 401 → `InvalidCredentials`, 5xx → `KratosUnavailable`. 3/3 pass, Biome clean.

> The harness-side root cause (minting far too many tokens) is fixed separately in test-suites#579; this makes the server's *reporting* honest.

Refs: test-suites#563, test-suites#579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-interactive login now reports Kratos rate-limited requests with a clear `429 Too Many Requests` response.
  * A new rate-limit audit event (`non_interactive_login.rate_limited`) is included for improved monitoring.

* **Bug Fixes**
  * Login error handling now distinguishes rate limiting from invalid credentials and temporary service outages.

* **Tests**
  * Added/extended unit tests to verify correct error mapping and the emitted audit event for rate limiting, invalid credentials, and service unavailability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->