### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -884,6 +884,7 @@ enum AuthorizationCredential {
   ORGANIZATION_ADMIN
   ORGANIZATION_ASSOCIATE
   ORGANIZATION_OWNER
+  PLATFORM_OPERATIONS_ADMIN
   SPACE_ADMIN
   SPACE_LEAD
   SPACE_MEMBER
@@ -1004,6 +1005,7 @@ enum AuthorizationPrivilege {
   MOVE_CONTRIBUTION
   MOVE_POST
   PLATFORM_ADMIN
+  PLATFORM_OPERATIONS_ADMIN
   PLATFORM_SETTINGS_ADMIN
   PUBLIC_SHARE
   READ
@@ -2905,6 +2907,7 @@ enum CredentialType {
   ORGANIZATION_ADMIN
   ORGANIZATION_ASSOCIATE
   ORGANIZATION_OWNER
+  PLATFORM_OPERATIONS_ADMIN
   SPACE_ADMIN
   SPACE_FEATURE_MEMO_MULTI_USER
   SPACE_FEATURE_OFFICE_DOCUMENTS
@@ -5019,7 +5022,7 @@ type Mutation {
   """Update the Application Form used by this RoleSet."""
   updateApplicationFormOnRoleSet(applicationFormData: UpdateApplicationFormOnRoleSetInput!): RoleSet!
   """
-  Set the admin per-capability grant on the virtual-assistant actor, governing what it may do system-invoked (default read-only). Requires platform-admin.
+  Set the admin per-capability grant on the virtual-assistant actor, governing what it may do system-invoked (default read-only). Requires the platform-operations-admin privilege.
   """
   updateAssistantActorCapabilities(grantData: GrantAssistantActorCapabilitiesInput!): VirtualAssistant!
   """Update the baseline License Plan on the specified Account."""
@@ -6659,6 +6662,7 @@ enum RoleName {
   OWNER
   PLATFORM_ASSISTANT_ACCESS
   PLATFORM_BETA_TESTER
+  PLATFORM_OPERATIONS_ADMIN
   PLATFORM_VC_CAMPAIGN
   REGISTERED
 }


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 316313 bytes
Snapshot md5: 004bb2b057906fd465eece7209faba71

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `PLATFORM_OPERATIONS_ADMIN` authorization option across supported credential, privilege, type, and role selections.
  * Updated the documented permission requirement for assistant actor capability updates to use the platform operations administrator privilege.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->