### PR TITLE
fix(conversion): recompute platformRolesAccess on L1→L0 and L1→L2 cross-L0 moves

### DIFF
--- a/src/services/api/conversion/conversion.resolver.mutations.spec.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.spec.ts
@@ -469,4 +469,205 @@ describe('ConversionResolverMutations', () => {
       ).not.toHaveBeenCalled();
     });
   });
+
+  // Regression guard for the anonymous-visibility leak: a cross-L0 move must
+  // recompute platformRolesAccess from the NEW target hierarchy BEFORE the
+  // authorization policy is re-applied — otherwise a public L1 moved into a
+  // private L0 keeps stale anonymous READ. Mirrors the moveSpaceL2ToSpaceL1
+  // recompute proof above.
+  describe('moveSpaceL1ToSpaceL0', () => {
+    const setupMoveL1L0HappyPath = (
+      platformRolesAccessFromTarget = { roles: ['REGISTERED'] }
+    ) => {
+      const savedSpaceId = 'saved-l1-space';
+      const movedSpace = {
+        id: savedSpaceId,
+        levelZeroSpaceID: 'target-l0',
+        platformRolesAccess: { roles: [] }, // old value before recompute
+      };
+      const savedSpace = { ...movedSpace };
+      const targetParentL0 = {
+        id: 'target-l0',
+        platformRolesAccess: platformRolesAccessFromTarget,
+      };
+
+      authorizationService.grantAccessOrFail.mockReturnValue(undefined);
+      (conversionService as any).moveSpaceL1ToSpaceL0OrFail.mockResolvedValue({
+        space: movedSpace,
+        removedActorIds: ['actor-removed'],
+      });
+      spaceService.save.mockResolvedValue(savedSpace);
+      // getSpaceOrFail sequence: 1. targetParentL0 (recompute), 2. moved space
+      // with parentSpace.authorization (getParentSpaceAuthorization), 3. return.
+      spaceService.getSpaceOrFail
+        .mockResolvedValueOnce(targetParentL0)
+        .mockResolvedValueOnce({
+          id: savedSpaceId,
+          parentSpace: { authorization: { id: 'parent-auth' } },
+        })
+        .mockResolvedValue({ id: savedSpaceId });
+      (spaceService as any).updatePlatformRolesAccessRecursively = vi
+        .fn()
+        .mockImplementation(async (space: any, parentAccess: any) => {
+          space.platformRolesAccess = parentAccess;
+          return space;
+        });
+      spaceAuthorizationService.applyAuthorizationPolicy.mockResolvedValue([]);
+      authorizationPolicyService.saveAll.mockResolvedValue(undefined);
+      (conversionService as any).invalidateUrlCachesForSubtree = vi
+        .fn()
+        .mockResolvedValue(undefined);
+      (conversionService as any).moveRoomsService = {
+        handleRoomsDuringMove: vi.fn().mockResolvedValue(undefined),
+      };
+      (conversionService as any).dispatchAutoInvitesAfterMove = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      return { movedSpace, targetParentL0 };
+    };
+
+    it('should reject non-PLATFORM_ADMIN before any service call', async () => {
+      authorizationService.grantAccessOrFail.mockImplementation(() => {
+        throw new Error('Unauthorized');
+      });
+
+      await expect(
+        resolver.moveSpaceL1ToSpaceL0(actorContext, {
+          spaceL1ID: 'space-l1',
+          targetSpaceL0ID: 'target-l0',
+        })
+      ).rejects.toThrow('Unauthorized');
+
+      expect(
+        (conversionService as any).moveSpaceL1ToSpaceL0OrFail
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should recompute platformRolesAccess from target L0 BEFORE applyAuthorizationPolicy', async () => {
+      const targetPlatformAccess = { roles: ['REGISTERED', 'ANONYMOUS'] };
+      const { movedSpace } = setupMoveL1L0HappyPath(targetPlatformAccess);
+
+      await resolver.moveSpaceL1ToSpaceL0(actorContext, {
+        spaceL1ID: 'space-l1',
+        targetSpaceL0ID: 'target-l0',
+      });
+
+      expect(
+        (spaceService as any).updatePlatformRolesAccessRecursively
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ id: movedSpace.id }),
+        targetPlatformAccess
+      );
+
+      const recomputeOrder = (spaceService as any)
+        .updatePlatformRolesAccessRecursively.mock.invocationCallOrder[0];
+      const authPolicyOrder =
+        spaceAuthorizationService.applyAuthorizationPolicy.mock
+          .invocationCallOrder[0];
+      expect(recomputeOrder).toBeLessThan(authPolicyOrder);
+
+      const recomputeCallArgs = (spaceService as any)
+        .updatePlatformRolesAccessRecursively.mock.calls[0];
+      expect(recomputeCallArgs[1]).toBe(targetPlatformAccess);
+    });
+  });
+
+  describe('moveSpaceL1ToSpaceL2', () => {
+    const setupMoveL1L2HappyPath = (
+      platformRolesAccessFromTarget = { roles: ['REGISTERED'] }
+    ) => {
+      const savedSpaceId = 'saved-l1-l2-space';
+      const movedSpace = {
+        id: savedSpaceId,
+        levelZeroSpaceID: 'target-l0',
+        platformRolesAccess: { roles: [] }, // old value before recompute
+      };
+      const savedSpace = { ...movedSpace };
+      const targetParentL1 = {
+        id: 'target-l1',
+        platformRolesAccess: platformRolesAccessFromTarget,
+      };
+
+      authorizationService.grantAccessOrFail.mockReturnValue(undefined);
+      (conversionService as any).moveSpaceL1ToSpaceL2OrFail.mockResolvedValue({
+        space: movedSpace,
+        removedActorIds: ['actor-removed'],
+      });
+      spaceService.save.mockResolvedValue(savedSpace);
+      // getSpaceOrFail sequence: 1. targetParentL1 (recompute), 2. moved space
+      // with parentSpace.authorization (getParentSpaceAuthorization), 3. return.
+      spaceService.getSpaceOrFail
+        .mockResolvedValueOnce(targetParentL1)
+        .mockResolvedValueOnce({
+          id: savedSpaceId,
+          parentSpace: { authorization: { id: 'parent-auth' } },
+        })
+        .mockResolvedValue({ id: savedSpaceId });
+      (spaceService as any).updatePlatformRolesAccessRecursively = vi
+        .fn()
+        .mockImplementation(async (space: any, parentAccess: any) => {
+          space.platformRolesAccess = parentAccess;
+          return space;
+        });
+      spaceAuthorizationService.applyAuthorizationPolicy.mockResolvedValue([]);
+      authorizationPolicyService.saveAll.mockResolvedValue(undefined);
+      (conversionService as any).invalidateUrlCachesForSubtree = vi
+        .fn()
+        .mockResolvedValue(undefined);
+      (conversionService as any).moveRoomsService = {
+        handleRoomsDuringMove: vi.fn().mockResolvedValue(undefined),
+      };
+      (conversionService as any).dispatchAutoInvitesAfterMove = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      return { movedSpace, targetParentL1 };
+    };
+
+    it('should reject non-PLATFORM_ADMIN before any service call', async () => {
+      authorizationService.grantAccessOrFail.mockImplementation(() => {
+        throw new Error('Unauthorized');
+      });
+
+      await expect(
+        resolver.moveSpaceL1ToSpaceL2(actorContext, {
+          spaceL1ID: 'space-l1',
+          targetSpaceL1ID: 'target-l1',
+        })
+      ).rejects.toThrow('Unauthorized');
+
+      expect(
+        (conversionService as any).moveSpaceL1ToSpaceL2OrFail
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should recompute platformRolesAccess from target L1 BEFORE applyAuthorizationPolicy', async () => {
+      const targetPlatformAccess = { roles: ['REGISTERED', 'ANONYMOUS'] };
+      const { movedSpace } = setupMoveL1L2HappyPath(targetPlatformAccess);
+
+      await resolver.moveSpaceL1ToSpaceL2(actorContext, {
+        spaceL1ID: 'space-l1',
+        targetSpaceL1ID: 'target-l1',
+      });
+
+      expect(
+        (spaceService as any).updatePlatformRolesAccessRecursively
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ id: movedSpace.id }),
+        targetPlatformAccess
+      );
+
+      const recomputeOrder = (spaceService as any)
+        .updatePlatformRolesAccessRecursively.mock.invocationCallOrder[0];
+      const authPolicyOrder =
+        spaceAuthorizationService.applyAuthorizationPolicy.mock
+          .invocationCallOrder[0];
+      expect(recomputeOrder).toBeLessThan(authPolicyOrder);
+
+      const recomputeCallArgs = (spaceService as any)
+        .updatePlatformRolesAccessRecursively.mock.calls[0];
+      expect(recomputeCallArgs[1]).toBe(targetPlatformAccess);
+    });
+  });
 });

--- a/src/services/api/conversion/conversion.resolver.mutations.ts
+++ b/src/services/api/conversion/conversion.resolver.mutations.ts
@@ -191,6 +191,20 @@ export class ConversionResolverMutations {
       await this.conversionService.moveSpaceL1ToSpaceL0OrFail(moveData);
     const savedSpace = await this.spaceService.save(space);
 
+    // Recompute platform-level access (anonymous/guest/registered visibility)
+    // from the NEW target L0 hierarchy BEFORE the authorization policy is
+    // re-applied. platformRolesAccess is a persisted, precomputed field that
+    // applyAuthorizationPolicy only READS — without this, a public L1 moved
+    // into a private L0 keeps stale anonymous READ (a visibility leak).
+    // Mirrors moveSpaceL2ToSpaceL1 / convertSpaceL1ToSpaceL0.
+    const targetParentL0 = await this.spaceService.getSpaceOrFail(
+      moveData.targetSpaceL0ID
+    );
+    await this.spaceService.updatePlatformRolesAccessRecursively(
+      savedSpace,
+      targetParentL0.platformRolesAccess
+    );
+
     const parentAuthorization = await this.getParentSpaceAuthorization(
       savedSpace.id
     );
@@ -240,6 +254,20 @@ export class ConversionResolverMutations {
     const { space, removedActorIds } =
       await this.conversionService.moveSpaceL1ToSpaceL2OrFail(moveData);
     const savedSpace = await this.spaceService.save(space);
+
+    // Recompute platform-level access (anonymous/guest/registered visibility)
+    // from the NEW target L1 hierarchy BEFORE the authorization policy is
+    // re-applied. platformRolesAccess is a persisted, precomputed field that
+    // applyAuthorizationPolicy only READS — without this, a public L1 demoted
+    // into a private chain keeps stale anonymous READ (a visibility leak).
+    // Mirrors moveSpaceL2ToSpaceL1 / convertSpaceL1ToSpaceL0.
+    const targetParentL1 = await this.spaceService.getSpaceOrFail(
+      moveData.targetSpaceL1ID
+    );
+    await this.spaceService.updatePlatformRolesAccessRecursively(
+      savedSpace,
+      targetParentL1.platformRolesAccess
+    );
 
     const parentAuthorization = await this.getParentSpaceAuthorization(
       savedSpace.id


### PR DESCRIPTION
Fixes #6303. Refs alkem-io/alkemio#1846.

## Problem

`moveSpaceL1ToSpaceL0` and `moveSpaceL1ToSpaceL2` re-applied the moved space's authorization policy **without** first recomputing `platformRolesAccess` from the new parent hierarchy. `applyAuthorizationPolicy` only **reads** that persisted jsonb — it never re-derives it — so the moved subtree kept the anonymous/guest/registered visibility computed under its **old** parent.

Result: moving a **public L1 into a private L0** left stale **anonymous READ** on a subspace now inside a private space (visibility leak); the reverse left a stale lockout. Confirmed by manual repro — a manual authorization-policy reset on the target L0 (which recomputes `platformRolesAccess`) fixes it, proving the move is missing that recompute.

## Change

Add, in each resolver, before `applyAuthorizationPolicy` (mirroring the existing `moveSpaceL2ToSpaceL1` and `convertSpaceL1ToSpaceL0`):

```ts
const targetParent = await this.spaceService.getSpaceOrFail(moveData.targetSpaceL0ID /* or L1 */);
await this.spaceService.updatePlatformRolesAccessRecursively(savedSpace, targetParent.platformRolesAccess);
```

## Why it's low risk

- Identical pattern to two already-shipped paths (`moveSpaceL2ToSpaceL1`, `convertSpaceL1ToSpaceL0`).
- Only touches these two mutations; no schema/DB change.
- `updatePlatformRolesAccessRecursively` recomputes a calculated field from settings + parent and cascades to descendants — idempotent.

## Tests

- **Unit** (this PR): `conversion.resolver.mutations.spec.ts` now has `moveSpaceL1ToSpaceL0` and `moveSpaceL1ToSpaceL2` blocks proving the recompute runs with the **target parent's** `platformRolesAccess` **before** `applyAuthorizationPolicy` (plus the platform-admin gate).
- **Cross-service** (alkem-io/test-suites): anonymous privacy-recompute it-specs in `move-L1-to-L0-authorization` / `move-L1-to-L2-authorization` — public→private revokes anonymous read, private→public restores it. Red before this fix, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where space visibility could remain incorrectly accessible across platform levels after moving spaces.
  * Updated access permissions to reflect the destination hierarchy before authorization is reapplied.
  * Added regression coverage for space moves between platform levels, including administrator access restrictions and permission recalculation order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->