### PR TITLE
fix(auth-reset): resilient per-template containment — one orphan template no longer denies a whole account's templates

### DIFF
--- a/src/domain/template/templates-manager/templates.manager.service.authorization.spec.ts
+++ b/src/domain/template/templates-manager/templates.manager.service.authorization.spec.ts
@@ -1,9 +1,15 @@
-import { RelationshipNotFoundException } from '@common/exceptions';
+import { LogContext } from '@common/enums';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+} from '@common/exceptions';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { LoggerService } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { type Mocked } from 'vitest';
 import { TemplateDefaultAuthorizationService } from '../template-default/template.default.service.authorization';
 import { TemplatesSetAuthorizationService } from '../templates-set/templates.set.service.authorization';
@@ -16,6 +22,7 @@ describe('TemplatesManagerAuthorizationService', () => {
   let templatesManagerService: Mocked<TemplatesManagerService>;
   let templateDefaultAuthorizationService: Mocked<TemplateDefaultAuthorizationService>;
   let templatesSetAuthorizationService: Mocked<TemplatesSetAuthorizationService>;
+  let logger: Mocked<LoggerService>;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -43,6 +50,7 @@ describe('TemplatesManagerAuthorizationService', () => {
     templatesSetAuthorizationService = module.get(
       TemplatesSetAuthorizationService
     ) as Mocked<TemplatesSetAuthorizationService>;
+    logger = module.get(WINSTON_MODULE_NEST_PROVIDER) as Mocked<LoggerService>;
   });
 
   const parentAuth = { id: 'parent-auth' } as any;
@@ -117,5 +125,104 @@ describe('TemplatesManagerAuthorizationService', () => {
       templateDefaultAuthorizationService.applyAuthorizationPolicy
     ).not.toHaveBeenCalled();
     expect(result.length).toBe(2); // 1 manager + 1 templates set
+  });
+
+  // Regression: auth-reset resilient per-templateDefault containment. A single
+  // malformed templateDefault throwing RelationshipNotFoundException must NOT
+  // abort the manager cascade; the manager's own inherited auth, the healthy
+  // sibling templateDefault, and the templatesSet auth must all survive, and
+  // the skip must be logged.
+  it('should skip a templateDefault that throws RelationshipNotFoundException and continue', async () => {
+    const td1 = { id: 'td-1', authorization: {} } as any;
+    const td2 = { id: 'td-2', authorization: {} } as any;
+    const templatesSet = { id: 'ts-1', authorization: {} } as any;
+
+    templatesManagerService.getTemplatesManagerOrFail.mockResolvedValue({
+      id: 'tm-1',
+      authorization: { id: 'tm-auth' },
+      templateDefaults: [td1, td2],
+      templatesSet,
+    } as any);
+
+    templateDefaultAuthorizationService.applyAuthorizationPolicy
+      .mockImplementationOnce(() => {
+        throw new RelationshipNotFoundException('boom', LogContext.TEMPLATES);
+      })
+      .mockReturnValueOnce({ id: 'td-2-auth-updated' } as any);
+    templatesSetAuthorizationService.applyAuthorizationPolicy.mockResolvedValue(
+      [{ id: 'ts-auth-updated' } as any]
+    );
+
+    const result = await service.applyAuthorizationPolicy('tm-1', parentAuth);
+
+    // Manager's own inherited auth + healthy sibling + templatesSet auth.
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'tm-inherited-auth' }),
+        expect.objectContaining({ id: 'td-2-auth-updated' }),
+        expect.objectContaining({ id: 'ts-auth-updated' }),
+      ])
+    );
+    // The broken templateDefault contributed nothing.
+    expect(result).toHaveLength(3);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  // A data anomaly inside the templatesSet cascade must not deny the manager +
+  // its healthy templateDefaults their re-inherited authorization.
+  it('should skip the templatesSet cascade when it throws EntityNotFoundException and still return the manager + defaults', async () => {
+    const td1 = { id: 'td-1', authorization: {} } as any;
+    const td2 = { id: 'td-2', authorization: {} } as any;
+    const templatesSet = { id: 'ts-1', authorization: {} } as any;
+
+    templatesManagerService.getTemplatesManagerOrFail.mockResolvedValue({
+      id: 'tm-1',
+      authorization: { id: 'tm-auth' },
+      templateDefaults: [td1, td2],
+      templatesSet,
+    } as any);
+
+    templateDefaultAuthorizationService.applyAuthorizationPolicy
+      .mockReturnValueOnce({ id: 'td-1-auth-updated' } as any)
+      .mockReturnValueOnce({ id: 'td-2-auth-updated' } as any);
+    templatesSetAuthorizationService.applyAuthorizationPolicy.mockRejectedValue(
+      new EntityNotFoundException('boom', LogContext.TEMPLATES)
+    );
+
+    const result = await service.applyAuthorizationPolicy('tm-1', parentAuth);
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'tm-inherited-auth' }),
+        expect.objectContaining({ id: 'td-1-auth-updated' }),
+        expect.objectContaining({ id: 'td-2-auth-updated' }),
+      ])
+    );
+    // Manager + 2 defaults; the templatesSet cascade contributed nothing.
+    expect(result).toHaveLength(3);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  // A non-anomaly error must still propagate out of the manager cascade.
+  it('should propagate unexpected (non-anomaly) errors from a templateDefault', async () => {
+    const td1 = { id: 'td-1', authorization: {} } as any;
+
+    templatesManagerService.getTemplatesManagerOrFail.mockResolvedValue({
+      id: 'tm-1',
+      authorization: { id: 'tm-auth' },
+      templateDefaults: [td1],
+      templatesSet: { id: 'ts-1', authorization: {} },
+    } as any);
+
+    templateDefaultAuthorizationService.applyAuthorizationPolicy.mockImplementation(
+      () => {
+        throw new Error('db down');
+      }
+    );
+
+    await expect(
+      service.applyAuthorizationPolicy('tm-1', parentAuth)
+    ).rejects.toThrow('db down');
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/src/domain/template/templates-manager/templates.manager.service.authorization.ts
+++ b/src/domain/template/templates-manager/templates.manager.service.authorization.ts
@@ -1,8 +1,12 @@
 import { LogContext } from '@common/enums';
-import { RelationshipNotFoundException } from '@common/exceptions';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+} from '@common/exceptions';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { TemplateDefaultAuthorizationService } from '../template-default/template.default.service.authorization';
 import { TemplatesSetAuthorizationService } from '../templates-set/templates.set.service.authorization';
 import { ITemplatesManager } from '.';
@@ -14,7 +18,9 @@ export class TemplatesManagerAuthorizationService {
     private authorizationPolicyService: AuthorizationPolicyService,
     private templatesManagerService: TemplatesManagerService,
     private templateDefaultAuthorizationService: TemplateDefaultAuthorizationService,
-    private templatesSetAuthorizationService: TemplatesSetAuthorizationService
+    private templatesSetAuthorizationService: TemplatesSetAuthorizationService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
   ) {}
 
   async applyAuthorizationPolicy(
@@ -58,20 +64,68 @@ export class TemplatesManagerAuthorizationService {
     updatedAuthorizations.push(templatesManager.authorization);
 
     for (const templateDefault of templatesManager.templateDefaults) {
-      const templateDefaultAuthorization =
-        await this.templateDefaultAuthorizationService.applyAuthorizationPolicy(
-          templateDefault,
-          parentAuthorization
-        );
-      updatedAuthorizations.push(templateDefaultAuthorization);
+      // Per-templateDefault containment: a single malformed templateDefault must
+      // not abort authorization for its healthy siblings or the templatesSet.
+      // Data-integrity anomalies are logged and skipped; other exceptions
+      // propagate.
+      try {
+        const templateDefaultAuthorization =
+          await this.templateDefaultAuthorizationService.applyAuthorizationPolicy(
+            templateDefault,
+            parentAuthorization
+          );
+        updatedAuthorizations.push(templateDefaultAuthorization);
+      } catch (err: unknown) {
+        if (
+          err instanceof RelationshipNotFoundException ||
+          err instanceof EntityNotFoundException
+        ) {
+          this.logger.error(
+            {
+              message: 'Auth-reset skipped templateDefault due to data anomaly',
+              templateDefaultId: templateDefault.id,
+              templatesManagerId: templatesManager.id,
+              error: (err as Error).message,
+            },
+            (err as Error).stack,
+            LogContext.TEMPLATES
+          );
+          continue;
+        }
+        throw err;
+      }
     }
 
-    const templatesSetUpdatedAuthorizations =
-      await this.templatesSetAuthorizationService.applyAuthorizationPolicy(
-        templatesManager.templatesSet,
-        parentAuthorization
-      );
-    updatedAuthorizations.push(...templatesSetUpdatedAuthorizations);
+    // Per-templatesSet containment: a data anomaly inside the templatesSet
+    // cascade must not deny the manager + its healthy templateDefaults their
+    // re-inherited authorization. Anomalies are logged and skipped; other
+    // exceptions propagate.
+    try {
+      const templatesSetUpdatedAuthorizations =
+        await this.templatesSetAuthorizationService.applyAuthorizationPolicy(
+          templatesManager.templatesSet,
+          parentAuthorization
+        );
+      updatedAuthorizations.push(...templatesSetUpdatedAuthorizations);
+    } catch (err: unknown) {
+      if (
+        err instanceof RelationshipNotFoundException ||
+        err instanceof EntityNotFoundException
+      ) {
+        this.logger.error(
+          {
+            message: 'Auth-reset skipped templatesSet due to data anomaly',
+            templatesSetId: templatesManager.templatesSet.id,
+            templatesManagerId: templatesManager.id,
+            error: (err as Error).message,
+          },
+          (err as Error).stack,
+          LogContext.TEMPLATES
+        );
+      } else {
+        throw err;
+      }
+    }
 
     return updatedAuthorizations;
   }

--- a/src/domain/template/templates-set/templates.set.service.authorization.spec.ts
+++ b/src/domain/template/templates-set/templates.set.service.authorization.spec.ts
@@ -1,8 +1,15 @@
+import { LogContext } from '@common/enums';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+} from '@common/exceptions';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { LoggerService } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { type Mocked } from 'vitest';
 import { TemplateAuthorizationService } from '../template/template.service.authorization';
 import { ITemplatesSet } from './templates.set.interface';
@@ -14,6 +21,7 @@ describe('TemplatesSetAuthorizationService', () => {
   let authorizationPolicyService: Mocked<AuthorizationPolicyService>;
   let templatesSetService: Mocked<TemplatesSetService>;
   let templateAuthorizationService: Mocked<TemplateAuthorizationService>;
+  let logger: Mocked<LoggerService>;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -38,6 +46,7 @@ describe('TemplatesSetAuthorizationService', () => {
     templateAuthorizationService = module.get(
       TemplateAuthorizationService
     ) as Mocked<TemplateAuthorizationService>;
+    logger = module.get(WINSTON_MODULE_NEST_PROVIDER) as Mocked<LoggerService>;
   });
 
   const parentAuth = { id: 'parent-auth' } as any;
@@ -118,5 +127,101 @@ describe('TemplatesSetAuthorizationService', () => {
       templateAuthorizationService.applyAuthorizationPolicy
     ).not.toHaveBeenCalled();
     expect(result).toHaveLength(1);
+  });
+
+  // Regression: auth-reset resilient per-template containment. A single orphan
+  // template (e.g. type='whiteboard' with whiteboardId=NULL) throwing
+  // RelationshipNotFoundException must NOT abort the whole templatesSet cascade;
+  // healthy siblings + the templatesSet's own inherited auth must still be
+  // returned and the skip must be logged.
+  it('should skip a template that throws RelationshipNotFoundException and continue with healthy siblings', async () => {
+    const template1 = { id: 'tpl-1' } as any;
+    const template2 = { id: 'tpl-2' } as any;
+
+    templatesSetService.getTemplatesSetOrFail.mockResolvedValue({
+      id: 'ts-1',
+      authorization: { id: 'ts-auth' },
+      templates: [template1, template2],
+    } as any);
+
+    templateAuthorizationService.applyAuthorizationPolicy
+      .mockRejectedValueOnce(
+        new RelationshipNotFoundException('boom', LogContext.TEMPLATES)
+      )
+      .mockResolvedValueOnce([{ id: 'tpl-2-auth' } as any]);
+
+    const result = await service.applyAuthorizationPolicy(
+      { id: 'ts-1' } as ITemplatesSet,
+      parentAuth
+    );
+
+    // The healthy sibling + the templatesSet's own inherited auth are present.
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'ts-inherited-auth' }),
+        expect.objectContaining({ id: 'tpl-2-auth' }),
+      ])
+    );
+    // The broken template contributed nothing.
+    expect(result).toHaveLength(2);
+    // The skip was logged exactly once.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  // Same guarantee for the default:-branch anomaly (unknown template.type)
+  // which surfaces as EntityNotFoundException.
+  it('should skip a template that throws EntityNotFoundException and continue with healthy siblings', async () => {
+    const template1 = { id: 'tpl-1' } as any;
+    const template2 = { id: 'tpl-2' } as any;
+
+    templatesSetService.getTemplatesSetOrFail.mockResolvedValue({
+      id: 'ts-1',
+      authorization: { id: 'ts-auth' },
+      templates: [template1, template2],
+    } as any);
+
+    templateAuthorizationService.applyAuthorizationPolicy
+      .mockRejectedValueOnce(
+        new EntityNotFoundException('boom', LogContext.TEMPLATES)
+      )
+      .mockResolvedValueOnce([{ id: 'tpl-2-auth' } as any]);
+
+    const result = await service.applyAuthorizationPolicy(
+      { id: 'ts-1' } as ITemplatesSet,
+      parentAuth
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'ts-inherited-auth' }),
+        expect.objectContaining({ id: 'tpl-2-auth' }),
+      ])
+    );
+    expect(result).toHaveLength(2);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  // A non-anomaly error (e.g. a DB outage) must still propagate — resilience is
+  // scoped strictly to data-integrity anomalies.
+  it('should propagate unexpected (non-anomaly) errors', async () => {
+    const template1 = { id: 'tpl-1' } as any;
+
+    templatesSetService.getTemplatesSetOrFail.mockResolvedValue({
+      id: 'ts-1',
+      authorization: { id: 'ts-auth' },
+      templates: [template1],
+    } as any);
+
+    templateAuthorizationService.applyAuthorizationPolicy.mockRejectedValue(
+      new Error('db down')
+    );
+
+    await expect(
+      service.applyAuthorizationPolicy(
+        { id: 'ts-1' } as ITemplatesSet,
+        parentAuth
+      )
+    ).rejects.toThrow('db down');
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/src/domain/template/templates-set/templates.set.service.authorization.ts
+++ b/src/domain/template/templates-set/templates.set.service.authorization.ts
@@ -1,6 +1,12 @@
+import { LogContext } from '@common/enums';
+import {
+  EntityNotFoundException,
+  RelationshipNotFoundException,
+} from '@common/exceptions';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { TemplateAuthorizationService } from '../template/template.service.authorization';
 import { ITemplatesSet } from '.';
 import { TemplatesSetService } from './templates.set.service';
@@ -10,7 +16,9 @@ export class TemplatesSetAuthorizationService {
   constructor(
     private authorizationPolicyService: AuthorizationPolicyService,
     private templatesSetService: TemplatesSetService,
-    private templateAuthorizationService: TemplateAuthorizationService
+    private templateAuthorizationService: TemplateAuthorizationService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
   ) {}
 
   async applyAuthorizationPolicy(
@@ -38,16 +46,44 @@ export class TemplatesSetAuthorizationService {
 
     if (templatesSet.templates) {
       for (const template of templatesSet.templates) {
-        const templateAuthorizations =
-          await this.templateAuthorizationService.applyAuthorizationPolicy(
-            template,
-            // Ensure templates inherit from the TemplatesSet authorization, not the original parent.
-            // Previously this passed parentAuthorization directly which caused templates to miss
-            // the credential rules applied to the TemplatesSet, resulting in missing READ access
-            // (e.g. for Callout Template contributionDefaults - issue #8804).
-            templatesSet.authorization
-          );
-        updatedAuthorizations.push(...templateAuthorizations);
+        // Per-template containment: a single malformed template (e.g. a
+        // type='whiteboard' template with whiteboardId=NULL, or an unknown
+        // template.type) must not abort authorization for its healthy siblings.
+        // Data-integrity anomalies (RelationshipNotFoundException,
+        // EntityNotFoundException) are logged at error level with structured
+        // context and skipped; every other exception propagates so genuine
+        // failures aren't silently masked. See auth-reset regression where a
+        // single orphan template denied a whole Account's templates.
+        try {
+          const templateAuthorizations =
+            await this.templateAuthorizationService.applyAuthorizationPolicy(
+              template,
+              // Ensure templates inherit from the TemplatesSet authorization, not the original parent.
+              // Previously this passed parentAuthorization directly which caused templates to miss
+              // the credential rules applied to the TemplatesSet, resulting in missing READ access
+              // (e.g. for Callout Template contributionDefaults - issue #8804).
+              templatesSet.authorization
+            );
+          updatedAuthorizations.push(...templateAuthorizations);
+        } catch (err: unknown) {
+          if (
+            err instanceof RelationshipNotFoundException ||
+            err instanceof EntityNotFoundException
+          ) {
+            this.logger.error(
+              {
+                message: 'Auth-reset skipped template due to data anomaly',
+                templateId: template.id,
+                templatesSetId: templatesSet.id,
+                error: (err as Error).message,
+              },
+              (err as Error).stack,
+              LogContext.TEMPLATES
+            );
+            continue;
+          }
+          throw err;
+        }
       }
     }
 


### PR DESCRIPTION
## Symptom

Templates under an Account (the L0 space's `TemplatesManager`) became **unreadable by everyone — including Global Admin** after an authorization reset. The whole `templatesManager` subtree lost its credential rules and no one could read the account's templates.

## Root cause

Introduced by `fc00fd19c` (#6094). The failure chain:

1. `template.service.authorization.ts` `applyAuthorizationPolicy` throws `RelationshipNotFoundException` when a required sub-entity is missing — the canonical case being a `type='whiteboard'` template whose `whiteboardId` is `NULL` — and `EntityNotFoundException` in the `default:` branch for an unknown `template.type`.
2. The template loops in `templates.set.service.authorization.ts` and `templates.manager.service.authorization.ts` had **no per-item error containment**, so one throw bubbled up.
3. It bubbled to the space-level `resilientCascade` that wraps the **entire** `templatesManager` step in `space.service.authorization.ts`, which returns `[]` at whole-`templatesManager` granularity.
4. Persistence is build-in-memory-then-`saveAll` (`auth-reset.controller.ts`). Because the resilient step returned `[]`, the `templatesManager` + `templatesSet` + `templateDefaults` + **every healthy sibling template** were dropped from the save batch and never re-inherited the platform-root `GLOBAL_ADMIN` CRUD rule → inaccessible.

## Fix

Push the resilient boundary **down to the smallest safe unit**. Instead of the whole `templatesManager` being all-or-nothing, one malformed template is skipped-and-logged while healthy siblings still get authorization applied and persisted. This mirrors the existing `resilientCascade` helpers in `space.service.authorization.ts` and `account.service.authorization.ts`.

- **`templates.set.service.authorization.ts`** — each per-template `applyAuthorizationPolicy` call is wrapped in per-template containment inside the loop.
- **`templates.manager.service.authorization.ts`** — each per-`templateDefault` call and the single `templatesSet` call are wrapped in the same containment.

In every case, **only** `RelationshipNotFoundException` and `EntityNotFoundException` are caught, logged at error level with structured context (`LogContext.TEMPLATES`, ids in a structured object — no dynamic data inlined in the message, per Constitution §5), and skipped (`continue` / skip-push). **All other exceptions propagate** so genuine failures (DB outage, programmer error) are never silently masked. The top-level `RelationshipNotFoundException` guard in the manager is unchanged.

## Regression tests

- `templates.set.service.authorization.spec.ts` — a broken first template (`RelationshipNotFoundException`, and separately `EntityNotFoundException`) is skipped, the healthy sibling + the templatesSet's own inherited auth are still returned, and the skip is logged. Plus a test asserting a non-anomaly `Error` still propagates.
- `templates.manager.service.authorization.spec.ts` — a broken first `templateDefault` is skipped while the manager auth + healthy sibling + templatesSet auth survive and the skip is logged; a `templatesSet`-cascade `EntityNotFoundException` is skipped while the manager + both `templateDefaults` survive; and a non-anomaly `Error` still propagates. Existing tests (including the top-level guard) are unchanged.

## Defense-in-depth

The **space-level `resilientCascade` is intentionally left in place** as a second, coarser safety net — this fix narrows the boundary but does not remove the outer guard. Its regression test (`space.service.authorization.spec.ts`, "should skip templatesManager cascade and continue when L0 space is missing templatesManager") remains passing and untouched.

## Follow-up (out of scope)

**Data repair is intentionally NOT part of this PR.** The orphan rows that trigger the anomaly — `type='whiteboard'` templates with `whiteboardId=NULL`, and spaces with `NULL collaborationId` — should be repaired or removed separately via a maintenance script or migration to eliminate the trigger at the source. This PR makes the auth-reset resilient to such rows; it does not clean them up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authorization processing now continues for healthy templates when an individual template or template set contains missing or inconsistent relationship data.
  - Invalid entries are skipped instead of preventing inherited and sibling authorizations from being applied.
  - Unexpected errors, such as service or database failures, continue to be reported normally.

- **Diagnostics**
  - Data-integrity anomalies are now logged with relevant context to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->