### PR TITLE
fix(auth): align dev Kratos session lifespan with OIDC BFF ceiling (720h)

### DIFF
--- a/.build/ory/kratos/kratos.yml
+++ b/.build/ory/kratos/kratos.yml
@@ -197,8 +197,15 @@ selfservice:
             - hook: session
 
 session:
-  lifespan: 48h
-  earliest_possible_extend: 24h
+  # Align with the OIDC BFF session's ABSOLUTE ceiling (alkemio.yml
+  # absolute_ttl_s = 2592000s = 720h = 30d), NOT the 14d idle window: an
+  # actively-used alkemio_session slides its idle window forward on every
+  # /api/private/graphql call up to that 30d ceiling. Keeping the Kratos SSO
+  # session shorter let the header's whoami-based login indicator flip to
+  # "logged out" while the still-valid alkemio_session kept authorizing CRUD
+  # (client-web#9965). Mirrors the prod/infra base values (720h / 360h).
+  lifespan: 720h
+  earliest_possible_extend: 360h
 
 log:
   level: debug

--- a/.build/ory/kratos/kratos.yml
+++ b/.build/ory/kratos/kratos.yml
@@ -206,8 +206,8 @@ session:
   # the still-valid alkemio_session kept authorizing CRUD (client-web#9965).
   #
   # Note these are NOT a shared deadline. Kratos' lifespan is a rolling window
-  # with no absolute cap: once a session is older than earliest_possible_extend,
-  # the next /sessions/whoami renews it to now + lifespan, indefinitely. So a
+  # with no absolute cap: once a session is within earliest_possible_extend of
+  # expiring, the next /sessions/whoami can renew it to now + lifespan. So a
   # Kratos session can outlive the BFF's 30d cap — harmless, because the BFF
   # session is the authoritative gate for both API access and the login
   # indicator (client-web#10053); Kratos alone never reads as logged in.

--- a/.build/ory/kratos/kratos.yml
+++ b/.build/ory/kratos/kratos.yml
@@ -197,13 +197,21 @@ selfservice:
             - hook: session
 
 session:
-  # Align with the OIDC BFF session's ABSOLUTE ceiling (alkemio.yml
-  # absolute_ttl_s = 2592000s = 720h = 30d), NOT the 14d idle window: an
-  # actively-used alkemio_session slides its idle window forward on every
-  # /api/private/graphql call up to that 30d ceiling. Keeping the Kratos SSO
-  # session shorter let the header's whoami-based login indicator flip to
-  # "logged out" while the still-valid alkemio_session kept authorizing CRUD
-  # (client-web#9965). Mirrors the prod/infra base values (720h / 360h).
+  # Sized so the Kratos SSO session never dies BEFORE the OIDC BFF session.
+  # The reference point is the BFF's absolute cap (alkemio.yml absolute_ttl_s =
+  # 2592000s = 720h = 30d), not its 14d idle window: an actively-used
+  # alkemio_session slides that idle window forward on every
+  # /api/private/graphql call, up to the 30d cap. At 48h Kratos expired first,
+  # so the header's whoami-based login indicator flipped to "logged out" while
+  # the still-valid alkemio_session kept authorizing CRUD (client-web#9965).
+  #
+  # Note these are NOT a shared deadline. Kratos' lifespan is a rolling window
+  # with no absolute cap: once a session is older than earliest_possible_extend,
+  # the next /sessions/whoami renews it to now + lifespan, indefinitely. So a
+  # Kratos session can outlive the BFF's 30d cap — harmless, because the BFF
+  # session is the authoritative gate for both API access and the login
+  # indicator (client-web#10053); Kratos alone never reads as logged in.
+  # Mirrors the prod/infra base values (720h / 360h).
   lifespan: 720h
   earliest_possible_extend: 360h
 


### PR DESCRIPTION
## Context

Investigation of alkem-io/client-web#9965 (header shows Login while CRUD stays authorized).

Since the OIDC BFF migration there are two decoupled sessions: the Kratos SSO session (`ory_kratos_session`, consulted only by the client header via whoami) and the BFF `alkemio_session` (sole gate for `/api/private/graphql`, self-refreshing against Hydra, 14d idle / 30d absolute).

## Change

Local dev Kratos ran `session.lifespan: 48h` — far below the BFF ceiling — so the divergence reproduced trivially in dev. Align to the BFF **absolute** ceiling (an actively-used BFF session slides its idle window to 30d), matching the prod/infra base values (`720h` / `360h`, unchanged there since 2023).

Dev-parity/config only — the client-side fix for the reported indicator divergence is in the companion client-web PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended sign-in session duration to reduce unexpected session expiration.
  * Updated the session renewal eligibility window to improve consistency of authentication over long periods.
  * Clarified session timing behavior to better align sign-in session lifetime with the configured OIDC “absolute” TTL ceiling and Kratos rolling renewal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->