### PR TITLE
Fix export whole-day calendar events having wrong date

### DIFF
--- a/src/domain/timeline/event/calendar.event.calendar-links.spec.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.spec.ts
@@ -1,7 +1,7 @@
 import {
   calculateCalendarEventEndDate,
   foldIcsLine,
-  formatDateOnly,
+  formatDateOnlyLocal,
   formatDatesForCalendar,
   generateCalendarUrls,
   generateICS,
@@ -22,7 +22,8 @@ describe('CalendarEventCalendarLinks', () => {
     expect(result.icalEnd).toBe('20260220T110000Z');
   });
 
-  it('formats whole-day dates as date-only values', () => {
+  it('formats whole-day dates as date-only values with an exclusive end', () => {
+    // Last covered day is the 21st; every target's end is exclusive (the 22nd).
     const result = formatDatesForCalendar(
       '2026-02-20T00:00:00Z',
       '2026-02-21T00:00:00Z',
@@ -31,14 +32,66 @@ describe('CalendarEventCalendarLinks', () => {
 
     expect(result.google).toBe('20260220/20260222');
     expect(result.outlookStart).toBe('2026-02-20');
-    expect(result.outlookEnd).toBe('2026-02-21');
+    expect(result.outlookEnd).toBe('2026-02-22');
     expect(result.icalStart).toBe('20260220');
-    expect(result.icalEnd).toBe('20260221');
+    expect(result.icalEnd).toBe('20260222');
     expect(result.wholeDay).toBe(true);
   });
 
-  it('formatDateOnly extracts YYYYMMDD from ISO string', () => {
-    expect(formatDateOnly('2026-02-20T10:00:00.000Z')).toBe('20260220');
+  it('formatDateOnlyLocal extracts the local wall-clock YYYYMMDD', () => {
+    // Constructed at local midnight so the assertion holds in any runner TZ.
+    const localMidnight = new Date(2026, 1, 20, 0, 0, 0); // 2026-02-20 local
+    expect(formatDateOnlyLocal(localMidnight.toISOString())).toBe('20260220');
+  });
+
+  describe('whole-day time-zone handling (Europe/Amsterdam)', () => {
+    // Reproduces the reported bug: a whole-day event stored as local midnight
+    // is read back (node-postgres, timestamp-without-tz) as the previous day in
+    // UTC. Slicing the UTC ISO produced an ICS date one day early; the export
+    // must emit the local calendar day instead.
+    const originalTz = process.env.TZ;
+
+    beforeEach(() => {
+      process.env.TZ = 'Europe/Amsterdam';
+    });
+
+    afterEach(() => {
+      process.env.TZ = originalTz;
+    });
+
+    it('exports the local calendar day for a whole-day event, not the UTC day', () => {
+      // Single-day whole-day event stored at Amsterdam local midnight:
+      // 2026-07-23 00:00 local is 2026-07-22T22:00Z. The last covered day is the
+      // 23rd (the end instant is later the same local day), so DTSTART is the
+      // 23rd and the exclusive DTEND is the 24th.
+      const startIso = '2026-07-22T22:00:00.000Z';
+      const endIso = '2026-07-22T22:30:00.000Z';
+
+      const result = formatDatesForCalendar(startIso, endIso, true);
+
+      // Without the local-date fix DTSTART would slip to the 22nd (UTC).
+      expect(result.icalStart).toBe('20260723');
+      expect(result.icalEnd).toBe('20260724');
+      expect(result.outlookStart).toBe('2026-07-23');
+      expect(result.outlookEnd).toBe('2026-07-24');
+      expect(result.google).toBe('20260723/20260724');
+    });
+
+    it('emits an exclusive DTEND (last day + 1) for a multi-day whole-day event', () => {
+      // The reported case: an event covering Jan 1–Jan 3 (three days). The
+      // stored end date is the last covered day (the 3rd); DTEND must be the
+      // 4th so importers show Jan 1–3 rather than Jan 1–2.
+      const result = formatDatesForCalendar(
+        '2001-01-01T00:00:00.000Z',
+        '2001-01-03T00:00:00.000Z',
+        true
+      );
+
+      expect(result.icalStart).toBe('20010101');
+      expect(result.icalEnd).toBe('20010104');
+      expect(result.outlookEnd).toBe('2001-01-04');
+      expect(result.google).toBe('20010101/20010104');
+    });
   });
 
   it('generates calendar URLs with encoded fields', () => {
@@ -87,7 +140,8 @@ describe('CalendarEventCalendarLinks', () => {
     expect(urls.googleCalendarUrl).toContain('dates=20260310/20260312');
     expect(urls.outlookCalendarUrl).toContain('allday=true');
     expect(urls.outlookCalendarUrl).toContain('startdt=2026-03-10');
-    expect(urls.outlookCalendarUrl).toContain('enddt=2026-03-11');
+    // Exclusive end — the day after the last covered day (the 11th → the 12th).
+    expect(urls.outlookCalendarUrl).toContain('enddt=2026-03-12');
   });
 
   it('generates RFC5545 iCalendar content', () => {

--- a/src/domain/timeline/event/calendar.event.calendar-links.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.ts
@@ -65,18 +65,31 @@ export const formatDatesForCalendar = (
   const endIso = toIsoString(end, 'endDate');
 
   if (wholeDay) {
-    const dateStart = formatDateOnly(startIso);
-    // For Google Calendar, end date must be exclusive for all-day events, so add 1 day
-    const endDateObj = new Date(endIso);
-    endDateObj.setUTCDate(endDateObj.getUTCDate() + 1);
-    const dateEndGoogle = formatDateOnly(endDateObj.toISOString());
-    const dateEnd = formatDateOnly(endIso);
+    // A whole-day event carries a calendar date, not an instant. The stored
+    // `timestamp` (without time zone) is read back by node-postgres in the
+    // process-local time zone — the same reference the client renders in — so
+    // the date-only value MUST be derived from the local wall-clock components,
+    // not from the UTC ISO string. Slicing the UTC ISO lands on the previous
+    // day for time zones east of UTC (e.g. Europe/Amsterdam, where the server
+    // runs: local midnight 2026-07-23 is 2026-07-22T22:00Z in UTC).
+    const dateStart = formatDateOnlyLocal(startIso);
+    // Whole-day end dates are EXCLUSIVE (RFC 5545 §3.6.1 for ICS; Google and
+    // Outlook all-day links use the same convention): the end must be the day
+    // AFTER the last covered day. The stored end date is the last covered day,
+    // so add one local day. All three targets share this exclusive end —
+    // previously only the Google URL added the +1, so ICS and Outlook were a
+    // day short and importers (Thunderbird, Outlook) showed the event ending
+    // one day early.
+    const exclusiveEnd = new Date(endIso);
+    exclusiveEnd.setDate(exclusiveEnd.getDate() + 1);
+    const exclusiveEndIso = exclusiveEnd.toISOString();
+    const dateEndExclusive = formatDateOnlyLocal(exclusiveEndIso);
     return {
-      google: `${dateStart}/${dateEndGoogle}`,
-      outlookStart: startIso.slice(0, 10),
-      outlookEnd: endIso.slice(0, 10),
+      google: `${dateStart}/${dateEndExclusive}`,
+      outlookStart: formatLocalDateHyphenated(startIso),
+      outlookEnd: formatLocalDateHyphenated(exclusiveEndIso),
       icalStart: dateStart,
-      icalEnd: dateEnd,
+      icalEnd: dateEndExclusive,
       wholeDay: true,
     };
   }
@@ -194,9 +207,34 @@ const sliceByBytes = (
 export const formatDateForCalendar = (iso: string): string =>
   iso.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 
-/** Extracts a date-only iCal value (YYYYMMDD) from an ISO-8601 string. */
-export const formatDateOnly = (iso: string): string =>
-  iso.slice(0, 10).replace(/-/g, '');
+/**
+ * Local wall-clock date parts of the instant an ISO-8601 string represents.
+ * Whole-day events are stored/read/displayed in the process-local time zone,
+ * so their date-only value must come from these local components rather than
+ * the UTC slice of the ISO string (which can be off by a day east of UTC).
+ */
+const localDateParts = (
+  iso: string
+): { year: string; month: string; day: string } => {
+  const d = new Date(iso);
+  return {
+    year: String(d.getFullYear()).padStart(4, '0'),
+    month: String(d.getMonth() + 1).padStart(2, '0'),
+    day: String(d.getDate()).padStart(2, '0'),
+  };
+};
+
+/** Local wall-clock date as an iCal date-only value (YYYYMMDD). */
+export const formatDateOnlyLocal = (iso: string): string => {
+  const { year, month, day } = localDateParts(iso);
+  return `${year}${month}${day}`;
+};
+
+/** Local wall-clock date as YYYY-MM-DD (Outlook all-day format). */
+const formatLocalDateHyphenated = (iso: string): string => {
+  const { year, month, day } = localDateParts(iso);
+  return `${year}-${month}-${day}`;
+};
 
 export const calculateCalendarEventEndDate = (event: ICalendarEvent): Date => {
   const start = toDate(event.startDate, 'startDate');


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and its purpose. Link related issues/specs if applicable. -->

## Schema Contract Checklist (Feature 002)

If this PR affects the GraphQL schema, complete ALL items below:

- [ ] Ran `npm run schema:print` (and optionally `npm run schema:sort`) to regenerate `schema.graphql`.
- [ ] Retrieved base snapshot (e.g. `git show origin/develop:schema.graphql > tmp/prev.schema.graphql`).
- [ ] Ran `npm run schema:diff` to produce `change-report.json` and `deprecations.json`.
- [ ] Reviewed classifications; only expected changes present.
- [ ] (Optional) Ran `npm run schema:validate` and artifacts passed validation.
- [ ] Committed ONLY `schema.graphql` (not the JSON artifacts).

### Change Report Summary

Paste the key counts from `change-report.json` (example format below) — remove any zero lines if desired:

```
Additive: X
Deprecated: Y
Deprecation Grace: Z
Breaking: B (override applied? yes/no)
Premature Removals: P
Invalid Deprecations: I
Info: N
```

### Deprecations Added / Updated

List new or updated deprecations with schedules (`REMOVE_AFTER=YYYY-MM-DD | reason`). Indicate any in grace period.

### Breaking Changes (If Any)

If BREAKING changes are intentional:

- Rationale:
- Risk assessment / mitigation:
- CODEOWNER approval with phrase `BREAKING-APPROVED` requested? (link)

### Other Notes

<!-- Testing strategy, migration notes, docs follow-up, etc. -->

---

Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.
