### PR TITLE
chore(008): bump quickstart file backup images

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -529,7 +529,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_file_service
     hostname: file-service
-    image: alkemio/file-service:v0.2.2
+    image: alkemio/file-service:v0.2.3
     depends_on:
       postgres:
         condition: service_healthy
@@ -564,7 +564,7 @@ services:
   # below waits for this to complete (service_completed_successfully).
   file-backup-migrate:
     container_name: alkemio_dev_file_backup_migrate
-    image: alkemio/file-backup-service:v0.0.4
+    image: alkemio/file-backup-service:v0.0.5
     depends_on:
       postgres:
         condition: service_healthy
@@ -587,7 +587,7 @@ services:
   file-backup-service:
     container_name: alkemio_dev_file_backup_service
     hostname: file-backup-service
-    image: alkemio/file-backup-service:v0.0.4
+    image: alkemio/file-backup-service:v0.0.5
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Outcome

Updates the local quickstart stack to the released, compatible continuous-file-backup pair:

- `alkemio/file-service:v0.2.3`
- `alkemio/file-backup-service:v0.0.5`

Both the backup worker and its one-shot ledger migration container now use v0.0.5. The worker fetches source bytes by content hash through the endpoint shipped in file-service v0.2.3.

## Release verification

Both DockerHub tags are published multi-architecture images (`linux/amd64` and `linux/arm64`):

- file-service: `sha256:677bd6b1bb5b48b78580d8a1ce425c7df48c601e48a697dd6b358db44814ab71`
- file-backup-service: `sha256:05700c1e5aa340b278dcaecb15598fc3cdf5c2129006a5edc4f1ba90ebc27ec1`

## Validation

- `docker compose -f quickstart-services.yml config --quiet`
- repository pre-commit typecheck and full Vitest suite
- `git diff --check`

Workspace spec: `workspace#008-continuous-file-backup`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated file storage and backup services to newer versions, improving reliability and compatibility of file handling and backup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->