### PR TITLE
fix(analytics): add alkemio team flag to office-doc view/contribution events

### DIFF
--- a/src/domain/community/user-lookup/user.lookup.service.spec.ts
+++ b/src/domain/community/user-lookup/user.lookup.service.spec.ts
@@ -8,7 +8,7 @@ import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { vi } from 'vitest';
-import { UserLookupService } from './user.lookup.service';
+import { isAlkemioEmail, UserLookupService } from './user.lookup.service';
 
 describe('UserLookupService', () => {
   let service: UserLookupService;
@@ -262,5 +262,19 @@ describe('UserLookupService', () => {
 
       expect(result).toBeDefined();
     });
+  });
+});
+
+describe('isAlkemioEmail', () => {
+  it.each([
+    ['team@alkem.io', true],
+    ['Team@Alkem.IO', true], // the domain part is case-insensitive
+    ['someone@example.com', false],
+    // look-alike suffix domains must not read as team addresses
+    ['attacker@alkem.io.example.com', false],
+    ['x@alkem.iodine.net', false],
+    ['alkem.io@example.com', false],
+  ])('%s → %s', (email, expected) => {
+    expect(isAlkemioEmail(email)).toBe(expected);
   });
 });

--- a/src/domain/community/user-lookup/user.lookup.service.spec.ts
+++ b/src/domain/community/user-lookup/user.lookup.service.spec.ts
@@ -2,13 +2,16 @@ import {
   EntityNotFoundException,
   EntityNotInitializedException,
 } from '@common/exceptions';
+import {
+  isAlkemioEmail,
+  UserLookupService,
+} from '@domain/community/user-lookup/user.lookup.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getEntityManagerToken } from '@nestjs/typeorm';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { vi } from 'vitest';
-import { isAlkemioEmail, UserLookupService } from './user.lookup.service';
 
 describe('UserLookupService', () => {
   let service: UserLookupService;

--- a/src/domain/community/user-lookup/user.lookup.service.ts
+++ b/src/domain/community/user-lookup/user.lookup.service.ts
@@ -21,9 +21,12 @@ import {
 import { User } from '../user/user.entity';
 import { IUser } from '../user/user.interface';
 
-// Utility function for checking Alkemio team email - can be used directly when email is available
+// Utility function for checking Alkemio team email - can be used directly when email is available.
+// Anchored at the end so look-alike suffix domains (e.g. `x@alkem.io.example.com`,
+// `x@alkem.iodine.net`) are NOT treated as team addresses; the domain part is
+// case-insensitive per RFC 5321.
 export const isAlkemioEmail = (email: string): boolean =>
-  /.*@alkem\.io/.test(email);
+  /@alkem\.io$/i.test(email);
 
 export class UserLookupService {
   constructor(

--- a/src/services/collaborative-document-integration/collaborative-document-integration.module.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.module.ts
@@ -3,6 +3,7 @@ import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { ActorLookupModule } from '@domain/actor/actor-lookup/actor.lookup.module';
 import { CollaboraDocumentModule } from '@domain/collaboration/collabora-document/collabora.document.module';
 import { MemoModule } from '@domain/common/memo';
+import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
 import { Module } from '@nestjs/common';
 import { ContributionReporterModule } from '@services/external/elasticsearch/contribution-reporter';
 import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
@@ -14,6 +15,7 @@ import { CollaborativeDocumentIntegrationService } from './collaborative-documen
     AuthorizationModule,
     ActorContextModule,
     ActorLookupModule,
+    UserLookupModule,
     MemoModule,
     CollaboraDocumentModule,
     ContributionReporterModule,

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
@@ -6,6 +6,7 @@ import { AuthorizationService } from '@core/authorization/authorization.service'
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { CollaboraDocumentService } from '@domain/collaboration/collabora-document/collabora.document.service';
 import { MemoService } from '@domain/common/memo';
+import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ContributionReporterService } from '@services/external/elasticsearch/contribution-reporter';
@@ -50,6 +51,9 @@ describe('CollaborativeDocumentIntegrationService', () => {
   let actorLookupService: {
     getActorTypesByIds: Mock;
   };
+  let userLookupService: {
+    getUsersByIds: Mock;
+  };
 
   const configServiceMock = {
     get: vi.fn((key: string) => {
@@ -82,6 +86,7 @@ describe('CollaborativeDocumentIntegrationService', () => {
     contributionReporter = module.get(ContributionReporterService) as any;
     communityResolver = module.get(CommunityResolverService) as any;
     actorLookupService = module.get(ActorLookupService) as any;
+    userLookupService = module.get(UserLookupService) as any;
   });
 
   describe('accessGranted', () => {
@@ -314,7 +319,10 @@ describe('CollaborativeDocumentIntegrationService', () => {
     // 012: the consumer resolves each actor id → ActorType once via the tolerant
     // batch lookup, then groups writeActors/readonlyActors by type. Pass the
     // type-by-id map a test wants the lookup to return.
-    const arrange = (typeById: Map<string, ActorType> = new Map()) => {
+    const arrange = (
+      typeById: Map<string, ActorType> = new Map(),
+      users: { id: string; email: string }[] = []
+    ) => {
       collaboraDocumentService.getCollaboraDocumentByStorageDocumentId.mockResolvedValue(
         {
           id: COLLABORA_DOCUMENT_ID,
@@ -328,6 +336,7 @@ describe('CollaborativeDocumentIntegrationService', () => {
         'space-root'
       );
       actorLookupService.getActorTypesByIds.mockResolvedValue(typeById);
+      userLookupService.getUsersByIds.mockResolvedValue(users);
       contributionReporter.officeDocumentContribution.mockReturnValue(
         undefined
       );
@@ -535,6 +544,99 @@ describe('CollaborativeDocumentIntegrationService', () => {
       expect(readIds).toEqual(['r-ghost']);
     });
 
+    // The aggregate `alkemio` team flag: true ONLY when the window has ≥1 user
+    // actor AND every user actor (across both sets) is an @alkem.io team member.
+    describe('alkemio team flag', () => {
+      it('is true when every user actor is an Alkemio-team member', async () => {
+        arrange(
+          new Map([
+            ['user-1', ActorType.USER],
+            ['user-2', ActorType.USER],
+          ]),
+          [
+            { id: 'user-1', email: 'a@alkem.io' },
+            { id: 'user-2', email: 'b@alkem.io' },
+          ]
+        );
+
+        await service.officeDocumentContributions({
+          documentId: STORAGE_DOCUMENT_ID,
+          writeActors: ['user-1'],
+          readonlyActors: ['user-2'],
+        } as any);
+
+        // only the user-type ids are looked up (non-user actors never participate)
+        expect(userLookupService.getUsersByIds).toHaveBeenCalledTimes(1);
+        expect(userLookupService.getUsersByIds.mock.calls[0][0]).toEqual(
+          expect.arrayContaining(['user-1', 'user-2'])
+        );
+        const arg =
+          contributionReporter.officeDocumentContribution.mock.calls[0][0];
+        expect(arg.alkemio).toBe(true);
+      });
+
+      it('is false when any user actor is outside the Alkemio team (mixed window)', async () => {
+        arrange(
+          new Map([
+            ['user-1', ActorType.USER],
+            ['user-2', ActorType.USER],
+          ]),
+          [
+            { id: 'user-1', email: 'polina@alkem.io' },
+            { id: 'user-2', email: 'someone@example.com' },
+          ]
+        );
+
+        await service.officeDocumentContributions({
+          documentId: STORAGE_DOCUMENT_ID,
+          writeActors: ['user-1'],
+          readonlyActors: ['user-2'],
+        } as any);
+
+        const arg =
+          contributionReporter.officeDocumentContribution.mock.calls[0][0];
+        expect(arg.alkemio).toBe(false);
+      });
+
+      it('is false when a user actor cannot be resolved to a user row', async () => {
+        // user-2 is a user-type actor but has no user row (deleted between
+        // emission and indexing) — the window cannot be confirmed team-only.
+        arrange(
+          new Map([
+            ['user-1', ActorType.USER],
+            ['user-2', ActorType.USER],
+          ]),
+          [{ id: 'user-1', email: 'a@alkem.io' }]
+        );
+
+        await service.officeDocumentContributions({
+          documentId: STORAGE_DOCUMENT_ID,
+          writeActors: ['user-1', 'user-2'],
+          readonlyActors: [],
+        } as any);
+
+        const arg =
+          contributionReporter.officeDocumentContribution.mock.calls[0][0];
+        expect(arg.alkemio).toBe(false);
+      });
+
+      it('is false when the window has no user actors', async () => {
+        arrange(new Map([['vc-1', ActorType.VIRTUAL_CONTRIBUTOR]]));
+
+        await service.officeDocumentContributions({
+          documentId: STORAGE_DOCUMENT_ID,
+          writeActors: ['vc-1'],
+          readonlyActors: [],
+        } as any);
+
+        // no user ids → the user lookup is skipped entirely
+        expect(userLookupService.getUsersByIds).not.toHaveBeenCalled();
+        const arg =
+          contributionReporter.officeDocumentContribution.mock.calls[0][0];
+        expect(arg.alkemio).toBe(false);
+      });
+    });
+
     // FR-008: no CollaboraDocument backs the storage document id → discard without throwing
     it('should discard the event without throwing when no CollaboraDocument resolves for the storage document id', async () => {
       collaboraDocumentService.getCollaboraDocumentByStorageDocumentId.mockResolvedValue(
@@ -590,7 +692,10 @@ describe('CollaborativeDocumentIntegrationService', () => {
     const STORAGE_DOCUMENT_ID = 'storage-doc-1';
     const COLLABORA_DOCUMENT_ID = 'collabora-doc-1';
 
-    const arrange = (typeById: Map<string, ActorType> = new Map()) => {
+    const arrange = (
+      typeById: Map<string, ActorType> = new Map(),
+      users: { id: string; email: string }[] = []
+    ) => {
       collaboraDocumentService.getCollaboraDocumentByStorageDocumentId.mockResolvedValue(
         {
           id: COLLABORA_DOCUMENT_ID,
@@ -604,6 +709,7 @@ describe('CollaborativeDocumentIntegrationService', () => {
         'space-root'
       );
       actorLookupService.getActorTypesByIds.mockResolvedValue(typeById);
+      userLookupService.getUsersByIds.mockResolvedValue(users);
       contributionReporter.officeDocumentView.mockReturnValue(undefined);
     };
 
@@ -682,6 +788,22 @@ describe('CollaborativeDocumentIntegrationService', () => {
       expect(arg.writeActors[ActorType.USER]).toEqual(['w1']);
       expect(arg.writeActors[ActorType.VIRTUAL_CONTRIBUTOR]).toEqual(['w2']);
       expect(arg.readonlyActors).toEqual({});
+    });
+
+    // the VIEW path computes the same `alkemio` team flag as the contribution path
+    it('computes the alkemio team flag on the VIEW record too', async () => {
+      arrange(new Map([['user-1', ActorType.USER]]), [
+        { id: 'user-1', email: 'polina@alkem.io' },
+      ]);
+
+      await service.officeDocumentViews({
+        documentId: STORAGE_DOCUMENT_ID,
+        writeActors: ['user-1'],
+        readonlyActors: [],
+      } as any);
+
+      const arg = contributionReporter.officeDocumentView.mock.calls[0][0];
+      expect(arg.alkemio).toBe(true);
     });
 
     // FR-008: no CollaboraDocument backs the storage document id → discard without throwing

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
@@ -620,6 +620,69 @@ describe('CollaborativeDocumentIntegrationService', () => {
         expect(arg.alkemio).toBe(false);
       });
 
+      it('is false when an actor id resolves to no type at all', async () => {
+        // `ghost` lands in the `unknown` bucket (FR-005): a participant of
+        // unknown provenance cannot be vouched for as team-internal, so the
+        // window must not be indexed as an Alkemio-team window.
+        arrange(new Map([['user-1', ActorType.USER]]), [
+          { id: 'user-1', email: 'a@alkem.io' },
+        ]);
+
+        await service.officeDocumentContributions({
+          documentId: STORAGE_DOCUMENT_ID,
+          writeActors: ['user-1', 'ghost'],
+          readonlyActors: [],
+        } as any);
+
+        // disqualified before any user lookup is issued
+        expect(userLookupService.getUsersByIds).not.toHaveBeenCalled();
+        const arg =
+          contributionReporter.officeDocumentContribution.mock.calls[0][0];
+        expect(arg.alkemio).toBe(false);
+        // ...and the record itself is still indexed, with the id preserved
+        expect(Object.values(arg.writeActors).flat()).toEqual(
+          expect.arrayContaining(['user-1', 'ghost'])
+        );
+      });
+
+      it('is false — and the record is still indexed — when the user lookup fails', async () => {
+        // The flag is analytics-only: a transient DB failure must not discard
+        // the whole contribution record.
+        arrange(new Map([['user-1', ActorType.USER]]));
+        userLookupService.getUsersByIds.mockRejectedValue(
+          new Error('connection terminated')
+        );
+
+        await service.officeDocumentContributions({
+          documentId: STORAGE_DOCUMENT_ID,
+          writeActors: ['user-1'],
+          readonlyActors: [],
+        } as any);
+
+        expect(
+          contributionReporter.officeDocumentContribution
+        ).toHaveBeenCalledTimes(1);
+        const arg =
+          contributionReporter.officeDocumentContribution.mock.calls[0][0];
+        expect(arg.alkemio).toBe(false);
+      });
+
+      it('is false for a look-alike suffix domain', async () => {
+        arrange(new Map([['user-1', ActorType.USER]]), [
+          { id: 'user-1', email: 'attacker@alkem.io.example.com' },
+        ]);
+
+        await service.officeDocumentContributions({
+          documentId: STORAGE_DOCUMENT_ID,
+          writeActors: ['user-1'],
+          readonlyActors: [],
+        } as any);
+
+        const arg =
+          contributionReporter.officeDocumentContribution.mock.calls[0][0];
+        expect(arg.alkemio).toBe(false);
+      });
+
       it('is false when the window has no user actors', async () => {
         arrange(new Map([['vc-1', ActorType.VIRTUAL_CONTRIBUTOR]]));
 

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -6,6 +6,10 @@ import { AuthorizationService } from '@core/authorization/authorization.service'
 import { ActorLookupService } from '@domain/actor/actor-lookup/actor.lookup.service';
 import { CollaboraDocumentService } from '@domain/collaboration/collabora-document/collabora.document.service';
 import { MemoService } from '@domain/common/memo';
+import {
+  isAlkemioEmail,
+  UserLookupService,
+} from '@domain/community/user-lookup/user.lookup.service';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MemoContributionsInputData } from '@services/collaborative-document-integration/inputs/memo.contributions.input.data';
@@ -50,7 +54,8 @@ export class CollaborativeDocumentIntegrationService {
     private readonly configService: ConfigService<AlkemioConfig, true>,
     private readonly contributionReporter: ContributionReporterService,
     private readonly communityResolver: CommunityResolverService,
-    private readonly actorLookupService: ActorLookupService
+    private readonly actorLookupService: ActorLookupService,
+    private readonly userLookupService: UserLookupService
   ) {
     this.maxCollaboratorsInRoom = this.configService.get(
       'collaboration.memo.max_collaborators_in_room',
@@ -323,6 +328,7 @@ export class CollaborativeDocumentIntegrationService {
       space: string;
       writeActors: TypedActorSet;
       readonlyActors: TypedActorSet;
+      alkemio: boolean;
     }) => void
   ): Promise<void> {
     try {
@@ -367,6 +373,7 @@ export class CollaborativeDocumentIntegrationService {
         space: levelZeroSpaceID,
         writeActors: this.groupActorsByType(writeActors, typeById),
         readonlyActors: this.groupActorsByType(readonlyActors, typeById),
+        alkemio: await this.isAlkemioTeamWindow(allIds, typeById),
       });
     } catch (e: any) {
       this.logger.warn?.(
@@ -401,6 +408,36 @@ export class CollaborativeDocumentIntegrationService {
       (grouped[key] ??= []).push(id);
     }
     return grouped;
+  }
+
+  /**
+   * Compute the aggregate window's `alkemio` team flag from the resolved actor
+   * types: `true` only when the window has at least one user actor AND every
+   * user actor resolves to an Alkemio-team (`@alkem.io`) email. Any non-team or
+   * unresolvable user (deleted between emission and indexing, or an id with no
+   * user row) drops the whole window to `false`, so filtering `alkemio:false`
+   * always retains genuine external usage. Non-user actors (VC/org/account) do
+   * not participate. `typeById` is the batch type resolution already computed
+   * for the two actor sets, so this adds only ONE extra batched user lookup.
+   */
+  private async isAlkemioTeamWindow(
+    allIds: string[],
+    typeById: Map<string, ActorType>
+  ): Promise<boolean> {
+    const userIds = allIds.filter(id => typeById.get(id) === ActorType.USER);
+    if (userIds.length === 0) {
+      return false;
+    }
+    const users = await this.userLookupService.getUsersByIds(userIds, {
+      select: { id: true, email: true },
+      loadEagerRelations: false,
+    });
+    // Every user id must resolve to a team email — a missing row (unresolvable
+    // user) leaves the counts unequal and correctly reads as non-team.
+    return (
+      users.length === userIds.length &&
+      users.every(user => isAlkemioEmail(user.email))
+    );
   }
 }
 

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -414,30 +414,58 @@ export class CollaborativeDocumentIntegrationService {
    * Compute the aggregate window's `alkemio` team flag from the resolved actor
    * types: `true` only when the window has at least one user actor AND every
    * user actor resolves to an Alkemio-team (`@alkem.io`) email. Any non-team or
-   * unresolvable user (deleted between emission and indexing, or an id with no
-   * user row) drops the whole window to `false`, so filtering `alkemio:false`
-   * always retains genuine external usage. Non-user actors (VC/org/account) do
-   * not participate. `typeById` is the batch type resolution already computed
+   * unresolvable participant drops the whole window to `false` — a user-type
+   * actor with no user row (deleted between emission and indexing), an actor id
+   * that resolved to no type at all (the `unknown` bucket of FR-005), or a
+   * failed lookup. Filtering `alkemio:false` therefore always retains genuine
+   * external usage. Non-user actors of a KNOWN non-user type (VC/org/account)
+   * do not participate. `typeById` is the batch type resolution already computed
    * for the two actor sets, so this adds only ONE extra batched user lookup.
+   *
+   * Never throws: the flag is analytics-only, so a failed lookup degrades to
+   * `false` rather than discarding the whole contribution record.
    */
   private async isAlkemioTeamWindow(
     allIds: string[],
     typeById: Map<string, ActorType>
   ): Promise<boolean> {
-    const userIds = allIds.filter(id => typeById.get(id) === ActorType.USER);
+    const userIds: string[] = [];
+    for (const id of allIds) {
+      const actorType = typeById.get(id);
+      // An id absent from the type resolution is a participant of unknown
+      // provenance — it cannot be vouched for as team-internal.
+      if (actorType === undefined) {
+        return false;
+      }
+      if (actorType === ActorType.USER) {
+        userIds.push(id);
+      }
+    }
     if (userIds.length === 0) {
       return false;
     }
-    const users = await this.userLookupService.getUsersByIds(userIds, {
-      select: { id: true, email: true },
-      loadEagerRelations: false,
-    });
-    // Every user id must resolve to a team email — a missing row (unresolvable
-    // user) leaves the counts unequal and correctly reads as non-team.
-    return (
-      users.length === userIds.length &&
-      users.every(user => isAlkemioEmail(user.email))
-    );
+    try {
+      const users = await this.userLookupService.getUsersByIds(userIds, {
+        select: { id: true, email: true },
+        loadEagerRelations: false,
+      });
+      // Every user id must resolve to a team email — a missing row (unresolvable
+      // user) leaves the counts unequal and correctly reads as non-team.
+      return (
+        users.length === userIds.length &&
+        users.every(user => isAlkemioEmail(user.email))
+      );
+    } catch (e: any) {
+      this.logger.warn?.(
+        {
+          message:
+            'Unable to resolve the Alkemio team flag for a Collabora document window; defaulting to false',
+          error: e?.message,
+        },
+        LogContext.COLLAB_DOCUMENT_INTEGRATION
+      );
+      return false;
+    }
   }
 }
 

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.spec.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.spec.ts
@@ -382,6 +382,7 @@ describe('ContributionReporterService', () => {
           [ActorType.VIRTUAL_CONTRIBUTOR]: ['vc-1'],
         },
         readonlyActors: { [ActorType.USER]: ['user-3'] },
+        alkemio: true,
       });
 
       await vi.waitFor(() => {
@@ -403,6 +404,9 @@ describe('ContributionReporterService', () => {
       expect(indexedDocument.readonlyActors).toEqual({
         [ActorType.USER]: ['user-3'],
       });
+      // the aggregate team flag is written through verbatim (the reporter does
+      // no resolution — the consumer computes it)
+      expect(indexedDocument.alkemio).toBe(true);
     });
 
     // FR-008 / C1: ONLY the typed shape is written — no flat-array field is
@@ -414,6 +418,7 @@ describe('ContributionReporterService', () => {
         space: 'space-root',
         writeActors: { [ActorType.USER]: ['user-1'] },
         readonlyActors: {},
+        alkemio: false,
       });
 
       await vi.waitFor(() => {
@@ -443,6 +448,7 @@ describe('ContributionReporterService', () => {
           [ActorType.VIRTUAL_CONTRIBUTOR]: ['vc-1'],
         },
         readonlyActors: {},
+        alkemio: false,
       });
 
       await vi.waitFor(() => {
@@ -464,6 +470,7 @@ describe('ContributionReporterService', () => {
         space: 'space-root',
         writeActors: { [ActorType.USER]: ['user-1'] },
         readonlyActors: {},
+        alkemio: false,
       });
 
       await vi.waitFor(() => {
@@ -489,6 +496,7 @@ describe('ContributionReporterService', () => {
           [ActorType.USER]: ['user-1', 'user-2'],
         },
         readonlyActors: { [ActorType.USER]: ['user-3'] },
+        alkemio: false,
       });
 
       await vi.waitFor(() => {
@@ -506,6 +514,8 @@ describe('ContributionReporterService', () => {
       expect(indexedDocument.readonlyActors).toEqual({
         [ActorType.USER]: ['user-3'],
       });
+      // the VIEW aggregate carries the same team flag, written through verbatim
+      expect(indexedDocument.alkemio).toBe(false);
     });
 
     // FR-008: only the typed shape is written — no flat-array field alongside.
@@ -516,6 +526,7 @@ describe('ContributionReporterService', () => {
         space: 'space-root',
         writeActors: { [ActorType.USER]: ['user-1'] },
         readonlyActors: {},
+        alkemio: false,
       });
 
       await vi.waitFor(() => {
@@ -539,6 +550,7 @@ describe('ContributionReporterService', () => {
         space: 'space-root',
         writeActors: { [ActorType.USER]: ['user-1'] },
         readonlyActors: {},
+        alkemio: false,
       });
 
       await vi.waitFor(() => {

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
@@ -21,7 +21,9 @@ import { ContributionAuthorDetails } from '../types/contribution.author.details'
 import { TypedActorSet, UNKNOWN_ACTOR_TYPE } from '../types/typed.actor.set';
 import { isElasticError, isElasticResponseError } from '../utils';
 
-const isFromAlkemioTeam = (email: string) => /.*@alkem\.io/.test(email);
+// Anchored at the end so look-alike suffix domains (e.g. `x@alkem.io.example.com`)
+// are NOT treated as team addresses; the domain part is case-insensitive per RFC 5321.
+const isFromAlkemioTeam = (email: string) => /@alkem\.io$/i.test(email);
 
 type ContributionActorContext = Partial<
   Pick<ActorContext, 'actorID' | 'isAnonymous' | 'guestName'>

--- a/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
+++ b/src/services/external/elasticsearch/contribution-reporter/contribution.reporter.service.ts
@@ -377,6 +377,7 @@ export class ContributionReporterService {
     space: string;
     writeActors: TypedActorSet;
     readonlyActors: TypedActorSet;
+    alkemio: boolean;
   }): void {
     this.officeDocumentAggregate(
       CONTRIBUTION_TYPE.OFFICE_DOCUMENT_CONTRIBUTION,
@@ -399,6 +400,7 @@ export class ContributionReporterService {
     space: string;
     writeActors: TypedActorSet;
     readonlyActors: TypedActorSet;
+    alkemio: boolean;
   }): void {
     this.officeDocumentAggregate(
       CONTRIBUTION_TYPE.OFFICE_DOCUMENT_VIEW,
@@ -420,6 +422,7 @@ export class ContributionReporterService {
       space: string;
       writeActors: TypedActorSet;
       readonlyActors: TypedActorSet;
+      alkemio: boolean;
     }
   ): void {
     void this.createAggregateDocument({
@@ -429,6 +432,7 @@ export class ContributionReporterService {
       space: contribution.space,
       writeActors: contribution.writeActors,
       readonlyActors: contribution.readonlyActors,
+      alkemio: contribution.alkemio,
     });
   }
 

--- a/src/services/external/elasticsearch/types/office.document.contribution.document.ts
+++ b/src/services/external/elasticsearch/types/office.document.contribution.document.ts
@@ -51,4 +51,14 @@ export type OfficeDocumentContributionDocument = {
    * {@link ActorType} — same type-keyed shape as {@link writeActors}.
    */
   readonlyActors: TypedActorSet;
+  /**
+   * True when the window is attributed to the Alkemio team: there is at least
+   * one resolvable user actor and every user actor (across both sets) is a
+   * member of the Alkemio team (by `@alkem.io` email). A window with no
+   * resolvable users, or with any non-team / unresolvable user, is `false`.
+   * Mirrors the per-author `alkemio` flag on {@link ContributionAuthorDetails}
+   * so both single-author and aggregate records can be split team vs. external
+   * in Kibana. Non-user actors (VC/org/account) never flip it.
+   */
+  alkemio: boolean;
 };

--- a/src/services/external/elasticsearch/types/office.document.contribution.document.ts
+++ b/src/services/external/elasticsearch/types/office.document.contribution.document.ts
@@ -55,10 +55,12 @@ export type OfficeDocumentContributionDocument = {
    * True when the window is attributed to the Alkemio team: there is at least
    * one resolvable user actor and every user actor (across both sets) is a
    * member of the Alkemio team (by `@alkem.io` email). A window with no
-   * resolvable users, or with any non-team / unresolvable user, is `false`.
+   * resolvable users, or with any participant that cannot be vouched for — a
+   * non-team user, a user with no user row, or an actor id that resolved to no
+   * type at all — is `false`.
    * Mirrors the per-author `alkemio` flag on {@link ContributionAuthorDetails}
    * so both single-author and aggregate records can be split team vs. external
-   * in Kibana. Non-user actors (VC/org/account) never flip it.
+   * in Kibana. Actors of a known non-user type (VC/org/account) never flip it.
    */
   alkemio: boolean;
 };


### PR DESCRIPTION
## Problem

`OFFICE_DOCUMENT_VIEW` and `OFFICE_DOCUMENT_CONTRIBUTION` aggregate contribution records have shipped **without the `alkemio` team boolean** since they went live (~2026-07-06). Every other contribution record — including `COLLABORA_DOCUMENT_OPENED` — carries it (via `ContributionAuthorDetails`), so today office-document view/edit usage cannot be split by Alkemio-team vs. external in Kibana. These two reporters simply never picked the field up.

## Fix

These two are **aggregate** records (one per document/window) carrying whole actor sets rather than a single author, so the flag needs a rule for mixed windows:

> `alkemio: true` only when the window has **≥1 user actor** AND **every** user actor (across `writeActors` + `readonlyActors`) is an `@alkem.io` team member.

Any non-team or unresolvable user drops the whole window to `false`, so filtering `alkemio:false` always retains genuine external usage. A window with no resolvable users is `false`. Non-user actors (VC/org/account) do not participate.

The reporter stays a pure pass-through; the flag is computed in the consumer (`CollaborativeDocumentIntegrationService`) where actor resolution already happens — reusing the existing batched actor-type lookup plus **one** additional batched user lookup.

## Changes

- `OfficeDocumentContributionDocument` — add the `alkemio: boolean` field.
- `ContributionReporterService` — thread `alkemio` through `officeDocumentContribution` / `officeDocumentView` → `officeDocumentAggregate` → `createAggregateDocument` (still no resolution).
- `CollaborativeDocumentIntegrationService` — compute the flag via the new `isAlkemioTeamWindow` helper; inject `UserLookupService` (+ module wiring).
- Tests updated/added in both spec files (team-only → true, mixed → false, unresolvable user → false, no users → false, VIEW parity).

## Notes

- No GraphQL schema change (this is an Elasticsearch analytics document, not a GraphQL type).
- Fixes existing data going forward only; it does not backfill records already indexed since ~2026-07-06.
- Side patch — no tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Office document contribution and view records now include an Alkemio team indicator (`alkemio`).
  * The indicator is set to `true` only when all resolvable user contributors across write/readonly actors are Alkemio-team users (based on email), and `false` otherwise (e.g., unresolved users, external users, or no user activity).
* **Bug Fixes**
  * Tightened email domain matching to only accept addresses ending exactly with `@alkem.io` (case-insensitive), excluding look-alike suffix domains.
* **Tests**
  * Expanded coverage for `alkemio` computation across contributions, views, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->