### PR TITLE
test(oidc): de-flake boot-resilience suite with a deterministic settle

### DIFF
--- a/src/core/auth/oidc/oidc.service.spec.ts
+++ b/src/core/auth/oidc/oidc.service.spec.ts
@@ -39,18 +39,21 @@ const makeFakeIssuer = () => {
 // The failure the live crash was caused by (openid-client RPError).
 const DISCOVERY_ERROR = new Error('outgoing request timed out after 3500ms');
 
-// Drive fake timers forward in backoff-sized rounds, flushing the discovery
-// promise chain each round, until the client is ready (or we give up).
-const settleDiscovery = async (service: OidcService): Promise<boolean> => {
-  for (let round = 0; round < 40; round++) {
-    try {
-      service.getClient();
-      return true;
-    } catch {
-      await vi.advanceTimersByTimeAsync(1000);
-    }
-  }
-  return false;
+// Deterministically settle the fire-and-forget discovery.
+//
+// The prior helper raced: it polled getClient() while advancing fake time in
+// fixed 1s steps, so whether the client was ready by a given step depended on how
+// many microtask turns the discovery promise chain happened to get — flaky under
+// parallel load.
+//
+// Instead: `advanceTimersByTimeAsync(0)` flushes the discovery promise chain at
+// t=0 (covers the immediate-success path, which schedules no backoff timer), then
+// `runAllTimersAsync` fires every pending/newly-scheduled backoff timer, flushing
+// microtasks between them, until the queue drains (the success path stops
+// scheduling once the client resolves). No polling, no race window.
+const settleDiscovery = async (): Promise<void> => {
+  await vi.advanceTimersByTimeAsync(0);
+  await vi.runAllTimersAsync();
 };
 
 describe('OidcService — boot resilience', () => {
@@ -92,7 +95,7 @@ describe('OidcService — boot resilience', () => {
     const service = makeService();
     service.onModuleInit();
 
-    expect(await settleDiscovery(service)).toBe(true);
+    await settleDiscovery();
     expect(service.getClient()).toBeInstanceOf(fakeIssuer.Client);
     expect(service.getIssuer()).toBe(fakeIssuer);
     expect(fakeIssuer.constructedWith[0]).toMatchObject({
@@ -108,7 +111,7 @@ describe('OidcService — boot resilience', () => {
     const service = makeService();
     service.onModuleInit();
 
-    expect(await settleDiscovery(service)).toBe(true);
+    await settleDiscovery();
     expect(service.getClient()).toBeInstanceOf(fakeIssuer.Client);
     expect(discoverMock).toHaveBeenCalledTimes(1);
   });
@@ -122,12 +125,14 @@ describe('OidcService — boot resilience', () => {
     // `discovering` while the first round is still in flight.
     service.onModuleInit();
     service.onModuleInit();
-    expect(await settleDiscovery(service)).toBe(true);
+    await settleDiscovery();
+    // The first round resolved the client (so the second init above was a no-op).
+    expect(service.getClient()).toBeInstanceOf(fakeIssuer.Client);
 
     // A later init, after discovery has completed, must short-circuit on
     // `this.client`.
     service.onModuleInit();
-    await settleDiscovery(service);
+    await settleDiscovery();
 
     expect(discoverMock).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Problem

The `OidcService — boot resilience` suite (`src/core/auth/oidc/oidc.service.spec.ts`, added in #6260) is **flaky**. Under parallel / coverage load it intermittently fails all 4 tests with `expected "vi.fn()" to be called at least once` and `expected false to be true`.

**Root cause:** the `settleDiscovery` helper polled `getClient()` while advancing fake time in fixed 1s steps. Discovery is fire-and-forget (`void this.initDiscovery()`), so whether the client was ready by a given step depended on how many microtask turns the discovery promise chain happened to get — a race that widens under coverage instrumentation and parallel scheduling. (Matches the "assertion runs before fire-and-forget async completes" pattern in `docs/testing-flakiness.md`.)

## Fix (test-only)

Replace the polling settle with a deterministic drain:

```ts
const settleDiscovery = async (): Promise<void> => {
  await vi.advanceTimersByTimeAsync(0); // flush the immediate-resolve discovery chain
  await vi.runAllTimersAsync();          // fire every backoff timer, flushing microtasks between them
};
```

**Production `oidc.service.ts` is unchanged** — same assertions, race-free settle.

## Verification

- **200/200 iterations green under v8 coverage** (`pnpm test:flake-verify src/core/auth/oidc/oidc.service.spec.ts`) — the doc's 200× bar.
- **Mutation-tested** (proves the tests still catch regressions, i.e. no false-positive passes):
  - Disabling discovery (`onModuleInit` no-op) → **all 4 tests fail**, including the previously-flaky `vi.fn() called` assertion.
  - Removing the dedup guard → **only** the "runs discovery only once" test fails (`called 3 times, expected 1`); the other three still pass.
- Full pre-commit suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of OIDC authentication tests by using deterministic handling of asynchronous discovery operations.
  - Updated coverage for startup resilience, recovery after failed discovery, and preventing duplicate discovery attempts.
  - Simplified test synchronization for scenarios involving multiple initialization attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->