### PR TITLE
ci: ARC hardening PoC verification workflows (dispatch-only)

### DIFF
--- a/.github/workflows/arc-poc-benchmark.yml
+++ b/.github/workflows/arc-poc-benchmark.yml
@@ -1,0 +1,81 @@
+# ARC hardening PoC — benchmark (workspace 025 follow-up).
+# Times the real CI workload (mirror of ci-tests.yml's test job, no Sonar, no
+# secrets) on a selectable runner: criteria 1, 5, 7 of
+# platform/github-self-hosted-runners/poc/README.md.
+#
+# Benchmark protocol: dispatch twice per runner — run 1 = cold cache,
+# run 2 = warm (on arc-poc the pnpm cache restores from the in-cluster cache
+# server; the pod itself is always fresh).
+#
+# workflow_dispatch ONLY — the arc-poc lane is trusted-trigger only.
+name: ARC PoC benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'Runner to benchmark'
+        required: true
+        default: 'arc-poc'
+        type: choice
+        options:
+          - arc-poc
+          - ubuntu-latest
+          - m4
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ${{ inputs.runner == 'm4' && fromJSON('["self-hosted", "macOS", "ARM64", "apple-silicon", "m4"]') || inputs.runner }}
+    timeout-minutes: 30
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
+
+      - name: Setup Node.js (pnpm cache via actions/cache)
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.22.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies (timed)
+        run: |
+          start=$(date +%s)
+          pnpm install --frozen-lockfile
+          echo "INSTALL_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Typecheck (timed)
+        run: |
+          start=$(date +%s)
+          pnpm run typecheck:native
+          echo "TYPECHECK_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Tests with coverage (timed)
+        timeout-minutes: 15
+        run: |
+          start=$(date +%s)
+          pnpm run test:ci
+          echo "TEST_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Benchmark summary
+        if: always()
+        run: |
+          {
+            echo "## ARC PoC benchmark — ${{ inputs.runner }}"
+            echo "| stage | seconds |"
+            echo "|---|---|"
+            echo "| install | ${INSTALL_SECONDS:-n/a} |"
+            echo "| typecheck | ${TYPECHECK_SECONDS:-n/a} |"
+            echo "| tests | ${TEST_SECONDS:-n/a} |"
+            echo ""
+            echo "- runner: \`${{ inputs.runner }}\`, host: \`$(hostname)\`"
+            echo "- cpus: $(getconf _NPROCESSORS_ONLN), node: $(node --version 2>/dev/null || echo n/a)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/arc-poc-containment.yml
+++ b/.github/workflows/arc-poc-containment.yml
@@ -1,0 +1,82 @@
+# ARC hardening PoC — containment verification (workspace 025 follow-up).
+# Proves the hardened arc-poc lane's isolation guarantees from INSIDE a job:
+# criteria 2 (ephemerality), 3 (network containment), 4 (no SA token) of
+# platform/github-self-hosted-runners/poc/README.md.
+#
+# workflow_dispatch ONLY — the arc-poc lane is trusted-trigger only; this must
+# never run on pull_request.
+name: ARC PoC containment
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  containment:
+    runs-on: arc-poc
+    timeout-minutes: 10
+    steps:
+      - name: Identify runner pod
+        run: |
+          echo "hostname: $(hostname)"
+          echo "user: $(id)"
+
+      - name: 'Criterion 4: no serviceaccount token mounted'
+        run: |
+          if [ -e /var/run/secrets/kubernetes.io ]; then
+            echo "FAIL: kubernetes serviceaccount secrets are mounted"
+            exit 1
+          fi
+          echo "PASS: no serviceaccount token in the pod"
+
+      - name: 'Criterion 3a: cloud metadata endpoint unreachable'
+        run: |
+          if curl -s -m 5 http://169.254.169.254/ -o /dev/null; then
+            echo "FAIL: metadata endpoint reachable"
+            exit 1
+          fi
+          echo "PASS: 169.254.169.254 blocked"
+
+      - name: 'Criterion 3b: kube API unreachable'
+        run: |
+          if curl -sk -m 5 https://kubernetes.default.svc.cluster.local/ -o /dev/null; then
+            echo "FAIL: kube API reachable"
+            exit 1
+          fi
+          echo "PASS: kube API blocked"
+
+      - name: 'Criterion 3c: cross-namespace service unreachable'
+        run: |
+          # coredns metrics in kube-system — exists in every Kapsule cluster;
+          # DNS egress is allowed on port 53 only, so 9153 must be blocked.
+          if curl -s -m 5 http://kube-dns.kube-system.svc.cluster.local:9153/metrics -o /dev/null; then
+            echo "FAIL: cross-namespace service reachable"
+            exit 1
+          fi
+          echo "PASS: cross-namespace service blocked"
+
+      - name: 'Positive control: in-cluster cache server reachable'
+        run: |
+          code=$(curl -s -m 5 -o /dev/null -w '%{http_code}' http://cache.arc-poc-cache.svc.cluster.local:3000/ || echo 000)
+          if [ "$code" = "000" ]; then
+            echo "FAIL: cache server NOT reachable (allowlist broken)"
+            exit 1
+          fi
+          echo "PASS: cache server reachable (HTTP $code)"
+
+      - name: 'Positive control: GitHub reachable'
+        run: |
+          curl -sf -m 10 https://api.github.com/zen && echo && echo "PASS: GitHub egress allowed"
+
+      - name: 'Criterion 2: ephemerality marker'
+        run: |
+          marker="$HOME/.arc-poc-ephemerality-marker"
+          if [ -f "$marker" ]; then
+            echo "FAIL: marker from a previous job exists — runner filesystem was reused"
+            cat "$marker"
+            exit 1
+          fi
+          date -u +"dropped %Y-%m-%dT%H:%M:%SZ by run ${GITHUB_RUN_ID}" > "$marker"
+          echo "PASS: fresh filesystem; marker dropped — re-run this workflow to prove the next pod is clean"


### PR DESCRIPTION
Two `workflow_dispatch`-only workflows for the ARC hardening PoC (alkem-io/platform#40, agents-hq `specs/025-self-hosted-runner-triage`):

- **arc-poc-containment.yml** — proves the hardened `arc-poc` lane's isolation from inside a job: no serviceaccount token, metadata endpoint / kube API / cross-namespace services unreachable, cache server + GitHub reachable (positive controls), ephemerality marker across runs.
- **arc-poc-benchmark.yml** — mirror of `ci-tests.yml`'s test job (no Sonar, no secrets) with per-stage timing, dispatchable on `arc-poc` / `ubuntu-latest` / `m4` for the placement benchmark the 025 triage called for.

Both are dispatch-only and cannot be triggered by pull requests — the `arc-poc` lane is trusted-trigger only. Merging adds no PR-time CI load; the workflows only run when explicitly dispatched.

Why merge is needed: GitHub only allows `workflow_dispatch` for workflows present on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)