### PR TITLE
fix: export whole-day calendar events on the correct date, TZ-independent (workspace#023-wholeday-calendar-timezone)

### DIFF
--- a/src/domain/timeline/event/calendar.event.calendar-links.spec.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.spec.ts
@@ -5,8 +5,66 @@ import {
   formatDatesForCalendar,
   generateCalendarUrls,
   generateICS,
+  validateCalendarDateRange,
 } from './calendar.event.calendar-links';
 import { ICalendarEvent } from './event.interface';
+
+describe('validateCalendarDateRange', () => {
+  const ID = 'evt-1';
+
+  it('accepts a single-day whole-day event (start === end)', () => {
+    // durationMinutes = 0 ⇒ end === start; the exclusive +1 day is added at export.
+    expect(() =>
+      validateCalendarDateRange(
+        '2026-07-20T00:00:00.000Z',
+        '2026-07-20T00:00:00.000Z',
+        ID,
+        true
+      )
+    ).not.toThrow();
+  });
+
+  it('accepts a multi-day whole-day event (end after start)', () => {
+    expect(() =>
+      validateCalendarDateRange(
+        '2026-07-20T00:00:00.000Z',
+        '2026-07-22T00:00:00.000Z',
+        ID,
+        true
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects a zero-length timed event (start === end)', () => {
+    expect(() =>
+      validateCalendarDateRange(
+        '2026-07-20T10:00:00.000Z',
+        '2026-07-20T10:00:00.000Z',
+        ID,
+        false
+      )
+    ).toThrow();
+  });
+
+  it('rejects an end before the start (whole-day and timed)', () => {
+    expect(() =>
+      validateCalendarDateRange(
+        '2026-07-22T00:00:00.000Z',
+        '2026-07-20T00:00:00.000Z',
+        ID,
+        true
+      )
+    ).toThrow();
+    expect(() =>
+      validateCalendarDateRange(
+        '2026-07-20T12:00:00.000Z',
+        '2026-07-20T10:00:00.000Z',
+        ID,
+        false
+      )
+    ).toThrow();
+  });
+});
 
 describe('CalendarEventCalendarLinks', () => {
   it('formats calendar dates for Google and Outlook', () => {

--- a/src/domain/timeline/event/calendar.event.calendar-links.spec.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.spec.ts
@@ -1,7 +1,7 @@
 import {
   calculateCalendarEventEndDate,
   foldIcsLine,
-  formatDateOnlyLocal,
+  formatDateOnlyUtc,
   formatDatesForCalendar,
   generateCalendarUrls,
   generateICS,
@@ -38,38 +38,23 @@ describe('CalendarEventCalendarLinks', () => {
     expect(result.wholeDay).toBe(true);
   });
 
-  it('formatDateOnlyLocal extracts the local wall-clock YYYYMMDD', () => {
-    // Constructed at local midnight so the assertion holds in any runner TZ.
-    const localMidnight = new Date(2026, 1, 20, 0, 0, 0); // 2026-02-20 local
-    expect(formatDateOnlyLocal(localMidnight.toISOString())).toBe('20260220');
+  it('formatDateOnlyUtc extracts the UTC calendar day YYYYMMDD', () => {
+    expect(formatDateOnlyUtc('2026-02-20T00:00:00.000Z')).toBe('20260220');
   });
 
-  describe('whole-day time-zone handling (Europe/Amsterdam)', () => {
-    // Reproduces the reported bug: a whole-day event stored as local midnight
-    // is read back (node-postgres, timestamp-without-tz) as the previous day in
-    // UTC. Slicing the UTC ISO produced an ICS date one day early; the export
-    // must emit the local calendar day instead.
-    const originalTz = process.env.TZ;
+  describe('whole-day date-only handling', () => {
+    // A whole-day event is a bare calendar date, sent by the client as
+    // UTC-midnight of the intended day and exported as that UTC calendar day —
+    // timezone-independent (see calendar.event.calendar-links.wholeday-tz.spec.ts).
 
-    beforeEach(() => {
-      process.env.TZ = 'Europe/Amsterdam';
-    });
+    it('exports the UTC calendar day with an exclusive end for a single-day event', () => {
+      // Whole-day "23 July 2026", single day, stored as UTC-midnight.
+      const result = formatDatesForCalendar(
+        '2026-07-23T00:00:00.000Z',
+        '2026-07-23T00:00:00.000Z',
+        true
+      );
 
-    afterEach(() => {
-      process.env.TZ = originalTz;
-    });
-
-    it('exports the local calendar day for a whole-day event, not the UTC day', () => {
-      // Single-day whole-day event stored at Amsterdam local midnight:
-      // 2026-07-23 00:00 local is 2026-07-22T22:00Z. The last covered day is the
-      // 23rd (the end instant is later the same local day), so DTSTART is the
-      // 23rd and the exclusive DTEND is the 24th.
-      const startIso = '2026-07-22T22:00:00.000Z';
-      const endIso = '2026-07-22T22:30:00.000Z';
-
-      const result = formatDatesForCalendar(startIso, endIso, true);
-
-      // Without the local-date fix DTSTART would slip to the 22nd (UTC).
       expect(result.icalStart).toBe('20260723');
       expect(result.icalEnd).toBe('20260724');
       expect(result.outlookStart).toBe('2026-07-23');

--- a/src/domain/timeline/event/calendar.event.calendar-links.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.ts
@@ -307,12 +307,22 @@ export const isIsoDateString = (value: string): boolean =>
 export const validateCalendarDateRange = (
   startIso: string,
   endIso: string,
-  eventId: string
+  eventId: string,
+  wholeDay = false
 ): void => {
   const start = new Date(startIso).getTime();
   const end = new Date(endIso).getTime();
 
-  if (Number.isNaN(start) || Number.isNaN(end) || start >= end) {
+  // A whole-day event may be a single day (start === end, i.e. durationMinutes 0);
+  // its exclusive end is added at export. A timed event must end strictly after
+  // its start.
+  const invalid =
+    Number.isNaN(start) ||
+    Number.isNaN(end) ||
+    start > end ||
+    (!wholeDay && start === end);
+
+  if (invalid) {
     throw new ValidationException(
       'Invalid calendar event date range',
       LogContext.CALENDAR,

--- a/src/domain/timeline/event/calendar.event.calendar-links.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.ts
@@ -65,29 +65,25 @@ export const formatDatesForCalendar = (
   const endIso = toIsoString(end, 'endDate');
 
   if (wholeDay) {
-    // A whole-day event carries a calendar date, not an instant. The stored
-    // `timestamp` (without time zone) is read back by node-postgres in the
-    // process-local time zone — the same reference the client renders in — so
-    // the date-only value MUST be derived from the local wall-clock components,
-    // not from the UTC ISO string. Slicing the UTC ISO lands on the previous
-    // day for time zones east of UTC (e.g. Europe/Amsterdam, where the server
-    // runs: local midnight 2026-07-23 is 2026-07-22T22:00Z in UTC).
-    const dateStart = formatDateOnlyLocal(startIso);
+    // A whole-day event is a bare calendar date, not an instant. Its canonical
+    // value is UTC-midnight of the intended date, so the date-only value is the
+    // UTC calendar day — timezone-independent for every server. (Deriving it from
+    // process-local parts slips a day west of UTC; the client is responsible for
+    // sending UTC-midnight so this holds end to end.)
+    const dateStart = formatDateOnlyUtc(startIso);
     // Whole-day end dates are EXCLUSIVE (RFC 5545 §3.6.1 for ICS; Google and
     // Outlook all-day links use the same convention): the end must be the day
-    // AFTER the last covered day. The stored end date is the last covered day,
-    // so add one local day. All three targets share this exclusive end —
-    // previously only the Google URL added the +1, so ICS and Outlook were a
-    // day short and importers (Thunderbird, Outlook) showed the event ending
-    // one day early.
+    // AFTER the last covered day. The stored end date is the last covered day, so
+    // add one UTC day (UTC has no DST, so day arithmetic is exact). All three
+    // targets share this exclusive end.
     const exclusiveEnd = new Date(endIso);
-    exclusiveEnd.setDate(exclusiveEnd.getDate() + 1);
+    exclusiveEnd.setUTCDate(exclusiveEnd.getUTCDate() + 1);
     const exclusiveEndIso = exclusiveEnd.toISOString();
-    const dateEndExclusive = formatDateOnlyLocal(exclusiveEndIso);
+    const dateEndExclusive = formatDateOnlyUtc(exclusiveEndIso);
     return {
       google: `${dateStart}/${dateEndExclusive}`,
-      outlookStart: formatLocalDateHyphenated(startIso),
-      outlookEnd: formatLocalDateHyphenated(exclusiveEndIso),
+      outlookStart: formatUtcDateHyphenated(startIso),
+      outlookEnd: formatUtcDateHyphenated(exclusiveEndIso),
       icalStart: dateStart,
       icalEnd: dateEndExclusive,
       wholeDay: true,
@@ -208,31 +204,31 @@ export const formatDateForCalendar = (iso: string): string =>
   iso.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 
 /**
- * Local wall-clock date parts of the instant an ISO-8601 string represents.
- * Whole-day events are stored/read/displayed in the process-local time zone,
- * so their date-only value must come from these local components rather than
- * the UTC slice of the ISO string (which can be off by a day east of UTC).
+ * UTC date parts of the instant an ISO-8601 string represents. A whole-day event
+ * is a bare calendar date whose canonical value is UTC-midnight of that date, so
+ * its date-only value is the UTC calendar day — independent of the server's
+ * process timezone (deriving it from process-local parts slips a day west of UTC).
  */
-const localDateParts = (
+const utcDateParts = (
   iso: string
 ): { year: string; month: string; day: string } => {
   const d = new Date(iso);
   return {
-    year: String(d.getFullYear()).padStart(4, '0'),
-    month: String(d.getMonth() + 1).padStart(2, '0'),
-    day: String(d.getDate()).padStart(2, '0'),
+    year: String(d.getUTCFullYear()).padStart(4, '0'),
+    month: String(d.getUTCMonth() + 1).padStart(2, '0'),
+    day: String(d.getUTCDate()).padStart(2, '0'),
   };
 };
 
-/** Local wall-clock date as an iCal date-only value (YYYYMMDD). */
-export const formatDateOnlyLocal = (iso: string): string => {
-  const { year, month, day } = localDateParts(iso);
+/** UTC calendar date as an iCal date-only value (YYYYMMDD). */
+export const formatDateOnlyUtc = (iso: string): string => {
+  const { year, month, day } = utcDateParts(iso);
   return `${year}${month}${day}`;
 };
 
-/** Local wall-clock date as YYYY-MM-DD (Outlook all-day format). */
-const formatLocalDateHyphenated = (iso: string): string => {
-  const { year, month, day } = localDateParts(iso);
+/** UTC calendar date as YYYY-MM-DD (Outlook all-day format). */
+const formatUtcDateHyphenated = (iso: string): string => {
+  const { year, month, day } = utcDateParts(iso);
   return `${year}-${month}-${day}`;
 };
 

--- a/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.harness.spec.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.harness.spec.ts
@@ -1,0 +1,33 @@
+import { execFileSync } from 'node:child_process';
+
+const SPEC =
+  'src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts';
+
+/**
+ * The sibling `*.wholeday-tz.spec.ts` asserts fixed date strings, which only prove
+ * timezone-INDEPENDENCE when the process runs under a NON-UTC timezone: under a UTC
+ * runner (e.g. CI) a regression to process-local date parts is invisible, because
+ * local parts and UTC parts coincide there. Node fixes the process timezone at
+ * startup (runtime `process.env.TZ` reassignment does not take effect), so this
+ * harness re-runs that spec once in a child process pinned to America/Los_Angeles
+ * (west of UTC, where the two diverge). A regression from `formatDateOnlyUtc` back
+ * to process-local derivation is then caught regardless of the outer runner's TZ.
+ *
+ * (The child runs only the named spec — not this harness — so there is no recursion.)
+ */
+describe('whole-day export timezone-independence (west-of-UTC harness)', () => {
+  it('the whole-day-tz spec still passes under a non-UTC process timezone', () => {
+    try {
+      execFileSync('pnpm', ['exec', 'vitest', 'run', SPEC], {
+        env: { ...process.env, TZ: 'America/Los_Angeles' },
+        stdio: 'pipe',
+        encoding: 'utf8',
+      });
+    } catch (error) {
+      const e = error as { stdout?: string; stderr?: string };
+      throw new Error(
+        `whole-day-tz spec failed under TZ=America/Los_Angeles (a process-local date regression):\n${e.stdout ?? ''}${e.stderr ?? ''}`
+      );
+    }
+  }, 60_000);
+});

--- a/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts
@@ -8,8 +8,11 @@ import { formatDatesForCalendar } from './calendar.event.calendar-links';
  * process-local derivation slipped a day.
  *
  * The process timezone is fixed at Node startup (runtime `process.env.TZ` reassignment
- * does NOT take effect), so this file is designed to be run under several launch-time
- * timezones and assert the SAME output each time:
+ * does NOT take effect), so these fixed-string assertions only prove TZ-independence
+ * when the process runs under a non-UTC timezone. `calendar.event.calendar-links.wholeday-tz.harness.spec.ts`
+ * re-runs this file in a child process pinned to `America/Los_Angeles`, so the guarantee
+ * holds in `test:ci` regardless of the runner's timezone (e.g. a UTC CI). To sweep it
+ * by hand across zones:
  *
  *   for z in UTC Europe/Amsterdam Europe/Sofia America/Los_Angeles; do \
  *     TZ=$z npx vitest run src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts; done

--- a/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts
@@ -41,4 +41,19 @@ describe('whole-day export is timezone-independent', () => {
     expect(result.icalStart).toBe('20261203');
     expect(result.icalEnd).toBe('20261204');
   });
+
+  it('keeps the exact day count for a multi-day whole-day span crossing a DST transition', () => {
+    // Europe spring-forward 2026 is 29 March. A whole-day event covering
+    // 28–30 March (3 days) is stored as UTC-midnight; UTC date math has no DST,
+    // so the exclusive end is exactly 31 March (last covered day 30 + 1).
+    const result = formatDatesForCalendar(
+      '2026-03-28T00:00:00.000Z',
+      '2026-03-30T00:00:00.000Z',
+      true
+    );
+
+    expect(result.icalStart).toBe('20260328');
+    expect(result.icalEnd).toBe('20260331');
+    expect(result.google).toBe('20260328/20260331');
+  });
 });

--- a/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts
+++ b/src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts
@@ -1,0 +1,44 @@
+import { formatDatesForCalendar } from './calendar.event.calendar-links';
+
+/**
+ * SC-001: a whole-day event exports on the picked calendar date regardless of the
+ * server's process timezone. The client sends a whole-day date as UTC-midnight of
+ * the intended day; the export derives the date-only value in UTC, so the result
+ * is identical under every server TZ — including west of UTC, where #6271's
+ * process-local derivation slipped a day.
+ *
+ * The process timezone is fixed at Node startup (runtime `process.env.TZ` reassignment
+ * does NOT take effect), so this file is designed to be run under several launch-time
+ * timezones and assert the SAME output each time:
+ *
+ *   for z in UTC Europe/Amsterdam Europe/Sofia America/Los_Angeles; do \
+ *     TZ=$z npx vitest run src/domain/timeline/event/calendar.event.calendar-links.wholeday-tz.spec.ts; done
+ */
+describe('whole-day export is timezone-independent', () => {
+  it('exports a whole-day "3 Dec 2026" event on the 3rd under any server timezone', () => {
+    // Whole-day 3 Dec → 4 Dec (last covered day = 4th), stored as UTC-midnight.
+    const result = formatDatesForCalendar(
+      '2026-12-03T00:00:00.000Z',
+      '2026-12-04T00:00:00.000Z',
+      true
+    );
+
+    expect(result.icalStart).toBe('20261203');
+    // Exclusive end (RFC 5545) = last covered day (4th) + 1 = 5th.
+    expect(result.icalEnd).toBe('20261205');
+    expect(result.outlookStart).toBe('2026-12-03');
+    expect(result.outlookEnd).toBe('2026-12-05');
+    expect(result.google).toBe('20261203/20261205');
+  });
+
+  it('keeps a single-day whole-day event on its day (exclusive end = next day)', () => {
+    const result = formatDatesForCalendar(
+      '2026-12-03T00:00:00.000Z',
+      '2026-12-03T00:00:00.000Z',
+      true
+    );
+
+    expect(result.icalStart).toBe('20261203');
+    expect(result.icalEnd).toBe('20261204');
+  });
+});

--- a/src/domain/timeline/event/dto/event.dto.create.ts
+++ b/src/domain/timeline/event/dto/event.dto.create.ts
@@ -33,6 +33,10 @@ export class CreateCalendarEventInput extends CreateNameableInput {
   })
   multipleDays!: boolean;
 
+  // For whole-day events this is the offset between the start and end dates
+  // (End − Start), NOT the event's length: a single-day whole-day event is 0, and
+  // the ICS/Google/Outlook export appends the RFC 5545 exclusive +1 day so it
+  // still covers one full day. Timed events store their true start→end duration.
   @Field(() => Number, {
     nullable: false,
     description: 'The length of the event in minutes.',

--- a/src/domain/timeline/event/dto/event.dto.update.ts
+++ b/src/domain/timeline/event/dto/event.dto.update.ts
@@ -30,6 +30,10 @@ export class UpdateCalendarEventInput extends UpdateNameableInput {
   })
   multipleDays!: boolean;
 
+  // For whole-day events this is the offset between the start and end dates
+  // (End − Start), NOT the event's length: a single-day whole-day event is 0, and
+  // the ICS/Google/Outlook export appends the RFC 5545 exclusive +1 day so it
+  // still covers one full day. Timed events store their true start→end duration.
   @Field(() => Number, {
     nullable: false,
     description: 'The length of the event in minutes.',

--- a/src/domain/timeline/event/event.resolver.fields.ts
+++ b/src/domain/timeline/event/event.resolver.fields.ts
@@ -138,7 +138,12 @@ export class CalendarEventResolverFields {
       'endDate'
     );
 
-    validateCalendarDateRange(startDateIso, endDateIso, event.id);
+    validateCalendarDateRange(
+      startDateIso,
+      endDateIso,
+      event.id,
+      event.wholeDay
+    );
 
     const profile = await this.calendarEventService.getProfileOrFail(event);
     const description = profile?.description ?? undefined;

--- a/src/domain/timeline/event/event.service.spec.ts
+++ b/src/domain/timeline/event/event.service.spec.ts
@@ -528,6 +528,39 @@ describe('CalendarEventService', () => {
       expect(result.startDate).toEqual(updateInput.startDate);
     });
 
+    it('applies durationMinutes/durationDays of 0 (shrinking a multi-day event to a single day)', async () => {
+      // Editing a 4-day whole-day event down to a single day sends 0/0. A truthy
+      // guard would drop those and keep the old multi-day span.
+      const updateInput = buildUpdateInput({
+        wholeDay: true,
+        durationMinutes: 0,
+        durationDays: 0,
+      });
+      const mockEvent = {
+        id: 'event-1',
+        nameID: 'test-event',
+        durationMinutes: 5760, // old 4-day span
+        durationDays: 4,
+        wholeDay: true,
+        multipleDays: true,
+        startDate: new Date('2025-06-15'),
+        type: CalendarEventType.EVENT,
+        visibleOnParentCalendar: true,
+        profile: { id: 'profile-1', displayName: 'Test Event' },
+        comments: { id: 'room-1' },
+      } as unknown as CalendarEvent;
+
+      vi.spyOn(calendarEventRepository, 'findOne').mockResolvedValue(mockEvent);
+      vi.spyOn(calendarEventRepository, 'save').mockImplementation(entity =>
+        Promise.resolve(entity as CalendarEvent)
+      );
+
+      const result = await service.updateCalendarEvent(updateInput);
+
+      expect(result.durationMinutes).toBe(0);
+      expect(result.durationDays).toBe(0);
+    });
+
     it('should update the profile when profileData is provided and profile exists', async () => {
       // Arrange
       const updatedProfile = {

--- a/src/domain/timeline/event/event.service.ts
+++ b/src/domain/timeline/event/event.service.ts
@@ -196,12 +196,11 @@ export class CalendarEventService {
         calendarEventData.profileData
       );
     }
-    if (calendarEventData.durationDays) {
-      calendarEvent.durationDays = calendarEventData.durationDays;
-    }
-    if (calendarEventData.durationMinutes) {
-      calendarEvent.durationMinutes = calendarEventData.durationMinutes;
-    }
+    // Assign unconditionally (like wholeDay/multipleDays/startDate below): a truthy
+    // guard would drop a legitimate 0 — e.g. a single-day whole-day event has
+    // durationMinutes 0, and shrinking a multi-day event to one day must persist.
+    calendarEvent.durationDays = calendarEventData.durationDays;
+    calendarEvent.durationMinutes = calendarEventData.durationMinutes;
     calendarEvent.wholeDay = calendarEventData.wholeDay;
     calendarEvent.multipleDays = calendarEventData.multipleDays;
     calendarEvent.startDate = calendarEventData.startDate;

--- a/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
+++ b/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
@@ -597,7 +597,12 @@ export class NotificationExternalAdapter {
       calculateCalendarEventEndDate(calendarEvent).toISOString(),
       'endDate'
     );
-    validateCalendarDateRange(startDateIso, endDateIso, calendarEvent.id);
+    validateCalendarDateRange(
+      startDateIso,
+      endDateIso,
+      calendarEvent.id,
+      calendarEvent.wholeDay
+    );
 
     const description = calendarEvent.profile?.description ?? undefined;
     const location = formatLocation(calendarEvent.profile?.location);

--- a/src/services/api-rest/calendar-event-ics/calendar-event-ics.service.ts
+++ b/src/services/api-rest/calendar-event-ics/calendar-event-ics.service.ts
@@ -54,7 +54,12 @@ export class CalendarEventIcsService {
       calculateCalendarEventEndDate(event).toISOString(),
       'endDate'
     );
-    validateCalendarDateRange(startDateIso, endDateIso, eventId);
+    validateCalendarDateRange(
+      startDateIso,
+      endDateIso,
+      eventId,
+      event.wholeDay
+    );
 
     const profile = await this.calendarEventService.getProfileOrFail(event);
     const description = profile.description ?? undefined;


### PR DESCRIPTION
Closes the export half of the whole-day calendar timezone bug. Follow-up of #6271 (superseded-in-part — its exclusive-end fix is kept).

## Problem
A **whole-day** event is a bare calendar date, but the export collapses the stored instant to a single day using the server's process timezone. On the UTC production server that lands a day early for every creator east of UTC (all of Europe). #6271 switched to *server-local* parts — correct only when the server TZ equals the creator's — which is why it was still broken on dev/acceptance.

## Change (export only — no schema, no migration)
- Derive whole-day `DTSTART`/`DTEND` (and the Google/Outlook date-only values) from **UTC** parts of the stored instant (`formatDateOnlyUtc` / `formatUtcDateHyphenated`), so the exported day is identical under every server timezone.
- Compute the RFC 5545 exclusive end (`+1` day) in **UTC** (`setUTCDate`) — **keeps #6271's genuine exclusive-end fix**, now DST-safe.
- **Timed events unchanged** (real UTC instant + `X-WR-TIMEZONE`).
- The client (paired PR) sends whole-day dates as UTC-midnight so this holds end to end.

## Tests
- New TZ-matrix spec — identical output under `TZ=UTC / Europe/Amsterdam / Europe/Sofia / America/Los_Angeles` (the west-of-UTC case that produced `20261202` now yields `20261203`); DST-crossing multi-day guard.
- Existing whole-day tests updated to the UTC-midnight convention; timed export is a byte-for-byte regression guard.
- Full `pnpm test` suite green; **no schema change** (`schema:diff` clean).

## Schema Contract
No GraphQL/schema change — `schema:diff` is empty.

## Links
- Cross-repo spec (source of truth): [`alkem-io/agents-hq` `specs/023-wholeday-calendar-timezone/`](https://github.com/alkem-io/agents-hq/pull/65) (+ `docs/decisions/0001-…`)
- Story: #6279 · Closes: #6267 · Supersedes-in-part: #6271
- **Paired client-web PR — ships in the same release** (must not be split).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed whole-day calendar exports to use consistent UTC date-only values across ICS, Outlook, and Google Calendar.
  - Corrected whole-day range handling, including the required exclusive end date and scenarios where start equals end.
  - Ensured event updates correctly persist `0` duration values when converting multi-day events to single-day.

- **Tests**
  - Added timezone-invariance coverage for whole-day export formatting (including child-process runs under a non-UTC timezone).
  - Added unit coverage for updating calendar event duration fields to `0`.

- **Documentation**
  - Clarified how whole-day date offsets are represented and how exports apply the exclusive `+1 day` rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->