### PR TITLE
feat(020): notification.sound user settings + backfill migration [workspace#020]

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -6739,6 +6739,8 @@ type UserSettingsNotification {
   organization: UserSettingsNotificationOrganization!
   """The notifications settings for Platform events for this User"""
   platform: UserSettingsNotificationPlatform!
+  """The sound playback settings for this User."""
+  sound: UserSettingsNotificationSound!
   """The notifications settings for Space events for this User"""
   space: UserSettingsNotificationSpace!
   """The notifications settings for User events for this User"""
@@ -6791,6 +6793,15 @@ type UserSettingsNotificationPlatformAdmin {
   userProfileCreated: UserSettingsNotificationChannels!
   """Receive a notification when a user profile is removed"""
   userProfileRemoved: UserSettingsNotificationChannels!
+}
+
+type UserSettingsNotificationSound {
+  """Play a sound when a chat message is received. Default true."""
+  chatMessage: Boolean!
+  """
+  Play a sound when a non-chat in-app notification is received. Default true.
+  """
+  inAppNotification: Boolean!
 }
 
 type UserSettingsNotificationSpace {
@@ -9483,6 +9494,8 @@ input UpdateUserSettingsNotificationInput {
   organization: UpdateUserSettingsNotificationOrganizationInput
   """Settings related to Platform Notifications."""
   platform: UpdateUserSettingsNotificationPlatformInput
+  """Settings related to notification sound playback."""
+  sound: UpdateUserSettingsNotificationSoundInput
   """Settings related to Space Notifications."""
   space: UpdateUserSettingsNotificationSpaceInput
   """Settings related to User Notifications."""
@@ -9528,6 +9541,15 @@ input UpdateUserSettingsNotificationPlatformInput {
   forumDiscussionComment: NotificationSettingInput
   """Receive a notification when a new Discussion is created in the Forum"""
   forumDiscussionCreated: NotificationSettingInput
+}
+
+input UpdateUserSettingsNotificationSoundInput {
+  """Play a sound when a chat message is received. Default true."""
+  chatMessage: Boolean
+  """
+  Play a sound when a non-chat in-app notification is received. Default true.
+  """
+  inAppNotification: Boolean
 }
 
 input UpdateUserSettingsNotificationSpaceAdminInput {

--- a/src/domain/community/user-settings/dto/user.settings.notification.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.notification.dto.create.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { CreateUserSettingsNotificationOrganizationInput } from './user.settings.notification.organization.dto.create';
 import { CreateUserSettingsNotificationPlatformInput } from './user.settings.notification.platform.dto.create';
+import { CreateUserSettingsNotificationSoundInput } from './user.settings.notification.sound.dto.create';
 import { CreateUserSettingsNotificationSpaceInput } from './user.settings.notification.space.dto.create';
 import { CreateUserSettingsNotificationUserInput } from './user.settings.notification.user.dto.create';
 import { CreateUserSettingsNotificationVirtualContributorInput } from './user.settings.notification.virtual.contributor.dto.create';
@@ -48,4 +49,12 @@ export class CreateUserSettingsNotificationInput {
   @ValidateNested()
   @Type(() => CreateUserSettingsNotificationSpaceInput)
   space?: CreateUserSettingsNotificationSpaceInput;
+
+  @Field(() => CreateUserSettingsNotificationSoundInput, {
+    nullable: true,
+    description: 'Settings related to notification sound playback.',
+  })
+  @ValidateNested()
+  @Type(() => CreateUserSettingsNotificationSoundInput)
+  sound?: CreateUserSettingsNotificationSoundInput;
 }

--- a/src/domain/community/user-settings/dto/user.settings.notification.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.notification.dto.update.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { UpdateUserSettingsNotificationOrganizationInput } from './user.settings.notification.organization.dto.update';
 import { UpdateUserSettingsNotificationPlatformInput } from './user.settings.notification.platform.dto.update';
+import { UpdateUserSettingsNotificationSoundInput } from './user.settings.notification.sound.dto.update';
 import { UpdateUserSettingsNotificationSpaceInput } from './user.settings.notification.space.dto.update';
 import { UpdateUserSettingsNotificationUserInput } from './user.settings.notification.user.dto.update';
 import { UpdateUserSettingsNotificationVirtualContributorInput } from './user.settings.notification.virtual.contributor.dto.update';
@@ -48,4 +49,12 @@ export class UpdateUserSettingsNotificationInput {
   @ValidateNested()
   @Type(() => UpdateUserSettingsNotificationSpaceInput)
   space?: UpdateUserSettingsNotificationSpaceInput;
+
+  @Field(() => UpdateUserSettingsNotificationSoundInput, {
+    nullable: true,
+    description: 'Settings related to notification sound playback.',
+  })
+  @ValidateNested()
+  @Type(() => UpdateUserSettingsNotificationSoundInput)
+  sound?: UpdateUserSettingsNotificationSoundInput;
 }

--- a/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.create.ts
@@ -1,6 +1,8 @@
 import { Field, InputType } from '@nestjs/graphql';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { IsBoolean, ValidateIf } from 'class-validator';
 
+// See the update input: an explicit null is invalid here too, since the matching
+// output fields are Boolean!. Omitting a field falls back to the `true` default.
 @InputType()
 export class CreateUserSettingsNotificationSoundInput {
   @Field(() => Boolean, {
@@ -8,7 +10,7 @@ export class CreateUserSettingsNotificationSoundInput {
     defaultValue: true,
     description: 'Play a sound when a chat message is received. Default true.',
   })
-  @IsOptional()
+  @ValidateIf((_object, value) => value !== undefined)
   @IsBoolean()
   chatMessage?: boolean;
 
@@ -18,7 +20,7 @@ export class CreateUserSettingsNotificationSoundInput {
     description:
       'Play a sound when a non-chat in-app notification is received. Default true.',
   })
-  @IsOptional()
+  @ValidateIf((_object, value) => value !== undefined)
   @IsBoolean()
   inAppNotification?: boolean;
 }

--- a/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.create.ts
@@ -1,0 +1,24 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+@InputType()
+export class CreateUserSettingsNotificationSoundInput {
+  @Field(() => Boolean, {
+    nullable: true,
+    defaultValue: true,
+    description: 'Play a sound when a chat message is received. Default true.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  chatMessage?: boolean;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    defaultValue: true,
+    description:
+      'Play a sound when a non-chat in-app notification is received. Default true.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  inAppNotification?: boolean;
+}

--- a/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.update.ts
@@ -1,0 +1,22 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+@InputType()
+export class UpdateUserSettingsNotificationSoundInput {
+  @Field(() => Boolean, {
+    nullable: true,
+    description: 'Play a sound when a chat message is received. Default true.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  chatMessage?: boolean;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Play a sound when a non-chat in-app notification is received. Default true.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  inAppNotification?: boolean;
+}

--- a/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.notification.sound.dto.update.ts
@@ -1,13 +1,18 @@
 import { Field, InputType } from '@nestjs/graphql';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { IsBoolean, ValidateIf } from 'class-validator';
 
+// Fields are omittable (a partial update leaves the sibling flag untouched), but
+// an explicit null is invalid: the matching output fields are Boolean!, so a
+// persisted null would fail the non-null check on every later read. `IsOptional`
+// would skip validation for null as well as undefined, so `ValidateIf` is used to
+// skip only when the field is absent.
 @InputType()
 export class UpdateUserSettingsNotificationSoundInput {
   @Field(() => Boolean, {
     nullable: true,
     description: 'Play a sound when a chat message is received. Default true.',
   })
-  @IsOptional()
+  @ValidateIf((_object, value) => value !== undefined)
   @IsBoolean()
   chatMessage?: boolean;
 
@@ -16,7 +21,7 @@ export class UpdateUserSettingsNotificationSoundInput {
     description:
       'Play a sound when a non-chat in-app notification is received. Default true.',
   })
-  @IsOptional()
+  @ValidateIf((_object, value) => value !== undefined)
   @IsBoolean()
   inAppNotification?: boolean;
 }

--- a/src/domain/community/user-settings/user.settings.notification.interface.ts
+++ b/src/domain/community/user-settings/user.settings.notification.interface.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { IUserSettingsNotificationOrganization } from './user.settings.notification.organization.interface';
 import { IUserSettingsNotificationPlatform } from './user.settings.notification.platform.interface';
+import { IUserSettingsNotificationSound } from './user.settings.notification.sound.interface';
 import { IUserSettingsNotificationSpace } from './user.settings.notification.space.interface';
 import { IUserSettingsNotificationUser } from './user.settings.notification.user.interface';
 import { IUserSettingsNotificationVirtualContributor } from './user.settings.notification.virtual.contributor.interface';
@@ -38,4 +39,10 @@ export abstract class IUserSettingsNotification {
       'The notifications settings for Virtual Contributor events for this User',
   })
   virtualContributor!: IUserSettingsNotificationVirtualContributor;
+
+  @Field(() => IUserSettingsNotificationSound, {
+    nullable: false,
+    description: 'The sound playback settings for this User.',
+  })
+  sound!: IUserSettingsNotificationSound;
 }

--- a/src/domain/community/user-settings/user.settings.notification.sound.interface.ts
+++ b/src/domain/community/user-settings/user.settings.notification.sound.interface.ts
@@ -1,0 +1,17 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('UserSettingsNotificationSound')
+export abstract class IUserSettingsNotificationSound {
+  @Field(() => Boolean, {
+    nullable: false,
+    description: 'Play a sound when a chat message is received. Default true.',
+  })
+  chatMessage!: boolean;
+
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      'Play a sound when a non-chat in-app notification is received. Default true.',
+  })
+  inAppNotification!: boolean;
+}

--- a/src/domain/community/user-settings/user.settings.service.spec.ts
+++ b/src/domain/community/user-settings/user.settings.service.spec.ts
@@ -287,6 +287,20 @@ describe('UserSettingsService', () => {
       expect(result.notification.sound.chatMessage).toBe(true);
       expect(result.notification.sound.inAppNotification).toBe(false);
     });
+
+    it('should treat an explicit null as a no-op rather than persisting it', () => {
+      const settings = buildSettings();
+      const updateData = {
+        notification: { sound: { chatMessage: null, inAppNotification: null } },
+      } as unknown as UpdateUserSettingsEntityInput;
+
+      const result = service.updateSettings(settings, updateData);
+
+      // The output fields are Boolean! — a persisted null would fail the non-null
+      // check on every later read of this User, so null must never be written.
+      expect(result.notification.sound.chatMessage).toBe(true);
+      expect(result.notification.sound.inAppNotification).toBe(true);
+    });
   });
 
   describe('updateSettings - homeSpace', () => {

--- a/src/domain/community/user-settings/user.settings.service.spec.ts
+++ b/src/domain/community/user-settings/user.settings.service.spec.ts
@@ -119,6 +119,10 @@ describe('UserSettingsService', () => {
         virtualContributor: {
           adminSpaceCommunityInvitation: defaultNotificationSetting(),
         },
+        sound: {
+          chatMessage: true,
+          inAppNotification: true,
+        },
       },
       homeSpace: {
         spaceID: null,
@@ -214,6 +218,74 @@ describe('UserSettingsService', () => {
       expect(
         result.communication.allowOtherUsersToContactViaEmail
       ).toBeUndefined();
+    });
+  });
+
+  describe('updateSettings - notification.sound', () => {
+    it('should update chatMessage when provided', () => {
+      const settings = buildSettings();
+      const updateData: UpdateUserSettingsEntityInput = {
+        notification: { sound: { chatMessage: false } },
+      };
+
+      const result = service.updateSettings(settings, updateData);
+
+      expect(result.notification.sound.chatMessage).toBe(false);
+    });
+
+    it('should update inAppNotification when provided', () => {
+      const settings = buildSettings();
+      const updateData: UpdateUserSettingsEntityInput = {
+        notification: { sound: { inAppNotification: false } },
+      };
+
+      const result = service.updateSettings(settings, updateData);
+
+      expect(result.notification.sound.inAppNotification).toBe(false);
+    });
+
+    it('should leave the sibling flag untouched on a partial update', () => {
+      const settings = buildSettings();
+      const updateData: UpdateUserSettingsEntityInput = {
+        notification: { sound: { chatMessage: false } },
+      };
+
+      const result = service.updateSettings(settings, updateData);
+
+      // Only chatMessage was in the payload → inAppNotification is unchanged.
+      expect(result.notification.sound.chatMessage).toBe(false);
+      expect(result.notification.sound.inAppNotification).toBe(true);
+    });
+
+    it('should leave both flags untouched when sound update data is omitted', () => {
+      const settings = buildSettings();
+      const updateData: UpdateUserSettingsEntityInput = {
+        notification: {},
+      };
+
+      const result = service.updateSettings(settings, updateData);
+
+      expect(result.notification.sound.chatMessage).toBe(true);
+      expect(result.notification.sound.inAppNotification).toBe(true);
+    });
+
+    it('should not write undefined as false when only one flag is provided', () => {
+      const settings = buildSettings({
+        notification: {
+          ...buildSettings().notification,
+          sound: { chatMessage: false, inAppNotification: false },
+        },
+      } as any);
+      const updateData: UpdateUserSettingsEntityInput = {
+        notification: { sound: { chatMessage: true } },
+      };
+
+      const result = service.updateSettings(settings, updateData);
+
+      // inAppNotification omitted from the payload → not coerced to any value,
+      // the stored false survives.
+      expect(result.notification.sound.chatMessage).toBe(true);
+      expect(result.notification.sound.inAppNotification).toBe(false);
     });
   });
 

--- a/src/domain/community/user-settings/user.settings.service.ts
+++ b/src/domain/community/user-settings/user.settings.service.ts
@@ -269,13 +269,16 @@ export class UserSettingsService {
     }
 
     // Sound playback preferences. Merge field-by-field (never by spread) so a
-    // partial update of one flag leaves the sibling flag untouched.
+    // partial update of one flag leaves the sibling flag untouched. The `!= null`
+    // guards skip both undefined and an explicit null: the output fields are
+    // Boolean!, so persisting a null would make every later read of this User
+    // fail the non-null check.
     if (updateData.notification?.sound) {
       const soundData = updateData.notification.sound;
-      if (soundData.chatMessage !== undefined) {
+      if (soundData.chatMessage != null) {
         settings.notification.sound.chatMessage = soundData.chatMessage;
       }
-      if (soundData.inAppNotification !== undefined) {
+      if (soundData.inAppNotification != null) {
         settings.notification.sound.inAppNotification =
           soundData.inAppNotification;
       }

--- a/src/domain/community/user-settings/user.settings.service.ts
+++ b/src/domain/community/user-settings/user.settings.service.ts
@@ -268,6 +268,19 @@ export class UserSettingsService {
       );
     }
 
+    // Sound playback preferences. Merge field-by-field (never by spread) so a
+    // partial update of one flag leaves the sibling flag untouched.
+    if (updateData.notification?.sound) {
+      const soundData = updateData.notification.sound;
+      if (soundData.chatMessage !== undefined) {
+        settings.notification.sound.chatMessage = soundData.chatMessage;
+      }
+      if (soundData.inAppNotification !== undefined) {
+        settings.notification.sound.inAppNotification =
+          soundData.inAppNotification;
+      }
+    }
+
     if (updateData.homeSpace) {
       // Note: spaceID can be explicitly set to null to clear
       if (updateData.homeSpace.spaceID !== undefined) {

--- a/src/domain/community/user/user.service.spec.ts
+++ b/src/domain/community/user/user.service.spec.ts
@@ -116,6 +116,17 @@ describe('UserService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('getDefaultUserSettings', () => {
+    it('should default both notification.sound flags to true', () => {
+      const defaults = (service as any).getDefaultUserSettings();
+
+      expect(defaults.notification.sound).toEqual({
+        chatMessage: true,
+        inAppNotification: true,
+      });
+    });
+  });
+
   describe('getUserByIdOrFail', () => {
     it('should throw EntityNotFoundException when userID is empty string', async () => {
       await expect(service.getUserByIdOrFail('')).rejects.toThrow(

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -384,6 +384,10 @@ export class UserService {
             push: true,
           },
         },
+        sound: {
+          chatMessage: true,
+          inAppNotification: true,
+        },
       },
       homeSpace: {
         spaceID: null,

--- a/src/migrations/1783953322515-AddNotificationSoundSettings.ts
+++ b/src/migrations/1783953322515-AddNotificationSoundSettings.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNotificationSoundSettings1783953322515
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add the "sound" group to the notification JSONB column for every
+    // pre-existing user_settings row. The new UserSettingsNotificationSound
+    // GraphQL fields are non-null, so legacy rows must carry the key or the
+    // resolver throws. The `IS NULL` guard makes this idempotent.
+    await queryRunner.query(`
+      UPDATE user_settings
+      SET notification = jsonb_set(
+        notification,
+        '{sound}',
+        '{"chatMessage": true, "inAppNotification": true}'::jsonb
+      )
+      WHERE notification -> 'sound' IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove the "sound" group from the notification JSONB column.
+    await queryRunner.query(`
+      UPDATE user_settings
+      SET notification = notification - 'sound'
+      WHERE notification -> 'sound' IS NOT NULL
+    `);
+  }
+}

--- a/src/migrations/1783953322515-AddNotificationSoundSettings.ts
+++ b/src/migrations/1783953322515-AddNotificationSoundSettings.ts
@@ -11,12 +11,12 @@ export class AddNotificationSoundSettings1783953322515
     await queryRunner.query(`
       UPDATE user_settings
       SET notification = jsonb_set(
-        notification,
+        COALESCE(notification, '{}'::jsonb),
         '{sound}',
         '{"chatMessage": true, "inAppNotification": true}'::jsonb
       )
       WHERE notification -> 'sound' IS NULL
-    `);
+         OR notification -> 'sound' = 'null'::jsonb
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1783953322515-AddNotificationSoundSettings.ts
+++ b/src/migrations/1783953322515-AddNotificationSoundSettings.ts
@@ -17,6 +17,7 @@ export class AddNotificationSoundSettings1783953322515
       )
       WHERE notification -> 'sound' IS NULL
          OR notification -> 'sound' = 'null'::jsonb
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/test/data/user.settings.mock.ts
+++ b/test/data/user.settings.mock.ts
@@ -183,6 +183,10 @@ export const userSettingsData: { userSettings: IUserSettings } = {
           },
         },
       },
+      sound: {
+        chatMessage: true,
+        inAppNotification: true,
+      },
     },
     homeSpace: {
       spaceID: null,


### PR DESCRIPTION
Server slice of workspace vertical feature **020-notifications-sounds** — adds two per-user, server-persisted sound preferences.

Workspace spec: `workspace#020-notifications-sounds`
Story: alkem-io/client-web#9889
ADR: docs/decisions/0002-notification-sound-settings-contract.md

## What
- New `notification.sound` group on `UserSettings`: `UserSettingsNotificationSound { chatMessage: Boolean!, inAppNotification: Boolean! }`, both default true, nested in the existing `notification` JSONB column (no DDL).
- Create input fields are optional-with-default; Update input fields nullable; `updateSettings` merges field-by-field so a partial update never clobbers the sibling flag.
- Backfill migration `1783953322515-AddNotificationSoundSettings.ts` (idempotent `jsonb_set … WHERE notification -> 'sound' IS NULL`). Ships in THIS PR with the non-null field — never split them, or existing users' settings query throws.
- `schema.graphql` regenerated with the new type.

## Rollout coupling (P4)
This PR is FIRST. It must merge and deploy to acceptance before the client-web PR (which codegens against the live schema) can merge. The client PR links back here.

## Test status
- user-settings + user Vitest suites green (268/268); `schema:diff` = additive only, 0 breaking; lint clean.
- Reviewer notes: (a) the migration DB round-trip (`migration:revert && migration:run` against seeded rows) still needs a run in a Postgres env; (b) a live GraphQL-playground read of `me.user.settings.notification.sound` for a pre-existing (backfilled) user is a manual acceptance step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user notification sound preferences for chat messages and in-app notifications.
  * Sound settings are configurable independently and default to enabled.
* **Bug Fixes**
  * Partial updates now preserve existing sound settings when only one flag is provided.
  * Empty objects and explicit null values no longer overwrite stored preferences.
* **Tests / Chores**
  * Added/extended tests for default values and update behavior.
  * Added a migration to populate default sound settings for existing users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->