### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: 'Login into ACR'
         uses: azure/docker-login@v2
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -53,7 +53,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: azure/k8s-deploy@v5.0.0
+      - uses: azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/26-server-migration.yaml
@@ -76,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -98,7 +98,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy to k3s on Hetzner
-        uses: azure/k8s-deploy@v5.0.0
+        uses: azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-server-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: 'Login into ACR'
         uses: azure/docker-login@v2
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -47,7 +47,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: azure/k8s-deploy@v5.0.0
+      - uses: azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/26-server-migration.yaml
@@ -70,10 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -92,7 +92,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy to k3s on Hetzner
-        uses: azure/k8s-deploy@v5.0.0
+        uses: azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-server-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: 'Login into ACR'
         uses: azure/docker-login@v2
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6'
 
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -79,7 +79,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: azure/k8s-deploy@v5.0.0
+      - uses: azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/26-server-migration.yaml
@@ -102,10 +102,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -124,7 +124,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy to k3s on Hetzner
-        uses: azure/k8s-deploy@v5.0.0
+        uses: azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-server-deployment-dev.yaml
@@ -143,10 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.0
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6'
 

--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: alkemio/${{ github.event.repository.name }}
           tags: |
@@ -21,18 +21,18 @@ jobs:
             type=semver,pattern=v{{major}}
             type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           dest: ${{ runner.temp }}/setup-pnpm
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,15 +18,15 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=4096"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.22.0'
           cache: 'pnpm'
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage-ci/
@@ -54,18 +54,18 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, apple-silicon, m4]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage
           path: coverage-ci/
 
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@v7
+        uses: sonarsource/sonarqube-scan-action@v8
         continue-on-error: true
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     # 1. Checkout the repository code
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         # Fetch depth 0 is important to get the base branch reference for diffing
         fetch-depth: 0
@@ -69,7 +69,7 @@ jobs:
     # 5b. Determine whether the review label changed
     - name: Determine Review Label State
       id: review_label_state
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -106,7 +106,7 @@ jobs:
     # 6. Post Metrics Comment
     - name: Post Metrics Comment
       if: steps.review_label_state.outputs.label_changed == 'true'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -161,7 +161,7 @@ jobs:
     # 7. Add Label Based on Review Type
     - name: Add Review Type Label
       if: steps.review_label_state.outputs.label_changed == 'true'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/schema-baseline.yml
+++ b/.github/workflows/schema-baseline.yml
@@ -22,7 +22,7 @@ jobs:
       SCHEMA_BOOTSTRAP_LIGHT: '1'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -34,12 +34,12 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.22.0'
           cache: 'pnpm'
@@ -112,7 +112,7 @@ jobs:
       - name: Import automation signing key
         if: steps.publish.outputs.baseline_changed == 'true'
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_GPG_PASSPHRASE }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Open pull request
         if: env.BASELINE_PR_BRANCH != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           BASELINE_PR_BRANCH: ${{ env.BASELINE_PR_BRANCH }}
         with:
@@ -223,7 +223,7 @@ jobs:
             core.exportVariable('BASELINE_FAILURE_PHASE', 'complete');
       - name: Upload baseline artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: schema-baseline-${{ github.run_id }}
           path: |
@@ -250,7 +250,7 @@ jobs:
 
       - name: Notify CODEOWNERS of failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/schema-baseline.yml
+++ b/.github/workflows/schema-baseline.yml
@@ -34,7 +34,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           dest: ${{ runner.temp }}/setup-pnpm
 

--- a/.github/workflows/schema-contract.yml
+++ b/.github/workflows/schema-contract.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0 # need full metadata for label-based baseline detection
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           dest: ${{ runner.temp }}/setup-pnpm
 

--- a/.github/workflows/schema-contract.yml
+++ b/.github/workflows/schema-contract.yml
@@ -24,17 +24,17 @@ jobs:
       SCHEMA_OVERRIDE_CODEOWNERS_PATH: '.github/CODEOWNERS'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # need full metadata for label-based baseline detection
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.22.0'
           cache: 'pnpm'
@@ -45,7 +45,7 @@ jobs:
       - name: Collect schema override reviews
         if: github.event_name == 'pull_request'
         id: collect_reviews
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           result-encoding: string
           script: |
@@ -189,7 +189,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: schema-artifacts
           path: |
@@ -203,7 +203,7 @@ jobs:
 
       - name: Post sticky PR comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: schema-contract
           message: ${{ steps.pr_comment.outputs.body }}


### PR DESCRIPTION
Bump GitHub Actions to latest releases (org-wide actions audit, 2026-07-21).

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4 v4.1.7 v6 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/github-script` | v7 | v9 |
| `actions/setup-node` | v6.2.0 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `azure/k8s-deploy` | v5.0.0 | v7.0.0 |
| `azure/setup-kubectl` | v4.0.0 | v5.1.0 |
| `crazy-max/ghaction-import-gpg` | v6 | v7 |
| `docker/build-push-action` | v5 | v7 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `marocchino/sticky-pull-request-comment` | v2 | v3 |
| `pnpm/action-setup` | v4 | v4 (held — v6 breaks on ARM self-hosted runners; re-bump after runner images gain libatomic1/Node ≥ 22.13) |
| `sonarsource/sonarqube-scan-action` | v7 | v8 |

Compatibility: all `with:` inputs validated against each action's schema at the target version; bumped actions run on node24 (GitHub-hosted runners OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Note:** `pnpm/action-setup` deliberately held at v4 — v6 fails on both self-hosted ARM fleets (ARC image missing `libatomic.so.1`; macOS M4 installer chain). Re-bump once runner images are fixed.
