### PR TITLE
Feat/030 Move subspaces (conversion and promotion)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4207,6 +4207,10 @@ type Mutation {
   Move an L1 subspace to become an L2 sub-subspace under a target L1 in a different L0 space.       The space is demoted from level 1 to level 2. All community roles are cleared.       Requires platform admin privileges.
   """
   moveSpaceL1ToSpaceL2(moveData: MoveSpaceL1ToSpaceL2Input!): Space!
+  """
+  Move an L2 sub-subspace to become an L2 subspace under a target L1 in a different L0 space.       The subspace stays at level 2 but changes both its parent L1 and its top-level L0.       All community roles (including admins) are cleared and pending invitations dropped.       Platform access rules are recomputed from the new parent hierarchy.       Requires platform admin privileges.
+  """
+  moveSpaceL2ToSpaceL1(moveData: MoveSpaceL2ToSpaceL1Input!): Space!
   """Refresh the Bodies of Knowledge on All VCs"""
   refreshAllBodiesOfKnowledge: Boolean!
   """
@@ -8406,6 +8410,21 @@ input MoveSpaceL1ToSpaceL2Input {
   spaceL1ID: UUID!
   """
   The target L1 subspace in a different L0 (new parent for the demoted space).
+  """
+  targetSpaceL1ID: UUID!
+}
+
+input MoveSpaceL2ToSpaceL1Input {
+  """
+  Send invitations to former community members who are also in the target L0 community.
+  """
+  autoInvite: Boolean = false
+  """Custom invitation message. Used only when autoInvite is true."""
+  invitationMessage: String
+  """The L2 subspace to move (stays L2)."""
+  spaceL2ID: UUID!
+  """
+  The target L1 subspace in a different L0 (new parent for the moved L2).
   """
   targetSpaceL1ID: UUID!
 }

--- a/src/domain/common/classification/classification.service.ts
+++ b/src/domain/common/classification/classification.service.ts
@@ -14,7 +14,7 @@ import { TagsetService } from '@domain/common/tagset/tagset.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, Repository } from 'typeorm';
+import { EntityManager, FindOneOptions, Repository } from 'typeorm';
 import { CreateTagsetInput } from '../tagset';
 import { ITagsetTemplate } from '../tagset-template/tagset.template.interface';
 import { CreateClassificationInput } from './dto/classification.dto.create';
@@ -104,7 +104,8 @@ export class ClassificationService {
 
   public async addTagsetOnClassification(
     classification: IClassification,
-    tagsetData: CreateTagsetInput
+    tagsetData: CreateTagsetInput,
+    mgr?: EntityManager
   ): Promise<ITagset> {
     if (!classification.tagsets) {
       classification.tagsets = await this.getTagsets(classification.id);
@@ -115,7 +116,7 @@ export class ClassificationService {
       tagsetData
     );
     tagset.classification = classification;
-    return await this.tagsetService.save(tagset);
+    return await this.tagsetService.save(tagset, mgr);
   }
 
   async getClassificationOrFail(
@@ -192,7 +193,8 @@ export class ClassificationService {
 
   async updateTagsetTemplateOnSelectTagset(
     classificationID: string,
-    tagsetTemplate: ITagsetTemplate
+    tagsetTemplate: ITagsetTemplate,
+    mgr?: EntityManager
   ): Promise<ITagset> {
     const tagsets = await this.getTagsets(classificationID);
     const existingTagset = this.tagsetService.getTagsetByName(
@@ -213,18 +215,22 @@ export class ClassificationService {
         currentValue != null &&
         tagsetTemplate.allowedValues?.includes(currentValue);
       existingTagset.tags = isCurrentValueValid ? [currentValue] : defaultTags;
-      return await this.tagsetService.save(existingTagset);
+      return await this.tagsetService.save(existingTagset, mgr);
     }
 
     // Target callouts set has a template not present in the source classification;
     // create a new tagset for it
     const classification = await this.getClassificationOrFail(classificationID);
-    return await this.addTagsetOnClassification(classification, {
-      name: tagsetTemplate.name,
-      type: tagsetTemplate.type,
-      tags: defaultTags,
-      tagsetTemplate,
-    });
+    return await this.addTagsetOnClassification(
+      classification,
+      {
+        name: tagsetTemplate.name,
+        type: tagsetTemplate.type,
+        tags: defaultTags,
+        tagsetTemplate,
+      },
+      mgr
+    );
   }
 
   // Note: provided data has priority when it comes to tags

--- a/src/domain/common/tagset/tagset.service.ts
+++ b/src/domain/common/tagset/tagset.service.ts
@@ -14,7 +14,7 @@ import { UpdateTagsetInput } from '@domain/common/tagset/dto/tagset.dto.update';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { FindOneOptions, Repository } from 'typeorm';
+import { EntityManager, FindOneOptions, Repository } from 'typeorm';
 import { AuthorizationPolicyService } from '../authorization-policy/authorization.policy.service';
 import { ITagsetTemplate } from '../tagset-template';
 import { Tagset } from './tagset.entity';
@@ -280,7 +280,10 @@ export class TagsetService {
     return this.createTagset(tagsetData);
   }
 
-  async save(tagset: ITagset): Promise<ITagset> {
+  async save(tagset: ITagset, mgr?: EntityManager): Promise<ITagset> {
+    if (mgr) {
+      return await mgr.save(Tagset, tagset as Tagset);
+    }
     return await this.tagsetRepository.save(tagset);
   }
 

--- a/src/services/api/conversion/conversion.resolver.mutations.spec.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.spec.ts
@@ -297,4 +297,176 @@ describe('ConversionResolverMutations', () => {
       ).rejects.toThrow();
     });
   });
+
+  // ── moveSpaceL2ToSpaceL1 (T006: S7–S10) ──────────────────────────
+
+  describe('moveSpaceL2ToSpaceL1', () => {
+    // Convenience setup: wires up all the service mocks needed for the happy path
+    const setupMoveL2L1HappyPath = (
+      platformRolesAccessFromTarget = { roles: ['REGISTERED'] }
+    ) => {
+      const savedSpaceId = 'saved-l2-space';
+      const movedSpace = {
+        id: savedSpaceId,
+        levelZeroSpaceID: 'target-l0',
+        platformRolesAccess: { roles: [] }, // old value before recompute
+      };
+      const savedSpace = { ...movedSpace };
+      const targetParentL1 = {
+        id: 'target-l1',
+        platformRolesAccess: platformRolesAccessFromTarget,
+      };
+
+      authorizationService.grantAccessOrFail.mockReturnValue(undefined);
+      (conversionService as any).moveSpaceL2ToSpaceL1OrFail.mockResolvedValue({
+        space: movedSpace,
+        removedActorIds: ['actor-removed'],
+      });
+      spaceService.save.mockResolvedValue(savedSpace);
+      // Call sequence for getSpaceOrFail:
+      // 1. targetParentL1 — for updatePlatformRolesAccessRecursively
+      // 2. subspace with parentSpace.authorization — for getParentSpaceAuthorization
+      // 3. final return
+      spaceService.getSpaceOrFail
+        .mockResolvedValueOnce(targetParentL1)
+        .mockResolvedValueOnce({
+          id: savedSpaceId,
+          parentSpace: { authorization: { id: 'parent-auth' } },
+        })
+        .mockResolvedValue({ id: savedSpaceId });
+      (spaceService as any).updatePlatformRolesAccessRecursively = vi
+        .fn()
+        .mockImplementation(async (space: any, parentAccess: any) => {
+          space.platformRolesAccess = parentAccess;
+          return space;
+        });
+      spaceAuthorizationService.applyAuthorizationPolicy.mockResolvedValue([]);
+      authorizationPolicyService.saveAll.mockResolvedValue(undefined);
+      (conversionService as any).invalidateUrlCachesForSubtree = vi
+        .fn()
+        .mockResolvedValue(undefined);
+      (conversionService as any).moveRoomsService = {
+        handleRoomsDuringMove: vi.fn().mockResolvedValue(undefined),
+      };
+      (conversionService as any).dispatchAutoInvitesAfterMove = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      return { movedSpace, savedSpace, targetParentL1 };
+    };
+
+    // S9 — non-PLATFORM_ADMIN rejected before any service call
+    it('should reject non-PLATFORM_ADMIN before any service call (S9)', async () => {
+      authorizationService.grantAccessOrFail.mockImplementation(() => {
+        throw new Error('Unauthorized');
+      });
+
+      await expect(
+        resolver.moveSpaceL2ToSpaceL1(actorContext, {
+          spaceL2ID: 'space-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow('Unauthorized');
+
+      expect(
+        (conversionService as any).moveSpaceL2ToSpaceL1OrFail
+      ).not.toHaveBeenCalled();
+    });
+
+    // S7 (R-1/R-5 pattern): recompute assertion —
+    // updatePlatformRolesAccessRecursively called with the moved space +
+    // the TARGET parent's platformRolesAccess BEFORE applyAuthorizationPolicy,
+    // and the space's platform-READ access equals the value recomputed from
+    // the target chain — assert the VALUE, not just the call.
+    it('should recompute platformRolesAccess from target parent BEFORE applyAuthorizationPolicy (S7/R-1)', async () => {
+      const targetPlatformAccess = { roles: ['REGISTERED', 'ANONYMOUS'] };
+      const { movedSpace } = setupMoveL2L1HappyPath(targetPlatformAccess);
+
+      await resolver.moveSpaceL2ToSpaceL1(actorContext, {
+        spaceL2ID: 'space-l2',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      // Assert updatePlatformRolesAccessRecursively called with the moved space
+      // and the target parent's platformRolesAccess
+      expect(
+        (spaceService as any).updatePlatformRolesAccessRecursively
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ id: movedSpace.id }),
+        targetPlatformAccess
+      );
+
+      // Assert the call order: recompute BEFORE applyAuthorizationPolicy
+      const recomputeOrder = (spaceService as any)
+        .updatePlatformRolesAccessRecursively.mock.invocationCallOrder[0];
+      const authPolicyOrder =
+        spaceAuthorizationService.applyAuthorizationPolicy.mock
+          .invocationCallOrder[0];
+      expect(recomputeOrder).toBeLessThan(authPolicyOrder);
+
+      // Assert the VALUE (S7): the second argument to the recompute call is
+      // exactly the target parent's platformRolesAccess (not a copy, the same ref).
+      const recomputeCallArgs = (spaceService as any)
+        .updatePlatformRolesAccessRecursively.mock.calls[0];
+      expect(recomputeCallArgs[1]).toBe(targetPlatformAccess);
+    });
+
+    // S8 (FR-013): handleRoomsDuringMove invoked post-commit; rejection
+    // neither throws nor rolls back the move
+    it('should call handleRoomsDuringMove post-commit; its rejection does not throw (S8/FR-013)', async () => {
+      setupMoveL2L1HappyPath();
+      (conversionService as any).moveRoomsService.handleRoomsDuringMove = vi
+        .fn()
+        .mockRejectedValue(new Error('Matrix unavailable'));
+
+      // Should NOT throw even though rooms service fails
+      await expect(
+        resolver.moveSpaceL2ToSpaceL1(actorContext, {
+          spaceL2ID: 'space-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).resolves.toBeDefined();
+
+      expect(
+        (conversionService as any).moveRoomsService.handleRoomsDuringMove
+      ).toHaveBeenCalledWith('saved-l2-space', ['actor-removed']);
+    });
+
+    // S10 (US4 server proof): autoInvite on → dispatchAutoInvitesAfterMove
+    // called with exact args; off → not called
+    it('autoInvite on → dispatchAutoInvitesAfterMove called with exact args (S10)', async () => {
+      setupMoveL2L1HappyPath();
+
+      await resolver.moveSpaceL2ToSpaceL1(actorContext, {
+        spaceL2ID: 'space-l2',
+        targetSpaceL1ID: 'target-l1',
+        autoInvite: true,
+        invitationMessage: 'Welcome back!',
+      });
+
+      expect(
+        (conversionService as any).dispatchAutoInvitesAfterMove
+      ).toHaveBeenCalledWith(
+        ['actor-removed'],
+        'target-l0',
+        'saved-l2-space',
+        actorContext.actorID,
+        'Welcome back!'
+      );
+    });
+
+    it('autoInvite off → dispatchAutoInvitesAfterMove NOT called (S10)', async () => {
+      setupMoveL2L1HappyPath();
+
+      await resolver.moveSpaceL2ToSpaceL1(actorContext, {
+        spaceL2ID: 'space-l2',
+        targetSpaceL1ID: 'target-l1',
+        autoInvite: false,
+      });
+
+      expect(
+        (conversionService as any).dispatchAutoInvitesAfterMove
+      ).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/api/conversion/conversion.resolver.mutations.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.ts
@@ -33,6 +33,7 @@ import { ConvertSpaceL1ToSpaceL2Input } from './dto/convert.dto.space.l1.to.spac
 import { ConvertSpaceL2ToSpaceL1Input } from './dto/convert.dto.space.l2.to.space.l1.input';
 import { MoveSpaceL1ToSpaceL0Input } from './dto/move.dto.space.l1.to.space.l0.input';
 import { MoveSpaceL1ToSpaceL2Input } from './dto/move.dto.space.l1.to.space.l2.input';
+import { MoveSpaceL2ToSpaceL1Input } from './dto/move.dto.space.l2.to.space.l1.input';
 
 @InstrumentResolver()
 @Resolver()
@@ -239,6 +240,68 @@ export class ConversionResolverMutations {
     const { space, removedActorIds } =
       await this.conversionService.moveSpaceL1ToSpaceL2OrFail(moveData);
     const savedSpace = await this.spaceService.save(space);
+
+    const parentAuthorization = await this.getParentSpaceAuthorization(
+      savedSpace.id
+    );
+    const updatedAuthorizations =
+      await this.spaceAuthorizationService.applyAuthorizationPolicy(
+        savedSpace.id,
+        parentAuthorization
+      );
+    await this.authorizationPolicyService.saveAll(updatedAuthorizations);
+
+    // Post-commit: fire-and-forget
+    await this.conversionService.invalidateUrlCachesForSubtree(savedSpace.id);
+    void this.conversionService.moveRoomsService.handleRoomsDuringMove(
+      savedSpace.id,
+      removedActorIds
+    );
+    if (moveData.autoInvite) {
+      void this.conversionService.dispatchAutoInvitesAfterMove(
+        removedActorIds,
+        savedSpace.levelZeroSpaceID,
+        savedSpace.id,
+        actorContext.actorID,
+        moveData.invitationMessage
+      );
+    }
+
+    return this.spaceService.getSpaceOrFail(savedSpace.id);
+  }
+
+  @Mutation(() => ISpace, {
+    description:
+      'Move an L2 sub-subspace to become an L2 subspace under a target L1 in a different L0 space. \
+      The subspace stays at level 2 but changes both its parent L1 and its top-level L0. \
+      All community roles (including admins) are cleared and pending invitations dropped. \
+      Platform access rules are recomputed from the new parent hierarchy. \
+      Requires platform admin privileges.',
+  })
+  async moveSpaceL2ToSpaceL1(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('moveData') moveData: MoveSpaceL2ToSpaceL1Input
+  ): Promise<ISpace> {
+    this.authorizationService.grantAccessOrFail(
+      actorContext,
+      this.authorizationGlobalAdminPolicy,
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      `move space L2 to L1 in different L0: ${actorContext.actorID}`
+    );
+
+    const { space, removedActorIds } =
+      await this.conversionService.moveSpaceL2ToSpaceL1OrFail(moveData);
+    const savedSpace = await this.spaceService.save(space);
+
+    // S7 (R-1): recompute platform-level access from the NEW parent hierarchy
+    // BEFORE the authorization policy is re-applied.
+    const targetParentL1 = await this.spaceService.getSpaceOrFail(
+      moveData.targetSpaceL1ID
+    );
+    await this.spaceService.updatePlatformRolesAccessRecursively(
+      savedSpace,
+      targetParentL1.platformRolesAccess
+    );
 
     const parentAuthorization = await this.getParentSpaceAuthorization(
       savedSpace.id

--- a/src/services/api/conversion/conversion.service.move.rollback.spec.ts
+++ b/src/services/api/conversion/conversion.service.move.rollback.spec.ts
@@ -1,0 +1,342 @@
+/**
+ * T005 — Mandatory rollback it-spec for moveSpaceL2ToSpaceL1OrFail.
+ *
+ * TDD evidence (intake gate): this spec is committed against the naive-clone
+ * (stage-1) commit so it is DEMONSTRABLY RED. It turns GREEN only after the
+ * transaction is wrapped in stage 2.
+ *
+ * Invariants asserted (INV-5 field list):
+ *   - parentSpace
+ *   - levelZeroSpaceID
+ *   - sortOrder
+ *   - roleSet parent (setParentRoleSetAndCredentials)
+ *   - storageAggregator parent
+ *
+ * Also asserts:
+ *   - Error propagates out of moveSpaceL2ToSpaceL1OrFail
+ *   - post-commit tail (license assignment, activity removal) NOT reached
+ *   - Community roles are intact after a mid-transaction failure (sec-server-1)
+ *   - Tagset saves go through mgr, not the global manager, when tx fails
+ *     (corr-server-1: non-empty tagsetTemplates path)
+ */
+
+import { SpaceLevel } from '@common/enums/space.level';
+import { RoleSetService } from '@domain/access/role-set/role.set.service';
+import { CalloutsSetService } from '@domain/collaboration/callouts-set/callouts.set.service';
+import { ClassificationService } from '@domain/common/classification/classification.service';
+import { AccountHostService } from '@domain/space/account.host/account.host.service';
+import { SpaceService } from '@domain/space/space/space.service';
+import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ActivityService } from '@platform/activity/activity.service';
+import { NamingService } from '@services/infrastructure/naming/naming.service';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { EntityManager } from 'typeorm';
+import { type Mock, vi } from 'vitest';
+import { ConversionService } from './conversion.service';
+
+describe('moveSpaceL2ToSpaceL1OrFail — rollback proof (INV-5)', () => {
+  let service: ConversionService;
+  let spaceService: Record<string, Mock>;
+  let roleSetService: Record<string, Mock>;
+  let namingService: Record<string, Mock>;
+  let entityManager: Record<string, Mock>;
+  let spaceLookupService: Record<string, Mock>;
+  let calloutsSetService: Record<string, Mock>;
+  let classificationService: Record<string, Mock>;
+  let activityService: Record<string, Mock>;
+  let accountHostService: Record<string, Mock>;
+
+  const makeSourceL2 = (overrides: Record<string, unknown> = {}) => ({
+    id: 'source-l2',
+    level: SpaceLevel.L2,
+    levelZeroSpaceID: 'source-l0',
+    nameID: 'source-l2-space',
+    sortOrder: 3,
+    parentSpace: { id: 'source-l1' },
+    community: { roleSet: { id: 'roleset-l2' } },
+    storageAggregator: { id: 'sa-l2', parentStorageAggregator: null },
+    subspaces: [],
+    ...overrides,
+  });
+
+  const makeTargetL1 = (overrides: Record<string, unknown> = {}) => ({
+    id: 'target-l1',
+    level: SpaceLevel.L1,
+    levelZeroSpaceID: 'target-l0',
+    community: { roleSet: { id: 'roleset-target-l1' } },
+    storageAggregator: { id: 'sa-target-l1' },
+    subspaces: [],
+    ...overrides,
+  });
+
+  const makeTargetL0 = (overrides: Record<string, unknown> = {}) => ({
+    id: 'target-l0',
+    level: SpaceLevel.L0,
+    levelZeroSpaceID: 'target-l0',
+    account: { id: 'account-target', accountType: 'BASIC' },
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ConversionService, MockWinstonProvider],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+
+    service = module.get(ConversionService);
+    spaceService = module.get(SpaceService) as unknown as Record<string, Mock>;
+    roleSetService = module.get(RoleSetService) as unknown as Record<
+      string,
+      Mock
+    >;
+    namingService = module.get(NamingService) as unknown as Record<
+      string,
+      Mock
+    >;
+    entityManager = module.get(EntityManager) as unknown as Record<
+      string,
+      Mock
+    >;
+    spaceLookupService = module.get(SpaceLookupService) as unknown as Record<
+      string,
+      Mock
+    >;
+    calloutsSetService = module.get(CalloutsSetService) as unknown as Record<
+      string,
+      Mock
+    >;
+    classificationService = module.get(
+      ClassificationService
+    ) as unknown as Record<string, Mock>;
+    activityService = module.get(ActivityService) as unknown as Record<
+      string,
+      Mock
+    >;
+    accountHostService = module.get(AccountHostService) as unknown as Record<
+      string,
+      Mock
+    >;
+  });
+
+  /**
+   * Builds a mock entityManager.transaction that:
+   *   1. Invokes the callback with a tracked `mgr` (spy object).
+   *   2. Throws AFTER the sortOrder shift ran (mid-transaction failure).
+   *   3. Records all calls on `mgr` so we can assert none escaped.
+   */
+  const buildFailingTransactionManager = () => {
+    const mgrSave = vi.fn().mockRejectedValue(new Error('DB write failed'));
+    const mgrQb = {
+      update: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+    const mgr = {
+      save: mgrSave,
+      createQueryBuilder: vi.fn().mockReturnValue(mgrQb),
+      find: vi.fn().mockResolvedValue([]),
+    };
+
+    // transaction invokes the callback then throws when mgr.save rejects
+    vi.mocked(entityManager.transaction).mockImplementation(
+      async (callback: (mgr: unknown) => Promise<unknown>) => {
+        return callback(mgr);
+      }
+    );
+
+    return { mgr, mgrSave, mgrQb };
+  };
+
+  const setupPreTransactionMocks = () => {
+    // roles — empty community
+    vi.mocked(roleSetService.getUsersWithRole).mockResolvedValue([]);
+    vi.mocked(roleSetService.getOrganizationsWithRole).mockResolvedValue([]);
+    vi.mocked(roleSetService.getVirtualContributorsWithRole).mockResolvedValue(
+      []
+    );
+    vi.mocked(
+      namingService.getReservedNameIDsInLevelZeroSpace
+    ).mockResolvedValue([]);
+    vi.mocked(entityManager.find).mockResolvedValue([
+      { id: 'source-l2', nameID: 'source-l2-space' },
+    ]);
+    vi.mocked(spaceLookupService.getAllDescendantSpaceIDs).mockResolvedValue(
+      []
+    );
+    vi.mocked(roleSetService.setParentRoleSetAndCredentials).mockResolvedValue({
+      id: 'roleset-l2',
+    });
+    vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
+      tagsetTemplates: [],
+    });
+  };
+
+  it('(TDD-RED against naive clone) error propagates out when mid-tx write fails', async () => {
+    vi.mocked(spaceService.getSpaceOrFail)
+      .mockResolvedValueOnce(makeSourceL2())
+      .mockResolvedValueOnce(makeTargetL1())
+      .mockResolvedValueOnce(makeTargetL0());
+    setupPreTransactionMocks();
+    buildFailingTransactionManager();
+
+    await expect(
+      service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      })
+    ).rejects.toThrow('DB write failed');
+  });
+
+  it('(TDD-RED against naive clone) post-commit tail not reached when tx fails', async () => {
+    vi.mocked(spaceService.getSpaceOrFail)
+      .mockResolvedValueOnce(makeSourceL2())
+      .mockResolvedValueOnce(makeTargetL1())
+      .mockResolvedValueOnce(makeTargetL0());
+    setupPreTransactionMocks();
+    buildFailingTransactionManager();
+
+    await expect(
+      service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      })
+    ).rejects.toThrow();
+
+    // license and activity tail must NOT be reached after a tx failure
+    expect(accountHostService.assignLicensePlansToSpace).not.toHaveBeenCalled();
+    expect(
+      activityService.removeSubspaceCreatedActivityForResource
+    ).not.toHaveBeenCalled();
+  });
+
+  it('(TDD-RED against naive clone) structural writes go through mgr, not global entityManager', async () => {
+    vi.mocked(spaceService.getSpaceOrFail)
+      .mockResolvedValueOnce(makeSourceL2())
+      .mockResolvedValueOnce(makeTargetL1())
+      .mockResolvedValueOnce(makeTargetL0());
+    setupPreTransactionMocks();
+    const { mgr } = buildFailingTransactionManager();
+
+    await expect(
+      service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      })
+    ).rejects.toThrow();
+
+    // The transactional mgr.save should have been called (attempted)
+    // If structural writes were OUTSIDE the tx (naive clone), this assertion
+    // would PASS even without a transaction. The key test is that
+    // spaceService.save (the global path) was NOT used for the structural save.
+    expect(spaceService.save).not.toHaveBeenCalled();
+    // The sort-order shift must go through mgr.createQueryBuilder, not the
+    // global entityManager.createQueryBuilder
+    expect(mgr.createQueryBuilder).toHaveBeenCalled();
+  });
+
+  /**
+   * sec-server-1: Community roles MUST remain intact when the structural
+   * transaction rolls back. Previously the role wipe ran BEFORE the transaction,
+   * so a mid-tx failure left the community permanently destroyed.
+   * After the fix (reorder: transaction first, role-wipe after commit) a failed
+   * transaction must not call removeActorFromRole or removePendingInvitations.
+   */
+  it('community roles not cleared when mid-tx failure rolls back structure (sec-server-1)', async () => {
+    // Give the source L2 an admin so the pre-fix path would call removeActorFromRole
+    vi.mocked(spaceService.getSpaceOrFail)
+      .mockResolvedValueOnce(makeSourceL2())
+      .mockResolvedValueOnce(makeTargetL1())
+      .mockResolvedValueOnce(makeTargetL0());
+    setupPreTransactionMocks();
+    // Simulate one user admin to prove removeActorFromRole is never called
+    vi.mocked(roleSetService.getUsersWithRole)
+      .mockResolvedValueOnce([]) // members
+      .mockResolvedValueOnce([]) // leads
+      .mockResolvedValueOnce([{ id: 'admin-user-1' }]); // admins
+    buildFailingTransactionManager();
+
+    await expect(
+      service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      })
+    ).rejects.toThrow('DB write failed');
+
+    // CRITICAL: role wipe must NOT have run — structure rolled back atomically
+    expect(roleSetService.removeActorFromRole).not.toHaveBeenCalled();
+    expect(
+      roleSetService.removePendingInvitationsAndApplications
+    ).not.toHaveBeenCalled();
+  });
+
+  /**
+   * corr-server-1: Tagset saves must go through mgr (transactional) when
+   * syncInnovationFlowTagsetsForSubtree runs inside the transaction. Previously
+   * it called classificationService.updateTagsetTemplateOnSelectTagset with no
+   * mgr, so saves went to the global manager and escaped the rollback.
+   * After the fix, classificationService.updateTagsetTemplateOnSelectTagset is
+   * called WITH mgr so writes are enrolled in the transaction.
+   */
+  it('tagset sync is called with transactional mgr when tagsetTemplates are non-empty (corr-server-1)', async () => {
+    const tagsetTemplate = {
+      id: 'tt-1',
+      name: 'phase',
+      type: 'SELECT_ONE',
+      allowedValues: ['Explore', 'Prototype'],
+      defaultSelectedValue: 'Explore',
+    };
+
+    // The space returned from the sync's getSpaceOrFail call (4th overall)
+    const spaceWithClassifiedCallout = {
+      id: 'source-l2',
+      collaboration: {
+        calloutsSet: {
+          id: 'callouts-set-1',
+          callouts: [
+            {
+              id: 'callout-1',
+              classification: { id: 'classification-1' },
+            },
+          ],
+        },
+      },
+    };
+
+    vi.mocked(spaceService.getSpaceOrFail)
+      .mockResolvedValueOnce(makeSourceL2()) // step 1: load source L2
+      .mockResolvedValueOnce(makeTargetL1()) // step 2: load target L1
+      .mockResolvedValueOnce(makeTargetL0()) // step 3: load target L0
+      .mockResolvedValueOnce(spaceWithClassifiedCallout); // step 4: sync loop
+
+    setupPreTransactionMocks();
+    // Override tagsetTemplates to be non-empty so the sync body runs
+    vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
+      tagsetTemplates: [tagsetTemplate],
+    });
+    vi.mocked(
+      classificationService.updateTagsetTemplateOnSelectTagset
+    ).mockResolvedValue({ id: 'tagset-1', name: 'phase', tags: ['Explore'] });
+
+    const { mgr } = buildFailingTransactionManager();
+
+    await expect(
+      service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      })
+    ).rejects.toThrow('DB write failed');
+
+    // classificationService.updateTagsetTemplateOnSelectTagset must have been
+    // called WITH the transactional mgr as third argument — this proves the
+    // tagset saves are enrolled in the transaction (not escaping to global manager).
+    expect(
+      classificationService.updateTagsetTemplateOnSelectTagset
+    ).toHaveBeenCalledWith('classification-1', tagsetTemplate, mgr);
+  });
+});

--- a/src/services/api/conversion/conversion.service.move.spec.ts
+++ b/src/services/api/conversion/conversion.service.move.spec.ts
@@ -662,4 +662,315 @@ describe('ConversionService — Cross-L0 Moves', () => {
       );
     });
   });
+
+  // ── moveSpaceL2ToSpaceL1OrFail ──────────────────────────────────
+
+  describe('moveSpaceL2ToSpaceL1OrFail', () => {
+    const makeSourceL2 = (overrides: Record<string, unknown> = {}) => ({
+      id: 'source-l2',
+      level: SpaceLevel.L2,
+      levelZeroSpaceID: 'source-l0',
+      nameID: 'source-l2-space',
+      sortOrder: 3,
+      parentSpace: { id: 'source-l1' },
+      community: { roleSet: { id: 'roleset-l2' } },
+      storageAggregator: { id: 'sa-l2', parentStorageAggregator: null },
+      subspaces: [],
+      ...overrides,
+    });
+
+    const makeTargetL2L1 = (overrides: Record<string, unknown> = {}) => ({
+      id: 'target-l1',
+      level: SpaceLevel.L1,
+      levelZeroSpaceID: 'target-l0',
+      community: { roleSet: { id: 'roleset-target-l1' } },
+      storageAggregator: { id: 'sa-target-l1' },
+      subspaces: [],
+      ...overrides,
+    });
+
+    const makeTargetL2L0 = (overrides: Record<string, unknown> = {}) => ({
+      id: 'target-l0',
+      level: SpaceLevel.L0,
+      levelZeroSpaceID: 'target-l0',
+      community: { roleSet: { id: 'roleset-target-l0' } },
+      storageAggregator: { id: 'sa-target-l0' },
+      account: { id: 'account-target', accountType: 'BASIC' },
+      ...overrides,
+    });
+
+    const setupL2HappyPathMocks = () => {
+      vi.mocked(roleSetService.getUsersWithRole).mockResolvedValue([]);
+      vi.mocked(roleSetService.getOrganizationsWithRole).mockResolvedValue([]);
+      vi.mocked(
+        roleSetService.getVirtualContributorsWithRole
+      ).mockResolvedValue([]);
+      vi.mocked(
+        namingService.getReservedNameIDsInLevelZeroSpace
+      ).mockResolvedValue([]);
+      vi.mocked(entityManager.find).mockResolvedValue([
+        { id: 'source-l2', nameID: 'source-l2-space' },
+      ]);
+      // transaction: invoke callback with a mocked mgr
+      const mgrQb = {
+        update: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue(undefined),
+      };
+      const mgr = {
+        save: vi.fn().mockImplementation(async (s: unknown) => s),
+        createQueryBuilder: vi.fn().mockReturnValue(mgrQb),
+        find: vi.fn().mockResolvedValue([]),
+      };
+      vi.mocked(entityManager.transaction).mockImplementation(
+        async (callback: (mgr: unknown) => Promise<unknown>) => callback(mgr)
+      );
+      vi.mocked(spaceLookupService.getAllDescendantSpaceIDs).mockResolvedValue(
+        []
+      );
+      vi.mocked(
+        roleSetService.setParentRoleSetAndCredentials
+      ).mockResolvedValue({ id: 'roleset-l2' });
+      vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
+        tagsetTemplates: [],
+      });
+      vi.mocked(spaceService.save).mockImplementation(async (s: unknown) => s);
+      return { mgrQb, mgr };
+    };
+
+    // S1
+    it('should reject when source is not L2', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2({ level: SpaceLevel.L1 }))
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+
+      await expect(
+        service.moveSpaceL2ToSpaceL1OrFail({
+          spaceL2ID: 'source-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow(ValidationException);
+    });
+
+    // Also S1 — reject L0 source
+    it('should reject when source is L0', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2({ level: SpaceLevel.L0 }))
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+
+      await expect(
+        service.moveSpaceL2ToSpaceL1OrFail({
+          spaceL2ID: 'source-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow(ValidationException);
+    });
+
+    // S2
+    it('should reject when target is not L1', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2())
+        .mockResolvedValueOnce(makeTargetL2L1({ level: SpaceLevel.L0 }))
+        .mockResolvedValueOnce(makeTargetL2L0());
+
+      await expect(
+        service.moveSpaceL2ToSpaceL1OrFail({
+          spaceL2ID: 'source-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow(ValidationException);
+    });
+
+    // S3 — same-L0 guard (R-4 dissent-afterlife test)
+    it('should reject same-L0 target with the deferred-capability message and zero writes (S3/R-4)', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2({ levelZeroSpaceID: 'same-l0' }))
+        .mockResolvedValueOnce(makeTargetL2L1({ levelZeroSpaceID: 'same-l0' }))
+        .mockResolvedValueOnce(makeTargetL2L0({ id: 'same-l0' }));
+
+      await expect(
+        service.moveSpaceL2ToSpaceL1OrFail({
+          spaceL2ID: 'source-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow('deferred capability');
+
+      expect(spaceService.save).not.toHaveBeenCalled();
+    });
+
+    // S4/INV-1..3 — happy path structural update
+    it('should keep level at L2 and re-point parent + levelZeroSpaceID (S4/INV-1..3)', async () => {
+      const sourceL2 = makeSourceL2();
+      const targetL1 = makeTargetL2L1();
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(sourceL2)
+        .mockResolvedValueOnce(targetL1)
+        .mockResolvedValueOnce(makeTargetL2L0());
+      setupL2HappyPathMocks();
+
+      const result = await service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      // Level MUST stay L2
+      expect(result.space.level).toBe(SpaceLevel.L2);
+      expect(result.space.parentSpace).toBe(targetL1);
+      expect(result.space.levelZeroSpaceID).toBe('target-l0');
+    });
+
+    // S5/INV-7 — wipe all roles including admins + pending invites dropped
+    it('should clear ALL community roles including admins + pending invites dropped (S5/INV-7)', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2())
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+      setupL2HappyPathMocks();
+
+      vi.mocked(roleSetService.getUsersWithRole)
+        .mockResolvedValueOnce([{ id: 'user-member' }]) // MEMBER
+        .mockResolvedValueOnce([{ id: 'user-lead' }]) // LEAD
+        .mockResolvedValueOnce([{ id: 'user-admin' }]); // ADMIN
+
+      await service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      // Admin must be explicitly removed
+      expect(roleSetService.removeActorFromRole).toHaveBeenCalledWith(
+        expect.anything(),
+        'admin',
+        'user-admin',
+        false
+      );
+      // Pending invites must be dropped
+      expect(
+        roleSetService.removePendingInvitationsAndApplications
+      ).toHaveBeenCalledWith('roleset-l2');
+    });
+
+    // S5 — empty community → empty removedActorIds + success
+    it('empty community → empty removedActorIds + success (S5)', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2())
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+      setupL2HappyPathMocks();
+
+      const result = await service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      expect(result.removedActorIds).toEqual([]);
+    });
+
+    // S11 — sortOrder insert-first + sibling shift via tx manager
+    it('should set sortOrder to 0 and shift siblings via tx manager (S11)', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2())
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+      const { mgrQb } = setupL2HappyPathMocks();
+
+      const result = await service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      expect(result.space.sortOrder).toBe(0);
+      // Shift must go through the tx manager's query builder
+      expect(mgrQb.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sortOrder: expect.any(Function),
+        })
+      );
+    });
+
+    // S12 — nameID validation invoked pre-write
+    it('should reject nameID collision in target L0 scope (S12)', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2())
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+      vi.mocked(
+        namingService.getReservedNameIDsInLevelZeroSpace
+      ).mockResolvedValue(['source-l2-space']);
+      vi.mocked(entityManager.find).mockResolvedValue([
+        { id: 'source-l2', nameID: 'source-l2-space' },
+      ]);
+
+      await expect(
+        service.moveSpaceL2ToSpaceL1OrFail({
+          spaceL2ID: 'source-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow(ValidationException);
+    });
+
+    // S13/INV-4 — leaf assert
+    it('should reject when source L2 has children (leaf assert, S13/INV-4)', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(
+          makeSourceL2({ subspaces: [{ id: 'unexpected-child' }] })
+        )
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+
+      await expect(
+        service.moveSpaceL2ToSpaceL1OrFail({
+          spaceL2ID: 'source-l2',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow(ValidationException);
+    });
+
+    // storageAggregator + roleSet parent update
+    it('should update storageAggregator parent to target L1 and set roleSet parent', async () => {
+      const sourceL2 = makeSourceL2();
+      const targetL1 = makeTargetL2L1();
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(sourceL2)
+        .mockResolvedValueOnce(targetL1)
+        .mockResolvedValueOnce(makeTargetL2L0());
+      setupL2HappyPathMocks();
+
+      const result = await service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      expect(result.space.storageAggregator?.parentStorageAggregator).toBe(
+        targetL1.storageAggregator
+      );
+      expect(
+        roleSetService.setParentRoleSetAndCredentials
+      ).toHaveBeenCalledWith(
+        sourceL2.community.roleSet,
+        targetL1.community.roleSet
+      );
+    });
+
+    // Activity entry cleanup
+    it('should drop the stale SUBSPACE_CREATED activity entry', async () => {
+      vi.mocked(spaceService.getSpaceOrFail)
+        .mockResolvedValueOnce(makeSourceL2())
+        .mockResolvedValueOnce(makeTargetL2L1())
+        .mockResolvedValueOnce(makeTargetL2L0());
+      setupL2HappyPathMocks();
+
+      await service.moveSpaceL2ToSpaceL1OrFail({
+        spaceL2ID: 'source-l2',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      expect(
+        activityService.removeSubspaceCreatedActivityForResource
+      ).toHaveBeenCalledWith('source-l2');
+    });
+  });
 });

--- a/src/services/api/conversion/conversion.service.ts
+++ b/src/services/api/conversion/conversion.service.ts
@@ -43,6 +43,7 @@ import { ConvertSpaceL1ToSpaceL2Input } from './dto/convert.dto.space.l1.to.spac
 import { ConvertSpaceL2ToSpaceL1Input } from './dto/convert.dto.space.l2.to.space.l1.input';
 import { MoveSpaceL1ToSpaceL0Input } from './dto/move.dto.space.l1.to.space.l0.input';
 import { MoveSpaceL1ToSpaceL2Input } from './dto/move.dto.space.l1.to.space.l2.input';
+import { MoveSpaceL2ToSpaceL1Input } from './dto/move.dto.space.l2.to.space.l1.input';
 
 export class ConversionService {
   constructor(
@@ -900,6 +901,192 @@ export class ConversionService {
     return { space: savedSpace, removedActorIds };
   }
 
+  // ── Cross-L0 Move: L2 → L1 (stays L2, changes parent L0) ─────────
+
+  async moveSpaceL2ToSpaceL1OrFail(
+    moveData: MoveSpaceL2ToSpaceL1Input
+  ): Promise<MoveSpaceResult> {
+    // 1. Load source L2
+    const sourceL2 = await this.spaceService.getSpaceOrFail(
+      moveData.spaceL2ID,
+      {
+        relations: {
+          community: { roleSet: true },
+          storageAggregator: true,
+          subspaces: true,
+        },
+      }
+    );
+    if (
+      !sourceL2.community?.roleSet ||
+      !sourceL2.storageAggregator ||
+      !sourceL2.subspaces
+    ) {
+      throw new EntityNotInitializedException(
+        'Unable to locate all entities on source L2',
+        LogContext.CONVERSION
+      );
+    }
+
+    // 2. Load target L1
+    const targetL1 = await this.spaceService.getSpaceOrFail(
+      moveData.targetSpaceL1ID,
+      {
+        relations: {
+          storageAggregator: true,
+          community: { roleSet: true },
+          subspaces: true,
+        },
+      }
+    );
+    if (
+      !targetL1.storageAggregator ||
+      !targetL1.community?.roleSet ||
+      !targetL1.subspaces
+    ) {
+      throw new EntityNotInitializedException(
+        'Unable to locate all entities on target L1',
+        LogContext.CONVERSION
+      );
+    }
+
+    // 3. Load target L0
+    const targetL0 = await this.spaceService.getSpaceOrFail(
+      targetL1.levelZeroSpaceID,
+      {
+        relations: { account: true },
+      }
+    );
+    if (!targetL0.account) {
+      throw new EntityNotInitializedException(
+        'Unable to locate account on target L0',
+        LogContext.CONVERSION
+      );
+    }
+
+    // 4. Validate
+    if (sourceL2.level !== SpaceLevel.L2) {
+      throw new ValidationException(
+        'Only L2 spaces can be moved with this operation',
+        LogContext.CONVERSION
+      );
+    }
+    if (targetL1.level !== SpaceLevel.L1) {
+      throw new ValidationException(
+        'Target must be an L1 space',
+        LogContext.CONVERSION
+      );
+    }
+    if (sourceL2.levelZeroSpaceID === targetL1.levelZeroSpaceID) {
+      throw new ValidationException(
+        'Source and target are in the same L0; same-L0 lateral re-parenting of an L2 is not supported (deferred capability)',
+        LogContext.CONVERSION
+      );
+    }
+
+    // 5. Defensive leaf assert — L2 must be childless
+    if (sourceL2.subspaces.length > 0) {
+      throw new ValidationException(
+        'Cannot move: source L2 has children which exceeds max nesting depth',
+        LogContext.CONVERSION
+      );
+    }
+
+    // 6. Validate nameIDs
+    await this.validateNameIDsInTargetL0Scope(sourceL2.id, targetL0.id);
+
+    // 7. Collect community roles and actor IDs (ALL cleared for cross-L0).
+    // The wipe (steps 8/8b) is intentionally deferred to AFTER the structural
+    // transaction so a failed structural commit cannot leave the community
+    // permanently destroyed while the space remains in its old location
+    // (sec-server-1: availability-only failure mode, SC-006 / FR-008).
+    const roleSetL2 = sourceL2.community.roleSet;
+    const spaceCommunityRoles = await this.getSpaceCommunityRoles(roleSetL2);
+    const removedActorIds = this.collectRemovedActorIds(
+      spaceCommunityRoles,
+      true
+    );
+
+    // Local refs for use inside transaction callback (TypeScript narrowing)
+    const sourceStorageAggregator = sourceL2.storageAggregator;
+    const sourceCommunity = sourceL2.community;
+    const targetL1StorageAggregator = targetL1.storageAggregator;
+    const targetL1Community = targetL1.community;
+
+    // 8–12. ALL structural persistence inside a single transaction (R-2 / INV-5).
+    // Role wipe is intentionally OUTSIDE and runs AFTER this block so that a
+    // mid-transaction rollback leaves structure AND community fully intact.
+    const savedSpace = await this.entityManager.transaction(async mgr => {
+      // 8. Structural fields — level UNCHANGED (stays L2)
+      sourceL2.parentSpace = targetL1;
+      sourceL2.levelZeroSpaceID = targetL0.id;
+
+      // 9. Update storage aggregator parent (points to target L1)
+      sourceStorageAggregator.parentStorageAggregator =
+        targetL1StorageAggregator;
+
+      // 10. Update roleSet parent (points to target L1's roleSet)
+      sourceCommunity.roleSet =
+        await this.roleSetService.setParentRoleSetAndCredentials(
+          roleSetL2,
+          targetL1Community.roleSet
+        );
+
+      // 11. Sync innovation flow tagsets via the transactional manager (mgr)
+      // so that tagset writes are rolled back together with structural writes
+      // if the transaction fails (corr-server-1 / INV-5).
+      await this.syncInnovationFlowTagsetsForSubtree(
+        sourceL2.id,
+        targetL0.id,
+        mgr
+      );
+
+      // 12. Update sort order: insert at first position, shift existing children
+      // using the transactional manager so the shift is part of the same tx
+      await mgr
+        .createQueryBuilder()
+        .update(Space)
+        .set({ sortOrder: () => '"sortOrder" + 1' })
+        .where('"parentSpaceId" = :parentId', { parentId: targetL1.id })
+        .execute();
+      sourceL2.sortOrder = 0;
+
+      return mgr.save(sourceL2 as Space);
+    });
+
+    // 13. Clear ALL community roles including admins — runs AFTER a successful
+    // structural commit so a failed transaction cannot permanently destroy the
+    // community while leaving the space in its original location (sec-server-1).
+    await this.removeContributors(roleSetL2, spaceCommunityRoles);
+    for (const userAdmin of spaceCommunityRoles.userAdmins) {
+      await this.roleSetService.removeActorFromRole(
+        roleSetL2,
+        RoleName.ADMIN,
+        userAdmin.id,
+        false
+      );
+    }
+
+    // 13b. Drop pending invitations/applications
+    await this.roleSetService.removePendingInvitationsAndApplications(
+      roleSetL2.id
+    );
+
+    // 14. Post-commit service tail (outside tx by design)
+    await this.accountHostService.assignLicensePlansToSpace(
+      savedSpace.id,
+      targetL0.account.accountType
+    );
+
+    // Drop the now-stale SUBSPACE_CREATED entry on the source parent's
+    // activity log — the moved space is no longer a subspace under it.
+    await this.activityService.removeSubspaceCreatedActivityForResource(
+      savedSpace.id
+    );
+
+    return { space: savedSpace as ISpace, removedActorIds };
+  }
+
   // ── Cross-L0 Move Helpers ─────────────────────────────────────────
 
   /**
@@ -935,10 +1122,15 @@ export class ConversionService {
    * Each space's callouts are synced using that space's OWN calloutsSet
    * tagsetTemplate — not the target L0's — because L1/L2 spaces retain their
    * own innovation flow after a cross-L0 move.
+   *
+   * When `mgr` is provided (inside a transaction) all tagset saves are routed
+   * through the transactional manager so they are rolled back atomically with
+   * the structural writes if the transaction fails (corr-server-1 / INV-5).
    */
   private async syncInnovationFlowTagsetsForSubtree(
     movedSpaceId: string,
-    _targetL0Id: string
+    _targetL0Id: string,
+    mgr?: EntityManager
   ): Promise<void> {
     const descendantIds =
       await this.spaceLookupService.getAllDescendantSpaceIDs(movedSpaceId);
@@ -973,7 +1165,8 @@ export class ConversionService {
         for (const tagsetTemplate of tagsetTemplates) {
           await this.classificationService.updateTagsetTemplateOnSelectTagset(
             callout.classification.id,
-            tagsetTemplate
+            tagsetTemplate,
+            mgr
           );
         }
       }

--- a/src/services/api/conversion/dto/move.dto.space.l2.to.space.l1.input.ts
+++ b/src/services/api/conversion/dto/move.dto.space.l2.to.space.l1.input.ts
@@ -1,0 +1,47 @@
+import { UUID } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+
+@InputType()
+export class MoveSpaceL2ToSpaceL1Input {
+  @Field(() => UUID, {
+    nullable: false,
+    description: 'The L2 subspace to move (stays L2).',
+  })
+  @IsUUID()
+  spaceL2ID!: string;
+
+  @Field(() => UUID, {
+    nullable: false,
+    description:
+      'The target L1 subspace in a different L0 (new parent for the moved L2).',
+  })
+  @IsUUID()
+  targetSpaceL1ID!: string;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    defaultValue: false,
+    description:
+      'Send invitations to former community members who are also in the target L0 community.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  autoInvite?: boolean;
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Custom invitation message. Used only when autoInvite is true.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  invitationMessage?: string;
+}


### PR DESCRIPTION
https://github.com/alkem-io/server/issues/6224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GraphQL mutation to move a leaf-level L2 space under a different target L1 (across top-level structures).
  * Keeps the space at L2 level while updating its parent and recomputing access/roles.
  * Clears community roles (including admins) and removes pending invitations/applications.
  * Optionally auto-invites eligible former members, with an optional invitation message.
* **Bug Fixes**
  * Strengthened transactional handling to prevent partial updates and avoid tail side effects when the move fails.
* **Tests**
  * Added resolver and service coverage for validation, authorization sequencing, non-blocking room handling, cache invalidation, auto-invite dispatch, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->