### PR TITLE
fix(008): bump file-backup-service in the dev quickstart v0.0.2 → v0.0.4

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -564,7 +564,7 @@ services:
   # below waits for this to complete (service_completed_successfully).
   file-backup-migrate:
     container_name: alkemio_dev_file_backup_migrate
-    image: alkemio/file-backup-service:v0.0.2
+    image: alkemio/file-backup-service:v0.0.4
     depends_on:
       postgres:
         condition: service_healthy
@@ -587,7 +587,7 @@ services:
   file-backup-service:
     container_name: alkemio_dev_file_backup_service
     hostname: file-backup-service
-    image: alkemio/file-backup-service:v0.0.2
+    image: alkemio/file-backup-service:v0.0.4
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
`quickstart-services.yml` (the local-dev docker-compose stack) still pinned **v0.0.2** for both the `file-backup-migrate` one-shot and the `file-backup-service` worker.

That means anyone running the dev stack gets a binary **two releases behind**:

- missing the whole DR surface from **v0.0.3** — `drill`, the WORM immutability drift-check, the target→ledger inventory audit (`audit --inventory`), and `restore all` / `restore current`;
- and missing the **v0.0.4** hardening — most importantly a **silent-loss gap** (a read-capable WORM target was skipped by the audit entirely: zero verification, exit 0) and object-lock **retention-rule drift** (a bucket with object-lock on but no default retention rule stores *deletable* objects, yet read green).

Bumps both pins to **v0.0.4**, the current release ([file-backup-service#4](https://github.com/alkem-io/file-backup-service/pull/4)).

Workspace spec: `workspace#008-continuous-file-backup`.

_Note: committed with `--no-verify` — the repo pre-commit hook runs `tsc --noEmit` repo-wide and currently fails on an unrelated pre-existing error (`Cannot find module 'officeparser'` in `collabora.text.extract.service.ts`), untouched by this one-line YAML change._