### PR TITLE
feat(029): detect signup language & persist as a user setting (server)

### DIFF
--- a/alkemio.yml
+++ b/alkemio.yml
@@ -557,6 +557,15 @@ mcp:
     # Maximum items returned in list responses
     max_response_items: ${MCP_MAX_RESPONSE_ITEMS}:100
 
+## Language detection & offer configuration (workspace#029-detect-signup-language)
+# eligible: comma-separated list of language codes the platform proactively detects,
+#           offers via the banner, and accepts as invitation suggestions.
+#           Subset of the supported languages; an empty value disables all proactive offers.
+# default:  the platform-wide fallback language.
+language:
+  eligible: ${LANGUAGE_ELIGIBLE}:nl
+  default: ${LANGUAGE_DEFAULT}:en
+
 ## Configuration of the legal / usability aspects of the platform
 platform:
   # Terms of usage that all users comply with

--- a/alkemio.yml
+++ b/alkemio.yml
@@ -557,7 +557,7 @@ mcp:
     # Maximum items returned in list responses
     max_response_items: ${MCP_MAX_RESPONSE_ITEMS}:100
 
-## Language detection & offer configuration (workspace#029-detect-signup-language)
+## Language detection & offer configuration
 # eligible: comma-separated list of language codes the platform proactively detects,
 #           offers via the banner, and accepts as invitation suggestions.
 #           Subset of the supported languages; an empty value disables all proactive offers.

--- a/schema.graphql
+++ b/schema.graphql
@@ -2278,6 +2278,10 @@ type Config {
   featureFlags: [PlatformFeatureFlag!]!
   """Integration with a 3rd party Geo information service"""
   geo: Geo!
+  """
+  Language configuration: eligible set for proactive offers and the platform default.
+  """
+  language: LanguageConfig!
   """Platform related locations."""
   locations: PlatformLocations!
   """Sentry (client monitoring) related configuration."""
@@ -3273,6 +3277,10 @@ type Invitation {
   nextEvents: [String!]!
   """The current state of this Lifecycle."""
   state: String!
+  """
+  Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).
+  """
+  suggestedLanguage: String
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
   welcomeMessage: String
@@ -3334,6 +3342,15 @@ type KratosIdentity {
   lastName: String
   """The current verification status of the email address."""
   verificationStatus: String!
+}
+
+type LanguageConfig {
+  """The platform-wide default interface language."""
+  default: String!
+  """
+  Languages the platform proactively detects, offers, and allows as invitation suggestions — subset of the supported set; empty = all proactive offers disabled.
+  """
+  eligible: [String!]!
 }
 
 type LatestReleaseDiscussion {
@@ -4845,6 +4862,10 @@ type PlatformInvitation {
   roleSetExtraRoles: [RoleName!]!
   """Whether to also add the invited user to the parent community."""
   roleSetInvitedToParent: Boolean!
+  """
+  Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).
+  """
+  suggestedLanguage: String
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
   welcomeMessage: String
@@ -6769,6 +6790,14 @@ type UserSettings {
   homeSpace: UserSettingsHomeSpace!
   """The ID of the entity"""
   id: UUID!
+  """
+  The interface language chosen by this User. Null = the User has never chosen a language (distinct from having chosen the platform default).
+  """
+  language: String
+  """
+  Whether this User has answered the one-time language offer (global across all languages — FR-005a). Latched true by any language write.
+  """
+  languageOfferAnswered: Boolean!
   """The notification settings for this User."""
   notification: UserSettingsNotification!
   """The privacy settings for this User"""
@@ -8346,6 +8375,10 @@ input InviteForEntryRoleOnRoleSetInput {
   invitedActorIDs: [UUID!]!
   invitedUserEmails: [String!]!
   roleSetID: UUID!
+  """
+  Optional language the inviter expects the invitees to prefer (single value for the whole batch — FR-014a; must be in the eligible set at compose time — DL-8). Recorded per-invitation so per-invitee granularity later is a UI change, not a migration (FR-014b).
+  """
+  suggestedLanguage: String
   """The welcome message to send"""
   welcomeMessage: String
 }
@@ -9598,6 +9631,14 @@ input UpdateUserSettingsEntityInput {
   designVersion: Int
   """Settings related to Home Space."""
   homeSpace: UpdateUserSettingsHomeSpaceInput
+  """
+  Set the user's interface language preference. Must be a value from the supported languages set. Any language write also latches languageOfferAnswered=true (FR-023 invariant).
+  """
+  language: String
+  """
+  Mark that this User has answered the one-time language offer. One-way latch: setting false is rejected (FR-005a).
+  """
+  languageOfferAnswered: Boolean
   """Settings related to this users Notifications preferences."""
   notification: UpdateUserSettingsNotificationInput
   """Settings related to Privacy."""

--- a/schema.graphql
+++ b/schema.graphql
@@ -3278,7 +3278,7 @@ type Invitation {
   """The current state of this Lifecycle."""
   state: String!
   """
-  Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).
+  Optional language the inviter expects the invitee to prefer; recorded per invitation.
   """
   suggestedLanguage: String
   """The date at which the entity was last updated."""
@@ -4341,7 +4341,7 @@ type Mutation {
   """Update the Application Form used by this RoleSet."""
   updateApplicationFormOnRoleSet(applicationFormData: UpdateApplicationFormOnRoleSetInput!): RoleSet!
   """
-  Set the admin per-capability grant on the virtual-assistant actor, governing what it may do system-invoked (default read-only). Requires platform-admin.
+  Set the admin per-capability grant on the virtual-assistant actor, governing what it may do system-invoked (default read-only). Requires the platform-operations-admin privilege.
   """
   updateAssistantActorCapabilities(grantData: GrantAssistantActorCapabilitiesInput!): VirtualAssistant!
   """Update the baseline License Plan on the specified Account."""
@@ -4863,7 +4863,7 @@ type PlatformInvitation {
   """Whether to also add the invited user to the parent community."""
   roleSetInvitedToParent: Boolean!
   """
-  Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).
+  Optional language the inviter expects the invitee to prefer; recorded per invitation.
   """
   suggestedLanguage: String
   """The date at which the entity was last updated."""
@@ -6795,7 +6795,7 @@ type UserSettings {
   """
   language: String
   """
-  Whether this User has answered the one-time language offer (global across all languages — FR-005a). Latched true by any language write.
+  Whether this User has answered the one-time language offer (global across all languages). Latched true by any language write.
   """
   languageOfferAnswered: Boolean!
   """The notification settings for this User."""
@@ -8376,7 +8376,7 @@ input InviteForEntryRoleOnRoleSetInput {
   invitedUserEmails: [String!]!
   roleSetID: UUID!
   """
-  Optional language the inviter expects the invitees to prefer (single value for the whole batch — FR-014a; must be in the eligible set at compose time — DL-8). Recorded per-invitation so per-invitee granularity later is a UI change, not a migration (FR-014b).
+  Optional language the inviter expects the invitees to prefer (single value for the whole batch). Must be in the eligible set at compose time. Recorded per-invitation so per-invitee granularity later is a UI change, not a migration.
   """
   suggestedLanguage: String
   """The welcome message to send"""
@@ -9632,11 +9632,11 @@ input UpdateUserSettingsEntityInput {
   """Settings related to Home Space."""
   homeSpace: UpdateUserSettingsHomeSpaceInput
   """
-  Set the user's interface language preference. Must be a value from the supported languages set. Any language write also latches languageOfferAnswered=true (FR-023 invariant).
+  Set the user's interface language preference. Must be a value from the supported languages set. Any language write also latches languageOfferAnswered=true.
   """
   language: String
   """
-  Mark that this User has answered the one-time language offer. One-way latch: setting false is rejected (FR-005a).
+  Mark that this User has answered the one-time language offer. One-way latch: setting false is rejected.
   """
   languageOfferAnswered: Boolean
   """Settings related to this users Notifications preferences."""

--- a/src/common/constants/supported.languages.spec.ts
+++ b/src/common/constants/supported.languages.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSupportedInterfaceLanguage,
+  parseSupportedEligibleLanguages,
+  resolveSupportedDefaultLanguage,
+  SUPPORTED_INTERFACE_LANGUAGES,
+} from './supported.languages';
+
+describe('isSupportedInterfaceLanguage', () => {
+  it('should return true for every member of SUPPORTED_INTERFACE_LANGUAGES', () => {
+    for (const lang of SUPPORTED_INTERFACE_LANGUAGES) {
+      expect(isSupportedInterfaceLanguage(lang)).toBe(true);
+    }
+  });
+
+  it('should return false for a non-supported code', () => {
+    expect(isSupportedInterfaceLanguage('xx')).toBe(false);
+  });
+
+  it('should return false for an empty string', () => {
+    expect(isSupportedInterfaceLanguage('')).toBe(false);
+  });
+
+  it('should be case-sensitive (uppercase EN is not supported)', () => {
+    expect(isSupportedInterfaceLanguage('EN')).toBe(false);
+  });
+});
+
+describe('parseSupportedEligibleLanguages', () => {
+  it('should parse a single supported language', () => {
+    expect(parseSupportedEligibleLanguages('nl')).toEqual(['nl']);
+  });
+
+  it('should parse multiple supported languages', () => {
+    expect(parseSupportedEligibleLanguages('nl,de,fr')).toEqual([
+      'nl',
+      'de',
+      'fr',
+    ]);
+  });
+
+  it('should trim whitespace from each entry', () => {
+    expect(parseSupportedEligibleLanguages(' nl , de ')).toEqual(['nl', 'de']);
+  });
+
+  it('should drop entries not in SUPPORTED_INTERFACE_LANGUAGES', () => {
+    expect(parseSupportedEligibleLanguages('nl,xx')).toEqual(['nl']);
+  });
+
+  it('should return [] when all entries are unsupported', () => {
+    expect(parseSupportedEligibleLanguages('xx,yy')).toEqual([]);
+  });
+
+  it('should return [] for an empty string', () => {
+    expect(parseSupportedEligibleLanguages('')).toEqual([]);
+  });
+
+  it('should return [] for undefined', () => {
+    expect(parseSupportedEligibleLanguages(undefined)).toEqual([]);
+  });
+
+  it('should deduplicate repeated supported entries', () => {
+    expect(parseSupportedEligibleLanguages('nl,nl,de')).toEqual(['nl', 'de']);
+  });
+
+  it('should drop empty segments from trailing commas', () => {
+    expect(parseSupportedEligibleLanguages('nl,')).toEqual(['nl']);
+  });
+});
+
+describe('resolveSupportedDefaultLanguage', () => {
+  it('should return the raw value when it is supported', () => {
+    expect(resolveSupportedDefaultLanguage('nl')).toBe('nl');
+  });
+
+  it('should return the fallback when raw is unsupported', () => {
+    expect(resolveSupportedDefaultLanguage('xx')).toBe('en');
+  });
+
+  it('should return the fallback when raw is undefined', () => {
+    expect(resolveSupportedDefaultLanguage(undefined)).toBe('en');
+  });
+
+  it('should use a custom fallback when provided', () => {
+    expect(resolveSupportedDefaultLanguage('xx', 'nl')).toBe('nl');
+  });
+
+  it('should return supported raw value even when a custom fallback is provided', () => {
+    expect(resolveSupportedDefaultLanguage('de', 'nl')).toBe('de');
+  });
+});

--- a/src/common/constants/supported.languages.ts
+++ b/src/common/constants/supported.languages.ts
@@ -1,0 +1,77 @@
+/**
+ * The stable set of interface languages supported by Alkemio.
+ * This is the SUPPORTED set — distinct from the ELIGIBLE set (subset, config-driven,
+ * used for proactive detection/offers). See plan.md → C2 (config-language contract).
+ *
+ * The user may persist any language from this set as their account preference (FR-008).
+ * The eligible set (in alkemio.yml: language.eligible) is a subset of this list used
+ * only for proactive detection and invitation suggestions.
+ */
+export const SUPPORTED_INTERFACE_LANGUAGES = [
+  'en',
+  'nl',
+  'es',
+  'bg',
+  'de',
+  'fr',
+] as const;
+
+export type SupportedInterfaceLanguage =
+  (typeof SUPPORTED_INTERFACE_LANGUAGES)[number];
+
+/**
+ * Returns true if `lang` is in SUPPORTED_INTERFACE_LANGUAGES.
+ * Pure — no logging, no side effects.
+ */
+export function isSupportedInterfaceLanguage(lang: string): boolean {
+  return (SUPPORTED_INTERFACE_LANGUAGES as readonly string[]).includes(lang);
+}
+
+/**
+ * Parses a comma-separated eligible-language string, trims entries, drops
+ * empties, deduplicates, and keeps ONLY values in SUPPORTED_INTERFACE_LANGUAGES.
+ *
+ * Pure — no logging. This helper has already removed unsupported values from
+ * its result, so callers that need to warn on dropped entries must inspect the
+ * RAW entries before parsing, e.g.
+ * `raw.split(',').map(s => s.trim()).filter(l => l.length > 0 && !isSupportedInterfaceLanguage(l))`.
+ *
+ * @param raw - The raw comma-separated string from config (e.g. `"nl,de,fr"`).
+ *              `undefined` or empty string → returns `[]`.
+ */
+export function parseSupportedEligibleLanguages(
+  raw: string | undefined
+): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of raw.split(',')) {
+    const lang = entry.trim();
+    if (
+      lang.length > 0 &&
+      isSupportedInterfaceLanguage(lang) &&
+      !seen.has(lang)
+    ) {
+      seen.add(lang);
+      result.push(lang);
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolves the default interface language from config.
+ *
+ * Returns `raw` if it is in SUPPORTED_INTERFACE_LANGUAGES; otherwise returns
+ * `fallback` (default `'en'`). Pure — no logging.
+ *
+ * @param raw - The raw default language from config.
+ * @param fallback - Value to use when `raw` is unset or unsupported. Defaults to `'en'`.
+ */
+export function resolveSupportedDefaultLanguage(
+  raw: string | undefined,
+  fallback = 'en'
+): string {
+  if (raw !== undefined && isSupportedInterfaceLanguage(raw)) return raw;
+  return fallback;
+}

--- a/src/common/constants/supported.languages.ts
+++ b/src/common/constants/supported.languages.ts
@@ -1,11 +1,11 @@
 /**
  * The stable set of interface languages supported by Alkemio.
  * This is the SUPPORTED set — distinct from the ELIGIBLE set (subset, config-driven,
- * used for proactive detection/offers). See plan.md → C2 (config-language contract).
+ * used for proactive detection/offers; configured via alkemio.yml → language.eligible).
  *
- * The user may persist any language from this set as their account preference (FR-008).
- * The eligible set (in alkemio.yml: language.eligible) is a subset of this list used
- * only for proactive detection and invitation suggestions.
+ * The user may persist any language from this set as their account preference.
+ * The eligible set is a subset of this list used only for proactive detection
+ * and invitation suggestions.
  */
 export const SUPPORTED_INTERFACE_LANGUAGES = [
   'en',

--- a/src/domain/access/invitation.platform/dto/platform.invitation.dto.create.ts
+++ b/src/domain/access/invitation.platform/dto/platform.invitation.dto.create.ts
@@ -9,4 +9,7 @@ export class CreatePlatformInvitationInput {
   roleSetID?: string;
   roleSetInvitedToParent!: boolean;
   roleSetExtraRoles!: RoleName[];
+
+  /** Optional language the inviter expects the invitee to prefer (FR-014b). */
+  suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation.platform/dto/platform.invitation.dto.create.ts
+++ b/src/domain/access/invitation.platform/dto/platform.invitation.dto.create.ts
@@ -10,6 +10,6 @@ export class CreatePlatformInvitationInput {
   roleSetInvitedToParent!: boolean;
   roleSetExtraRoles!: RoleName[];
 
-  /** Optional language the inviter expects the invitee to prefer (FR-014b). */
+  /** Optional language the inviter expects the invitee to prefer; recorded per invitation. */
   suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation.platform/platform.invitation.entity.ts
+++ b/src/domain/access/invitation.platform/platform.invitation.entity.ts
@@ -1,4 +1,8 @@
-import { LONGER_TEXT_LENGTH, SMALL_TEXT_LENGTH } from '@common/constants';
+import {
+  LONGER_TEXT_LENGTH,
+  SMALL_TEXT_LENGTH,
+  TINY_TEXT_LENGTH,
+} from '@common/constants';
 import { RoleName } from '@common/enums/role.name';
 import { RoleSet } from '@domain/access/role-set/role.set.entity';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
@@ -43,4 +47,7 @@ export class PlatformInvitation
 
   @Column('boolean', { default: false })
   profileCreated!: boolean;
+
+  @Column('varchar', { length: TINY_TEXT_LENGTH, nullable: true })
+  suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation.platform/platform.invitation.interface.ts
+++ b/src/domain/access/invitation.platform/platform.invitation.interface.ts
@@ -54,4 +54,11 @@ export class IPlatformInvitation extends IAuthorizable {
     description: 'The platform role the user will receive when they sign up',
   })
   platformRole?: RoleName;
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).',
+  })
+  suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation.platform/platform.invitation.interface.ts
+++ b/src/domain/access/invitation.platform/platform.invitation.interface.ts
@@ -58,7 +58,7 @@ export class IPlatformInvitation extends IAuthorizable {
   @Field(() => String, {
     nullable: true,
     description:
-      'Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).',
+      'Optional language the inviter expects the invitee to prefer; recorded per invitation.',
   })
   suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation/dto/invitation.dto.create.ts
+++ b/src/domain/access/invitation/dto/invitation.dto.create.ts
@@ -12,4 +12,7 @@ export class CreateInvitationInput {
   invitedToParent!: boolean;
 
   extraRoles?: RoleName[];
+
+  /** Optional language the inviter expects the invitee to prefer (FR-014b). */
+  suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation/dto/invitation.dto.create.ts
+++ b/src/domain/access/invitation/dto/invitation.dto.create.ts
@@ -13,6 +13,6 @@ export class CreateInvitationInput {
 
   extraRoles?: RoleName[];
 
-  /** Optional language the inviter expects the invitee to prefer (FR-014b). */
+  /** Optional language the inviter expects the invitee to prefer; recorded per invitation. */
   suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation/invitation.entity.ts
+++ b/src/domain/access/invitation/invitation.entity.ts
@@ -1,4 +1,4 @@
-import { LONGER_TEXT_LENGTH } from '@common/constants';
+import { LONGER_TEXT_LENGTH, TINY_TEXT_LENGTH } from '@common/constants';
 import { RoleName } from '@common/enums/role.name';
 import { RoleSet } from '@domain/access/role-set/role.set.entity';
 import { Actor } from '@domain/actor/actor/actor.entity';
@@ -62,4 +62,7 @@ export class Invitation extends AuthorizableEntity implements IInvitation {
 
   @Column('simple-array', { nullable: false })
   extraRoles!: RoleName[];
+
+  @Column('varchar', { length: TINY_TEXT_LENGTH, nullable: true })
+  suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation/invitation.interface.ts
+++ b/src/domain/access/invitation/invitation.interface.ts
@@ -30,4 +30,11 @@ export class IInvitation extends IAuthorizable {
       'Additional roles to assign to the Actor, in addition to the entry Role.',
   })
   extraRoles!: RoleName[];
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).',
+  })
+  suggestedLanguage?: string;
 }

--- a/src/domain/access/invitation/invitation.interface.ts
+++ b/src/domain/access/invitation/invitation.interface.ts
@@ -34,7 +34,7 @@ export class IInvitation extends IAuthorizable {
   @Field(() => String, {
     nullable: true,
     description:
-      'Optional language the inviter expects the invitee to prefer (FR-014b — recorded per invitation; DL-1 ruling: present on both Invitation and PlatformInvitation).',
+      'Optional language the inviter expects the invitee to prefer; recorded per invitation.',
   })
   suggestedLanguage?: string;
 }

--- a/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
+++ b/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
@@ -3,10 +3,11 @@ import {
   MID_TEXT_LENGTH,
   UUID_LENGTH,
 } from '@common/constants';
+import { SUPPORTED_INTERFACE_LANGUAGES } from '@common/constants/supported.languages';
 import { RoleName } from '@common/enums/role.name';
 import { UUID } from '@domain/common/scalars';
 import { Field, InputType } from '@nestjs/graphql';
-import { IsEmail, IsOptional, MaxLength } from 'class-validator';
+import { IsEmail, IsIn, IsOptional, MaxLength } from 'class-validator';
 
 @InputType()
 export class InviteForEntryRoleOnRoleSetInput {
@@ -37,4 +38,13 @@ export class InviteForEntryRoleOnRoleSetInput {
     description: 'Additional roles to assign in addition to the entry Role.',
   })
   extraRoles!: RoleName[];
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Optional language the inviter expects the invitees to prefer (single value for the whole batch — FR-014a; must be in the eligible set at compose time — DL-8). Recorded per-invitation so per-invitee granularity later is a UI change, not a migration (FR-014b).',
+  })
+  @IsOptional()
+  @IsIn([...SUPPORTED_INTERFACE_LANGUAGES])
+  suggestedLanguage?: string;
 }

--- a/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
+++ b/src/domain/access/role-set/dto/role.set.dto.entry.role.invite.ts
@@ -42,7 +42,7 @@ export class InviteForEntryRoleOnRoleSetInput {
   @Field(() => String, {
     nullable: true,
     description:
-      'Optional language the inviter expects the invitees to prefer (single value for the whole batch — FR-014a; must be in the eligible set at compose time — DL-8). Recorded per-invitation so per-invitee granularity later is a UI change, not a migration (FR-014b).',
+      'Optional language the inviter expects the invitees to prefer (single value for the whole batch). Must be in the eligible set at compose time. Recorded per-invitation so per-invitee granularity later is a UI change, not a migration.',
   })
   @IsOptional()
   @IsIn([...SUPPORTED_INTERFACE_LANGUAGES])

--- a/src/domain/access/role-set/role.set.eligible.language.guard.spec.ts
+++ b/src/domain/access/role-set/role.set.eligible.language.guard.spec.ts
@@ -4,7 +4,7 @@ import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { RoleSetEligibleLanguageGuard } from './role.set.eligible.language.guard';
 
 /**
- * Unit tests for the compose-time eligible-language guard (T006 / DL-8 / R-8).
+ * Unit tests for the compose-time eligible-language guard.
  */
 describe('RoleSetEligibleLanguageGuard', () => {
   async function buildGuard(

--- a/src/domain/access/role-set/role.set.eligible.language.guard.spec.ts
+++ b/src/domain/access/role-set/role.set.eligible.language.guard.spec.ts
@@ -1,0 +1,95 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { RoleSetEligibleLanguageGuard } from './role.set.eligible.language.guard';
+
+/**
+ * Unit tests for the compose-time eligible-language guard (T006 / DL-8 / R-8).
+ */
+describe('RoleSetEligibleLanguageGuard', () => {
+  async function buildGuard(
+    eligible: string
+  ): Promise<RoleSetEligibleLanguageGuard> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RoleSetEligibleLanguageGuard],
+    })
+      .useMocker(token => {
+        if (token === ConfigService) {
+          return {
+            get: (key: string) => {
+              if (key === 'language') return { eligible, default: 'en' };
+              return undefined;
+            },
+          };
+        }
+        return defaultMockerFactory(token);
+      })
+      .compile();
+
+    return module.get(RoleSetEligibleLanguageGuard);
+  }
+
+  it('should accept an eligible language without throwing', async () => {
+    const guard = await buildGuard('nl');
+
+    expect(() => guard.isEligibleLanguageOrFail('nl')).not.toThrow();
+  });
+
+  it('should reject a supported-but-ineligible language (de) with ValidationException and a static message', async () => {
+    // eligible = 'nl' only; 'de' is in supported set but not eligible
+    const guard = await buildGuard('nl');
+
+    expect(() => guard.isEligibleLanguageOrFail('de')).toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Suggested language is not in the eligible set'
+        ),
+      })
+    );
+  });
+
+  it('should reject any language when the eligible set is empty (kill switch)', async () => {
+    const guard = await buildGuard('');
+
+    expect(() => guard.isEligibleLanguageOrFail('nl')).toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Suggested language is not in the eligible set'
+        ),
+      })
+    );
+  });
+
+  it('should return the eligible list from getEligibleLanguages', async () => {
+    const guard = await buildGuard('nl,de');
+
+    expect(guard.getEligibleLanguages()).toEqual(['nl', 'de']);
+  });
+
+  it('should return an empty array from getEligibleLanguages when the set is empty', async () => {
+    const guard = await buildGuard('');
+
+    expect(guard.getEligibleLanguages()).toEqual([]);
+  });
+
+  it('should drop unsupported entries from getEligibleLanguages (3655923939)', async () => {
+    // 'xx' is not in SUPPORTED_INTERFACE_LANGUAGES — must be dropped
+    const guard = await buildGuard('nl,xx,de');
+
+    expect(guard.getEligibleLanguages()).toEqual(['nl', 'de']);
+    expect(guard.getEligibleLanguages()).not.toContain('xx');
+  });
+
+  it('should reject an unsupported eligible config entry via isEligibleLanguageOrFail (3655923939)', async () => {
+    // Even if 'xx' appears in config, it must not be accepted as eligible
+    const guard = await buildGuard('xx');
+
+    expect(() => guard.isEligibleLanguageOrFail('xx')).toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Suggested language is not in the eligible set'
+        ),
+      })
+    );
+  });
+});

--- a/src/domain/access/role-set/role.set.eligible.language.guard.ts
+++ b/src/domain/access/role-set/role.set.eligible.language.guard.ts
@@ -1,0 +1,50 @@
+import { parseSupportedEligibleLanguages } from '@common/constants/supported.languages';
+import { LogContext } from '@common/enums/logging.context';
+import { ValidationException } from '@common/exceptions';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AlkemioConfig } from '@src/types';
+
+/**
+ * Validates that a `suggestedLanguage` value on an invitation input is in the
+ * currently configured eligible-language set (DL-8 compose-time check).
+ *
+ * Separate from the consumption-time check in registration (which silently skips
+ * ineligible stored suggestions — FR-018): this guard is called once up front in
+ * the invite mutation, before any invitation row is written.
+ *
+ * An empty eligible set rejects every suggestion (config kill-switch — R-8).
+ */
+@Injectable()
+export class RoleSetEligibleLanguageGuard {
+  constructor(
+    private readonly configService: ConfigService<AlkemioConfig, true>
+  ) {}
+
+  /**
+   * Returns the current eligible language list from config.
+   * Uses parseSupportedEligibleLanguages so the result is always filtered
+   * against SUPPORTED_INTERFACE_LANGUAGES — identical to Config.language.eligible
+   * (3655923939).
+   */
+  getEligibleLanguages(): string[] {
+    const languageConfig = this.configService.get('language', { infer: true });
+    const raw: string = languageConfig?.eligible ?? '';
+    return parseSupportedEligibleLanguages(raw);
+  }
+
+  /**
+   * Throws a ValidationException if `language` is not in the current eligible set.
+   * Call this once up front when `suggestedLanguage` is provided on the invite input.
+   */
+  isEligibleLanguageOrFail(language: string): void {
+    const eligible = this.getEligibleLanguages();
+    if (!eligible.includes(language)) {
+      throw new ValidationException(
+        'Suggested language is not in the eligible set. Only eligible languages may be suggested on an invitation (DL-8).',
+        LogContext.COMMUNITY,
+        { language, eligible }
+      );
+    }
+  }
+}

--- a/src/domain/access/role-set/role.set.eligible.language.guard.ts
+++ b/src/domain/access/role-set/role.set.eligible.language.guard.ts
@@ -7,13 +7,13 @@ import { AlkemioConfig } from '@src/types';
 
 /**
  * Validates that a `suggestedLanguage` value on an invitation input is in the
- * currently configured eligible-language set (DL-8 compose-time check).
+ * currently configured eligible-language set (compose-time check).
  *
  * Separate from the consumption-time check in registration (which silently skips
- * ineligible stored suggestions — FR-018): this guard is called once up front in
+ * ineligible stored suggestions): this guard is called once up front in
  * the invite mutation, before any invitation row is written.
  *
- * An empty eligible set rejects every suggestion (config kill-switch — R-8).
+ * An empty eligible set rejects every suggestion (config kill-switch).
  */
 @Injectable()
 export class RoleSetEligibleLanguageGuard {
@@ -41,7 +41,7 @@ export class RoleSetEligibleLanguageGuard {
     const eligible = this.getEligibleLanguages();
     if (!eligible.includes(language)) {
       throw new ValidationException(
-        'Suggested language is not in the eligible set. Only eligible languages may be suggested on an invitation (DL-8).',
+        'Suggested language is not in the eligible set. Only eligible languages may be suggested on an invitation.',
         LogContext.COMMUNITY,
         { language, eligible }
       );

--- a/src/domain/access/role-set/role.set.module.ts
+++ b/src/domain/access/role-set/role.set.module.ts
@@ -26,6 +26,7 @@ import { EntityResolverModule } from '@services/infrastructure/entity-resolver/e
 import { RoleModule } from '../role/role.module';
 import { RoleSetMembershipStatusDataLoader } from './role.set.data.loader.membership.status';
 import { RoleSetActorRolesDataLoader } from './role.set.data.loaders.actor.roles';
+import { RoleSetEligibleLanguageGuard } from './role.set.eligible.language.guard';
 import { RoleSet } from './role.set.entity';
 import { RoleSetResolverFields } from './role.set.resolver.fields';
 import { RoleSetResolverFieldsPublic } from './role.set.resolver.fields.public';
@@ -72,6 +73,7 @@ import { RoleSetServiceLifecycleInvitation } from './role.set.service.lifecycle.
     RoleSetService,
     RoleSetAuthorizationService,
     RoleSetLicenseService,
+    RoleSetEligibleLanguageGuard,
     RoleSetResolverMutations,
     RoleSetResolverMutationsMembership,
     RoleSetResolverFields,
@@ -86,6 +88,7 @@ import { RoleSetServiceLifecycleInvitation } from './role.set.service.lifecycle.
     RoleSetService,
     RoleSetAuthorizationService,
     RoleSetLicenseService,
+    RoleSetEligibleLanguageGuard,
     RoleSetActorRolesDataLoader,
     RoleSetMembershipStatusDataLoader,
   ],

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.spec.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.spec.ts
@@ -1,5 +1,5 @@
+import { LogContext } from '@common/enums';
 import { CommunityMembershipStatus } from '@common/enums/community.membership.status';
-import { RoleName } from '@common/enums/role.name';
 import { RoleSetInvitationResultType } from '@common/enums/role.set.invitation.result.type';
 import { RoleSetType } from '@common/enums/role.set.type';
 import { ValidationException } from '@common/exceptions';
@@ -18,6 +18,7 @@ import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { type Mock } from 'vitest';
+import { RoleSetEligibleLanguageGuard } from './role.set.eligible.language.guard';
 import { RoleSetResolverMutationsMembership } from './role.set.resolver.mutations.membership';
 import { RoleSetService } from './role.set.service';
 import { RoleSetAuthorizationService } from './role.set.service.authorization';
@@ -36,6 +37,7 @@ describe('RoleSetResolverMutationsMembership', () => {
   let userLookupService: UserLookupService;
   let communityResolverService: CommunityResolverService;
   let authorizationPolicyService: AuthorizationPolicyService;
+  let eligibleLanguageGuard: RoleSetEligibleLanguageGuard;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -70,6 +72,9 @@ describe('RoleSetResolverMutationsMembership', () => {
     );
     authorizationPolicyService = module.get<AuthorizationPolicyService>(
       AuthorizationPolicyService
+    );
+    eligibleLanguageGuard = module.get<RoleSetEligibleLanguageGuard>(
+      RoleSetEligibleLanguageGuard
     );
   });
 
@@ -765,6 +770,233 @@ describe('RoleSetResolverMutationsMembership', () => {
       );
 
       expect(result).toBe(updatedRoleSet);
+    });
+  });
+
+  // T008 — suggestedLanguage fan-out (R-5 / R-7 mitigations, DL-8)
+  // Verifies that inviteForEntryRoleOnRoleSet threads suggestedLanguage into
+  // BOTH the Invitation (existing-actor path) and PlatformInvitation (new-email
+  // path), and that the compose-time eligible guard fires before any row is
+  // written (DL-8).
+  describe('inviteForEntryRoleOnRoleSet - suggestedLanguage fan-out (T008)', () => {
+    // Shared helpers to reduce boilerplate across the three sub-tests.
+    function setupBaseRoleSet() {
+      const mockRoleSet = {
+        id: 'rs-fan',
+        type: RoleSetType.SPACE,
+        authorization: { id: 'auth-fan' },
+        parentRoleSet: undefined,
+        license: { entitlements: [] },
+      } as any;
+      (roleSetService.getRoleSetOrFail as Mock).mockResolvedValue(mockRoleSet);
+      (authorizationService.grantAccessOrFail as Mock).mockReturnValue(
+        undefined
+      );
+      (invitationService.getInvitationsOrFail as Mock).mockResolvedValue([]);
+      (
+        roleSetAuthorizationService.applyAuthorizationPolicyOnInvitationsApplications as Mock
+      ).mockResolvedValue([]);
+      (authorizationPolicyService.saveAll as Mock).mockResolvedValue(undefined);
+      (
+        communityResolverService.getCommunityForRoleSet as Mock
+      ).mockResolvedValue({ id: 'comm-fan' });
+      return mockRoleSet;
+    }
+
+    it('should pass suggestedLanguage nl to CreateInvitationInput for existing actor (Invitation entity path, US5-AS7)', async () => {
+      // Batch: 1 existing actor, suggestedLanguage 'nl' — verifies the
+      // Invitation entity (DL-1) receives the suggested language.
+      const actorContext = { actorID: 'user-1' } as any;
+      setupBaseRoleSet();
+
+      // eligible set includes 'nl' — guard must pass
+      (eligibleLanguageGuard.isEligibleLanguageOrFail as Mock).mockReturnValue(
+        undefined
+      );
+
+      (actorLookupService.validateActorsAndGetTypes as Mock).mockResolvedValue(
+        new Map([['actor-1', 'user']])
+      );
+      (roleSetService.findOpenInvitation as Mock).mockResolvedValue(undefined);
+      (roleSetService.findOpenApplication as Mock).mockResolvedValue(undefined);
+      (roleSetService.isMember as Mock).mockResolvedValue(false);
+
+      const mockInvitation = {
+        id: 'inv-fan',
+        invitedActorID: 'actor-1',
+        suggestedLanguage: 'nl',
+      } as any;
+      (roleSetService.createInvitationExistingActor as Mock).mockResolvedValue(
+        mockInvitation
+      );
+      (invitationService.getInvitationsOrFail as Mock).mockResolvedValue([
+        mockInvitation,
+      ]);
+
+      await resolver.inviteForEntryRoleOnRoleSet(actorContext, {
+        roleSetID: 'rs-fan',
+        invitedActorIDs: ['actor-1'],
+        invitedUserEmails: [],
+        extraRoles: [],
+        suggestedLanguage: 'nl',
+      } as any);
+
+      // createInvitationExistingActor must receive a CreateInvitationInput
+      // that carries suggestedLanguage: 'nl' (Invitation entity path — DL-1).
+      expect(roleSetService.createInvitationExistingActor).toHaveBeenCalledWith(
+        expect.objectContaining({ suggestedLanguage: 'nl' })
+      );
+    });
+
+    it('should pass suggestedLanguage nl to createPlatformInvitation for new email users (PlatformInvitation entity path, US5-AS7)', async () => {
+      // Batch: 2 new email users, suggestedLanguage 'nl' — verifies the
+      // PlatformInvitation entity receives the suggested language.
+      const actorContext = { actorID: 'user-1' } as any;
+      setupBaseRoleSet();
+
+      (eligibleLanguageGuard.isEligibleLanguageOrFail as Mock).mockReturnValue(
+        undefined
+      );
+
+      (actorLookupService.validateActorsAndGetTypes as Mock).mockResolvedValue(
+        new Map()
+      );
+      // Both emails are genuinely new users (not found by getUserByEmail)
+      (userLookupService.getUserByEmail as Mock).mockResolvedValue(undefined);
+
+      const platformInvitationSvc = (resolver as any).platformInvitationService;
+      (
+        platformInvitationSvc.getExistingPlatformInvitationForRoleSet as Mock
+      ).mockResolvedValue(undefined);
+
+      const mockPInv1 = {
+        id: 'pinv-1',
+        email: 'new1@test.com',
+        suggestedLanguage: 'nl',
+      } as any;
+      const mockPInv2 = {
+        id: 'pinv-2',
+        email: 'new2@test.com',
+        suggestedLanguage: 'nl',
+      } as any;
+      (roleSetService.createPlatformInvitation as Mock)
+        .mockResolvedValueOnce(mockPInv1)
+        .mockResolvedValueOnce(mockPInv2);
+
+      await resolver.inviteForEntryRoleOnRoleSet(actorContext, {
+        roleSetID: 'rs-fan',
+        invitedActorIDs: [],
+        invitedUserEmails: ['new1@test.com', 'new2@test.com'],
+        extraRoles: [],
+        suggestedLanguage: 'nl',
+      } as any);
+
+      // Both PlatformInvitation rows must receive suggestedLanguage: 'nl'
+      // (verifies the fan-out helper threads the field through — R-5 mitigation).
+      expect(roleSetService.createPlatformInvitation).toHaveBeenCalledTimes(2);
+      expect(roleSetService.createPlatformInvitation).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(), // roleSet
+        'new1@test.com',
+        expect.anything(), // welcomeMessage
+        expect.anything(), // inviteToParentRoleSet
+        expect.anything(), // extraRoles
+        expect.anything(), // actorContext
+        'nl' // suggestedLanguage must be threaded through
+      );
+      expect(roleSetService.createPlatformInvitation).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        'new2@test.com',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'nl'
+      );
+    });
+
+    it('should send null suggestedLanguage when omitted — invitation succeeds and no language is recorded (FR-015)', async () => {
+      // Batch with no suggestedLanguage — both entity paths should receive
+      // undefined/null and the mutation must still succeed.
+      const actorContext = { actorID: 'user-1' } as any;
+      setupBaseRoleSet();
+
+      (actorLookupService.validateActorsAndGetTypes as Mock).mockResolvedValue(
+        new Map([['actor-omit', 'user']])
+      );
+      (roleSetService.findOpenInvitation as Mock).mockResolvedValue(undefined);
+      (roleSetService.findOpenApplication as Mock).mockResolvedValue(undefined);
+      (roleSetService.isMember as Mock).mockResolvedValue(false);
+
+      const mockInvitationOmit = {
+        id: 'inv-omit',
+        invitedActorID: 'actor-omit',
+        suggestedLanguage: undefined,
+      } as any;
+      (roleSetService.createInvitationExistingActor as Mock).mockResolvedValue(
+        mockInvitationOmit
+      );
+      (invitationService.getInvitationsOrFail as Mock).mockResolvedValue([
+        mockInvitationOmit,
+      ]);
+
+      const result = await resolver.inviteForEntryRoleOnRoleSet(actorContext, {
+        roleSetID: 'rs-fan',
+        invitedActorIDs: ['actor-omit'],
+        invitedUserEmails: [],
+        extraRoles: [],
+        // no suggestedLanguage field
+      } as any);
+
+      // The guard must NOT be called when suggestedLanguage is absent
+      expect(
+        eligibleLanguageGuard.isEligibleLanguageOrFail
+      ).not.toHaveBeenCalled();
+      // The mutation must succeed and produce one invitation result
+      expect(result).toHaveLength(1);
+      // The CreateInvitationInput must carry undefined (not a stale 'nl')
+      expect(roleSetService.createInvitationExistingActor).toHaveBeenCalledWith(
+        expect.objectContaining({ suggestedLanguage: undefined })
+      );
+    });
+
+    it('should reject suggestedLanguage de before any row is written (DL-8 compose-time guard)', async () => {
+      // 'de' is in the supported set but NOT in the eligible set.
+      // isEligibleLanguageOrFail must throw a ValidationException before
+      // createInvitationExistingActor or createPlatformInvitation is called.
+      const actorContext = { actorID: 'user-1' } as any;
+      setupBaseRoleSet();
+
+      (actorLookupService.validateActorsAndGetTypes as Mock).mockResolvedValue(
+        new Map([['actor-de', 'user']])
+      );
+
+      // Simulate the guard throwing for 'de' (as it would when eligible=['nl'])
+      (
+        eligibleLanguageGuard.isEligibleLanguageOrFail as Mock
+      ).mockImplementation(() => {
+        throw new ValidationException(
+          "Suggested language 'de' is not in the eligible set [nl].",
+          LogContext.COMMUNITY
+        );
+      });
+
+      await expect(
+        resolver.inviteForEntryRoleOnRoleSet(actorContext, {
+          roleSetID: 'rs-fan',
+          invitedActorIDs: ['actor-de'],
+          invitedUserEmails: [],
+          extraRoles: [],
+          suggestedLanguage: 'de',
+        } as any)
+      ).rejects.toThrow(ValidationException);
+
+      // No invitation row must be written — the guard fires up front (DL-8)
+      expect(
+        roleSetService.createInvitationExistingActor
+      ).not.toHaveBeenCalled();
+      expect(roleSetService.createPlatformInvitation).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.spec.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.spec.ts
@@ -773,12 +773,10 @@ describe('RoleSetResolverMutationsMembership', () => {
     });
   });
 
-  // T008 — suggestedLanguage fan-out (R-5 / R-7 mitigations, DL-8)
   // Verifies that inviteForEntryRoleOnRoleSet threads suggestedLanguage into
   // BOTH the Invitation (existing-actor path) and PlatformInvitation (new-email
-  // path), and that the compose-time eligible guard fires before any row is
-  // written (DL-8).
-  describe('inviteForEntryRoleOnRoleSet - suggestedLanguage fan-out (T008)', () => {
+  // path), and that the compose-time eligible guard fires before any row is written.
+  describe('inviteForEntryRoleOnRoleSet - suggestedLanguage fan-out', () => {
     // Shared helpers to reduce boilerplate across the three sub-tests.
     function setupBaseRoleSet() {
       const mockRoleSet = {
@@ -803,9 +801,9 @@ describe('RoleSetResolverMutationsMembership', () => {
       return mockRoleSet;
     }
 
-    it('should pass suggestedLanguage nl to CreateInvitationInput for existing actor (Invitation entity path, US5-AS7)', async () => {
+    it('should pass suggestedLanguage nl to CreateInvitationInput for existing actor (Invitation entity path)', async () => {
       // Batch: 1 existing actor, suggestedLanguage 'nl' — verifies the
-      // Invitation entity (DL-1) receives the suggested language.
+      // Invitation entity receives the suggested language.
       const actorContext = { actorID: 'user-1' } as any;
       setupBaseRoleSet();
 
@@ -842,13 +840,13 @@ describe('RoleSetResolverMutationsMembership', () => {
       } as any);
 
       // createInvitationExistingActor must receive a CreateInvitationInput
-      // that carries suggestedLanguage: 'nl' (Invitation entity path — DL-1).
+      // that carries suggestedLanguage: 'nl' (Invitation entity path).
       expect(roleSetService.createInvitationExistingActor).toHaveBeenCalledWith(
         expect.objectContaining({ suggestedLanguage: 'nl' })
       );
     });
 
-    it('should pass suggestedLanguage nl to createPlatformInvitation for new email users (PlatformInvitation entity path, US5-AS7)', async () => {
+    it('should pass suggestedLanguage nl to createPlatformInvitation for new email users (PlatformInvitation entity path)', async () => {
       // Batch: 2 new email users, suggestedLanguage 'nl' — verifies the
       // PlatformInvitation entity receives the suggested language.
       const actorContext = { actorID: 'user-1' } as any;
@@ -892,7 +890,7 @@ describe('RoleSetResolverMutationsMembership', () => {
       } as any);
 
       // Both PlatformInvitation rows must receive suggestedLanguage: 'nl'
-      // (verifies the fan-out helper threads the field through — R-5 mitigation).
+      // (verifies the fan-out helper threads the field through each path).
       expect(roleSetService.createPlatformInvitation).toHaveBeenCalledTimes(2);
       expect(roleSetService.createPlatformInvitation).toHaveBeenNthCalledWith(
         1,
@@ -916,7 +914,7 @@ describe('RoleSetResolverMutationsMembership', () => {
       );
     });
 
-    it('should send null suggestedLanguage when omitted — invitation succeeds and no language is recorded (FR-015)', async () => {
+    it('should send null suggestedLanguage when omitted — invitation succeeds and no language is recorded', async () => {
       // Batch with no suggestedLanguage — both entity paths should receive
       // undefined/null and the mutation must still succeed.
       const actorContext = { actorID: 'user-1' } as any;
@@ -961,7 +959,7 @@ describe('RoleSetResolverMutationsMembership', () => {
       );
     });
 
-    it('should reject suggestedLanguage de before any row is written (DL-8 compose-time guard)', async () => {
+    it('should reject suggestedLanguage de before any row is written (compose-time guard)', async () => {
       // 'de' is in the supported set but NOT in the eligible set.
       // isEligibleLanguageOrFail must throw a ValidationException before
       // createInvitationExistingActor or createPlatformInvitation is called.
@@ -992,7 +990,7 @@ describe('RoleSetResolverMutationsMembership', () => {
         } as any)
       ).rejects.toThrow(ValidationException);
 
-      // No invitation row must be written — the guard fires up front (DL-8)
+      // No invitation row must be written — the guard fires up front
       expect(
         roleSetService.createInvitationExistingActor
       ).not.toHaveBeenCalled();

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -62,6 +62,7 @@ import { InviteForEntryRoleOnRoleSetInput } from './dto/role.set.dto.entry.role.
 import { JoinAsEntryRoleOnRoleSetInput } from './dto/role.set.dto.entry.role.join';
 import { UpdateApplicationFormOnRoleSetInput } from './dto/role.set.dto.update.application.form';
 import { RoleSetInvitationResult } from './dto/role.set.invitation.result';
+import { RoleSetEligibleLanguageGuard } from './role.set.eligible.language.guard';
 import { IRoleSet } from './role.set.interface';
 import { RoleSetService } from './role.set.service';
 import { RoleSetAuthorizationService } from './role.set.service.authorization';
@@ -94,6 +95,7 @@ export class RoleSetResolverMutationsMembership {
     private licenseService: LicenseService,
     private lifecycleService: LifecycleService,
     private roleSetCacheService: RoleSetCacheService,
+    private eligibleLanguageGuard: RoleSetEligibleLanguageGuard,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
@@ -304,6 +306,14 @@ export class RoleSetResolverMutationsMembership {
       `create invitation RoleSet: ${roleSet.id}`
     );
 
+    // Validate suggestedLanguage against the eligible set up front (DL-8 compose-time check).
+    // Empty eligible set rejects every suggestion (config kill switch — R-8).
+    if (invitationData.suggestedLanguage) {
+      this.eligibleLanguageGuard.isEligibleLanguageOrFail(
+        invitationData.suggestedLanguage
+      );
+    }
+
     const { authorizedToInviteToParentRoleSet } =
       this.getPrivilegesOnParentRoleSets(roleSet, actorContext);
 
@@ -346,7 +356,8 @@ export class RoleSetResolverMutationsMembership {
       actorContext,
       authorizedToInviteToParentRoleSet,
       invitationData.extraRoles,
-      invitationData.welcomeMessage
+      invitationData.welcomeMessage,
+      invitationData.suggestedLanguage
     );
 
     const newUserInvitationResults =
@@ -356,7 +367,8 @@ export class RoleSetResolverMutationsMembership {
         authorizedToInviteToParentRoleSet,
         invitationData.welcomeMessage,
         invitationData.extraRoles,
-        actorContext
+        actorContext,
+        invitationData.suggestedLanguage
       );
     invitationResults.push(...newUserInvitationResults);
 
@@ -392,7 +404,8 @@ export class RoleSetResolverMutationsMembership {
     authorizedToInviteToParentRoleSet: boolean,
     welcomeMessage: string | undefined,
     extraRoles: RoleName[],
-    actorContext: ActorContext
+    actorContext: ActorContext,
+    suggestedLanguage?: string
   ): Promise<RoleSetInvitationResult[]> {
     const invitationResults: RoleSetInvitationResult[] = [];
     // Rely on check already being made that there is no user with the emails
@@ -433,7 +446,8 @@ export class RoleSetResolverMutationsMembership {
           welcomeMessage || '',
           inviteToParentRoleSet,
           extraRoles,
-          actorContext
+          actorContext,
+          suggestedLanguage
         );
       const result: RoleSetInvitationResult = {
         type: RoleSetInvitationResultType.INVITED_TO_PLATFORM_AND_ROLE_SET,
@@ -739,7 +753,8 @@ export class RoleSetResolverMutationsMembership {
     actorContext: ActorContext,
     authorizedToInviteToParentRoleSet: boolean,
     extraRoles: RoleName[],
-    welcomeMessage: string | undefined
+    welcomeMessage: string | undefined,
+    suggestedLanguage?: string
   ): Promise<RoleSetInvitationResult[]> {
     const invitationResults: RoleSetInvitationResult[] = [];
     for (const actorID of actorIDs) {
@@ -768,6 +783,7 @@ export class RoleSetResolverMutationsMembership {
         invitedToParent: invitedToParent,
         extraRoles: extraRoles,
         welcomeMessage,
+        suggestedLanguage,
       };
 
       const openInvitation = await this.roleSetService.findOpenInvitation(

--- a/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
+++ b/src/domain/access/role-set/role.set.resolver.mutations.membership.ts
@@ -306,8 +306,8 @@ export class RoleSetResolverMutationsMembership {
       `create invitation RoleSet: ${roleSet.id}`
     );
 
-    // Validate suggestedLanguage against the eligible set up front (DL-8 compose-time check).
-    // Empty eligible set rejects every suggestion (config kill switch — R-8).
+    // Validate suggestedLanguage against the eligible set up front (compose-time check).
+    // An empty eligible set rejects every suggestion (config kill switch).
     if (invitationData.suggestedLanguage) {
       this.eligibleLanguageGuard.isEligibleLanguageOrFail(
         invitationData.suggestedLanguage

--- a/src/domain/access/role-set/role.set.service.ts
+++ b/src/domain/access/role-set/role.set.service.ts
@@ -1536,7 +1536,8 @@ export class RoleSetService {
     welcomeMessage: string,
     roleSetInvitedToParent: boolean,
     extraRoles: RoleName[],
-    actorContext: ActorContext
+    actorContext: ActorContext,
+    suggestedLanguage?: string
   ): Promise<IPlatformInvitation> {
     const externalInvitationInput: CreatePlatformInvitationInput = {
       roleSetID: roleSet.id,
@@ -1545,6 +1546,7 @@ export class RoleSetService {
       roleSetInvitedToParent,
       roleSetExtraRoles: extraRoles,
       createdBy: actorContext.actorID,
+      suggestedLanguage,
     };
     const externalInvitation =
       await this.platformInvitationService.createPlatformInvitation(

--- a/src/domain/community/user-settings/dto/user.settings.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.create.ts
@@ -1,6 +1,7 @@
+import { SUPPORTED_INTERFACE_LANGUAGES } from '@common/constants/supported.languages';
 import { Field, InputType, Int } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, ValidateNested } from 'class-validator';
+import { IsIn, IsInt, IsOptional, ValidateNested } from 'class-validator';
 import { CreateUserSettingsAssistantInput } from './user.settings.assistant.dto.create';
 import { CreateUserSettingsCommunicationInput } from './user.settings.communications.dto.create';
 import { CreateUserSettingsHomeSpaceInput } from './user.settings.home.space.dto.create';
@@ -58,4 +59,21 @@ export class CreateUserSettingsInput {
   @IsOptional()
   @IsInt()
   designVersion?: number;
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Initial interface language for this User. Null = user has never chosen a language.',
+  })
+  @IsOptional()
+  @IsIn([...SUPPORTED_INTERFACE_LANGUAGES])
+  language?: string | null;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Whether this User has already answered the one-time language offer (global flag — FR-005a).',
+  })
+  @IsOptional()
+  languageOfferAnswered?: boolean;
 }

--- a/src/domain/community/user-settings/dto/user.settings.dto.create.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.create.ts
@@ -72,7 +72,7 @@ export class CreateUserSettingsInput {
   @Field(() => Boolean, {
     nullable: true,
     description:
-      'Whether this User has already answered the one-time language offer (global flag — FR-005a).',
+      'Whether this User has already answered the one-time language offer.',
   })
   @IsOptional()
   languageOfferAnswered?: boolean;

--- a/src/domain/community/user-settings/dto/user.settings.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.update.ts
@@ -64,7 +64,7 @@ export class UpdateUserSettingsEntityInput {
   @Field(() => String, {
     nullable: true,
     description:
-      "Set the user's interface language preference. Must be a value from the supported languages set. Any language write also latches languageOfferAnswered=true (FR-023 invariant).",
+      "Set the user's interface language preference. Must be a value from the supported languages set. Any language write also latches languageOfferAnswered=true.",
   })
   @IsOptional()
   @IsIn([...SUPPORTED_INTERFACE_LANGUAGES])
@@ -73,7 +73,7 @@ export class UpdateUserSettingsEntityInput {
   @Field(() => Boolean, {
     nullable: true,
     description:
-      'Mark that this User has answered the one-time language offer. One-way latch: setting false is rejected (FR-005a).',
+      'Mark that this User has answered the one-time language offer. One-way latch: setting false is rejected.',
   })
   @IsOptional()
   languageOfferAnswered?: boolean;

--- a/src/domain/community/user-settings/dto/user.settings.dto.update.ts
+++ b/src/domain/community/user-settings/dto/user.settings.dto.update.ts
@@ -1,6 +1,7 @@
+import { SUPPORTED_INTERFACE_LANGUAGES } from '@common/constants/supported.languages';
 import { Field, InputType, Int } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, ValidateNested } from 'class-validator';
+import { IsIn, IsInt, IsOptional, ValidateNested } from 'class-validator';
 import { UpdateUserSettingsAssistantInput } from './user.settings.assistant.dto.update';
 import { UpdateUserSettingsCommunicationInput } from './user.settings.communications.dto.update';
 import { UpdateUserSettingsHomeSpaceInput } from './user.settings.home.space.dto.update';
@@ -59,4 +60,21 @@ export class UpdateUserSettingsEntityInput {
   @IsOptional()
   @IsInt()
   designVersion?: number;
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      "Set the user's interface language preference. Must be a value from the supported languages set. Any language write also latches languageOfferAnswered=true (FR-023 invariant).",
+  })
+  @IsOptional()
+  @IsIn([...SUPPORTED_INTERFACE_LANGUAGES])
+  language?: string | null;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Mark that this User has answered the one-time language offer. One-way latch: setting false is rejected (FR-005a).',
+  })
+  @IsOptional()
+  languageOfferAnswered?: boolean;
 }

--- a/src/domain/community/user-settings/user.settings.entity.ts
+++ b/src/domain/community/user-settings/user.settings.entity.ts
@@ -1,3 +1,4 @@
+import { TINY_TEXT_LENGTH } from '@common/constants';
 import { AuthorizableEntity } from '@domain/common/entity/authorizable-entity';
 import { Column, Entity } from 'typeorm';
 import { IUserSettingsAssistant } from './user.settings.assistant.interface';
@@ -33,4 +34,10 @@ export class UserSettings extends AuthorizableEntity implements IUserSettings {
 
   @Column('int', { nullable: false, default: DESIGN_VERSION_CURRENT_DEFAULT })
   designVersion!: number;
+
+  @Column('varchar', { length: TINY_TEXT_LENGTH, nullable: true })
+  language!: string | null;
+
+  @Column('boolean', { nullable: false, default: false })
+  languageOfferAnswered!: boolean;
 }

--- a/src/domain/community/user-settings/user.settings.interface.ts
+++ b/src/domain/community/user-settings/user.settings.interface.ts
@@ -45,4 +45,18 @@ export class IUserSettings extends IAuthorizable {
       'The design version this User has selected (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).',
   })
   designVersion!: number;
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'The interface language chosen by this User. Null = the User has never chosen a language (distinct from having chosen the platform default).',
+  })
+  language!: string | null;
+
+  @Field(() => Boolean, {
+    nullable: false,
+    description:
+      'Whether this User has answered the one-time language offer (global across all languages — FR-005a). Latched true by any language write.',
+  })
+  languageOfferAnswered!: boolean;
 }

--- a/src/domain/community/user-settings/user.settings.interface.ts
+++ b/src/domain/community/user-settings/user.settings.interface.ts
@@ -56,7 +56,7 @@ export class IUserSettings extends IAuthorizable {
   @Field(() => Boolean, {
     nullable: false,
     description:
-      'Whether this User has answered the one-time language offer (global across all languages — FR-005a). Latched true by any language write.',
+      'Whether this User has answered the one-time language offer (global across all languages). Latched true by any language write.',
   })
   languageOfferAnswered!: boolean;
 }

--- a/src/domain/community/user-settings/user.settings.service.spec.ts
+++ b/src/domain/community/user-settings/user.settings.service.spec.ts
@@ -484,8 +484,8 @@ describe('UserSettingsService', () => {
       ).toThrow(ValidationException);
     });
 
-    it('should accept a supported non-eligible language (e.g. "es") without throwing (FR-008)', () => {
-      // FR-008: the FULL supported set is allowed, not just the eligible subset
+    it('should accept a supported non-eligible language (e.g. "es") without throwing', () => {
+      // The FULL supported set is allowed, not just the eligible subset
       const settings = buildSettings({
         language: null,
         languageOfferAnswered: false,

--- a/src/domain/community/user-settings/user.settings.service.spec.ts
+++ b/src/domain/community/user-settings/user.settings.service.spec.ts
@@ -381,6 +381,123 @@ describe('UserSettingsService', () => {
     });
   });
 
+  describe('updateSettings - language / languageOfferAnswered', () => {
+    it('should set language and latch languageOfferAnswered when language is provided', () => {
+      const settings = buildSettings({
+        language: null,
+        languageOfferAnswered: false,
+      } as any);
+      const result = service.updateSettings(settings, { language: 'nl' });
+
+      expect(result.language).toBe('nl');
+      expect(result.languageOfferAnswered).toBe(true);
+    });
+
+    it('should latch languageOfferAnswered to true (decline path) without writing a language', () => {
+      const settings = buildSettings({
+        language: null,
+        languageOfferAnswered: false,
+      } as any);
+      const result = service.updateSettings(settings, {
+        languageOfferAnswered: true,
+      });
+
+      expect(result.language).toBeNull();
+      expect(result.languageOfferAnswered).toBe(true);
+    });
+
+    it('should throw ValidationException when languageOfferAnswered is set to false (one-way latch)', () => {
+      const settings = buildSettings({
+        language: null,
+        languageOfferAnswered: true,
+      } as any);
+
+      expect(() =>
+        service.updateSettings(settings, { languageOfferAnswered: false })
+      ).toThrow(ValidationException);
+    });
+
+    it('should leave other settings blocks untouched by a language-only update', () => {
+      const settings = buildSettings({
+        language: null,
+        languageOfferAnswered: false,
+        designVersion: 3,
+      } as any);
+      const result = service.updateSettings(settings, { language: 'en' });
+
+      expect(result.designVersion).toBe(3);
+      expect(result.privacy.contributionRolesPubliclyVisible).toBe(false);
+    });
+
+    it('should not change language when language update is omitted', () => {
+      const settings = buildSettings({
+        language: 'nl',
+        languageOfferAnswered: true,
+      } as any);
+      const result = service.updateSettings(settings, {});
+
+      expect(result.language).toBe('nl');
+      expect(result.languageOfferAnswered).toBe(true);
+    });
+
+    it('should treat explicit null for language as a no-op (not clear language or latch)', () => {
+      // GraphQL nullable Boolean/String: sending null must not clear the stored
+      // language or touch the latch — it behaves like an omitted field.
+      const settings = buildSettings({
+        language: 'nl',
+        languageOfferAnswered: true,
+      } as any);
+      const updateData = {
+        language: null,
+      } as unknown as UpdateUserSettingsEntityInput;
+
+      const result = service.updateSettings(settings, updateData);
+
+      expect(result.language).toBe('nl');
+      expect(result.languageOfferAnswered).toBe(true);
+    });
+
+    it('should treat explicit null for languageOfferAnswered as a no-op', () => {
+      // An explicit null on the nullable Boolean must not trigger the rejection
+      // path (false check) or change the latch state.
+      const settings = buildSettings({
+        language: null,
+        languageOfferAnswered: false,
+      } as any);
+      const updateData = {
+        languageOfferAnswered: null,
+      } as unknown as UpdateUserSettingsEntityInput;
+
+      const result = service.updateSettings(settings, updateData);
+
+      expect(result.languageOfferAnswered).toBe(false);
+    });
+
+    it('should throw ValidationException when language is not in SUPPORTED_INTERFACE_LANGUAGES (3656016008)', () => {
+      const settings = buildSettings({
+        language: null,
+        languageOfferAnswered: false,
+      } as any);
+
+      expect(() =>
+        service.updateSettings(settings, { language: 'xx' })
+      ).toThrow(ValidationException);
+    });
+
+    it('should accept a supported non-eligible language (e.g. "es") without throwing (FR-008)', () => {
+      // FR-008: the FULL supported set is allowed, not just the eligible subset
+      const settings = buildSettings({
+        language: null,
+        languageOfferAnswered: false,
+      } as any);
+
+      const result = service.updateSettings(settings, { language: 'es' });
+
+      expect(result.language).toBe('es');
+      expect(result.languageOfferAnswered).toBe(true);
+    });
+  });
+
   describe('updateSettings - designVersion', () => {
     it('should update designVersion when provided', () => {
       // buildSettings() seeds the current default; switching back to the

--- a/src/domain/community/user-settings/user.settings.service.ts
+++ b/src/domain/community/user-settings/user.settings.service.ts
@@ -319,7 +319,7 @@ export class UserSettingsService {
       settings.designVersion = updateData.designVersion;
     }
 
-    // Language preference + one-way latch (FR-023 / R-3):
+    // Language preference + one-way latch:
     // (a) Any non-null language write latches languageOfferAnswered = true
     //     (invariant: language ≠ NULL ⇒ flag = true).
     // (b) Setting languageOfferAnswered = true without a language is the
@@ -329,7 +329,7 @@ export class UserSettingsService {
     // (d) An explicit null for either field behaves like an omitted field
     //     (no-op), matching the designVersion pattern above.
     if (updateData.language != null) {
-      // Enforce UserSettings.language ∈ SUPPORTED_INTERFACE_LANGUAGES (FR-008 / 3656016008).
+      // Enforce UserSettings.language ∈ SUPPORTED_INTERFACE_LANGUAGES.
       // DTO @IsIn catches API requests but internal callers (registration seeding,
       // reconciliation) bypass DTO validation — this service-level guard is the
       // last line of defence.
@@ -350,7 +350,7 @@ export class UserSettingsService {
     if (updateData.languageOfferAnswered != null) {
       if (updateData.languageOfferAnswered === false) {
         throw new ValidationException(
-          'languageOfferAnswered cannot be set back to false — it is a one-way latch (FR-005a / R-3)',
+          'languageOfferAnswered cannot be set back to false — it is a one-way latch',
           LogContext.COMMUNITY
         );
       }

--- a/src/domain/community/user-settings/user.settings.service.ts
+++ b/src/domain/community/user-settings/user.settings.service.ts
@@ -1,3 +1,7 @@
+import {
+  isSupportedInterfaceLanguage,
+  SUPPORTED_INTERFACE_LANGUAGES,
+} from '@common/constants/supported.languages';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
 import { LogContext } from '@common/enums/logging.context';
 import {
@@ -38,6 +42,8 @@ export class UserSettingsService {
       },
       designVersion:
         settingsData.designVersion ?? DESIGN_VERSION_CURRENT_DEFAULT,
+      language: settingsData.language ?? null,
+      languageOfferAnswered: settingsData.languageOfferAnswered ?? false,
     });
     settings.authorization = new AuthorizationPolicy(
       AuthorizationPolicyType.USER_SETTINGS
@@ -311,6 +317,45 @@ export class UserSettingsService {
     // unsupported — the column is NOT NULL with a default of 2).
     if (updateData.designVersion != null) {
       settings.designVersion = updateData.designVersion;
+    }
+
+    // Language preference + one-way latch (FR-023 / R-3):
+    // (a) Any non-null language write latches languageOfferAnswered = true
+    //     (invariant: language ≠ NULL ⇒ flag = true).
+    // (b) Setting languageOfferAnswered = true without a language is the
+    //     decline path (stores the answered flag, leaves language null).
+    // (c) Setting languageOfferAnswered = false is rejected — the latch is
+    //     one-way; un-answering is not a valid state transition.
+    // (d) An explicit null for either field behaves like an omitted field
+    //     (no-op), matching the designVersion pattern above.
+    if (updateData.language != null) {
+      // Enforce UserSettings.language ∈ SUPPORTED_INTERFACE_LANGUAGES (FR-008 / 3656016008).
+      // DTO @IsIn catches API requests but internal callers (registration seeding,
+      // reconciliation) bypass DTO validation — this service-level guard is the
+      // last line of defence.
+      if (!isSupportedInterfaceLanguage(updateData.language)) {
+        throw new ValidationException(
+          'Language is not supported',
+          LogContext.COMMUNITY,
+          {
+            language: updateData.language,
+            supported: [...SUPPORTED_INTERFACE_LANGUAGES],
+          }
+        );
+      }
+      settings.language = updateData.language;
+      settings.languageOfferAnswered = true;
+    }
+
+    if (updateData.languageOfferAnswered != null) {
+      if (updateData.languageOfferAnswered === false) {
+        throw new ValidationException(
+          'languageOfferAnswered cannot be set back to false — it is a one-way latch (FR-005a / R-3)',
+          LogContext.COMMUNITY
+        );
+      }
+      // true: latch the flag (decline path — no language written)
+      settings.languageOfferAnswered = true;
     }
 
     return settings;

--- a/src/domain/community/user/user.service.spec.ts
+++ b/src/domain/community/user/user.service.spec.ts
@@ -125,6 +125,18 @@ describe('UserService', () => {
         inAppNotification: true,
       });
     });
+
+    it('should default language to null (never chose)', () => {
+      const defaults = (service as any).getDefaultUserSettings();
+
+      expect(defaults.language).toBeNull();
+    });
+
+    it('should default languageOfferAnswered to false', () => {
+      const defaults = (service as any).getDefaultUserSettings();
+
+      expect(defaults.languageOfferAnswered).toBe(false);
+    });
   });
 
   describe('getUserByIdOrFail', () => {

--- a/src/domain/community/user/user.service.ts
+++ b/src/domain/community/user/user.service.ts
@@ -401,6 +401,8 @@ export class UserService {
         enabledCapabilities: getReadOnlyDefaultCapabilityToggles(),
       },
       designVersion: DESIGN_VERSION_CURRENT_DEFAULT,
+      language: null,
+      languageOfferAnswered: false,
     };
     return settings;
   }

--- a/src/migrations/1785000000000-AddUserLanguagePreference.ts
+++ b/src/migrations/1785000000000-AddUserLanguagePreference.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add user-language-preference columns to support workspace#029-detect-signup-language.
+ *
+ * Rules (DL-4 / R-1 — load-bearing invariants):
+ * - METADATA-ONLY, ADD-ONLY: no row UPDATEs, no concrete language values written.
+ * - Existing rows read {language: NULL, languageOfferAnswered: false} after up() —
+ *   the languageOfferAnswered column defaults to false so no backfill is needed.
+ * - The NULL language is the discriminator for "never chose a language" (US4 target).
+ * - NO authorization_policy writes, NO authorizationPolicyResetAll, NO jsonb touch.
+ * - safe down(): drops all four columns (each is nullable or has a server-set default).
+ *
+ * Columns added:
+ *   user_settings.language             varchar(16) NULL         — chosen interface language
+ *   user_settings.languageOfferAnswered boolean NOT NULL DEFAULT false — one-way latch
+ *   invitation.suggestedLanguage        varchar(16) NULL         — inviter's suggested language
+ *   platform_invitation.suggestedLanguage varchar(16) NULL       — inviter's suggested language
+ */
+export class AddUserLanguagePreference1785000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "language" varchar(16)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "languageOfferAnswered" boolean NOT NULL DEFAULT false`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "invitation" ADD COLUMN IF NOT EXISTS "suggestedLanguage" varchar(16)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "platform_invitation" ADD COLUMN IF NOT EXISTS "suggestedLanguage" varchar(16)`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "platform_invitation" DROP COLUMN IF EXISTS "suggestedLanguage"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "invitation" DROP COLUMN IF EXISTS "suggestedLanguage"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN IF EXISTS "languageOfferAnswered"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN IF EXISTS "language"`
+    );
+  }
+}

--- a/src/migrations/1785000000000-AddUserLanguagePreference.ts
+++ b/src/migrations/1785000000000-AddUserLanguagePreference.ts
@@ -1,21 +1,20 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 /**
- * Add user-language-preference columns to support workspace#029-detect-signup-language.
+ * Add user-language-preference columns.
  *
- * Rules (DL-4 / R-1 — load-bearing invariants):
- * - METADATA-ONLY, ADD-ONLY: no row UPDATEs, no concrete language values written.
- * - Existing rows read {language: NULL, languageOfferAnswered: false} after up() —
- *   the languageOfferAnswered column defaults to false so no backfill is needed.
- * - The NULL language is the discriminator for "never chose a language" (US4 target).
- * - NO authorization_policy writes, NO authorizationPolicyResetAll, NO jsonb touch.
- * - safe down(): drops all four columns (each is nullable or has a server-set default).
+ * Safe schema-only migration — no row UPDATEs, no concrete language values written.
+ * Existing rows read {language: NULL, languageOfferAnswered: false} after up();
+ * the languageOfferAnswered column defaults to false so no backfill is needed.
+ * A NULL language means the user has never chosen a language.
+ * No authorization_policy writes, no authorizationPolicyResetAll, no jsonb touch.
+ * Safe down(): drops all four columns (each is nullable or has a server-set default).
  *
  * Columns added:
- *   user_settings.language             varchar(16) NULL         — chosen interface language
- *   user_settings.languageOfferAnswered boolean NOT NULL DEFAULT false — one-way latch
- *   invitation.suggestedLanguage        varchar(16) NULL         — inviter's suggested language
- *   platform_invitation.suggestedLanguage varchar(16) NULL       — inviter's suggested language
+ *   user_settings.language               varchar(16) NULL         — chosen interface language
+ *   user_settings.languageOfferAnswered  boolean NOT NULL DEFAULT false — one-way latch
+ *   invitation.suggestedLanguage         varchar(16) NULL         — inviter's suggested language
+ *   platform_invitation.suggestedLanguage varchar(16) NULL        — inviter's suggested language
  */
 export class AddUserLanguagePreference1785000000000
   implements MigrationInterface

--- a/src/platform/configuration/config/config.interface.ts
+++ b/src/platform/configuration/config/config.interface.ts
@@ -3,6 +3,7 @@ import { IPlatformFeatureFlag } from '../feature-flag/platform.feature.flag.inte
 import { IApmConfig } from './apm';
 import { IAuthenticationConfig } from './authentication';
 import { IGeoConfig } from './integrations';
+import { ILanguageConfig } from './language/language.config.interface';
 import { IPlatformLocations } from './locations';
 import { ISentryConfig } from './sentry';
 import { IStorageConfig } from './storage';
@@ -51,4 +52,11 @@ export abstract class IConfig {
     description: 'Integration with a 3rd party Geo information service',
   })
   geo?: IGeoConfig;
+
+  @Field(() => ILanguageConfig, {
+    nullable: false,
+    description:
+      'Language configuration: eligible set for proactive offers and the platform default.',
+  })
+  language?: ILanguageConfig;
 }

--- a/src/platform/configuration/config/config.service.spec.ts
+++ b/src/platform/configuration/config/config.service.spec.ts
@@ -1,19 +1,220 @@
+import { RoleSetEligibleLanguageGuard } from '@domain/access/role-set/role.set.eligible.language.guard';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { KonfigService } from './config.service';
 
+/**
+ * Unit tests for language config parsing in KonfigService (contract C2 / T005).
+ * Tests call getConfig() directly to ensure the real wiring is exercised, not
+ * just an inline re-implementation of the parse logic.
+ */
 describe('ConfigService', () => {
   let service: KonfigService;
 
-  beforeEach(async () => {
+  /**
+   * Minimal ConfigService stub that returns controlled language values and
+   * enough platform stubs for getConfig() to complete without errors.
+   */
+  function makeConfigServiceStub(languageConfig: {
+    eligible: string;
+    default: string;
+  }) {
+    return {
+      get: (key: string) => {
+        if (key === 'language') return languageConfig;
+        if (key === 'hosting.endpoint_cluster') return 'http://localhost:3000';
+        if (key === 'hosting.subscriptions.enabled') return false;
+        if (key === 'hosting.environment') return 'test';
+        if (key === 'platform')
+          return {
+            documentation_path: '/docs',
+            terms: '',
+            privacy: '',
+            security: '',
+            support: '',
+            feedback: '',
+            forumreleases: '',
+            about: '',
+            landing: '',
+            blog: '',
+            impact: '',
+            inspiration: '',
+            innovationLibrary: '',
+            foundation: '',
+            contactsupport: '',
+            switchplan: '',
+            opensource: '',
+            releases: '',
+            help: '',
+            community: '',
+            newuser: '',
+            tips: '',
+            aup: '',
+            landing_page: { enabled: false },
+            guidance_engine: { enabled: false },
+          };
+        if (key === 'monitoring')
+          return {
+            sentry: {
+              enabled: false,
+              endpoint: '',
+              submit_pii: false,
+              environment: 'test',
+            },
+            apm: { rumEnabled: false, endpoint: '' },
+          };
+        if (key === 'integrations.geo')
+          return { enabled: false, rest_endpoint: '' };
+        if (key === 'storage.file') return { max_file_size: 0 };
+        if (key === 'identity.authentication.providers.ory')
+          return {
+            kratos_public_base_url: 'http://kratos:4433',
+            issuer: 'http://kratos:4433',
+          };
+        if (key === 'communications.enabled') return false;
+        if (key === 'communications.discussions.enabled') return false;
+        if (key === 'notifications.enabled') return false;
+        if (key === 'collaboration.whiteboards.enabled') return false;
+        if (key === 'collaboration.memo.enabled') return false;
+        if (key === 'platform.landing_page.enabled') return false;
+        if (key === 'platform.guidance_engine.enabled') return false;
+        return undefined;
+      },
+    };
+  }
+
+  async function buildServiceWithLanguageConfig(languageConfig: {
+    eligible: string;
+    default: string;
+  }): Promise<KonfigService> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [KonfigService],
+    })
+      .useMocker(token => {
+        if (token === ConfigService) {
+          return makeConfigServiceStub(languageConfig);
+        }
+        return defaultMockerFactory(token);
+      })
+      .compile();
+
+    return module.get<KonfigService>(KonfigService);
+  }
+
+  it('should be defined', async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [KonfigService, ConfigService],
-    }).compile();
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
 
     service = module.get<KonfigService>(KonfigService);
+    expect(service).toBeDefined();
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('language config parsing (contract C2)', () => {
+    it('should return eligible:[nl] and default:en from the yml defaults', async () => {
+      service = await buildServiceWithLanguageConfig({
+        eligible: 'nl',
+        default: 'en',
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.eligible).toEqual(['nl']);
+      expect(config.language?.default).toBe('en');
+    });
+
+    it('should parse a comma-separated multi-value eligible string', async () => {
+      service = await buildServiceWithLanguageConfig({
+        eligible: 'nl,de,fr',
+        default: 'en',
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.eligible).toEqual(['nl', 'de', 'fr']);
+    });
+
+    it('should return an empty array when eligible is an empty string (kill-switch)', async () => {
+      service = await buildServiceWithLanguageConfig({
+        eligible: '',
+        default: 'en',
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.eligible).toEqual([]);
+    });
+
+    it('should trim whitespace from eligible values', async () => {
+      service = await buildServiceWithLanguageConfig({
+        eligible: ' nl , de ',
+        default: 'en',
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.eligible).toEqual(['nl', 'de']);
+    });
+
+    it('should drop eligible values that are not in SUPPORTED_INTERFACE_LANGUAGES', async () => {
+      // 'xx' is not a supported language — it must be silently dropped
+      service = await buildServiceWithLanguageConfig({
+        eligible: 'nl,xx',
+        default: 'en',
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.eligible).toEqual(['nl']);
+      // 'xx' must NOT appear in the list
+      expect(config.language?.eligible).not.toContain('xx');
+    });
+
+    it('should return an empty eligible list when all configured values are unsupported', async () => {
+      service = await buildServiceWithLanguageConfig({
+        eligible: 'xx,yy',
+        default: 'en',
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.eligible).toEqual([]);
+    });
+
+    it('should fall back default to "en" when LANGUAGE_DEFAULT is set to an unsupported value (3655923899)', async () => {
+      service = await buildServiceWithLanguageConfig({
+        eligible: 'nl',
+        default: 'xx', // not in SUPPORTED_INTERFACE_LANGUAGES
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.default).toBe('en');
+    });
+
+    it('should accept a supported LANGUAGE_DEFAULT without falling back', async () => {
+      service = await buildServiceWithLanguageConfig({
+        eligible: 'nl',
+        default: 'nl',
+      });
+
+      const config = await service.getConfig();
+      expect(config.language?.default).toBe('nl');
+    });
+
+    it('guard and config resolve an identical eligible set for the same raw config (3655923939)', async () => {
+      // Both KonfigService and RoleSetEligibleLanguageGuard call
+      // parseSupportedEligibleLanguages — invoke BOTH for the same raw string
+      // (mixing supported + unsupported) and assert they agree, so a future
+      // divergence between the two paths is actually caught.
+      const languageConfig = { eligible: 'nl,xx,de', default: 'en' };
+      service = await buildServiceWithLanguageConfig(languageConfig);
+
+      const config = await service.getConfig();
+      // 'xx' must be dropped; 'nl' and 'de' must be kept (in order)
+      expect(config.language?.eligible).toEqual(['nl', 'de']);
+
+      // The invite-time compose guard MUST resolve the same eligible set.
+      const guard = new RoleSetEligibleLanguageGuard({
+        get: (key: string) => (key === 'language' ? languageConfig : undefined),
+      } as any);
+      expect(guard.getEligibleLanguages()).toEqual(config.language?.eligible);
+    });
   });
 });

--- a/src/platform/configuration/config/config.service.spec.ts
+++ b/src/platform/configuration/config/config.service.spec.ts
@@ -5,7 +5,7 @@ import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { KonfigService } from './config.service';
 
 /**
- * Unit tests for language config parsing in KonfigService (contract C2 / T005).
+ * Unit tests for language config parsing in KonfigService.
  * Tests call getConfig() directly to ensure the real wiring is exercised, not
  * just an inline re-implementation of the parse logic.
  */

--- a/src/platform/configuration/config/config.service.ts
+++ b/src/platform/configuration/config/config.service.ts
@@ -1,5 +1,9 @@
+import {
+  parseSupportedEligibleLanguages,
+  resolveSupportedDefaultLanguage,
+} from '@common/constants/supported.languages';
 import { PlatformFeatureFlagName } from '@common/enums/platform.feature.flag.name';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AlkemioConfig } from '@src/types';
 import { IAuthenticationProviderConfig } from './authentication/providers/authentication.provider.config.interface';
@@ -8,6 +12,8 @@ import { IConfig } from './config.interface';
 
 @Injectable()
 export class KonfigService {
+  private readonly logger = new Logger(KonfigService.name);
+
   constructor(private configService: ConfigService<AlkemioConfig, true>) {}
 
   async getConfig(): Promise<IConfig> {
@@ -31,6 +37,34 @@ export class KonfigService {
     const fileConfig = this.configService.get('storage.file', {
       infer: true,
     });
+    const languageConfig = this.configService.get('language', { infer: true });
+    const eligibleRaw: string = languageConfig?.eligible ?? '';
+    // parseSupportedEligibleLanguages handles split/trim/dedup and filters to
+    // SUPPORTED_INTERFACE_LANGUAGES. Warn on any value that gets dropped.
+    const eligible = parseSupportedEligibleLanguages(eligibleRaw);
+    if (eligibleRaw) {
+      const parsedRaw = eligibleRaw
+        .split(',')
+        .map((s: string) => s.trim())
+        .filter((s: string) => s.length > 0);
+      for (const lang of parsedRaw) {
+        if (!eligible.includes(lang)) {
+          this.logger.warn(
+            `Configured eligible language '${lang}' is not in SUPPORTED_INTERFACE_LANGUAGES and will be ignored.`
+          );
+        }
+      }
+    }
+    // resolveSupportedDefaultLanguage falls back to 'en' and warns when the
+    // configured LANGUAGE_DEFAULT is set but not in the supported set (3655923899).
+    const rawDefault = languageConfig?.default;
+    const resolvedDefault = resolveSupportedDefaultLanguage(rawDefault);
+    if (rawDefault !== undefined && resolvedDefault !== rawDefault) {
+      this.logger.warn(
+        `Configured default language '${rawDefault}' is not in SUPPORTED_INTERFACE_LANGUAGES; falling back to 'en'.`
+      );
+    }
+
     return {
       authentication: {
         providers: await this.getAuthenticationProvidersConfig(),
@@ -133,6 +167,10 @@ export class KonfigService {
         file: {
           maxFileSize: fileConfig?.max_file_size,
         },
+      },
+      language: {
+        eligible,
+        default: resolvedDefault,
       },
     };
   }

--- a/src/platform/configuration/config/language/language.config.interface.ts
+++ b/src/platform/configuration/config/language/language.config.interface.ts
@@ -1,0 +1,29 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Language configuration surfaced to the client via the platform Config query.
+ * Contract C2 (anonymous-readable — the platform query carries no auth guard).
+ *
+ * eligible: the subset of supported languages the platform proactively detects,
+ *           offers, and accepts as an invitation suggestion. An empty list disables
+ *           all proactive offers (kill switch — DL-2 / R-8).
+ * default:  the platform-wide fallback language shown when no preference is known.
+ *
+ * Source: alkemio.yml → language: { eligible, default }
+ * Env overrides: LANGUAGE_ELIGIBLE (comma-separated), LANGUAGE_DEFAULT.
+ */
+@ObjectType('LanguageConfig')
+export class ILanguageConfig {
+  @Field(() => [String], {
+    nullable: false,
+    description:
+      'Languages the platform proactively detects, offers, and allows as invitation suggestions — subset of the supported set; empty = all proactive offers disabled.',
+  })
+  eligible!: string[];
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'The platform-wide default interface language.',
+  })
+  default!: string;
+}

--- a/src/platform/configuration/config/language/language.config.interface.ts
+++ b/src/platform/configuration/config/language/language.config.interface.ts
@@ -1,12 +1,12 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
 /**
- * Language configuration surfaced to the client via the platform Config query.
- * Contract C2 (anonymous-readable — the platform query carries no auth guard).
+ * Language configuration surfaced to the client via the platform Config query
+ * (anonymous-readable — the platform query carries no auth guard).
  *
  * eligible: the subset of supported languages the platform proactively detects,
  *           offers, and accepts as an invitation suggestion. An empty list disables
- *           all proactive offers (kill switch — DL-2 / R-8).
+ *           all proactive offers.
  * default:  the platform-wide fallback language shown when no preference is known.
  *
  * Source: alkemio.yml → language: { eligible, default }

--- a/src/services/api/registration/registration.service.spec.ts
+++ b/src/services/api/registration/registration.service.spec.ts
@@ -287,7 +287,6 @@ describe('RegistrationService', () => {
       ).toHaveBeenCalledTimes(1);
     });
 
-    // T009 — registration-time language seeding (FR-016 / DL-7 / DL-8)
     describe('language seeding from platform invitations', () => {
       const freshUser = {
         id: 'user-seed',
@@ -346,11 +345,11 @@ describe('RegistrationService', () => {
         expect(userService.updateUserSettings).not.toHaveBeenCalled();
       });
 
-      it('should drop an unsupported value from the configured eligible set and skip it without throwing (3656333133)', async () => {
+      it('should drop an unsupported value from the configured eligible set and skip it without throwing', async () => {
         // Misconfigured eligible = 'nl,xx' where 'xx' is not in SUPPORTED_INTERFACE_LANGUAGES.
         // parseSupportedEligibleLanguages filters 'xx' out, so an invitation suggesting 'xx'
-        // is silently skipped (FR-018) rather than passed to updateUserSettings, which now
-        // rejects unsupported languages — seeding must not throw during registration.
+        // is silently skipped rather than passed to updateUserSettings, which rejects
+        // unsupported languages — seeding must not throw during registration.
         configService.get.mockImplementation((key: string) => {
           if (key === 'language') return { eligible: 'nl,xx', default: 'en' };
           return undefined;
@@ -375,12 +374,12 @@ describe('RegistrationService', () => {
         expect(userService.updateUserSettings).not.toHaveBeenCalled();
       });
 
-      it('should pick the latest-created eligible invitation when multiple exist (DL-7)', async () => {
+      it('should pick the latest-created eligible invitation when multiple exist', async () => {
         // Two DISTINCT eligible languages: pi-old='en' (created earlier),
         // pi-new='nl' (created later).  With eligible='nl,en', both are
         // candidates.  The latest-created one (pi-new → 'nl') must win.
         // An ascending-sort implementation would incorrectly seed 'en' and
-        // fail the assertion — this is what makes the test meaningful (R-6).
+        // fail the assertion — this is what makes the test meaningful.
         configService.get.mockImplementation((key: string) => {
           if (key === 'language') return { eligible: 'nl,en', default: 'en' };
           return undefined;
@@ -413,7 +412,7 @@ describe('RegistrationService', () => {
         // The latest-created eligible invitation (pi-new → 'nl') must be
         // selected and the call must happen exactly once.  If the sort were
         // ascending, 'en' (pi-old) would be seeded instead and this assertion
-        // would fail — proving the sort direction is correct (DL-7).
+        // would fail — proving the sort direction is correct.
         expect(userService.updateUserSettings).toHaveBeenCalledTimes(1);
         expect(userService.updateUserSettings).toHaveBeenCalledWith(freshUser, {
           language: 'nl',
@@ -465,12 +464,11 @@ describe('RegistrationService', () => {
         expect(userService.updateUserSettings).not.toHaveBeenCalled();
       });
 
-      // Regression test for corr-server-1 / spec-server-1 / qual-server-1:
-      // The real production path has user.settings === undefined because
-      // grantCredentialsAllUsersReceive fetches the user with no relations and
-      // User.settings is eager:false.  The previous guard `!user.settings →
-      // return` silently aborted seeding.  The fix reloads the user with
-      // { relations: { settings: true } } when settings is absent.
+      // Regression: the real production path has user.settings === undefined
+      // because grantCredentialsAllUsersReceive fetches the user with no
+      // relations and User.settings is eager:false.  The previous guard
+      // `!user.settings → return` silently aborted seeding.  The fix reloads
+      // the user with { relations: { settings: true } } when settings is absent.
       it('should reload settings and seed language when user.settings is not loaded (production path)', async () => {
         // Simulates what grantCredentialsAllUsersReceive returns: user WITHOUT
         // the settings relation loaded (eager:false, no options passed).

--- a/src/services/api/registration/registration.service.spec.ts
+++ b/src/services/api/registration/registration.service.spec.ts
@@ -13,6 +13,7 @@ import { UserService } from '@domain/community/user/user.service';
 import { UserAuthorizationService } from '@domain/community/user/user.service.authorization';
 import { AccountService } from '@domain/space/account/account.service';
 import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotificationPlatformAdapter } from '@services/adapters/notification-adapter/notification.platform.adapter';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
@@ -28,6 +29,7 @@ describe('RegistrationService', () => {
     getUserByIdOrFail: Mock;
     getAccount: Mock;
     deleteUser: Mock;
+    updateUserSettings: Mock;
   };
   let userAuthorizationService: {
     grantCredentialsAllUsersReceive: Mock;
@@ -60,6 +62,7 @@ describe('RegistrationService', () => {
   let accountService: { deleteAccountOrFail: Mock };
   let _organizationService: { getAccount: Mock; deleteOrganization: Mock };
   let notificationPlatformAdapter: { platformUserProfileCreated: Mock };
+  let configService: { get: Mock };
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -90,6 +93,12 @@ describe('RegistrationService', () => {
     notificationPlatformAdapter = module.get(
       NotificationPlatformAdapter
     ) as any;
+    configService = module.get(ConfigService) as any;
+    // Default: eligible = 'nl' (single eligible language).
+    configService.get.mockImplementation((key: string) => {
+      if (key === 'language') return { eligible: 'nl', default: 'en' };
+      return undefined;
+    });
   });
 
   describe('registerNewUser', () => {
@@ -229,7 +238,12 @@ describe('RegistrationService', () => {
   });
 
   describe('processPendingInvitations', () => {
-    const user = { id: 'user-1', email: 'test@example.com' } as any;
+    // A fresh user (language=null, flag=false) — the default state post-migration.
+    const user = {
+      id: 'user-1',
+      email: 'test@example.com',
+      settings: { language: null, languageOfferAnswered: false },
+    } as any;
 
     it('should return empty array when no platform invitations exist', async () => {
       platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
@@ -271,6 +285,266 @@ describe('RegistrationService', () => {
       expect(
         roleSetService.createInvitationExistingActor
       ).toHaveBeenCalledTimes(1);
+    });
+
+    // T009 — registration-time language seeding (FR-016 / DL-7 / DL-8)
+    describe('language seeding from platform invitations', () => {
+      const freshUser = {
+        id: 'user-seed',
+        email: 'seed@example.com',
+        settings: { language: null, languageOfferAnswered: false },
+      } as any;
+
+      beforeEach(() => {
+        // Suppress the role-set and auth flow for these seeding-focused tests.
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          []
+        );
+        userService.updateUserSettings = vi.fn().mockResolvedValue(freshUser);
+      });
+
+      it('should seed language from an nl invitation and latch the flag', async () => {
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-nl',
+              roleSet: undefined, // no roleSet → skipped in loop, but seeding runs first
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'nl',
+              createdDate: new Date('2024-01-01'),
+            },
+          ]
+        );
+
+        await service.processPendingInvitations(freshUser);
+
+        expect(userService.updateUserSettings).toHaveBeenCalledWith(freshUser, {
+          language: 'nl',
+        });
+      });
+
+      it('should skip an ineligible suggestion (de) and not seed', async () => {
+        // eligible = 'nl' from the default configService mock; 'de' is not eligible.
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-de',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'de',
+              createdDate: new Date('2024-01-01'),
+            },
+          ]
+        );
+
+        await service.processPendingInvitations(freshUser);
+
+        expect(userService.updateUserSettings).not.toHaveBeenCalled();
+      });
+
+      it('should drop an unsupported value from the configured eligible set and skip it without throwing (3656333133)', async () => {
+        // Misconfigured eligible = 'nl,xx' where 'xx' is not in SUPPORTED_INTERFACE_LANGUAGES.
+        // parseSupportedEligibleLanguages filters 'xx' out, so an invitation suggesting 'xx'
+        // is silently skipped (FR-018) rather than passed to updateUserSettings, which now
+        // rejects unsupported languages — seeding must not throw during registration.
+        configService.get.mockImplementation((key: string) => {
+          if (key === 'language') return { eligible: 'nl,xx', default: 'en' };
+          return undefined;
+        });
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-xx',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'xx',
+              createdDate: new Date('2024-01-01'),
+            },
+          ]
+        );
+
+        await expect(
+          service.processPendingInvitations(freshUser)
+        ).resolves.not.toThrow();
+        expect(userService.updateUserSettings).not.toHaveBeenCalled();
+      });
+
+      it('should pick the latest-created eligible invitation when multiple exist (DL-7)', async () => {
+        // Two DISTINCT eligible languages: pi-old='en' (created earlier),
+        // pi-new='nl' (created later).  With eligible='nl,en', both are
+        // candidates.  The latest-created one (pi-new → 'nl') must win.
+        // An ascending-sort implementation would incorrectly seed 'en' and
+        // fail the assertion — this is what makes the test meaningful (R-6).
+        configService.get.mockImplementation((key: string) => {
+          if (key === 'language') return { eligible: 'nl,en', default: 'en' };
+          return undefined;
+        });
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-old',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'en', // older, eligible — must NOT win
+              createdDate: new Date('2024-01-01'),
+            },
+            {
+              id: 'pi-new',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'nl', // newer, eligible — must win
+              createdDate: new Date('2024-06-01'),
+            },
+          ]
+        );
+
+        await service.processPendingInvitations(freshUser);
+
+        // The latest-created eligible invitation (pi-new → 'nl') must be
+        // selected and the call must happen exactly once.  If the sort were
+        // ascending, 'en' (pi-old) would be seeded instead and this assertion
+        // would fail — proving the sort direction is correct (DL-7).
+        expect(userService.updateUserSettings).toHaveBeenCalledTimes(1);
+        expect(userService.updateUserSettings).toHaveBeenCalledWith(freshUser, {
+          language: 'nl',
+        });
+      });
+
+      it('should not seed when settings are already set (language ≠ null)', async () => {
+        const userWithLanguage = {
+          id: 'user-set',
+          email: 'set@example.com',
+          settings: { language: 'en', languageOfferAnswered: true },
+        } as any;
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-nl',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'nl',
+              createdDate: new Date('2024-01-01'),
+            },
+          ]
+        );
+
+        await service.processPendingInvitations(userWithLanguage);
+
+        expect(userService.updateUserSettings).not.toHaveBeenCalled();
+      });
+
+      it('should not seed when no suggestedLanguage on any invitation', async () => {
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-no-lang',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: undefined,
+              createdDate: new Date('2024-01-01'),
+            },
+          ]
+        );
+
+        await service.processPendingInvitations(freshUser);
+
+        expect(userService.updateUserSettings).not.toHaveBeenCalled();
+      });
+
+      // Regression test for corr-server-1 / spec-server-1 / qual-server-1:
+      // The real production path has user.settings === undefined because
+      // grantCredentialsAllUsersReceive fetches the user with no relations and
+      // User.settings is eager:false.  The previous guard `!user.settings →
+      // return` silently aborted seeding.  The fix reloads the user with
+      // { relations: { settings: true } } when settings is absent.
+      it('should reload settings and seed language when user.settings is not loaded (production path)', async () => {
+        // Simulates what grantCredentialsAllUsersReceive returns: user WITHOUT
+        // the settings relation loaded (eager:false, no options passed).
+        const userWithoutSettings = {
+          id: 'user-seed-prod',
+          email: 'prod@example.com',
+          settings: undefined, // ← the real production state
+        } as any;
+
+        // The user object that getUserByIdOrFail returns when called with
+        // { relations: { settings: true } } — a fresh account.
+        const userWithSettings = {
+          id: 'user-seed-prod',
+          email: 'prod@example.com',
+          settings: { language: null, languageOfferAnswered: false },
+        } as any;
+
+        userService.getUserByIdOrFail.mockResolvedValue(userWithSettings);
+        userService.updateUserSettings = vi
+          .fn()
+          .mockResolvedValue(userWithSettings);
+
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-nl-prod',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'nl',
+              createdDate: new Date('2024-01-01'),
+            },
+          ]
+        );
+
+        await service.processPendingInvitations(userWithoutSettings);
+
+        // getUserByIdOrFail must be called with settings relation to hydrate settings
+        expect(userService.getUserByIdOrFail).toHaveBeenCalledWith(
+          'user-seed-prod',
+          { relations: { settings: true } }
+        );
+        // Language must be seeded on the reloaded (settings-bearing) user object
+        expect(userService.updateUserSettings).toHaveBeenCalledWith(
+          userWithSettings,
+          { language: 'nl' }
+        );
+      });
+
+      it('should not reload settings when user.settings is already loaded', async () => {
+        // freshUser already has settings populated — no extra DB fetch needed.
+        platformInvitationService.findPlatformInvitationsForUser.mockResolvedValue(
+          [
+            {
+              id: 'pi-nl-preloaded',
+              roleSet: undefined,
+              createdBy: 'creator',
+              roleSetExtraRoles: [],
+              roleSetInvitedToParent: false,
+              suggestedLanguage: 'nl',
+              createdDate: new Date('2024-01-01'),
+            },
+          ]
+        );
+
+        await service.processPendingInvitations(freshUser);
+
+        // No reload when settings are already on the object
+        expect(userService.getUserByIdOrFail).not.toHaveBeenCalled();
+        expect(userService.updateUserSettings).toHaveBeenCalledWith(freshUser, {
+          language: 'nl',
+        });
+      });
     });
   });
 

--- a/src/services/api/registration/registration.service.ts
+++ b/src/services/api/registration/registration.service.ts
@@ -199,10 +199,10 @@ export class RegistrationService {
       );
 
     // Seed language from the latest-created platform invitation that carries an
-    // eligible suggested language (DL-7 determinism — latest-created wins).
+    // eligible suggested language (latest-created wins).
     // Must run before the loop so the settings update is complete before any
     // invitation authorization writes (no interleaving issue — both are in the
-    // same synchronous processPendingInvitations call, FR-016 / DL-12).
+    // same synchronous processPendingInvitations call).
     await this.seedLanguageFromInvitation(user, platformInvitations);
 
     const roleSetInvitations: IInvitation[] = [];
@@ -248,17 +248,17 @@ export class RegistrationService {
 
   /**
    * Seeds the new account's language setting from the latest-created platform
-   * invitation that carries an eligible suggestedLanguage (FR-016, DL-7, DL-8).
+   * invitation that carries an eligible suggestedLanguage.
    *
    * Rules:
    * - Only seeds when the account still has {language: null, languageOfferAnswered: false}
    *   (a fresh account that has not yet had a language written by any other path).
    * - Eligible = currently configured language.eligible list; an invitation whose
-   *   suggestedLanguage is no longer eligible is silently skipped (FR-018).
+   *   suggestedLanguage is no longer eligible is silently skipped.
    * - Among the invitations that pass eligibility, the latest-created (highest
-   *   createdDate) wins (DL-7 determinism).
+   *   createdDate) wins.
    * - Writing language also latches languageOfferAnswered = true via
-   *   UserSettingsService.updateSettings (T004 invariant).
+   *   UserSettingsService.updateSettings.
    */
   private async seedLanguageFromInvitation(
     user: IUser,
@@ -269,7 +269,7 @@ export class RegistrationService {
     // relations, so user.settings is undefined on the real production path —
     // User.settings is declared eager:false (user.entity.ts).  Reload with the
     // relation when it is missing so the guard below operates on real data, not
-    // on an absent proxy.  (corr-server-1 / spec-server-1 / qual-server-1)
+    // on an absent proxy.
     let settingsUser = user;
     if (!settingsUser.settings) {
       settingsUser = await this.userService.getUserByIdOrFail(user.id, {
@@ -290,17 +290,17 @@ export class RegistrationService {
     // Use the shared helper so the eligible set here matches Config.language.eligible
     // and the compose-time RoleSetEligibleLanguageGuard, and unsupported values are
     // filtered out: a stored suggestion that is not in SUPPORTED_INTERFACE_LANGUAGES is
-    // silently skipped (FR-018) rather than passed to updateUserSettings, which now
-    // rejects unsupported languages (3656333133).
+    // silently skipped rather than passed to updateUserSettings, which rejects
+    // unsupported languages.
     const eligible = parseSupportedEligibleLanguages(languageConfig?.eligible);
 
     if (eligible.length === 0) {
-      // Kill switch: empty eligible set — no seeding (FR-018).
+      // Kill switch: empty eligible set — no seeding.
       return;
     }
 
     // Sort by createdDate descending to get the latest-created invitation first
-    // (DL-7 determinism: latest-created with an eligible suggestion wins).
+    // (latest-created with an eligible suggestion wins).
     const sorted = [...platformInvitations].sort((a, b) => {
       const aTime = a.createdDate ? new Date(a.createdDate).getTime() : 0;
       const bTime = b.createdDate ? new Date(b.createdDate).getTime() : 0;
@@ -315,10 +315,10 @@ export class RegistrationService {
         // can read user.settings without hitting an undefined dereference.
         await this.userService.updateUserSettings(settingsUser, {
           language: lang,
-          // languageOfferAnswered is automatically latched by updateSettings (T004)
+          // languageOfferAnswered is automatically latched by updateSettings
         });
         this.logger.verbose?.(
-          `Seeded language '${lang}' from platform invitation for user ${settingsUser.id} (DL-7/FR-016)`,
+          `Seeded language '${lang}' from platform invitation for user ${settingsUser.id}`,
           LogContext.COMMUNITY
         );
         return;

--- a/src/services/api/registration/registration.service.ts
+++ b/src/services/api/registration/registration.service.ts
@@ -1,3 +1,4 @@
+import { parseSupportedEligibleLanguages } from '@common/constants/supported.languages';
 import { LogContext } from '@common/enums/logging.context';
 import { OrganizationVerificationEnum } from '@common/enums/organization.verification';
 import { RoleName } from '@common/enums/role.name';
@@ -10,6 +11,7 @@ import { CreateInvitationInput } from '@domain/access/invitation/dto/invitation.
 import { IInvitation } from '@domain/access/invitation/invitation.interface';
 import { InvitationService } from '@domain/access/invitation/invitation.service';
 import { InvitationAuthorizationService } from '@domain/access/invitation/invitation.service.authorization';
+import { IPlatformInvitation } from '@domain/access/invitation.platform/platform.invitation.interface';
 import { PlatformInvitationService } from '@domain/access/invitation.platform/platform.invitation.service';
 import { RoleSetService } from '@domain/access/role-set/role.set.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -23,8 +25,10 @@ import { UserAuthorizationService } from '@domain/community/user/user.service.au
 import { AccountService } from '@domain/space/account/account.service';
 import { AccountAuthorizationService } from '@domain/space/account/account.service.authorization';
 import { Inject, LoggerService } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { NotificationInputPlatformUserRegistered } from '@services/adapters/notification-adapter/dto/platform/notification.dto.input.platform.user.registered';
 import { NotificationPlatformAdapter } from '@services/adapters/notification-adapter/notification.platform.adapter';
+import { AlkemioConfig } from '@src/types';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 export class RegistrationService {
@@ -42,6 +46,7 @@ export class RegistrationService {
     private applicationService: ApplicationService,
     private roleSetService: RoleSetService,
     private notificationPlatformAdapter: NotificationPlatformAdapter,
+    private configService: ConfigService<AlkemioConfig, true>,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
@@ -193,6 +198,13 @@ export class RegistrationService {
         user.email
       );
 
+    // Seed language from the latest-created platform invitation that carries an
+    // eligible suggested language (DL-7 determinism — latest-created wins).
+    // Must run before the loop so the settings update is complete before any
+    // invitation authorization writes (no interleaving issue — both are in the
+    // same synchronous processPendingInvitations call, FR-016 / DL-12).
+    await this.seedLanguageFromInvitation(user, platformInvitations);
+
     const roleSetInvitations: IInvitation[] = [];
     for (const platformInvitation of platformInvitations) {
       const roleSet = platformInvitation.roleSet;
@@ -232,6 +244,86 @@ export class RegistrationService {
       );
     }
     return roleSetInvitations;
+  }
+
+  /**
+   * Seeds the new account's language setting from the latest-created platform
+   * invitation that carries an eligible suggestedLanguage (FR-016, DL-7, DL-8).
+   *
+   * Rules:
+   * - Only seeds when the account still has {language: null, languageOfferAnswered: false}
+   *   (a fresh account that has not yet had a language written by any other path).
+   * - Eligible = currently configured language.eligible list; an invitation whose
+   *   suggestedLanguage is no longer eligible is silently skipped (FR-018).
+   * - Among the invitations that pass eligibility, the latest-created (highest
+   *   createdDate) wins (DL-7 determinism).
+   * - Writing language also latches languageOfferAnswered = true via
+   *   UserSettingsService.updateSettings (T004 invariant).
+   */
+  private async seedLanguageFromInvitation(
+    user: IUser,
+    platformInvitations: IPlatformInvitation[]
+  ): Promise<void> {
+    // Ensure the settings relation is loaded.  grantCredentialsAllUsersReceive
+    // (called earlier in finalizeUserRegistration) fetches the user with no
+    // relations, so user.settings is undefined on the real production path —
+    // User.settings is declared eager:false (user.entity.ts).  Reload with the
+    // relation when it is missing so the guard below operates on real data, not
+    // on an absent proxy.  (corr-server-1 / spec-server-1 / qual-server-1)
+    let settingsUser = user;
+    if (!settingsUser.settings) {
+      settingsUser = await this.userService.getUserByIdOrFail(user.id, {
+        relations: { settings: true },
+      });
+    }
+
+    // Only seed for a truly fresh account (null language + flag false).
+    if (
+      !settingsUser.settings ||
+      settingsUser.settings.language !== null ||
+      settingsUser.settings.languageOfferAnswered !== false
+    ) {
+      return;
+    }
+
+    const languageConfig = this.configService.get('language', { infer: true });
+    // Use the shared helper so the eligible set here matches Config.language.eligible
+    // and the compose-time RoleSetEligibleLanguageGuard, and unsupported values are
+    // filtered out: a stored suggestion that is not in SUPPORTED_INTERFACE_LANGUAGES is
+    // silently skipped (FR-018) rather than passed to updateUserSettings, which now
+    // rejects unsupported languages (3656333133).
+    const eligible = parseSupportedEligibleLanguages(languageConfig?.eligible);
+
+    if (eligible.length === 0) {
+      // Kill switch: empty eligible set — no seeding (FR-018).
+      return;
+    }
+
+    // Sort by createdDate descending to get the latest-created invitation first
+    // (DL-7 determinism: latest-created with an eligible suggestion wins).
+    const sorted = [...platformInvitations].sort((a, b) => {
+      const aTime = a.createdDate ? new Date(a.createdDate).getTime() : 0;
+      const bTime = b.createdDate ? new Date(b.createdDate).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    for (const invitation of sorted) {
+      const lang = invitation.suggestedLanguage;
+      if (lang && eligible.includes(lang)) {
+        // Found the latest-created eligible suggestion — seed and latch.
+        // Use settingsUser (which has settings loaded) so updateUserSettings
+        // can read user.settings without hitting an undefined dereference.
+        await this.userService.updateUserSettings(settingsUser, {
+          language: lang,
+          // languageOfferAnswered is automatically latched by updateSettings (T004)
+        });
+        this.logger.verbose?.(
+          `Seeded language '${lang}' from platform invitation for user ${settingsUser.id} (DL-7/FR-016)`,
+          LogContext.COMMUNITY
+        );
+        return;
+      }
+    }
   }
 
   async deleteUserWithPendingMemberships(

--- a/src/types/alkemio.config.ts
+++ b/src/types/alkemio.config.ts
@@ -290,6 +290,14 @@ export type AlkemioConfig = {
       max_collaborators_in_room: number;
     };
   };
+  language: {
+    /**
+     * Comma-separated list of language codes the platform proactively offers.
+     * Parsed by KonfigService into a string[]. Empty string ⇒ empty array (kill switch).
+     */
+    eligible: string;
+    default: string;
+  };
   platform: {
     terms: string;
     privacy: string;

--- a/test/data/user.settings.mock.ts
+++ b/test/data/user.settings.mock.ts
@@ -196,5 +196,7 @@ export const userSettingsData: { userSettings: IUserSettings } = {
       enabledCapabilities: [],
     },
     designVersion: DESIGN_VERSION_CURRENT_DEFAULT,
+    language: null,
+    languageOfferAnswered: false,
   },
 };


### PR DESCRIPTION
## Detect signup language & persist it as a user setting — server slice

Backend slice of the cross-repo feature **`workspace#029-detect-signup-language`** (delivery story [alkem-io/alkemio#2017](https://github.com/alkem-io/alkemio/issues/2017)). Delivered autonomously via `/forge`.

### What & why
Makes the interface language a **user-account setting** (it was browser-only), and adds the server surface for a proactive, non-blocking Dutch-first language offer:

- **`UserSettings.language`** (nullable — `null` = *never chose*, the US4 discriminator) + **`UserSettings.languageOfferAnswered`** (non-null, the global FR-005a "answered" flag) with a **one-way latch**: any language write latches `answered=true`; a `languageOfferAnswered:false` input is rejected.
- **`Config.language { eligible, default }`** — the eligible-language set as *configuration* (from `alkemio.yml`, env-overridable), anonymous-readable so the pre-auth offer works. Dutch-only this release; empty set = kill-switch. Not hard-coded, not an admin CRUD.
- **`suggestedLanguage`** on the batch invite input, fanned to **both** `Invitation` **and** `PlatformInvitation` (per-invitation storage, FR-014a/b — operator ruling), compose-time eligible-validated (ineligible rejected; omitted still sends).
- **Registration-time seeding**: a fresh account is seeded from the latest-created eligible `PlatformInvitation.suggestedLanguage` (FR-016), silently skipping ineligible ones.
- **Migration** `AddUserLanguagePreference` — add-only, metadata-only, **zero row writes**, no auth-policy reset, reversible `down()`. Existing rows read `{language: null, languageOfferAnswered: false}` — no displayed-language change at release (SC-005).

All GraphQL changes are **additive** (`schema:diff` → additive:12 / breaking:0).

### Evidence digest
- **Gates:** `pnpm lint` ✅ · `pnpm test:ci:no:coverage` ✅ **7281 tests** · `pnpm build` ✅ · `schema:diff` additive-only ✅ · `migration:validate` ✅ (independent Haiku gate audit ✅).
- **Live verification** (against a running stack): anonymous `platform.configuration.language` → `{eligible:[nl], default:en}` confirmed; C1/C2/C3 contract fields present in the live schema. Authenticated gql-live/test-suites tracks were **env-blocked** (running server lacks `ENABLE_NON_INTERACTIVE_LOGIN`; headless curl can't mint a Hydra bearer) — the invariants are covered by the 7281-test suite + adversarial review.
- **Adversarial review** (3 rounds, Opus panel × correctness/spec-compliance/quality/security): caught a **HIGH production bug the unit tests masked** — registration-time seeding was dead on the real signup path (`User.settings` is `eager:false`, unloaded), so FR-016/US5 never ran in production. **Fixed** (`registration.service.ts` now hydrates settings before seeding) + regression tests that drive the real unhydrated path.
- **Security: PASS** (SOC 2 / ISO 27001 catalog) — self-scoped writes (own-user `grantAccessOrFail(UPDATE)`), DTO `@IsIn(SUPPORTED)` + eligible-guard double-bounding, idempotent add-only migration with no auth reset, all additive schema. No IDOR/injection/secret/PII-log findings. Post-review drift gate on the fix delta: clean.

### Tracked debt (non-blocking, ≤ medium)
- Config-parse (comma-split eligible) unit-tested via an inline copy rather than invoking `ConfigService.getConfig()`; parse logic copy-pasted in ~3 places (extract + test the real path).
- Empty-string `LANGUAGE_ELIGIBLE` env override coerces oddly (low) — `alkemio.yml` empty-set kill-switch is unaffected.
- `RoleSetEligibleLanguageGuard` is a plain injectable, not a Nest `CanActivate` (naming nit).

### Links
- Spec / plan / tasks / ADR: `agents-hq/specs/029-detect-signup-language/` (`spec.md`, `plan.md`, `repos.yaml`, `tasks/server.md`, `docs/decisions/0005-user-language-preference-contract.md`)
- Full run ledger: `agents-hq/specs/029-detect-signup-language/forge-run.md`

> ⚠️ Commits are **unsigned** (automated run — the YubiKey touch can't be provided). Re-sign before merge if branch protection requires per-commit signatures; squash-merge signs the landed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform interface language preferences (eligible set and platform default), including a kill-switch to disable proactive offers.
  * Invitations and Role Set invite inputs can now include an optional suggested language, validated against the eligible set.
  * User settings now support selecting an interface language and a one-way “language offer answered” latch.
  * New registrations can seed a user’s language from the most recent eligible platform invitation.

* **Bug Fixes**
  * Ineligible or unsupported suggested languages are rejected before invitation creation.
  * User language and the answered latch can’t be overwritten or unset unintentionally.

* **Tests**
  * Added coverage for language eligibility, seeding behavior, and settings latch rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->