### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -884,6 +884,7 @@ enum AuthorizationCredential {
   ORGANIZATION_ADMIN
   ORGANIZATION_ASSOCIATE
   ORGANIZATION_OWNER
+  PLATFORM_OPERATIONS_ADMIN
   SPACE_ADMIN
   SPACE_LEAD
   SPACE_MEMBER
@@ -1004,6 +1005,7 @@ enum AuthorizationPrivilege {
   MOVE_CONTRIBUTION
   MOVE_POST
   PLATFORM_ADMIN
+  PLATFORM_OPERATIONS_ADMIN
   PLATFORM_SETTINGS_ADMIN
   PUBLIC_SHARE
   READ
@@ -1729,6 +1731,10 @@ type Config {
   featureFlags: [PlatformFeatureFlag!]!
   """Integration with a 3rd party Geo information service"""
   geo: Geo!
+  """
+  Language configuration: eligible set for proactive offers and the platform default.
+  """
+  language: LanguageConfig!
   """Platform related locations."""
   locations: PlatformLocations!
   """Sentry (client monitoring) related configuration."""
@@ -2905,6 +2911,7 @@ enum CredentialType {
   ORGANIZATION_ADMIN
   ORGANIZATION_ASSOCIATE
   ORGANIZATION_OWNER
+  PLATFORM_OPERATIONS_ADMIN
   SPACE_ADMIN
   SPACE_FEATURE_MEMO_MULTI_USER
   SPACE_FEATURE_OFFICE_DOCUMENTS
@@ -3799,6 +3806,10 @@ type Invitation {
   nextEvents: [String!]!
   """The current state of this Lifecycle."""
   state: String!
+  """
+  Optional language the inviter expects the invitee to prefer; recorded per invitation.
+  """
+  suggestedLanguage: String
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
   welcomeMessage: String
@@ -3816,6 +3827,10 @@ input InviteForEntryRoleOnRoleSetInput {
   invitedActorIDs: [UUID!]!
   invitedUserEmails: [String!]!
   roleSetID: UUID!
+  """
+  Optional language the inviter expects the invitees to prefer (single value for the whole batch). Must be in the eligible set at compose time. Recorded per-invitation so per-invitee granularity later is a UI change, not a migration.
+  """
+  suggestedLanguage: String
   """The welcome message to send"""
   welcomeMessage: String
 }
@@ -3854,6 +3869,15 @@ type KratosIdentity {
   lastName: String
   """The current verification status of the email address."""
   verificationStatus: String!
+}
+
+type LanguageConfig {
+  """The platform-wide default interface language."""
+  default: String!
+  """
+  Languages the platform proactively detects, offers, and allows as invitation suggestions — subset of the supported set; empty = all proactive offers disabled.
+  """
+  eligible: [String!]!
 }
 
 type LatestReleaseDiscussion {
@@ -5019,7 +5043,7 @@ type Mutation {
   """Update the Application Form used by this RoleSet."""
   updateApplicationFormOnRoleSet(applicationFormData: UpdateApplicationFormOnRoleSetInput!): RoleSet!
   """
-  Set the admin per-capability grant on the virtual-assistant actor, governing what it may do system-invoked (default read-only). Requires platform-admin.
+  Set the admin per-capability grant on the virtual-assistant actor, governing what it may do system-invoked (default read-only). Requires the platform-operations-admin privilege.
   """
   updateAssistantActorCapabilities(grantData: GrantAssistantActorCapabilitiesInput!): VirtualAssistant!
   """Update the baseline License Plan on the specified Account."""
@@ -5730,6 +5754,10 @@ type PlatformInvitation {
   roleSetExtraRoles: [RoleName!]!
   """Whether to also add the invited user to the parent community."""
   roleSetInvitedToParent: Boolean!
+  """
+  Optional language the inviter expects the invitee to prefer; recorded per invitation.
+  """
+  suggestedLanguage: String
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
   welcomeMessage: String
@@ -6659,6 +6687,7 @@ enum RoleName {
   OWNER
   PLATFORM_ASSISTANT_ACCESS
   PLATFORM_BETA_TESTER
+  PLATFORM_OPERATIONS_ADMIN
   PLATFORM_VC_CAMPAIGN
   REGISTERED
 }
@@ -8766,6 +8795,14 @@ input UpdateUserSettingsEntityInput {
   designVersion: Int
   """Settings related to Home Space."""
   homeSpace: UpdateUserSettingsHomeSpaceInput
+  """
+  Set the user's interface language preference. Must be a value from the supported languages set. Any language write also latches languageOfferAnswered=true.
+  """
+  language: String
+  """
+  Mark that this User has answered the one-time language offer. One-way latch: setting false is rejected.
+  """
+  languageOfferAnswered: Boolean
   """Settings related to this users Notifications preferences."""
   notification: UpdateUserSettingsNotificationInput
   """Settings related to Privacy."""
@@ -9337,6 +9374,14 @@ type UserSettings {
   homeSpace: UserSettingsHomeSpace!
   """The ID of the entity"""
   id: UUID!
+  """
+  The interface language chosen by this User. Null = the User has never chosen a language (distinct from having chosen the platform default).
+  """
+  language: String
+  """
+  Whether this User has answered the one-time language offer (global across all languages). Latched true by any language write.
+  """
+  languageOfferAnswered: Boolean!
   """The notification settings for this User."""
   notification: UserSettingsNotification!
   """The privacy settings for this User"""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 317952 bytes
Snapshot md5: a246f04f9d796a1c5badbbae51c178b3

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform language configuration, including a default language and eligible language options.
  * Invitations can now include a suggested language.
  * Users can select their interface language and record whether they have responded to a language offer.
  * Added a dedicated operations administration privilege for platform management tasks.
* **Documentation**
  * Updated access requirements for assistant capability management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->