### PR TITLE
Contributors/spaces callout - manual selection

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -291,6 +291,14 @@ enum CalloutFramingType {
   WHITEBOARD
 }
 
+"""
+The selection mode for a collection callout (Contributors or Subspaces). AUTO (default) returns the full computed set; CUSTOM restricts to the admin-curated selectedIds list.
+"""
+enum CalloutSelectionMode {
+  AUTO
+  CUSTOM
+}
+
 enum CalloutsSetType {
   COLLABORATION
   KNOWLEDGE_BASE
@@ -1931,6 +1939,17 @@ type CalloutPostCreated {
   sortOrder: Float!
 }
 
+type CalloutSelectionSettings {
+  """
+  The selection mode: AUTO (full computed set) or CUSTOM (admin-curated subset).
+  """
+  mode: CalloutSelectionMode!
+  """
+  The selected actor/space IDs in CUSTOM mode (0–500 entries). Ignored when mode is AUTO.
+  """
+  selectedIds: [ID!]!
+}
+
 type CalloutSettings {
   """Callout Contribution Settings."""
   contribution: CalloutSettingsContribution!
@@ -1960,6 +1979,10 @@ type CalloutSettingsFraming {
   Configuration for a contributor-collection callout. Present only when framing.type = CONTRIBUTORS.
   """
   contributors: CalloutContributorsSettings
+  """
+  Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Absent / null ⇒ AUTO (full computed set).
+  """
+  selection: CalloutSelectionSettings
 }
 
 type CalloutsSet {
@@ -2042,7 +2065,9 @@ type CollaboraDocument {
 }
 
 type CollaboraEditorUrlResult {
-  """When the access token expires, as an absolute Unix timestamp in milliseconds (the WOPI access_token_ttl passed through from the WOPI host); 0 means it does not expire."""
+  """
+  When the access token expires, as an absolute Unix timestamp in milliseconds (the WOPI access_token_ttl passed through from the WOPI host); 0 means it does not expire.
+  """
   accessTokenTTL: Float!
   """The URL to open the document in the Collabora editor."""
   editorUrl: String!
@@ -2465,6 +2490,15 @@ type CreateCalloutFramingData {
   whiteboard: CreateWhiteboardData
 }
 
+type CreateCalloutSelectionSettingsData {
+  """The selection mode (AUTO or CUSTOM). Defaults to AUTO when omitted."""
+  mode: CalloutSelectionMode
+  """
+  The curated selection of actor/space IDs (CUSTOM mode). At most 500. Deduplicated by the server.
+  """
+  selectedIds: [ID!]
+}
+
 type CreateCalloutSettingsContributionData {
   """Allowed Contribution types."""
   allowedTypes: [CalloutContributionType!]
@@ -2492,6 +2526,10 @@ type CreateCalloutSettingsFramingData {
   Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS.
   """
   contributors: CreateCalloutContributorsSettingsData
+  """
+  Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}.
+  """
+  selection: CreateCalloutSelectionSettingsData
 }
 
 type CreateCalloutsSetData {
@@ -5193,7 +5231,9 @@ type Query {
   aiServer: AiServer!
   """Retrieves the editor URL for the specified CollaboraDocument."""
   collaboraEditorUrl(collaboraDocumentID: UUID!): CollaboraEditorUrlResult!
-  """Whether the WOPI save service backing this CollaboraDocument is currently reachable. A side-effect-free health check — unlike collaboraEditorUrl it issues no access token and records no analytics — used to surface a save-path outage in the editor."""
+  """
+  Whether the WOPI save service backing this CollaboraDocument is currently reachable. A side-effect-free health check — unlike collaboraEditorUrl it issues no access token and records no analytics — used to surface a save-path outage in the editor.
+  """
   collaboraServiceAvailable(collaboraDocumentID: UUID!): Boolean!
   """Active Spaces only, order by most active in the past X days."""
   exploreSpaces(options: ExploreSpacesInput): [Space!]!
@@ -7527,6 +7567,15 @@ input CreateCalloutOnCalloutsSetInput {
   sortOrder: Float
 }
 
+input CreateCalloutSelectionSettingsInput {
+  """The selection mode (AUTO or CUSTOM). Defaults to AUTO when omitted."""
+  mode: CalloutSelectionMode
+  """
+  The curated selection of actor/space IDs (CUSTOM mode). At most 500. Deduplicated by the server.
+  """
+  selectedIds: [ID!]
+}
+
 input CreateCalloutSettingsContributionInput {
   """Allowed Contribution types."""
   allowedTypes: [CalloutContributionType!]
@@ -7547,6 +7596,10 @@ input CreateCalloutSettingsFramingInput {
   Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS.
   """
   contributors: CreateCalloutContributorsSettingsInput
+  """
+  Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}.
+  """
+  selection: CreateCalloutSelectionSettingsInput
 }
 
 input CreateCalloutSettingsInput {
@@ -8875,6 +8928,17 @@ input UpdateCalloutPublishInfoInput {
   publisherID: UUID
 }
 
+input UpdateCalloutSelectionSettingsInput {
+  """
+  The selection mode (AUTO or CUSTOM). When omitted, the stored mode is unchanged.
+  """
+  mode: CalloutSelectionMode
+  """
+  Replaces the curated selection in full (CUSTOM mode). At most 500 entries. Deduplicated by the server. When omitted, the stored list is unchanged.
+  """
+  selectedIds: [ID!]
+}
+
 input UpdateCalloutSettingsContributionInput {
   """Indicate who can add more contributions to the callout."""
   canAddContributions: CalloutAllowedActors
@@ -8893,6 +8957,10 @@ input UpdateCalloutSettingsFramingInput {
   Configuration for a contributor-collection callout. Provide only when framing.type = CONTRIBUTORS.
   """
   contributors: UpdateCalloutContributorsSettingsInput
+  """
+  Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}.
+  """
+  selection: UpdateCalloutSelectionSettingsInput
 }
 
 input UpdateCalloutSettingsInput {

--- a/src/common/enums/callout.selection.mode.ts
+++ b/src/common/enums/callout.selection.mode.ts
@@ -1,0 +1,12 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum CalloutSelectionMode {
+  AUTO = 'auto',
+  CUSTOM = 'custom',
+}
+
+registerEnumType(CalloutSelectionMode, {
+  name: 'CalloutSelectionMode',
+  description:
+    'The selection mode for a collection callout (Contributors or Subspaces). AUTO (default) returns the full computed set; CUSTOM restricts to the admin-curated selectedIds list.',
+});

--- a/src/domain/collaboration/callout-framing/callout.framing.selection.validation.spec.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.selection.validation.spec.ts
@@ -1,0 +1,289 @@
+import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
+import { ValidationException } from '@common/exceptions';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+import { ICalloutSettingsFraming } from '../callout-settings/callout.settings.framing.interface';
+import { CalloutFraming } from './callout.framing.entity';
+import { CalloutFramingService } from './callout.framing.service';
+
+// Covers the selection-settings validation + normalization
+// (workspace#025-callout-manual-selection, FR-013/FR-022).
+// Contract: S8 (kind-scoping) + S9 (partial-update semantics).
+describe('CalloutFramingService.validateAndNormalizeSelectionSettings', () => {
+  let service: CalloutFramingService;
+
+  const baseFraming = (
+    selection?: ICalloutSettingsFraming['selection']
+  ): ICalloutSettingsFraming => ({
+    commentsEnabled: true,
+    selection,
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalloutFramingService,
+        MockWinstonProvider,
+        repositoryProviderMockFactory(CalloutFraming),
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+    service = module.get(CalloutFramingService);
+  });
+
+  // --- Kind-scoping (S8 / FR-013) ---
+
+  it('accepts selection on a CONTRIBUTORS framing (S8)', () => {
+    const framing = baseFraming();
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      { mode: CalloutSelectionMode.CUSTOM, selectedIds: ['id-1'] }
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.CUSTOM);
+    expect(result.selection?.selectedIds).toEqual(['id-1']);
+  });
+
+  it('accepts selection on a SPACES framing (S8)', () => {
+    const framing = baseFraming();
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.SPACES,
+      framing,
+      { mode: CalloutSelectionMode.CUSTOM, selectedIds: ['id-2'] }
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.CUSTOM);
+    expect(result.selection?.selectedIds).toEqual(['id-2']);
+  });
+
+  it('rejects selection on a NONE framing (S8 / FR-013)', () => {
+    expect(() =>
+      service.validateAndNormalizeSelectionSettings(
+        CalloutFramingType.NONE,
+        baseFraming(),
+        { mode: CalloutSelectionMode.CUSTOM, selectedIds: [] }
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('rejects selection on a WHITEBOARD framing (S8 / FR-013)', () => {
+    expect(() =>
+      service.validateAndNormalizeSelectionSettings(
+        CalloutFramingType.WHITEBOARD,
+        baseFraming(),
+        { mode: CalloutSelectionMode.AUTO }
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('rejects selection on a LINK framing (S8 / FR-013)', () => {
+    expect(() =>
+      service.validateAndNormalizeSelectionSettings(
+        CalloutFramingType.LINK,
+        baseFraming(),
+        { mode: CalloutSelectionMode.AUTO }
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('rejects selection on a MEMO framing (S8 / FR-013)', () => {
+    expect(() =>
+      service.validateAndNormalizeSelectionSettings(
+        CalloutFramingType.MEMO,
+        baseFraming(),
+        { mode: CalloutSelectionMode.AUTO }
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('rejects selection on a MEDIA_GALLERY framing (S8 / FR-013)', () => {
+    expect(() =>
+      service.validateAndNormalizeSelectionSettings(
+        CalloutFramingType.MEDIA_GALLERY,
+        baseFraming(),
+        { mode: CalloutSelectionMode.AUTO }
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('rejects selection on a POLL framing (S8 / FR-013)', () => {
+    expect(() =>
+      service.validateAndNormalizeSelectionSettings(
+        CalloutFramingType.POLL,
+        baseFraming(),
+        { mode: CalloutSelectionMode.AUTO }
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('rejects selection on a COLLABORA_DOCUMENT framing (S8 / FR-013)', () => {
+    expect(() =>
+      service.validateAndNormalizeSelectionSettings(
+        CalloutFramingType.COLLABORA_DOCUMENT,
+        baseFraming(),
+        { mode: CalloutSelectionMode.AUTO }
+      )
+    ).toThrow(ValidationException);
+  });
+
+  // --- 013 contract: contributors still rejected on SPACES (byte-identical guard) ---
+
+  it('does not interfere with the contributors rejection on SPACES (013 FR-004b)', () => {
+    // The contributors validator (called before this one) already threw; this
+    // test just confirms that validateAndNormalizeSelectionSettings accepts a
+    // SPACES framing with no incoming selection and returns the default.
+    const framing = baseFraming(undefined);
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.SPACES,
+      framing,
+      undefined
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.AUTO);
+    expect(result.selection?.selectedIds).toEqual([]);
+  });
+
+  // --- Default materialization (FR-002/FR-016) ---
+
+  it('materializes {AUTO, []} when selection is absent on a CONTRIBUTORS framing', () => {
+    const framing = baseFraming(undefined);
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      undefined
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.AUTO);
+    expect(result.selection?.selectedIds).toEqual([]);
+  });
+
+  it('materializes {AUTO, []} when selection is absent on a SPACES framing', () => {
+    const framing = baseFraming(undefined);
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.SPACES,
+      framing,
+      undefined
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.AUTO);
+    expect(result.selection?.selectedIds).toEqual([]);
+  });
+
+  // --- Partial-update semantics (S9 / FR-022) ---
+
+  it('updates only mode when selectedIds is omitted (S9)', () => {
+    const framing = baseFraming({
+      mode: CalloutSelectionMode.AUTO,
+      selectedIds: ['existing-id'],
+    });
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      { mode: CalloutSelectionMode.CUSTOM }
+    );
+    // mode changed, selectedIds kept
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.CUSTOM);
+    expect(result.selection?.selectedIds).toEqual(['existing-id']);
+  });
+
+  it('updates only selectedIds when mode is omitted (S9)', () => {
+    const framing = baseFraming({
+      mode: CalloutSelectionMode.CUSTOM,
+      selectedIds: ['old-id'],
+    });
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      { selectedIds: ['new-id-1', 'new-id-2'] }
+    );
+    // mode kept, selectedIds replaced
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.CUSTOM);
+    expect(result.selection?.selectedIds).toEqual(['new-id-1', 'new-id-2']);
+  });
+
+  it('replaces selectedIds in full (not merging) when provided (S9)', () => {
+    const framing = baseFraming({
+      mode: CalloutSelectionMode.CUSTOM,
+      selectedIds: ['a', 'b', 'c'],
+    });
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      { selectedIds: ['x'] }
+    );
+    expect(result.selection?.selectedIds).toEqual(['x']);
+  });
+
+  it('keeps stored CUSTOM mode when incomingSelection is undefined (S9 / US3 / FR-019)', () => {
+    const framing = baseFraming({
+      mode: CalloutSelectionMode.CUSTOM,
+      selectedIds: ['a'],
+    });
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      undefined // no incoming — keep stored
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.CUSTOM);
+    expect(result.selection?.selectedIds).toEqual(['a']);
+  });
+
+  // --- Deduplication (FR-004 / T004) ---
+
+  it('deduplicates selectedIds (FR-004)', () => {
+    const framing = baseFraming();
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      { selectedIds: ['a', 'b', 'a', 'c', 'b'] }
+    );
+    expect(result.selection?.selectedIds).toEqual(['a', 'b', 'c']);
+  });
+
+  // --- Non-destructive custom → auto toggle (FR-019 server side) ---
+
+  it('switching to AUTO keeps the stored selectedIds in the framing object (FR-019)', () => {
+    // The selectedIds list is preserved in storage; AUTO simply ignores it.
+    const framing = baseFraming({
+      mode: CalloutSelectionMode.CUSTOM,
+      selectedIds: ['id-1', 'id-2'],
+    });
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      { mode: CalloutSelectionMode.AUTO }
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.AUTO);
+    // selectedIds preserved (not cleared) — AUTO ignores them at read time
+    expect(result.selection?.selectedIds).toEqual(['id-1', 'id-2']);
+  });
+
+  // --- Non-collection framing strips any stale selection ---
+
+  it('strips stale selection on a non-collection framing type change', () => {
+    const framing = baseFraming({
+      mode: CalloutSelectionMode.CUSTOM,
+      selectedIds: ['orphan'],
+    });
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.NONE,
+      framing,
+      undefined // no incoming
+    );
+    expect(result.selection).toBeUndefined();
+  });
+
+  // --- Empty custom selection is valid (FR-003 / US3-AS4) ---
+
+  it('accepts CUSTOM + empty selectedIds as a valid state (FR-003)', () => {
+    const framing = baseFraming();
+    const result = service.validateAndNormalizeSelectionSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing,
+      { mode: CalloutSelectionMode.CUSTOM, selectedIds: [] }
+    );
+    expect(result.selection?.mode).toBe(CalloutSelectionMode.CUSTOM);
+    expect(result.selection?.selectedIds).toEqual([]);
+  });
+});

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -2,6 +2,7 @@ import { ProfileType } from '@common/enums';
 import { ActorType } from '@common/enums/actor.type';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
 import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import {
   CONTRIBUTOR_ACTOR_TYPES,
   isContributorActorType,
@@ -773,6 +774,73 @@ export class CalloutFramingService {
         !hasLocatableType)
     ) {
       contributors.defaultView = ContributorCollectionView.LIST;
+    }
+
+    return framingSettings;
+  }
+
+  /**
+   * Validate + normalize the selection settings against the framing type
+   * (FR-013/FR-022 — workspace#025-callout-manual-selection). Mutates and
+   * returns the framing settings object so the caller can persist the result.
+   *
+   * Called AFTER validateAndNormalizeContributorsSettings at both create and
+   * update call sites in CalloutService.
+   *
+   * Rules:
+   * - `selection` present only iff `framingType ∈ {CONTRIBUTORS, SPACES}`.
+   * - On collection kinds: materialize a missing `selection` to
+   *   `{mode: AUTO, selectedIds: []}` (FR-002/FR-016 default).
+   * - Partial-update semantics (FR-022): omitted field ⇒ keep stored value;
+   *   provided field ⇒ replace whole. Works identically for create (no stored
+   *   value → both fields default to AUTO / []).
+   * - `selectedIds` is deduplicated in place (FR-004/T004).
+   * - The byte-identical contributors guard above is kept untouched.
+   */
+  public validateAndNormalizeSelectionSettings(
+    framingType: CalloutFramingType,
+    framingSettings: ICalloutSettingsFraming,
+    incomingSelection?: { mode?: CalloutSelectionMode; selectedIds?: string[] }
+  ): ICalloutSettingsFraming {
+    const isCollectionKind =
+      framingType === CalloutFramingType.CONTRIBUTORS ||
+      framingType === CalloutFramingType.SPACES;
+
+    if (!isCollectionKind) {
+      // Any provided selection on a non-collection kind is a caller error.
+      if (incomingSelection !== undefined) {
+        throw new ValidationException(
+          'Selection settings can only be set when framing.type ∈ {CONTRIBUTORS, SPACES}.',
+          LogContext.COLLABORATION
+        );
+      }
+      // Non-collection framing: strip any stale selection that might linger
+      // from a type change (defensive; the merge path in CalloutService strips
+      // it too, but belt-and-suspenders).
+      delete framingSettings.selection;
+      return framingSettings;
+    }
+
+    // --- Collection kind ---
+    // Materialize the stored block if absent (read-time default — FR-016).
+    if (!framingSettings.selection) {
+      framingSettings.selection = {
+        mode: CalloutSelectionMode.AUTO,
+        selectedIds: [],
+      };
+    }
+
+    if (incomingSelection !== undefined) {
+      // Partial-update: only replace the fields that were explicitly provided.
+      if (incomingSelection.mode !== undefined) {
+        framingSettings.selection.mode = incomingSelection.mode;
+      }
+      if (incomingSelection.selectedIds !== undefined) {
+        // Deduplicate, preserving first occurrence (FR-004).
+        framingSettings.selection.selectedIds = [
+          ...new Set(incomingSelection.selectedIds),
+        ];
+      }
     }
 
     return framingSettings;

--- a/src/domain/collaboration/callout-settings/callout.settings.framing.interface.ts
+++ b/src/domain/collaboration/callout-settings/callout.settings.framing.interface.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { ICalloutContributorsSettings } from './callout.settings.contributors.interface';
+import { ICalloutSelectionSettings } from './callout.settings.selection.interface';
 
 @ObjectType('CalloutSettingsFraming')
 export abstract class ICalloutSettingsFraming {
@@ -15,4 +16,11 @@ export abstract class ICalloutSettingsFraming {
       'Configuration for a contributor-collection callout. Present only when framing.type = CONTRIBUTORS.',
   })
   contributors?: ICalloutContributorsSettings;
+
+  @Field(() => ICalloutSelectionSettings, {
+    nullable: true,
+    description:
+      'Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Absent / null ⇒ AUTO (full computed set).',
+  })
+  selection?: ICalloutSelectionSettings;
 }

--- a/src/domain/collaboration/callout-settings/callout.settings.selection.interface.ts
+++ b/src/domain/collaboration/callout-settings/callout.settings.selection.interface.ts
@@ -1,0 +1,26 @@
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+
+/**
+ * The per-callout selection settings block — valid only on collection callouts
+ * (framing.type ∈ {CONTRIBUTORS, SPACES}). Absent at read time ⇒ AUTO.
+ *
+ * One shared block for BOTH collection kinds (workspace#025-callout-manual-selection,
+ * architect ruling). The callout's kind routes which host set validates/resolves.
+ */
+@ObjectType('CalloutSelectionSettings')
+export abstract class ICalloutSelectionSettings {
+  @Field(() => CalloutSelectionMode, {
+    nullable: false,
+    description:
+      'The selection mode: AUTO (full computed set) or CUSTOM (admin-curated subset).',
+  })
+  mode!: CalloutSelectionMode;
+
+  @Field(() => [ID], {
+    nullable: false,
+    description:
+      'The selected actor/space IDs in CUSTOM mode (0–500 entries). Ignored when mode is AUTO.',
+  })
+  selectedIds!: string[];
+}

--- a/src/domain/collaboration/callout-settings/dto/callout.settings.framing.dto.create.ts
+++ b/src/domain/collaboration/callout-settings/dto/callout.settings.framing.dto.create.ts
@@ -2,6 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { IsOptional, ValidateNested } from 'class-validator';
 import { CreateCalloutContributorsSettingsInput } from './callout.settings.contributors.dto.create';
+import { CreateCalloutSelectionSettingsInput } from './callout.settings.selection.dto.create';
 
 @InputType()
 @ObjectType('CreateCalloutSettingsFramingData')
@@ -21,4 +22,14 @@ export class CreateCalloutSettingsFramingInput {
   @ValidateNested()
   @Type(() => CreateCalloutContributorsSettingsInput)
   contributors?: CreateCalloutContributorsSettingsInput;
+
+  @Field(() => CreateCalloutSelectionSettingsInput, {
+    nullable: true,
+    description:
+      'Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateCalloutSelectionSettingsInput)
+  selection?: CreateCalloutSelectionSettingsInput;
 }

--- a/src/domain/collaboration/callout-settings/dto/callout.settings.framing.dto.update.ts
+++ b/src/domain/collaboration/callout-settings/dto/callout.settings.framing.dto.update.ts
@@ -2,6 +2,7 @@ import { Field, InputType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { IsOptional, ValidateNested } from 'class-validator';
 import { UpdateCalloutContributorsSettingsInput } from './callout.settings.contributors.dto.update';
+import { UpdateCalloutSelectionSettingsInput } from './callout.settings.selection.dto.update';
 
 @InputType()
 export class UpdateCalloutSettingsFramingInput {
@@ -20,4 +21,14 @@ export class UpdateCalloutSettingsFramingInput {
   @ValidateNested()
   @Type(() => UpdateCalloutContributorsSettingsInput)
   contributors?: UpdateCalloutContributorsSettingsInput;
+
+  @Field(() => UpdateCalloutSelectionSettingsInput, {
+    nullable: true,
+    description:
+      'Manual-selection settings for collection callouts (CONTRIBUTORS or SPACES). Provide only when framing.type ∈ {CONTRIBUTORS, SPACES}.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateCalloutSelectionSettingsInput)
+  selection?: UpdateCalloutSelectionSettingsInput;
 }

--- a/src/domain/collaboration/callout-settings/dto/callout.settings.selection.dto.create.ts
+++ b/src/domain/collaboration/callout-settings/dto/callout.settings.selection.dto.create.ts
@@ -1,0 +1,33 @@
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
+import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
+import { ArrayMaxSize, IsEnum, IsOptional, IsUUID } from 'class-validator';
+
+/**
+ * CREATE-time selection settings. Both fields are optional (partial-update
+ * semantics apply from the start; the normalizer applies defaults — FR-022).
+ *
+ * Dual-decorated (@InputType + @ObjectType) so it can nest inside the dual
+ * CreateCalloutSettingsFramingData, matching the contributors pattern.
+ */
+@InputType()
+@ObjectType('CreateCalloutSelectionSettingsData')
+export class CreateCalloutSelectionSettingsInput {
+  @Field(() => CalloutSelectionMode, {
+    nullable: true,
+    description:
+      'The selection mode (AUTO or CUSTOM). Defaults to AUTO when omitted.',
+  })
+  @IsOptional()
+  @IsEnum(CalloutSelectionMode)
+  mode?: CalloutSelectionMode;
+
+  @Field(() => [ID], {
+    nullable: true,
+    description:
+      'The curated selection of actor/space IDs (CUSTOM mode). At most 500. Deduplicated by the server.',
+  })
+  @IsOptional()
+  @IsUUID('4', { each: true })
+  @ArrayMaxSize(500)
+  selectedIds?: string[];
+}

--- a/src/domain/collaboration/callout-settings/dto/callout.settings.selection.dto.update.ts
+++ b/src/domain/collaboration/callout-settings/dto/callout.settings.selection.dto.update.ts
@@ -1,0 +1,30 @@
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { ArrayMaxSize, IsEnum, IsOptional, IsUUID } from 'class-validator';
+
+/**
+ * Partial-update selection settings (FR-022): an omitted field leaves the
+ * stored value unchanged; a provided field replaces its stored value whole.
+ * The id list is never merged — it is replaced in full.
+ */
+@InputType()
+export class UpdateCalloutSelectionSettingsInput {
+  @Field(() => CalloutSelectionMode, {
+    nullable: true,
+    description:
+      'The selection mode (AUTO or CUSTOM). When omitted, the stored mode is unchanged.',
+  })
+  @IsOptional()
+  @IsEnum(CalloutSelectionMode)
+  mode?: CalloutSelectionMode;
+
+  @Field(() => [ID], {
+    nullable: true,
+    description:
+      'Replaces the curated selection in full (CUSTOM mode). At most 500 entries. Deduplicated by the server. When omitted, the stored list is unchanged.',
+  })
+  @IsOptional()
+  @IsUUID('4', { each: true })
+  @ArrayMaxSize(500)
+  selectedIds?: string[];
+}

--- a/src/domain/collaboration/callout/callout.service.selection.scope.spec.ts
+++ b/src/domain/collaboration/callout/callout.service.selection.scope.spec.ts
@@ -1,0 +1,414 @@
+import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
+import { ValidationException } from '@common/exceptions';
+import { RoleSetService } from '@domain/access/role-set/role.set.service';
+import { Space } from '@domain/space/space/space.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockCacheManager } from '@test/mocks/cache-manager.mock';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+import { Callout } from './callout.entity';
+import { CalloutService } from './callout.service';
+
+/**
+ * Tests for the private scope guard (validateSelectionScopeGuard + helpers)
+ * via the public createCallout and updateCallout surfaces.
+ *
+ * Mitigates R-2 (repos.yaml) — AC3 server-authoritative write-time guard.
+ * Contract: S7 write-side (graphql-selection-settings.md).
+ */
+describe('CalloutService — selection scope guard (T008)', () => {
+  let service: CalloutService;
+  let roleSetService: RoleSetService;
+  let module: TestingModule;
+
+  // Minimal CalloutFramingService stubs: just enough for createCallout flow.
+  const mockFramingService = {
+    createCalloutFraming: vi.fn(),
+    validateAndNormalizeContributorsSettings: vi.fn((_, s) => s),
+    validateAndNormalizeSelectionSettings: vi.fn((_, s, inc) => {
+      // Simulate the real normalizer: materialize {AUTO, []} if absent.
+      if (!s.selection) {
+        s.selection = {
+          mode: CalloutSelectionMode.AUTO,
+          selectedIds: [],
+        };
+      }
+      if (inc !== undefined) {
+        if (inc.mode !== undefined) s.selection.mode = inc.mode;
+        if (inc.selectedIds !== undefined)
+          s.selection.selectedIds = inc.selectedIds;
+      }
+      return s;
+    }),
+  };
+
+  const mockContributionDefaultsService = {
+    createCalloutContributionDefaults: vi.fn(),
+    updateCalloutContributionDefaults: vi.fn(),
+  };
+
+  const mockClassificationService = {
+    createClassification: vi.fn().mockReturnValue({ id: 'cls-1' }),
+    updateClassification: vi.fn(),
+  };
+
+  // Subspace with id helper
+  const subspace = (id: string) => ({ id });
+
+  // Host space with community + roleSet + subspaces
+  const hostSpaceWithSubspaces = (subspaceIds: string[]) => ({
+    id: 'host-space-1',
+    community: {
+      roleSet: { id: 'rs-1' },
+    },
+    subspaces: subspaceIds.map(subspace),
+  });
+
+  const hostSpaceWithCommunity = () => ({
+    id: 'host-space-1',
+    community: {
+      roleSet: { id: 'rs-1' },
+    },
+    subspaces: [],
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(Callout, 'create').mockImplementation((input: any) => {
+      const entity = new Callout();
+      Object.assign(entity, input);
+      return entity as any;
+    });
+
+    module = await Test.createTestingModule({
+      providers: [
+        CalloutService,
+        repositoryProviderMockFactory(Callout),
+        MockCacheManager,
+        MockWinstonProvider,
+        {
+          provide: RoleSetService,
+          useValue: {
+            getUsersWithRole: vi.fn().mockResolvedValue([]),
+            getOrganizationsWithRole: vi.fn().mockResolvedValue([]),
+            getVirtualContributorsWithRole: vi.fn().mockResolvedValue([]),
+          },
+        },
+      ],
+    })
+      .useMocker(token => {
+        // Use real framing-service stubs for the methods we control.
+        if (
+          typeof token === 'function' &&
+          token.name === 'CalloutFramingService'
+        ) {
+          return mockFramingService;
+        }
+        if (
+          typeof token === 'function' &&
+          token.name === 'CalloutContributionDefaultsService'
+        ) {
+          return mockContributionDefaultsService;
+        }
+        if (
+          typeof token === 'function' &&
+          token.name === 'ClassificationService'
+        ) {
+          return mockClassificationService;
+        }
+        return defaultMockerFactory(token);
+      })
+      .compile();
+
+    service = module.get(CalloutService);
+    roleSetService = module.get(RoleSetService);
+
+    // Attach a `manager` mock to the repository so validateSelectionScopeGuard
+    // can call manager.findOne(Space, ...) and manager.createQueryBuilder().
+    // The repositoryMockFactory only creates method mocks from Repository.prototype;
+    // `manager` is a property (EntityManager instance), so it needs to be wired here.
+    const { getRepositoryToken } = await import('@nestjs/typeorm');
+    const calloutRepo = module.get<any>(getRepositoryToken(Callout));
+    calloutRepo.manager = {
+      findOne: vi.fn(),
+      createQueryBuilder: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        from: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        getRawOne: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    // Set up defaults for the framing service mocks
+    mockFramingService.createCalloutFraming.mockResolvedValue({
+      id: 'framing-1',
+      type: CalloutFramingType.CONTRIBUTORS,
+      profile: { storageBucket: { id: 'sb-1' } },
+    });
+    mockContributionDefaultsService.createCalloutContributionDefaults.mockReturnValue(
+      { id: 'defaults-1' }
+    );
+  });
+
+  /**
+   * Wire the repository mock's `manager.findOne` to return different values
+   * based on the entity class queried.
+   *
+   * The `manager` is attached in `beforeEach`; here we configure what
+   * `findOne` returns for this test's host-space fixture.
+   */
+  function mockManagerFindOne(space: any) {
+    const { getRepositoryToken } = require('@nestjs/typeorm');
+    const calloutRepo = module.get<any>(getRepositoryToken(Callout));
+    vi.mocked(calloutRepo.manager.findOne).mockImplementation(
+      async (entity: any) => {
+        if (entity === Space) return space;
+        return null;
+      }
+    );
+  }
+
+  function makeContributorsCalloutInput(selection: {
+    mode: CalloutSelectionMode;
+    selectedIds: string[];
+  }) {
+    return {
+      nameID: 'test-callout',
+      framing: {
+        type: CalloutFramingType.CONTRIBUTORS,
+        profile: { displayName: 'Test', tagsets: [] },
+        tags: [],
+      },
+      settings: {
+        framing: { selection },
+        contribution: { allowedTypes: [] },
+      },
+      contributions: [],
+      classification: {},
+    } as any;
+  }
+
+  function makeSpacesCalloutInput(selection: {
+    mode: CalloutSelectionMode;
+    selectedIds: string[];
+  }) {
+    return {
+      nameID: 'test-spaces-callout',
+      framing: {
+        type: CalloutFramingType.SPACES,
+        profile: { displayName: 'Test', tagsets: [] },
+        tags: [],
+      },
+      settings: {
+        framing: { selection },
+        contribution: { allowedTypes: [] },
+      },
+      contributions: [],
+      classification: {},
+    } as any;
+  }
+
+  describe('CONTRIBUTORS scope guard', () => {
+    it('accepts an in-scope contributor id (member of host RoleSet)', async () => {
+      const eligibleId = 'user-eligible-1';
+      vi.mocked(roleSetService.getUsersWithRole).mockResolvedValue([
+        { id: eligibleId } as any,
+      ]);
+      mockManagerFindOne(hostSpaceWithCommunity());
+
+      // Should NOT throw
+      await expect(
+        service.createCallout(
+          makeContributorsCalloutInput({
+            mode: CalloutSelectionMode.CUSTOM,
+            selectedIds: [eligibleId],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          'host-space-1'
+        )
+      ).resolves.toBeDefined();
+    });
+
+    it('rejects a foreign-space contributor id not in host RoleSet', async () => {
+      // All role lookups return empty → the foreign id is not eligible
+      vi.mocked(roleSetService.getUsersWithRole).mockResolvedValue([]);
+      vi.mocked(roleSetService.getOrganizationsWithRole).mockResolvedValue([]);
+      vi.mocked(
+        roleSetService.getVirtualContributorsWithRole
+      ).mockResolvedValue([]);
+      mockManagerFindOne(hostSpaceWithCommunity());
+
+      await expect(
+        service.createCallout(
+          makeContributorsCalloutInput({
+            mode: CalloutSelectionMode.CUSTOM,
+            selectedIds: ['foreign-space-user-id'],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          'host-space-1'
+        )
+      ).rejects.toThrow(ValidationException);
+    });
+
+    it('accepts an empty selection regardless of membership (FR-003)', async () => {
+      mockManagerFindOne(hostSpaceWithCommunity());
+
+      // Empty CUSTOM selection: no scope check needed
+      await expect(
+        service.createCallout(
+          makeContributorsCalloutInput({
+            mode: CalloutSelectionMode.CUSTOM,
+            selectedIds: [],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          'host-space-1'
+        )
+      ).resolves.toBeDefined();
+    });
+
+    it('rejects a non-empty CUSTOM selection when there is no host space (template context)', async () => {
+      await expect(
+        service.createCallout(
+          makeContributorsCalloutInput({
+            mode: CalloutSelectionMode.CUSTOM,
+            selectedIds: ['some-id'],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          undefined // no parentSpaceId → template/KB context
+        )
+      ).rejects.toThrow(ValidationException);
+    });
+
+    it('accepts AUTO mode even with non-empty ids (guard skips AUTO)', async () => {
+      mockManagerFindOne(hostSpaceWithCommunity());
+
+      await expect(
+        service.createCallout(
+          makeContributorsCalloutInput({
+            mode: CalloutSelectionMode.AUTO,
+            selectedIds: ['any-id'],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          'host-space-1'
+        )
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('SPACES scope guard', () => {
+    it('accepts an in-scope direct subspace id', async () => {
+      const directSubspaceId = 'sub-1';
+      mockManagerFindOne(hostSpaceWithSubspaces([directSubspaceId, 'sub-2']));
+
+      mockFramingService.createCalloutFraming.mockResolvedValue({
+        id: 'framing-2',
+        type: CalloutFramingType.SPACES,
+        profile: { storageBucket: { id: 'sb-2' } },
+      });
+
+      await expect(
+        service.createCallout(
+          makeSpacesCalloutInput({
+            mode: CalloutSelectionMode.CUSTOM,
+            selectedIds: [directSubspaceId],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          'host-space-1'
+        )
+      ).resolves.toBeDefined();
+    });
+
+    it('rejects a foreign subspace id (not a direct subspace)', async () => {
+      mockManagerFindOne(hostSpaceWithSubspaces(['sub-1', 'sub-2']));
+
+      mockFramingService.createCalloutFraming.mockResolvedValue({
+        id: 'framing-3',
+        type: CalloutFramingType.SPACES,
+        profile: { storageBucket: { id: 'sb-3' } },
+      });
+
+      await expect(
+        service.createCallout(
+          makeSpacesCalloutInput({
+            mode: CalloutSelectionMode.CUSTOM,
+            selectedIds: ['foreign-space-from-another-host'],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          'host-space-1'
+        )
+      ).rejects.toThrow(ValidationException);
+    });
+
+    it('rejects a non-empty CUSTOM spaces selection without a host space', async () => {
+      mockFramingService.createCalloutFraming.mockResolvedValue({
+        id: 'framing-4',
+        type: CalloutFramingType.SPACES,
+        profile: { storageBucket: { id: 'sb-4' } },
+      });
+
+      await expect(
+        service.createCallout(
+          makeSpacesCalloutInput({
+            mode: CalloutSelectionMode.CUSTOM,
+            selectedIds: ['some-subspace-id'],
+          }),
+          [],
+          { id: 'agg-1' } as any,
+          'user-1',
+          undefined
+        )
+      ).rejects.toThrow(ValidationException);
+    });
+  });
+
+  describe('mode / empty list bypasses', () => {
+    it('AUTO mode skips the scope guard entirely (no DB calls for validation)', async () => {
+      // Using NONE framing type (non-collection), AUTO, no parentSpaceId:
+      // the normalizer will strip any selection; guard is never invoked.
+      mockFramingService.createCalloutFraming.mockResolvedValue({
+        id: 'framing-5',
+        type: CalloutFramingType.NONE,
+        profile: { storageBucket: { id: 'sb-5' } },
+      });
+
+      const input = {
+        nameID: 'test',
+        framing: {
+          type: CalloutFramingType.NONE,
+          profile: { displayName: 'Test', tagsets: [] },
+          tags: [],
+        },
+        settings: {
+          framing: { selection: undefined },
+          contribution: { allowedTypes: [] },
+        },
+        contributions: [],
+        classification: {},
+      } as any;
+
+      await expect(
+        service.createCallout(input, [], { id: 'agg-1' } as any, 'user-1')
+      ).resolves.toBeDefined();
+
+      expect(roleSetService.getUsersWithRole).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/domain/collaboration/callout/callout.service.spec.ts
+++ b/src/domain/collaboration/callout/callout.service.spec.ts
@@ -711,6 +711,11 @@ describe('CalloutService', () => {
       vi.mocked(
         framingService.validateAndNormalizeContributorsSettings
       ).mockImplementation((_type, settings) => settings as any);
+      // workspace#025: validateAndNormalizeSelectionSettings must also be a
+      // pass-through here so callout.settings.framing stays a plain object.
+      vi.mocked(
+        framingService.validateAndNormalizeSelectionSettings
+      ).mockImplementation((_type, settings) => settings as any);
 
       await service.updateCallout(
         callout,

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -5,7 +5,9 @@ import {
   CalloutContributionType,
 } from '@common/enums/callout.contribution.type';
 import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import { CalloutVisibility } from '@common/enums/callout.visibility';
+import { RoleName } from '@common/enums/role.name';
 import { RoomType } from '@common/enums/room.type';
 import {
   EntityNotFoundException,
@@ -14,6 +16,7 @@ import {
   ValidationException,
 } from '@common/exceptions';
 import { limitAndShuffle } from '@common/utils';
+import { RoleSetService } from '@domain/access/role-set/role.set.service';
 import { Callout } from '@domain/collaboration/callout/callout.entity';
 import { ICallout } from '@domain/collaboration/callout/callout.interface';
 import { CreateCalloutInput } from '@domain/collaboration/callout/dto/index';
@@ -28,6 +31,7 @@ import { CreateWhiteboardInput } from '@domain/common/whiteboard/dto/whiteboard.
 import { IRoom } from '@domain/communication/room/room.interface';
 import { RoomService } from '@domain/communication/room/room.service';
 import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
+import { Space } from '@domain/space/space/space.entity';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { IStorageBucket } from '@domain/storage/storage-bucket/storage.bucket.interface';
 import { Injectable } from '@nestjs/common';
@@ -72,6 +76,7 @@ export class CalloutService {
     private collaboraDocumentService: CollaboraDocumentService,
     private storageAggregatorResolverService: StorageAggregatorResolverService,
     private classificationService: ClassificationService,
+    private roleSetService: RoleSetService,
     @InjectRepository(Callout)
     private calloutRepository: Repository<Callout>
   ) {}
@@ -114,6 +119,24 @@ export class CalloutService {
         callout.framing.type,
         callout.settings.framing
       );
+
+    // Validate + normalize selection settings (workspace#025, FR-013/FR-022).
+    // Runs after contributors normalization so the framing type is stable.
+    callout.settings.framing =
+      this.calloutFramingService.validateAndNormalizeSelectionSettings(
+        callout.framing.type,
+        callout.settings.framing,
+        calloutData.settings?.framing?.selection
+      );
+
+    // AC3 host-scope guard: reject any selectedId not in the host's RoleSet
+    // (contributors) or not a direct subspace of the host (spaces). Only runs
+    // when the normalized selection is CUSTOM + non-empty (FR-006).
+    await this.validateSelectionScopeGuard(
+      callout.framing.type,
+      callout.settings.framing.selection,
+      parentSpaceId
+    );
 
     if (callout.settings.visibility === CalloutVisibility.PUBLISHED) {
       callout.publishedDate = new Date();
@@ -483,6 +506,41 @@ export class CalloutService {
         callout.framing.type,
         callout.settings.framing
       );
+
+    // Re-validate + normalize selection settings (workspace#025, FR-013/FR-022).
+    // Strip stale selection on framing-type change (non-collection type change)
+    // and apply partial-update semantics for the new value.
+    if (
+      callout.framing.type !== CalloutFramingType.CONTRIBUTORS &&
+      callout.framing.type !== CalloutFramingType.SPACES &&
+      callout.settings.framing.selection
+    ) {
+      delete callout.settings.framing.selection;
+    }
+    callout.settings.framing =
+      this.calloutFramingService.validateAndNormalizeSelectionSettings(
+        callout.framing.type,
+        callout.settings.framing,
+        calloutUpdateData.settings?.framing?.selection
+      );
+
+    // AC3 host-scope guard on update: only validate ids the caller explicitly
+    // submitted in this request (FR-008: stale stored ids must be inert — no
+    // admin action required to remove a since-departed member/subspace).
+    // The guard still runs in full on the CREATE path (line ~135) where there
+    // are no pre-existing stored ids.
+    if (
+      calloutUpdateData.settings?.framing?.selection?.selectedIds !== undefined
+    ) {
+      const updateParentSpaceId = callout.calloutsSet
+        ? await this.getParentSpaceId(callout.calloutsSet.id)
+        : undefined;
+      await this.validateSelectionScopeGuard(
+        callout.framing.type,
+        callout.settings.framing.selection,
+        updateParentSpaceId
+      );
+    }
 
     if (calloutUpdateData.classification) {
       callout.classification = this.classificationService.updateClassification(
@@ -1052,6 +1110,128 @@ export class CalloutService {
     }
 
     return result;
+  }
+
+  /**
+   * AC3 host-scope guard (workspace#025, FR-006/FR-007).
+   * Enforced at WRITE time on CUSTOM selections with at least one id.
+   *
+   * CONTRIBUTORS: every selectedId must be an accepted community member of the
+   *   host space (any role across USER/ORG/VC — uses the same RoleSetService
+   *   reads as ContributorCollectionService). Uses three role fetches and union
+   *   into a Set for the cheapest single-pass check over the submitted ids.
+   * SPACES: every selectedId must be a direct subspace of the host space.
+   *   Since the host's subspaces are already the only read-time resolution
+   *   surface, this write-time guard is the PRIMARY barrier.
+   * Template/KB context (no host space): any non-empty selection is rejected.
+   *
+   * Auto skips when: mode is AUTO, selectedIds is empty, or framing is not a
+   * collection kind (normalization already ensures this is consistent).
+   */
+  private async validateSelectionScopeGuard(
+    framingType: CalloutFramingType,
+    selection:
+      | { mode: CalloutSelectionMode; selectedIds: string[] }
+      | undefined,
+    hostSpaceId: string | undefined
+  ): Promise<void> {
+    if (!selection) return;
+    if (selection.mode !== CalloutSelectionMode.CUSTOM) return;
+    if (selection.selectedIds.length === 0) return;
+    if (
+      framingType !== CalloutFramingType.CONTRIBUTORS &&
+      framingType !== CalloutFramingType.SPACES
+    ) {
+      return; // normalizer already rejects non-collection kinds with selection
+    }
+
+    // Non-empty CUSTOM selection without a host space → reject (template/KB).
+    if (!hostSpaceId) {
+      throw new ValidationException(
+        'Selection requires a host space: custom selection is not allowed on template or knowledge-base callouts.',
+        LogContext.COLLABORATION
+      );
+    }
+
+    if (framingType === CalloutFramingType.CONTRIBUTORS) {
+      await this.validateContributorSelectionScope(
+        selection.selectedIds,
+        hostSpaceId
+      );
+    } else {
+      await this.validateSubspaceSelectionScope(
+        selection.selectedIds,
+        hostSpaceId
+      );
+    }
+  }
+
+  private async validateContributorSelectionScope(
+    selectedIds: string[],
+    hostSpaceId: string
+  ): Promise<void> {
+    // Load the host Space → community → roleSet
+    // (Space owns the FK to Community; Community owns the FK to RoleSet).
+    const spaceWithCommunity = await this.calloutRepository.manager.findOne(
+      Space,
+      {
+        where: { id: hostSpaceId },
+        relations: { community: { roleSet: true } },
+      }
+    );
+    if (!spaceWithCommunity?.community?.roleSet) {
+      throw new ValidationException(
+        'Unable to resolve host community for selection scope validation.',
+        LogContext.COLLABORATION
+      );
+    }
+    const roleSet = spaceWithCommunity.community.roleSet;
+
+    // Union all member/lead/admin ids across all three contributor actor types.
+    const allRoles = [RoleName.MEMBER, RoleName.LEAD, RoleName.ADMIN];
+    const eligibleIds = new Set<string>();
+    for (const role of allRoles) {
+      const [users, orgs, vcs] = await Promise.all([
+        this.roleSetService.getUsersWithRole(roleSet, role),
+        this.roleSetService.getOrganizationsWithRole(roleSet, role),
+        this.roleSetService.getVirtualContributorsWithRole(roleSet, role),
+      ]);
+      for (const u of users) eligibleIds.add(u.id);
+      for (const o of orgs) eligibleIds.add(o.id);
+      for (const v of vcs) eligibleIds.add(v.id);
+    }
+
+    const offender = selectedIds.find(id => !eligibleIds.has(id));
+    if (offender) {
+      throw new ValidationException(
+        'One or more selected contributors are not accepted community members of this space.',
+        LogContext.COLLABORATION,
+        { offendingId: offender }
+      );
+    }
+  }
+
+  private async validateSubspaceSelectionScope(
+    selectedIds: string[],
+    hostSpaceId: string
+  ): Promise<void> {
+    // Load the host space's direct subspaces.
+    const hostSpace = await this.calloutRepository.manager.findOne(Space, {
+      where: { id: hostSpaceId },
+      relations: { subspaces: true },
+    });
+    const subspaceIds = new Set(
+      (hostSpace?.subspaces ?? []).map((s: { id: string }) => s.id)
+    );
+
+    const offender = selectedIds.find(id => !subspaceIds.has(id));
+    if (offender) {
+      throw new ValidationException(
+        'One or more selected subspaces are not direct subspaces of this space.',
+        LogContext.COLLABORATION,
+        { offendingId: offender }
+      );
+    }
   }
 
   /**

--- a/src/domain/collaboration/contributor-collection/contributor.collection.service.spec.ts
+++ b/src/domain/collaboration/contributor-collection/contributor.collection.service.spec.ts
@@ -1,4 +1,5 @@
 import { ActorType } from '@common/enums/actor.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import { UserInformationVisibility } from '@common/enums/user.information.visibility';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { RoleSetService } from '@domain/access/role-set/role.set.service';
@@ -21,7 +22,10 @@ describe('ContributorCollectionService', () => {
   const roleSet = { id: 'role-set-1' } as any;
   const community = { id: 'community-1' } as any;
 
-  const calloutWith = (contributorTypes: ActorType[]): ICallout =>
+  const calloutWith = (
+    contributorTypes: ActorType[],
+    selection?: { mode: CalloutSelectionMode; selectedIds: string[] }
+  ): ICallout =>
     ({
       id: 'callout-1',
       settings: {
@@ -32,6 +36,7 @@ describe('ContributorCollectionService', () => {
             defaultContributorType: contributorTypes[0],
             defaultView: 'list',
           },
+          selection,
         },
       },
     }) as unknown as ICallout;
@@ -77,7 +82,10 @@ describe('ContributorCollectionService', () => {
             generateUrlForVC: vi.fn(),
           },
         },
-        { provide: EntityManager, useValue: { findOne: vi.fn() } },
+        {
+          provide: EntityManager,
+          useValue: { findOne: vi.fn(), find: vi.fn().mockResolvedValue([]) },
+        },
       ],
     }).compile();
 
@@ -183,6 +191,142 @@ describe('ContributorCollectionService', () => {
       );
 
       expect(counts.users).toBe(1);
+    });
+  });
+
+  // --- Selection settings (workspace#025, T010) ---
+  describe('CUSTOM selection mode intersection (T010 / FR-007)', () => {
+    const anon = new ActorContext();
+
+    it('[S1] legacy-shaped callout without selection block ⇒ AUTO behavior (byte-identical)', async () => {
+      mockFindOne(spaceWithVisibility());
+      // calloutWith() with no selection = undefined → read-time AUTO default
+      const counts = await service.getContributorCounts(
+        calloutWith([ActorType.ORGANIZATION]),
+        anon
+      );
+      expect(counts.organizations).toBe(1); // u1 returned by default mock
+    });
+
+    it('[S2] AUTO mode with non-empty selectedIds ⇒ selectedIds are inert (full set returned)', async () => {
+      mockFindOne(spaceWithVisibility());
+      // AUTO + some ids → filter NOT applied
+      const counts = await service.getContributorCounts(
+        calloutWith([ActorType.ORGANIZATION], {
+          mode: CalloutSelectionMode.AUTO,
+          selectedIds: ['some-other-id'],
+        }),
+        anon
+      );
+      expect(counts.organizations).toBe(1); // full set
+    });
+
+    it('[S3] CUSTOM + members-only space + anonymous viewer → selected member users NOT returned', async () => {
+      mockFindOne(spaceWithVisibility(UserInformationVisibility.MEMBERS_ONLY));
+      vi.spyOn(roleSetService, 'isMember').mockResolvedValue(false);
+      // 'u1' would be selected, but members-only hides all users from anon
+      const result = await service.getContributors(
+        calloutWith([ActorType.USER], {
+          mode: CalloutSelectionMode.CUSTOM,
+          selectedIds: ['u1'],
+        }),
+        ActorType.USER,
+        anon // anonymous
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('[S4] CUSTOM + selected id absent from RoleSet (departed) ⇒ silently dropped', async () => {
+      mockFindOne(spaceWithVisibility());
+      // u1 is the only "member" in the RoleSet (default mock), but we select 'other-id'
+      const result = await service.getContributors(
+        calloutWith([ActorType.USER], {
+          mode: CalloutSelectionMode.CUSTOM,
+          selectedIds: ['other-id'],
+        }),
+        ActorType.USER,
+        anon
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('[S4] all selected ids departed → returns [] (empty state, never fallback)', async () => {
+      mockFindOne(spaceWithVisibility());
+      vi.spyOn(roleSetService, 'getUsersWithRole').mockResolvedValue([]);
+      const result = await service.getContributors(
+        calloutWith([ActorType.USER], {
+          mode: CalloutSelectionMode.CUSTOM,
+          selectedIds: ['gone-1', 'gone-2'],
+        }),
+        ActorType.USER,
+        anon
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('[S5] counts equal rendered set per type (CUSTOM filters count too)', async () => {
+      mockFindOne(spaceWithVisibility());
+      // Default mock returns [{ id: 'u1' }] for USER member
+      // We select 'u1' → count should be 1
+      const countsWithSelection = await service.getContributorCounts(
+        calloutWith([ActorType.USER], {
+          mode: CalloutSelectionMode.CUSTOM,
+          selectedIds: ['u1'],
+        }),
+        anon
+      );
+      expect(countsWithSelection.users).toBe(1);
+
+      // We select 'non-member' → count should be 0
+      const countsEmpty = await service.getContributorCounts(
+        calloutWith([ActorType.USER], {
+          mode: CalloutSelectionMode.CUSTOM,
+          selectedIds: ['non-member'],
+        }),
+        anon
+      );
+      expect(countsEmpty.users).toBe(0);
+    });
+
+    it('[S6] result order equals the AUTO order filtered (leads first, then alphabetical)', async () => {
+      mockFindOne(spaceWithVisibility());
+      // Mock: LEAD role → u1; MEMBER → u2, u3
+      vi.spyOn(roleSetService, 'getUsersWithRole').mockImplementation(
+        async (_rs, role) =>
+          role === 'lead'
+            ? ([{ id: 'u1' }] as any)
+            : role === 'member'
+              ? ([{ id: 'u2' }, { id: 'u3' }] as any)
+              : []
+      );
+
+      // Select only u2 (plain member) and u1 (lead) — ordering: leads first
+      const result = await service.getContributors(
+        calloutWith([ActorType.USER], {
+          mode: CalloutSelectionMode.CUSTOM,
+          selectedIds: ['u2', 'u1'],
+        }),
+        ActorType.USER,
+        anon
+      );
+      // IDs present; profiles will be undefined (entityManager.find returns [])
+      // but the important thing is the order: u1 (lead rank 2) before u2 (member rank 1)
+      expect(result.map(r => r.id)).toEqual(['u1', 'u2']);
+    });
+
+    it('[FR-011] id outside included contributorTypes ⇒ type-filter still applies', async () => {
+      mockFindOne(spaceWithVisibility());
+      // Callout only includes ORGANIZATION; we query USER → type filter returns []
+      // before selection even runs
+      const result = await service.getContributors(
+        calloutWith([ActorType.ORGANIZATION], {
+          mode: CalloutSelectionMode.CUSTOM,
+          selectedIds: ['u1'],
+        }),
+        ActorType.USER, // querying USER, which is not in contributorTypes
+        anon
+      );
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/domain/collaboration/contributor-collection/contributor.collection.service.ts
+++ b/src/domain/collaboration/contributor-collection/contributor.collection.service.ts
@@ -1,4 +1,5 @@
 import { ActorType } from '@common/enums/actor.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import { RoleName } from '@common/enums/role.name';
 import { UserInformationVisibility } from '@common/enums/user.information.visibility';
 import { VisualType } from '@common/enums/visual.type';
@@ -46,6 +47,22 @@ export class ContributorCollectionService {
     callout: ICallout
   ): ICalloutContributorsSettings | undefined {
     return callout.settings?.framing?.contributors;
+  }
+
+  /**
+   * Read-time defaulting for the selection block (FR-016):
+   * absent / null ⇒ {AUTO, []} — defensive, covers rows the migration
+   * never saw and the deploy-to-migrate window.
+   */
+  private getSelectionMode(callout: ICallout): CalloutSelectionMode {
+    return (
+      callout.settings?.framing?.selection?.mode ?? CalloutSelectionMode.AUTO
+    );
+  }
+
+  private getSelectedIds(callout: ICallout): Set<string> {
+    const ids = callout.settings?.framing?.selection?.selectedIds ?? [];
+    return new Set(ids);
   }
 
   /**
@@ -281,7 +298,16 @@ export class ContributorCollectionService {
       }
     }
 
-    const ranked = await this.getRankedIdsForType(roleSet, type);
+    let ranked = await this.getRankedIdsForType(roleSet, type);
+
+    // CUSTOM-mode intersection: apply the stored selectedIds as a FINAL Set.has
+    // filter AFTER the eligibility + visibility pipeline (FR-007 shrink-only).
+    // AUTO skips the filter entirely. Ordering code is untouched (FR-010).
+    if (this.getSelectionMode(callout) === CalloutSelectionMode.CUSTOM) {
+      const selectedIds = this.getSelectedIds(callout);
+      ranked = ranked.filter(r => selectedIds.has(r.id));
+    }
+
     const profilesById = await this.loadProfilesById(ranked.map(r => r.id));
 
     const items: (IContributorCollectionItem & { rank: number })[] = [];
@@ -356,6 +382,17 @@ export class ContributorCollectionService {
     }
     const { roleSet, space } = context;
 
+    const selectionMode = this.getSelectionMode(callout);
+    const selectedIds =
+      selectionMode === CalloutSelectionMode.CUSTOM
+        ? this.getSelectedIds(callout)
+        : null; // null → AUTO, no filter
+
+    const applySelectionFilter = (
+      ranked: { id: string }[]
+    ): { id: string }[] =>
+      selectedIds !== null ? ranked.filter(r => selectedIds.has(r.id)) : ranked;
+
     if (settings.contributorTypes.includes(ActorType.USER)) {
       const hide = await this.shouldHideMemberUsers(
         space,
@@ -364,7 +401,7 @@ export class ContributorCollectionService {
       );
       if (!hide) {
         const ranked = await this.getRankedIdsForType(roleSet, ActorType.USER);
-        counts.users = ranked.length;
+        counts.users = applySelectionFilter(ranked).length;
       }
     }
     if (settings.contributorTypes.includes(ActorType.ORGANIZATION)) {
@@ -372,14 +409,14 @@ export class ContributorCollectionService {
         roleSet,
         ActorType.ORGANIZATION
       );
-      counts.organizations = ranked.length;
+      counts.organizations = applySelectionFilter(ranked).length;
     }
     if (settings.contributorTypes.includes(ActorType.VIRTUAL_CONTRIBUTOR)) {
       const ranked = await this.getRankedIdsForType(
         roleSet,
         ActorType.VIRTUAL_CONTRIBUTOR
       );
-      counts.virtualContributors = ranked.length;
+      counts.virtualContributors = applySelectionFilter(ranked).length;
     }
     return counts;
   }

--- a/src/domain/collaboration/space-collection/space.collection.service.spec.ts
+++ b/src/domain/collaboration/space-collection/space.collection.service.spec.ts
@@ -1,3 +1,4 @@
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import { ICallout } from '@domain/collaboration/callout/callout.interface';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
@@ -10,6 +11,15 @@ describe('SpaceCollectionService', () => {
   let communityResolver: CommunityResolverService;
 
   const callout = { id: 'callout-1' } as ICallout;
+
+  const calloutWithSelection = (
+    mode: CalloutSelectionMode,
+    selectedIds: string[]
+  ): ICallout =>
+    ({
+      id: 'callout-1',
+      settings: { framing: { selection: { mode, selectedIds } } },
+    }) as unknown as ICallout;
 
   const subspace = (
     id: string,
@@ -76,5 +86,90 @@ describe('SpaceCollectionService', () => {
     const result = await service.getSubspaces(callout);
 
     expect(result).toEqual([]);
+  });
+
+  // --- CUSTOM selection mode (workspace#025, T011) ---
+  describe('CUSTOM selection mode intersection (T011 / FR-007)', () => {
+    const hostSpaceWithSubs = () => ({
+      id: 'host-space',
+      subspaces: [
+        subspace('a', 30, 'Alpha'),
+        subspace('b', 10, 'Bravo'),
+        subspace('c', 20, 'Charlie', true), // pinned
+      ],
+    });
+
+    it('[S1] legacy callout without selection block ⇒ AUTO full set returned', async () => {
+      vi.mocked(
+        communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+      ).mockResolvedValue(hostSpaceWithSubs() as any);
+
+      const result = await service.getSubspaces(callout); // no selection in callout
+      expect(result).toHaveLength(3);
+    });
+
+    it('[S2] AUTO + non-empty selectedIds ⇒ selectedIds inert, full set returned', async () => {
+      vi.mocked(
+        communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+      ).mockResolvedValue(hostSpaceWithSubs() as any);
+
+      const result = await service.getSubspaces(
+        calloutWithSelection(CalloutSelectionMode.AUTO, ['a'])
+      );
+      expect(result).toHaveLength(3);
+    });
+
+    it('CUSTOM + selected subset ⇒ only selected subspaces returned (pinned-first order)', async () => {
+      vi.mocked(
+        communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+      ).mockResolvedValue(hostSpaceWithSubs() as any);
+
+      const result = await service.getSubspaces(
+        calloutWithSelection(CalloutSelectionMode.CUSTOM, ['c', 'a'])
+      );
+      expect(result.map(s => s.id)).toEqual(['c', 'a']); // c is pinned → first
+    });
+
+    it('[S4] CUSTOM + foreign persisted id ⇒ silently dropped (never in subspaces list)', async () => {
+      vi.mocked(
+        communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+      ).mockResolvedValue(hostSpaceWithSubs() as any);
+
+      const result = await service.getSubspaces(
+        calloutWithSelection(CalloutSelectionMode.CUSTOM, [
+          'foreign-id-from-another-space',
+        ])
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('CUSTOM + all selected subspaces deleted ⇒ empty (existing empty state)', async () => {
+      vi.mocked(
+        communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+      ).mockResolvedValue({ id: 'host-space', subspaces: [] } as any);
+
+      const result = await service.getSubspaces(
+        calloutWithSelection(CalloutSelectionMode.CUSTOM, ['a', 'b'])
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('[S7-read] selected subset returned in pinned-first then sortOrder', async () => {
+      vi.mocked(
+        communityResolver.getSpaceWithSubspacesFromCollaborationCallout
+      ).mockResolvedValue({
+        id: 'host-space',
+        subspaces: [
+          subspace('x', 5, 'X'),
+          subspace('y', 1, 'Y'),
+          subspace('z', 10, 'Z', true), // pinned
+        ],
+      } as any);
+
+      const result = await service.getSubspaces(
+        calloutWithSelection(CalloutSelectionMode.CUSTOM, ['x', 'y', 'z'])
+      );
+      expect(result.map(s => s.id)).toEqual(['z', 'y', 'x']);
+    });
   });
 });

--- a/src/domain/collaboration/space-collection/space.collection.service.ts
+++ b/src/domain/collaboration/space-collection/space.collection.service.ts
@@ -1,3 +1,4 @@
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import { ICallout } from '@domain/collaboration/callout/callout.interface';
 import { ISpace } from '@domain/space/space/space.interface';
 import { orderSubspaces } from '@domain/space/space/subspace.ordering';
@@ -48,6 +49,25 @@ export class SpaceCollectionService {
     if (!hostSpace || !hostSpace.subspaces) {
       return [];
     }
-    return orderSubspaces(hostSpace.subspaces);
+
+    // Apply pinned-first, then sortOrder ordering (FR-010).
+    const ordered = orderSubspaces(hostSpace.subspaces);
+
+    // CUSTOM-mode intersection: apply the stored selectedIds as a FINAL
+    // Set.has filter AFTER ordering (shrink-only, FR-007). AUTO returns the
+    // full ordered list. The intersection IS the host-membership re-check
+    // (a persisted foreign id can never appear in hostSpace.subspaces —
+    // FR-008 stale-id inertness is free).
+    const selectionMode =
+      callout.settings?.framing?.selection?.mode ?? CalloutSelectionMode.AUTO;
+
+    if (selectionMode === CalloutSelectionMode.CUSTOM) {
+      const selectedIds = new Set(
+        callout.settings?.framing?.selection?.selectedIds ?? []
+      );
+      return ordered.filter(s => selectedIds.has(s.id));
+    }
+
+    return ordered;
   }
 }

--- a/src/migrations/1784000000000-AddCalloutSelectionSettings.ts
+++ b/src/migrations/1784000000000-AddCalloutSelectionSettings.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add the `selection` key to the framing settings of every existing
+ * collection callout and collection-callout template that lacks it
+ * (workspace#025-callout-manual-selection, FR-015 / US5-AS1..AS4).
+ *
+ * Rules:
+ * - ADD-ONLY, idempotent: the `IS NULL` guard means a pre-existing selection
+ *   (e.g. a CUSTOM one already set via the API, or a previous migration run)
+ *   is NEVER overwritten.
+ * - Scope: callout rows whose callout_framing.type ∈ ('contributors','spaces')
+ *   ONLY. This covers both live collection callouts and their template callouts
+ *   (template callouts are callout rows — same table, same framing-type filter).
+ *   All other callout kinds (NONE/WHITEBOARD/LINK/MEMO/MEDIA_GALLERY/POLL/
+ *   COLLABORA_DOCUMENT) are NOT touched.
+ * - Zero row creation, zero authorization_policy writes, no authorizationPolicyResetAll.
+ *
+ * The read path already defaults an absent selection to AUTO with an empty list
+ * (FR-016) so the migration is a backfill convenience, not a correctness gate.
+ *
+ * down() strips the `selection` key from the same scoped set of rows so a
+ * revert is safe. CUSTOM selections lose their stored list on rollback, which
+ * is the safe direction (they degrade to AUTO).
+ */
+export class AddCalloutSelectionSettings1784000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // jsonb_set with `create_missing = true` upserts the nested path.
+    // The `co.settings ? 'framing'` guard ensures we only touch rows that
+    // already have a framing JSONB block (belt-and-suspenders; all collection
+    // callouts created via the API have it).
+    await queryRunner.query(`
+      UPDATE callout co
+      SET settings = jsonb_set(
+        co.settings,
+        '{framing,selection}',
+        '{"mode":"auto","selectedIds":[]}'::jsonb,
+        true
+      )
+      FROM callout_framing cf
+      WHERE cf.id = co."framingId"
+        AND cf.type IN ('contributors', 'spaces')
+        AND co.settings ? 'framing'
+        AND co.settings -> 'framing' -> 'selection' IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE callout co
+      SET settings = jsonb_set(
+        co.settings,
+        '{framing}',
+        (co.settings -> 'framing') #- '{selection}',
+        false
+      )
+      FROM callout_framing cf
+      WHERE cf.id = co."framingId"
+        AND cf.type IN ('contributors', 'spaces')
+        AND co.settings -> 'framing' -> 'selection' IS NOT NULL
+    `);
+  }
+}

--- a/src/migrations/__tests__/1784000000000-AddCalloutSelectionSettings.spec.ts
+++ b/src/migrations/__tests__/1784000000000-AddCalloutSelectionSettings.spec.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { AddCalloutSelectionSettings1784000000000 } from '../1784000000000-AddCalloutSelectionSettings';
+
+/**
+ * Static-analysis assertions for the AddCalloutSelectionSettings migration
+ * (workspace#025-callout-manual-selection, T014 / FR-015 / US5-AS1..AS4).
+ *
+ * These tests can run without a database connection because they inspect the
+ * migration source code directly rather than executing it.
+ *
+ * Mitigates R-3 (repos.yaml): validates that the migration is add-only,
+ * scoped to collection kinds, and writes no authorization records.
+ */
+describe('AddCalloutSelectionSettings migration (1784000000000)', () => {
+  const migrationSrc = readFileSync(
+    resolve(
+      __dirname,
+      '../1784000000000-AddCalloutSelectionSettings.ts'
+    ),
+    'utf8'
+  );
+
+  it('exports the expected class', () => {
+    expect(AddCalloutSelectionSettings1784000000000).toBeDefined();
+    const instance = new AddCalloutSelectionSettings1784000000000();
+    expect(typeof instance.up).toBe('function');
+    expect(typeof instance.down).toBe('function');
+  });
+
+  it('up() SQL does NOT execute against authorization_policy table (no auth writes — FR-015)', () => {
+    // Extract SQL strings (content inside template literals in up() and down())
+    // and verify none write to the authorization_policy table.
+    const sqlBlocks = migrationSrc.match(/await queryRunner\.query\(`([\s\S]*?)`\)/g) ?? [];
+    const combinedSql = sqlBlocks.join('\n');
+    // Should not update or insert into the authorization_policy table.
+    expect(combinedSql).not.toMatch(/UPDATE\s+authorization_policy/i);
+    expect(combinedSql).not.toMatch(/INSERT\s+INTO\s+authorization_policy/i);
+  });
+
+  it('up() SQL does NOT call authorizationPolicyResetAll (no auth reset — FR-015)', () => {
+    const sqlBlocks = migrationSrc.match(/await queryRunner\.query\(`([\s\S]*?)`\)/g) ?? [];
+    const combinedSql = sqlBlocks.join('\n');
+    expect(combinedSql).not.toMatch(/authorizationPolicyResetAll/i);
+  });
+
+  it('up() SQL is scoped to collection kinds only: contributors and spaces (dissent ruling)', () => {
+    // The WHERE clause must restrict to the two collection types.
+    expect(migrationSrc).toMatch(/IN\s*\(\s*['"]contributors['"]\s*,\s*['"]spaces['"]\s*\)/i);
+  });
+
+  it('up() SQL is add-only: uses jsonb_set with IS NULL guard (idempotent, never overwrites)', () => {
+    // Must use jsonb_set (additive) and IS NULL guard (idempotent).
+    expect(migrationSrc).toMatch(/jsonb_set/);
+    expect(migrationSrc).toMatch(/IS NULL/i);
+  });
+
+  it('up() SQL uses the correct callout_framing join for scoping', () => {
+    // Must join to callout_framing to scope by type.
+    expect(migrationSrc).toMatch(/callout_framing/);
+    expect(migrationSrc).toMatch(/framingId/);
+  });
+
+  it('up() SQL does NOT reference INSERT or CREATE (no row creation — FR-015)', () => {
+    const upSection = migrationSrc.slice(
+      migrationSrc.indexOf('public async up'),
+      migrationSrc.indexOf('public async down')
+    );
+    // Should only be UPDATE (jsonb_set = update existing JSON), no new row creation.
+    expect(upSection).not.toMatch(/\bINSERT\b/i);
+    expect(upSection).not.toMatch(/\bCREATE\b/i);
+  });
+
+  it('down() SQL strips the selection key without creating new rows', () => {
+    const downSection = migrationSrc.slice(
+      migrationSrc.indexOf('public async down')
+    );
+    expect(downSection).toMatch(/jsonb_set|#-/); // strip operator or jsonb_set
+    expect(downSection).not.toMatch(/\bINSERT\b/i);
+    expect(downSection).not.toMatch(/\bCREATE\b/i);
+  });
+
+  it('migration class name includes the timestamp 1784000000000', () => {
+    expect(migrationSrc).toMatch(/AddCalloutSelectionSettings1784000000000/);
+  });
+});

--- a/src/schema-contract/classify/build-report.ts
+++ b/src/schema-contract/classify/build-report.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { DiffContext, indexSDL, sha256 } from '../diff/diff-core';
 import { diffEnums } from '../diff/diff-enum';
+import { diffInputs } from '../diff/diff-inputs';
 import { diffScalars } from '../diff/diff-scalar';
 import { diffTypes } from '../diff/diff-types';
 import { ChangeReport, ChangeType, ElementType } from '../model';
@@ -15,6 +16,7 @@ export function buildChangeReport(
   diffTypes(oldIdx, newIdx, ctx);
   diffEnums(oldIdx, newIdx, ctx);
   diffScalars(oldIdx, newIdx, ctx);
+  diffInputs(oldIdx, newIdx, ctx);
 
   const report: ChangeReport = {
     snapshotId: sha256(newSDL),

--- a/src/schema-contract/diff/diff-core.ts
+++ b/src/schema-contract/diff/diff-core.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'crypto';
 import {
   DocumentNode,
   EnumTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
   Kind,
   ObjectTypeDefinitionNode,
   parse,
@@ -21,6 +22,7 @@ export interface IndexedSchema {
   types: Record<string, ObjectTypeDefinitionNode>;
   enums: Record<string, EnumTypeDefinitionNode>;
   scalars: Record<string, ScalarTypeDefinitionNode>;
+  inputs: Record<string, InputObjectTypeDefinitionNode>;
   rawSDL: string;
 }
 
@@ -37,6 +39,7 @@ export function indexSDL(sdl: string): IndexedSchema {
   const types: Record<string, ObjectTypeDefinitionNode> = {};
   const enums: Record<string, EnumTypeDefinitionNode> = {};
   const scalars: Record<string, ScalarTypeDefinitionNode> = {};
+  const inputs: Record<string, InputObjectTypeDefinitionNode> = {};
   for (const def of doc.definitions) {
     switch (def.kind) {
       case 'ObjectTypeDefinition':
@@ -48,11 +51,14 @@ export function indexSDL(sdl: string): IndexedSchema {
       case 'ScalarTypeDefinition':
         if (def.name?.value) scalars[def.name.value] = def;
         break;
+      case 'InputObjectTypeDefinition':
+        if (def.name?.value) inputs[def.name.value] = def;
+        break;
       default:
         break;
     }
   }
-  return { doc, types, enums, scalars, rawSDL: sdl };
+  return { doc, types, enums, scalars, inputs, rawSDL: sdl };
 }
 
 export function emptyCounts(): ClassificationCount {

--- a/src/schema-contract/diff/diff-inputs.ts
+++ b/src/schema-contract/diff/diff-inputs.ts
@@ -1,0 +1,129 @@
+// T025-F2: Diff InputObjectTypeDefinition nodes — tracks new input types and new
+// fields on existing input types as ADDITIVE; removed input types / fields as
+// BREAKING. Input fields carry no @deprecated directives (the spec forbids it),
+// so deprecation logic is intentionally omitted here.
+import { InputValueDefinitionNode, TypeNode } from 'graphql';
+import { ChangeType, ElementType } from '../model';
+import { unionKeys } from './cleanup';
+import { DiffContext, IndexedSchema, pushEntry } from './diff-core';
+
+function printTypeNode(node: TypeNode): string {
+  switch (node.kind) {
+    case 'NamedType':
+      return node.name.value;
+    case 'NonNullType':
+      return printTypeNode(node.type) + '!';
+    case 'ListType':
+      return '[' + printTypeNode(node.type) + ']';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+export function diffInputs(
+  oldIdx: IndexedSchema,
+  newIdx: IndexedSchema,
+  ctx: DiffContext
+) {
+  const allNames = unionKeys(oldIdx.inputs, newIdx.inputs);
+  for (const name of allNames) {
+    const o = oldIdx.inputs[name];
+    const n = newIdx.inputs[name];
+
+    if (!o && n) {
+      // New input type added — ADDITIVE
+      pushEntry(ctx, {
+        element: name,
+        elementType: ElementType.TYPE,
+        changeType: ChangeType.ADDITIVE,
+        detail: `Input type added: ${name}`,
+      });
+      continue;
+    }
+
+    if (o && !n) {
+      // Input type removed — BREAKING (any consumer may rely on it)
+      pushEntry(ctx, {
+        element: name,
+        elementType: ElementType.TYPE,
+        changeType: ChangeType.BREAKING,
+        detail: `Input type removed: ${name}`,
+      });
+      continue;
+    }
+
+    if (o && n) {
+      const oldFields =
+        o.fields?.reduce<Record<string, InputValueDefinitionNode>>((m, f) => {
+          m[f.name.value] = f;
+          return m;
+        }, {}) ?? {};
+      const newFields =
+        n.fields?.reduce<Record<string, InputValueDefinitionNode>>((m, f) => {
+          m[f.name.value] = f;
+          return m;
+        }, {}) ?? {};
+
+      const fieldNames = new Set([
+        ...Object.keys(oldFields),
+        ...Object.keys(newFields),
+      ]);
+
+      for (const fname of fieldNames) {
+        const of = oldFields[fname];
+        const nf = newFields[fname];
+        const key = `${name}.${fname}`;
+
+        if (!of && nf) {
+          // New field on existing input type — ADDITIVE when optional (nullable),
+          // BREAKING when required (NonNull), because existing callers omit it.
+          const isRequired = nf.type.kind === 'NonNullType';
+          pushEntry(ctx, {
+            element: key,
+            elementType: ElementType.FIELD,
+            changeType: isRequired ? ChangeType.BREAKING : ChangeType.ADDITIVE,
+            detail: isRequired
+              ? `Input field added (required — breaking for callers): ${key} : ${printTypeNode(nf.type)}`
+              : `Input field added: ${key} : ${printTypeNode(nf.type)}`,
+          });
+          continue;
+        }
+
+        if (of && !nf) {
+          // Field removed from input type — BREAKING (producers / callers may rely on it)
+          pushEntry(ctx, {
+            element: key,
+            elementType: ElementType.FIELD,
+            changeType: ChangeType.BREAKING,
+            detail: `Input field removed: ${key}`,
+          });
+          continue;
+        }
+
+        if (of && nf) {
+          const oldTypeStr = printTypeNode(of.type);
+          const newTypeStr = printTypeNode(nf.type);
+          if (oldTypeStr !== newTypeStr) {
+            pushEntry(ctx, {
+              element: key,
+              elementType: ElementType.FIELD,
+              changeType: ChangeType.BREAKING,
+              detail: `Input field type changed: ${key} ${oldTypeStr} -> ${newTypeStr}`,
+            });
+          }
+          // Description-only change is INFO
+          const oldDesc = of.description?.value ?? '';
+          const newDesc = nf.description?.value ?? '';
+          if (oldDesc !== newDesc) {
+            pushEntry(ctx, {
+              element: key,
+              elementType: ElementType.FIELD,
+              changeType: ChangeType.INFO,
+              detail: `Description changed for input field ${key}`,
+            });
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schema-contract/diff/diff-inputs.ts
+++ b/src/schema-contract/diff/diff-inputs.ts
@@ -1,7 +1,11 @@
-// T025-F2: Diff InputObjectTypeDefinition nodes — tracks new input types and new
-// fields on existing input types as ADDITIVE; removed input types / fields as
-// BREAKING. Input fields carry no @deprecated directives (the spec forbids it),
-// so deprecation logic is intentionally omitted here.
+// Diff InputObjectTypeDefinition nodes — tracks new input types and new fields on
+// existing input types as ADDITIVE; removed input types / fields as BREAKING; and a
+// nullability relaxation (required -> optional) as non-breaking (INFO).
+// NOTE: GraphQL DOES allow @deprecated on INPUT_FIELD_DEFINITION (except on a required
+// field without a default). Deprecation grace-period tracking (REMOVE_AFTER) for input
+// fields is not yet wired here: an input-field removal is classified BREAKING outright
+// (safe/conservative — requires BREAKING-APPROVED) rather than flowing through the
+// deprecate-then-remove workflow that object fields / enum values use. Follow-up.
 import { InputValueDefinitionNode, TypeNode } from 'graphql';
 import { ChangeType, ElementType } from '../model';
 import { unionKeys } from './cleanup';
@@ -76,8 +80,10 @@ export function diffInputs(
 
         if (!of && nf) {
           // New field on existing input type — ADDITIVE when optional (nullable),
-          // BREAKING when required (NonNull), because existing callers omit it.
-          const isRequired = nf.type.kind === 'NonNullType';
+          // BREAKING only when required (NonNull) AND without a default value: a
+          // required field that supplies a default can still be omitted by existing
+          // callers, so its addition is backward-compatible.
+          const isRequired = nf.type.kind === 'NonNullType' && !nf.defaultValue;
           pushEntry(ctx, {
             element: key,
             elementType: ElementType.FIELD,
@@ -104,10 +110,17 @@ export function diffInputs(
           const oldTypeStr = printTypeNode(of.type);
           const newTypeStr = printTypeNode(nf.type);
           if (oldTypeStr !== newTypeStr) {
+            // Relaxing a required field to optional (e.g. String! -> String) is
+            // backward-compatible for existing callers; only tightening or other
+            // type changes are breaking.
+            const becameOptional =
+              of.type.kind === 'NonNullType' &&
+              nf.type.kind !== 'NonNullType' &&
+              printTypeNode(of.type.type) === printTypeNode(nf.type);
             pushEntry(ctx, {
               element: key,
               elementType: ElementType.FIELD,
-              changeType: ChangeType.BREAKING,
+              changeType: becameOptional ? ChangeType.INFO : ChangeType.BREAKING,
               detail: `Input field type changed: ${key} ${oldTypeStr} -> ${newTypeStr}`,
             });
           }

--- a/src/services/api/input-creator/input.creator.service.ts
+++ b/src/services/api/input-creator/input.creator.service.ts
@@ -1,4 +1,5 @@
 import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import { LogContext } from '@common/enums/logging.context';
 import { validateAndConvertVisualTypeName } from '@common/enums/visual.type';
 import { RelationshipNotFoundException } from '@common/exceptions';
@@ -152,7 +153,10 @@ export class InputCreatorService {
       framing: this.buildCreateCalloutFramingInputFromCalloutFraming(
         callout.framing
       ),
-      settings: callout.settings,
+      settings: this.stripSelectionFromSettings(
+        callout.settings,
+        callout.framing.type
+      ),
       contributionDefaults:
         this.buildCreateCalloutContributionDefaultsInputFromCalloutContributionDefaults(
           callout.contributionDefaults
@@ -618,5 +622,37 @@ export class InputCreatorService {
       tagsetInputs.push(this.buildCreateTagsetInputFromTagset(tagset));
     }
     return tagsetInputs;
+  }
+
+  /**
+   * Template-capture strip (workspace#025, FR-017 / US5-AS5):
+   * Collection-kind callouts in CUSTOM mode must NOT serialize their selected
+   * ids into the template — the template must be AUTO so a space created from
+   * it self-populates from its own members/subspaces.
+   *
+   * Deep-copies the settings object to avoid mutating the live callout in
+   * memory. Non-collection kinds are returned unchanged.
+   */
+  private stripSelectionFromSettings(
+    settings: any,
+    framingType: CalloutFramingType
+  ): any {
+    const isCollectionKind =
+      framingType === CalloutFramingType.CONTRIBUTORS ||
+      framingType === CalloutFramingType.SPACES;
+
+    if (!isCollectionKind) {
+      return settings;
+    }
+
+    // Deep-copy so the live callout object is not mutated in memory.
+    const copy = JSON.parse(JSON.stringify(settings));
+    if (copy?.framing) {
+      copy.framing.selection = {
+        mode: CalloutSelectionMode.AUTO,
+        selectedIds: [],
+      };
+    }
+    return copy;
   }
 }

--- a/src/tools/schema/diff-schema.ts
+++ b/src/tools/schema/diff-schema.ts
@@ -33,6 +33,7 @@ import {
   pushEntry,
   sha256,
 } from '../../schema-contract/diff/diff-core';
+import { diffInputs } from '../../schema-contract/diff/diff-inputs';
 import { parseDeprecationReason } from './deprecation-parser';
 import { performOverrideEvaluationAsync } from './override';
 import {
@@ -724,6 +725,7 @@ async function buildReport(
   diffTypes(oldIdx, newIdx, ctx);
   diffEnums(oldIdx, newIdx, ctx);
   diffScalars(oldIdx, newIdx, ctx);
+  diffInputs(oldIdx, newIdx, ctx);
   const report: ChangeReport = {
     snapshotId: sha256(newSDL),
     baseSnapshotId: sha256(oldSDL),

--- a/test/schema/diff-inputs.spec.ts
+++ b/test/schema/diff-inputs.spec.ts
@@ -1,0 +1,118 @@
+// T025-F2: Tests for InputObjectTypeDefinition diffing (diff-inputs.ts)
+import {
+  createDiffContext,
+  indexSDL,
+} from '../../src/schema-contract/diff/diff-core';
+import { diffInputs } from '../../src/schema-contract/diff/diff-inputs';
+import { ChangeType } from '../../src/schema-contract/model';
+
+describe('diffInputs — InputObjectTypeDefinition diff (feature 025 fix)', () => {
+  it('classifies a new input type as ADDITIVE', () => {
+    const oldSDL = 'type Query { ping: String }';
+    const newSDL = `type Query { ping: String }
+input NewInput { id: ID }`;
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    expect(
+      ctx.entries.some(
+        e =>
+          e.element === 'NewInput' &&
+          e.changeType === ChangeType.ADDITIVE &&
+          e.detail.includes('Input type added: NewInput')
+      )
+    ).toBe(true);
+  });
+
+  it('classifies a removed input type as BREAKING', () => {
+    const oldSDL = `type Query { ping: String }
+input RemovedInput { id: ID }`;
+    const newSDL = 'type Query { ping: String }';
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    expect(
+      ctx.entries.some(
+        e =>
+          e.element === 'RemovedInput' && e.changeType === ChangeType.BREAKING
+      )
+    ).toBe(true);
+  });
+
+  it('classifies a new optional input field on existing type as ADDITIVE', () => {
+    const oldSDL = `type Query { ping: String }
+input ExistingInput { id: ID }`;
+    const newSDL = `type Query { ping: String }
+input ExistingInput { id: ID, newField: String }`;
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    expect(
+      ctx.entries.some(
+        e =>
+          e.element === 'ExistingInput.newField' &&
+          e.changeType === ChangeType.ADDITIVE
+      )
+    ).toBe(true);
+  });
+
+  it('classifies a new required input field on existing type as BREAKING', () => {
+    const oldSDL = `type Query { ping: String }
+input ExistingInput { id: ID }`;
+    const newSDL = `type Query { ping: String }
+input ExistingInput { id: ID, required: String! }`;
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    expect(
+      ctx.entries.some(
+        e =>
+          e.element === 'ExistingInput.required' &&
+          e.changeType === ChangeType.BREAKING
+      )
+    ).toBe(true);
+  });
+
+  it('classifies a removed input field as BREAKING', () => {
+    const oldSDL = `type Query { ping: String }
+input ExistingInput { id: ID, gone: String }`;
+    const newSDL = `type Query { ping: String }
+input ExistingInput { id: ID }`;
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    expect(
+      ctx.entries.some(
+        e =>
+          e.element === 'ExistingInput.gone' &&
+          e.changeType === ChangeType.BREAKING
+      )
+    ).toBe(true);
+  });
+
+  it('detects no change when input type is identical', () => {
+    const sdl = `type Query { ping: String }
+input SameInput { id: ID, name: String }`;
+    const oldIdx = indexSDL(sdl);
+    const newIdx = indexSDL(sdl);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    expect(ctx.entries).toHaveLength(0);
+  });
+
+  it('indexes InputObjectTypeDefinition separately from ObjectTypeDefinition', () => {
+    const sdl = `type Query { ping: String }
+type ObjectType { id: ID }
+input InputType { id: ID }`;
+    const idx = indexSDL(sdl);
+    expect(idx.inputs).toHaveProperty('InputType');
+    expect(idx.types).toHaveProperty('ObjectType');
+    expect(idx.inputs).not.toHaveProperty('ObjectType');
+    expect(idx.types).not.toHaveProperty('InputType');
+  });
+});

--- a/test/schema/diff-inputs.spec.ts
+++ b/test/schema/diff-inputs.spec.ts
@@ -115,4 +115,54 @@ input InputType { id: ID }`;
     expect(idx.inputs).not.toHaveProperty('ObjectType');
     expect(idx.types).not.toHaveProperty('InputType');
   });
+
+  it('classifies a new required input field WITH a default value as ADDITIVE', () => {
+    const oldSDL = `type Query { ping: String }
+input ExistingInput { id: ID }`;
+    const newSDL = `type Query { ping: String }
+input ExistingInput { id: ID, requiredWithDefault: String! = "x" }`;
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    expect(
+      ctx.entries.some(
+        e =>
+          e.element === 'ExistingInput.requiredWithDefault' &&
+          e.changeType === ChangeType.ADDITIVE
+      )
+    ).toBe(true);
+  });
+
+  it('classifies a required -> optional input field relaxation as INFO (non-breaking)', () => {
+    const oldSDL = `type Query { ping: String }
+input ExistingInput { id: ID, name: String! }`;
+    const newSDL = `type Query { ping: String }
+input ExistingInput { id: ID, name: String }`;
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    const entry = ctx.entries.find(
+      e =>
+        e.element === 'ExistingInput.name' && e.detail.includes('type changed')
+    );
+    expect(entry?.changeType).toBe(ChangeType.INFO);
+  });
+
+  it('classifies an optional -> required input field tightening as BREAKING', () => {
+    const oldSDL = `type Query { ping: String }
+input ExistingInput { id: ID, name: String }`;
+    const newSDL = `type Query { ping: String }
+input ExistingInput { id: ID, name: String! }`;
+    const oldIdx = indexSDL(oldSDL);
+    const newIdx = indexSDL(newSDL);
+    const ctx = createDiffContext();
+    diffInputs(oldIdx, newIdx, ctx);
+    const entry = ctx.entries.find(
+      e =>
+        e.element === 'ExistingInput.name' && e.detail.includes('type changed')
+    );
+    expect(entry?.changeType).toBe(ChangeType.BREAKING);
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual selection controls for contributor and space collection callouts.
  * Supports automatic selection or curated custom lists of up to 500 entries.
  * Custom selections now filter displayed contributors, spaces, and related counts.
  * Added validation to ensure selected entries belong to the relevant host space.

* **Bug Fixes**
  * Existing callouts receive safe automatic-selection defaults.
  * Invalid, duplicate, deleted, or out-of-scope selections are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->