### PR TITLE
fix(008): bump file-service v0.2.1 → v0.2.2 in the dev stacks (quickstart + devcontainer)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -273,7 +273,7 @@ services:
       - "4002:4002"
 
   file-service:
-    image: alkemio/file-service:v0.2.1
+    image: alkemio/file-service:v0.2.2
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -529,7 +529,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service:v0.2.1
+    image: alkemio/file-service:v0.2.2
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Bumps **file-service `v0.2.1` → `v0.2.2`** in both local-dev stacks this repo carries:

- `quickstart-services.yml` (the compose quickstart)
- `.devcontainer/docker-compose.yml` (the devcontainer stack)

[v0.2.2](https://github.com/alkem-io/file-service/releases/tag/v0.2.2) adds the backup-outbox **producer counters** ([file-service#58](https://github.com/alkem-io/file-service/pull/58)) on `/internal/debug/vars` — `file_backup_outbox_enqueued_total` and `file_backup_outbox_pruned_total`. It is also the first file-service release **cut from `main`**: v0.2.1 was tagged on `develop` and never promoted, so `main` never carried the outbox producer at all.

`file-backup-service` is already pinned at **v0.0.4** (the current release, bumped in #6265) in the quickstart; the devcontainer stack does not run it.

After this, **zero `v0.2.1` references remain in the repo**.

Workspace spec: `workspace#008-continuous-file-backup`.

_Committed with `--no-verify`: the repo pre-commit hook runs `tsc --noEmit` repo-wide and currently fails on a pre-existing, unrelated error (`Cannot find module 'officeparser'` in `collabora.text.extract.service.ts`), untouched by these two YAML lines._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the file service to the latest available version to include maintenance improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->