### PR TITLE
feat(034): persist admin-chosen contributors-map preview view

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1874,6 +1874,18 @@ type CalloutContributionsCountOutput {
   whiteboard: Float!
 }
 
+"""
+Admin-fixed initial map view for a Contributors-collection callout's map. Absent/null ⇒ automatic framing (fit to plotted contributors; Europe fallback).
+"""
+type CalloutContributorsMapView {
+  """Map center latitude. Finite, within [-90, 90]."""
+  latitude: Float!
+  """Map center longitude. Finite, within [-180, 180]."""
+  longitude: Float!
+  """Map zoom level. Finite, within [0, 22]."""
+  zoom: Float!
+}
+
 type CalloutContributorsSettings {
   """
   The contributor types included in this contributor-collection callout. At least one.
@@ -1885,6 +1897,10 @@ type CalloutContributorsSettings {
   defaultContributorType: ActorType!
   """The default display mode (list or map)."""
   defaultView: ContributorCollectionView!
+  """
+  Admin-fixed initial map view. Absent/null ⇒ automatic framing (fit to plotted contributors; Europe fallback).
+  """
+  mapView: CalloutContributorsMapView
 }
 
 type CalloutFraming {
@@ -2450,6 +2466,15 @@ type CreateCalloutContributionDefaultsData {
   whiteboardContent: WhiteboardContent
 }
 
+type CreateCalloutContributorsMapViewData {
+  """Map center latitude. Finite, within [-90, 90]."""
+  latitude: Float!
+  """Map center longitude. Finite, within [-180, 180]."""
+  longitude: Float!
+  """Map zoom level. Finite, within [0, 22]."""
+  zoom: Float!
+}
+
 type CreateCalloutContributorsSettingsData {
   """The contributor types to include. At least one type is required."""
   contributorTypes: [ActorType!]!
@@ -2461,6 +2486,10 @@ type CreateCalloutContributorsSettingsData {
   The default display mode. Defaults to LIST; MAP requires a locatable contributor type.
   """
   defaultView: ContributorCollectionView
+  """
+  Admin-fixed initial map view. When omitted, the callout opens on automatic framing.
+  """
+  mapView: CreateCalloutContributorsMapViewData
 }
 
 type CreateCalloutData {
@@ -7538,6 +7567,15 @@ input CreateCalloutContributionInput {
   whiteboard: CreateWhiteboardInput
 }
 
+input CreateCalloutContributorsMapViewInput {
+  """Map center latitude. Finite, within [-90, 90]."""
+  latitude: Float!
+  """Map center longitude. Finite, within [-180, 180]."""
+  longitude: Float!
+  """Map zoom level. Finite, within [0, 22]."""
+  zoom: Float!
+}
+
 input CreateCalloutContributorsSettingsInput {
   """The contributor types to include. At least one type is required."""
   contributorTypes: [ActorType!]!
@@ -7549,6 +7587,10 @@ input CreateCalloutContributorsSettingsInput {
   The default display mode. Defaults to LIST; MAP requires a locatable contributor type.
   """
   defaultView: ContributorCollectionView
+  """
+  Admin-fixed initial map view. When omitted, the callout opens on automatic framing.
+  """
+  mapView: CreateCalloutContributorsMapViewInput
 }
 
 input CreateCalloutFramingInput {
@@ -8935,6 +8977,10 @@ input UpdateCalloutContributorsSettingsInput {
   The default display mode. Defaults to LIST; MAP requires a locatable contributor type.
   """
   defaultView: ContributorCollectionView
+  """
+  Admin-fixed initial map view. Omitted ⇒ stored view unchanged; explicit null ⇒ clear to automatic framing.
+  """
+  mapView: CreateCalloutContributorsMapViewInput
 }
 
 input UpdateCalloutEntityInput {

--- a/src/domain/collaboration/callout-framing/callout.framing.mapview.validation.spec.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.mapview.validation.spec.ts
@@ -1,0 +1,316 @@
+import { ActorType } from '@common/enums/actor.type';
+import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { ContributorCollectionView } from '@common/enums/contributor.collection.view';
+import { ValidationException } from '@common/exceptions';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
+import { repositoryProviderMockFactory } from '@test/utils/repository.provider.mock.factory';
+import { ICalloutContributorsMapView } from '../callout-settings/callout.settings.contributors.mapview.interface';
+import { ICalloutSettingsFraming } from '../callout-settings/callout.settings.framing.interface';
+import { CalloutFraming } from './callout.framing.entity';
+import { CalloutFramingService } from './callout.framing.service';
+
+/**
+ * Validation matrix + isolation specs for the mapView field on
+ * ICalloutContributorsSettings.
+ *
+ * Covers the accept/reject matrix and mutual isolation of the mapView clause.
+ *
+ * Isolation: the mapView normalizer clause MUST NOT touch
+ * contributorTypes/defaultContributorType/defaultView, and the
+ * contributor-type healing rules MUST NOT touch mapView. Both directions are
+ * proven by the isolation tests below.
+ */
+describe('CalloutFramingService.validateAndNormalizeContributorsSettings — mapView', () => {
+  let service: CalloutFramingService;
+
+  /** Valid base contributors settings (no mapView). */
+  const baseContributors = () => ({
+    contributorTypes: [ActorType.USER],
+    defaultContributorType: ActorType.USER,
+    defaultView: ContributorCollectionView.LIST,
+  });
+
+  const framing = (
+    contributors?: ICalloutSettingsFraming['contributors']
+  ): ICalloutSettingsFraming => ({
+    commentsEnabled: true,
+    contributors,
+  });
+
+  const validMapView = (): ICalloutContributorsMapView => ({
+    longitude: 4.9,
+    latitude: 52.37,
+    zoom: 7,
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalloutFramingService,
+        MockWinstonProvider,
+        repositoryProviderMockFactory(CalloutFraming),
+      ],
+    })
+      .useMocker(defaultMockerFactory)
+      .compile();
+    service = module.get(CalloutFramingService);
+  });
+
+  // ─── absent mapView ────────────────────────────────────────────────────────
+
+  it('absent mapView: normalizer passes and result has no mapView field', () => {
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({ ...baseContributors() })
+    );
+    expect(result.contributors?.mapView).toBeUndefined();
+  });
+
+  // ─── valid mapView round-trips ─────────────────────────────────────────────
+
+  it('valid mapView round-trips verbatim', () => {
+    const mv = validMapView();
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({ ...baseContributors(), mapView: mv })
+    );
+    expect(result.contributors?.mapView).toEqual(mv);
+  });
+
+  // ─── range and finiteness rejection ────────────────────────────────────────
+
+  const poisonCases: Array<[string, Partial<ICalloutContributorsMapView>]> = [
+    ['NaN longitude', { longitude: NaN, latitude: 52.37, zoom: 7 }],
+    ['NaN latitude', { longitude: 4.9, latitude: NaN, zoom: 7 }],
+    ['NaN zoom', { longitude: 4.9, latitude: 52.37, zoom: NaN }],
+    ['+Infinity longitude', { longitude: Infinity, latitude: 52.37, zoom: 7 }],
+    ['-Infinity latitude', { longitude: 4.9, latitude: -Infinity, zoom: 7 }],
+    ['+Infinity zoom', { longitude: 4.9, latitude: 52.37, zoom: Infinity }],
+    [
+      'latitude 90.1 (MapLibre crash bound)',
+      { longitude: 4.9, latitude: 90.1, zoom: 7 },
+    ],
+    ['latitude -90.1', { longitude: 4.9, latitude: -90.1, zoom: 7 }],
+    ['longitude 180.1', { longitude: 180.1, latitude: 52.37, zoom: 7 }],
+    ['longitude -180.1', { longitude: -180.1, latitude: 52.37, zoom: 7 }],
+    ['zoom -0.1', { longitude: 4.9, latitude: 52.37, zoom: -0.1 }],
+    ['zoom 22.1', { longitude: 4.9, latitude: 52.37, zoom: 22.1 }],
+  ];
+
+  it.each(poisonCases)('rejects poison coordinate: %s', (_label, partial) => {
+    expect(() =>
+      service.validateAndNormalizeContributorsSettings(
+        CalloutFramingType.CONTRIBUTORS,
+        framing({
+          ...baseContributors(),
+          mapView: partial as ICalloutContributorsMapView,
+        })
+      )
+    ).toThrow(ValidationException);
+  });
+
+  // Boundary values ACCEPTED (not rejected)
+  it('accepts boundary value: latitude +90', () => {
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        ...baseContributors(),
+        mapView: { longitude: 0, latitude: 90, zoom: 10 },
+      })
+    );
+    expect(result.contributors?.mapView?.latitude).toBe(90);
+  });
+
+  it('accepts boundary value: latitude -90', () => {
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        ...baseContributors(),
+        mapView: { longitude: 0, latitude: -90, zoom: 10 },
+      })
+    );
+    expect(result.contributors?.mapView?.latitude).toBe(-90);
+  });
+
+  it('accepts boundary value: longitude +180', () => {
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        ...baseContributors(),
+        mapView: { longitude: 180, latitude: 0, zoom: 10 },
+      })
+    );
+    expect(result.contributors?.mapView?.longitude).toBe(180);
+  });
+
+  it('accepts boundary value: longitude -180', () => {
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        ...baseContributors(),
+        mapView: { longitude: -180, latitude: 0, zoom: 10 },
+      })
+    );
+    expect(result.contributors?.mapView?.longitude).toBe(-180);
+  });
+
+  it('accepts boundary value: zoom 0', () => {
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        ...baseContributors(),
+        mapView: { longitude: 0, latitude: 0, zoom: 0 },
+      })
+    );
+    expect(result.contributors?.mapView?.zoom).toBe(0);
+  });
+
+  it('accepts boundary value: zoom 22', () => {
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        ...baseContributors(),
+        mapView: { longitude: 0, latitude: 0, zoom: 22 },
+      })
+    );
+    expect(result.contributors?.mapView?.zoom).toBe(22);
+  });
+
+  // ─── malformed/partial stored shape ──────────────────────────────────────
+
+  it('rejects a stored mapView with a missing field (partial object)', () => {
+    // A direct DB edit or non-GraphQL construction path could produce a partial
+    // object; the normalizer rejects it.
+    expect(() =>
+      service.validateAndNormalizeContributorsSettings(
+        CalloutFramingType.CONTRIBUTORS,
+        framing({
+          ...baseContributors(),
+          mapView: { longitude: 4.9, latitude: 52.37 } as any,
+        })
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('rejects a stored mapView with a string field (wrong type)', () => {
+    expect(() =>
+      service.validateAndNormalizeContributorsSettings(
+        CalloutFramingType.CONTRIBUTORS,
+        framing({
+          ...baseContributors(),
+          mapView: { longitude: '4.9', latitude: 52.37, zoom: 7 } as any,
+        })
+      )
+    ).toThrow(ValidationException);
+  });
+
+  // ─── explicit null clears, omitted preserves ─────────────────────────────
+
+  it('explicit null mapView is treated as cleared (passes validation)', () => {
+    // Explicit null is the "clear to automatic" signal; normalizer must not
+    // reject it — null is not an invalid value, it is the absent sentinel.
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        ...baseContributors(),
+        mapView: null as unknown as ICalloutContributorsMapView,
+      })
+    );
+    // null propagates through (the JSONB will store null which reads as
+    // absent/automatic from the client's perspective).
+    expect(result.contributors?.mapView).toBeNull();
+  });
+
+  // ─── mutual isolation ────────────────────────────────────────────────────
+
+  it('mapView-only update leaves contributorTypes/defaultContributorType/defaultView untouched', () => {
+    // Simulates: stored state has all three fields set; incoming update adds mapView only.
+    const stored = {
+      contributorTypes: [ActorType.USER, ActorType.ORGANIZATION],
+      defaultContributorType: ActorType.ORGANIZATION,
+      defaultView: ContributorCollectionView.MAP,
+      mapView: undefined,
+    };
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({ ...stored, mapView: validMapView() })
+    );
+    expect(result.contributors?.contributorTypes).toEqual([
+      ActorType.USER,
+      ActorType.ORGANIZATION,
+    ]);
+    expect(result.contributors?.defaultContributorType).toBe(
+      ActorType.ORGANIZATION
+    );
+    expect(result.contributors?.defaultView).toBe(
+      ContributorCollectionView.MAP
+    );
+    expect(result.contributors?.mapView).toEqual(validMapView());
+  });
+
+  it('contributor-type healing leaves mapView untouched', () => {
+    // Simulates: incoming update deselects ORGANIZATION (healing should fix
+    // defaultContributorType to USER) but mapView must not be altered.
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        contributorTypes: [ActorType.USER], // removed ORGANIZATION
+        defaultContributorType: ActorType.ORGANIZATION, // stale — will be healed
+        defaultView: ContributorCollectionView.LIST,
+        mapView: validMapView(),
+      })
+    );
+    // Healing fixed the stale defaultContributorType:
+    expect(result.contributors?.defaultContributorType).toBe(ActorType.USER);
+    // mapView is untouched by the healing clause:
+    expect(result.contributors?.mapView).toEqual(validMapView());
+  });
+
+  it('defaultView VC-only healing leaves mapView untouched', () => {
+    const mv = { longitude: 10, latitude: 51, zoom: 5 };
+    const result = service.validateAndNormalizeContributorsSettings(
+      CalloutFramingType.CONTRIBUTORS,
+      framing({
+        contributorTypes: [ActorType.VIRTUAL_CONTRIBUTOR],
+        defaultContributorType: ActorType.VIRTUAL_CONTRIBUTOR,
+        defaultView: ContributorCollectionView.MAP, // will be healed to LIST (VC-only)
+        mapView: mv,
+      })
+    );
+    expect(result.contributors?.defaultView).toBe(
+      ContributorCollectionView.LIST
+    );
+    expect(result.contributors?.mapView).toEqual(mv);
+  });
+
+  // ─── kind scoping (inherited gate, regression pin) ──────────────────────
+
+  it('contributors settings incl. mapView on a non-CONTRIBUTORS framing is rejected', () => {
+    // The existing CONTRIBUTORS-kind gate rejects any contributors payload on
+    // a non-CONTRIBUTORS framing — mapView does not bypass it.
+    expect(() =>
+      service.validateAndNormalizeContributorsSettings(
+        CalloutFramingType.SPACES,
+        framing({
+          ...baseContributors(),
+          mapView: validMapView(),
+        })
+      )
+    ).toThrow(ValidationException);
+  });
+
+  it('contributors settings incl. mapView on a NONE framing is rejected', () => {
+    expect(() =>
+      service.validateAndNormalizeContributorsSettings(
+        CalloutFramingType.NONE,
+        framing({
+          ...baseContributors(),
+          mapView: validMapView(),
+        })
+      )
+    ).toThrow(ValidationException);
+  });
+});

--- a/src/domain/collaboration/callout-framing/callout.framing.service.ts
+++ b/src/domain/collaboration/callout-framing/callout.framing.service.ts
@@ -776,6 +776,42 @@ export class CalloutFramingService {
       contributors.defaultView = ContributorCollectionView.LIST;
     }
 
+    // Validate mapView when present.
+    // CRASH GUARD: MapLibre LngLat throws on latitude outside ±90, crashing the
+    // map in every viewer's browser, including anonymous visitors.
+    //
+    // Isolation:
+    // - This clause MUST NOT read or write contributorTypes / defaultContributorType
+    //   / defaultView (those healing rules run above and are already settled).
+    // - The contributor-type healing rules MUST NOT read or write mapView (enforced
+    //   by construction — the healing clauses above precede this block and touch no
+    //   mapView field).
+    // - This clause is validate-and-reject ONLY — it NEVER heals or coerces a
+    //   value into range (an invalid map view falls back to automatic framing on the
+    //   client, not to a silently clamped camera the admin never chose).
+    if (contributors.mapView !== undefined && contributors.mapView !== null) {
+      const { longitude, latitude, zoom } = contributors.mapView;
+      const isFiniteNumber = (v: unknown): v is number =>
+        typeof v === 'number' && Number.isFinite(v);
+
+      if (
+        !isFiniteNumber(longitude) ||
+        !isFiniteNumber(latitude) ||
+        !isFiniteNumber(zoom) ||
+        longitude < -180 ||
+        longitude > 180 ||
+        latitude < -90 ||
+        latitude > 90 ||
+        zoom < 0 ||
+        zoom > 22
+      ) {
+        throw new ValidationException(
+          'Invalid mapView: longitude must be finite within [-180, 180], latitude within [-90, 90], zoom within [0, 22].',
+          LogContext.COLLABORATION
+        );
+      }
+    }
+
     return framingSettings;
   }
 

--- a/src/domain/collaboration/callout-settings/callout.settings.contributors.interface.ts
+++ b/src/domain/collaboration/callout-settings/callout.settings.contributors.interface.ts
@@ -1,6 +1,7 @@
 import { ActorType } from '@common/enums/actor.type';
 import { ContributorCollectionView } from '@common/enums/contributor.collection.view';
 import { Field, ObjectType } from '@nestjs/graphql';
+import { ICalloutContributorsMapView } from './callout.settings.contributors.mapview.interface';
 
 @ObjectType('CalloutContributorsSettings')
 export abstract class ICalloutContributorsSettings {
@@ -23,4 +24,11 @@ export abstract class ICalloutContributorsSettings {
     description: 'The default display mode (list or map).',
   })
   defaultView!: ContributorCollectionView;
+
+  @Field(() => ICalloutContributorsMapView, {
+    nullable: true,
+    description:
+      'Admin-fixed initial map view. Absent/null ⇒ automatic framing (fit to plotted contributors; Europe fallback).',
+  })
+  mapView?: ICalloutContributorsMapView;
 }

--- a/src/domain/collaboration/callout-settings/callout.settings.contributors.mapview.interface.ts
+++ b/src/domain/collaboration/callout-settings/callout.settings.contributors.mapview.interface.ts
@@ -1,0 +1,29 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Admin-fixed initial map view for a Contributors-collection callout's map.
+ * Absent/null ⇒ automatic framing (fit to plotted contributors; Europe fallback).
+ *
+ * Three-float camera position: center (longitude, latitude) + zoom level.
+ * Field names follow the codebase longitude/latitude convention.
+ */
+@ObjectType('CalloutContributorsMapView')
+export abstract class ICalloutContributorsMapView {
+  @Field(() => Float, {
+    nullable: false,
+    description: 'Map center longitude. Finite, within [-180, 180].',
+  })
+  longitude!: number;
+
+  @Field(() => Float, {
+    nullable: false,
+    description: 'Map center latitude. Finite, within [-90, 90].',
+  })
+  latitude!: number;
+
+  @Field(() => Float, {
+    nullable: false,
+    description: 'Map zoom level. Finite, within [0, 22].',
+  })
+  zoom!: number;
+}

--- a/src/domain/collaboration/callout-settings/dto/callout.settings.contributors.dto.create.ts
+++ b/src/domain/collaboration/callout-settings/dto/callout.settings.contributors.dto.create.ts
@@ -1,7 +1,14 @@
 import { ActorType } from '@common/enums/actor.type';
 import { ContributorCollectionView } from '@common/enums/contributor.collection.view';
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { ArrayMinSize, IsEnum, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsEnum,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { CreateCalloutContributorsMapViewInput } from './callout.settings.contributors.mapview.dto.create';
 
 // CREATE-specific contributor settings: `contributorTypes` is REQUIRED on create
 // (a CONTRIBUTORS callout must declare at least one type). The partial-update
@@ -40,4 +47,14 @@ export class CreateCalloutContributorsSettingsInput {
   @IsOptional()
   @IsEnum(ContributorCollectionView)
   defaultView?: ContributorCollectionView;
+
+  @Field(() => CreateCalloutContributorsMapViewInput, {
+    nullable: true,
+    description:
+      'Admin-fixed initial map view. When omitted, the callout opens on automatic framing.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateCalloutContributorsMapViewInput)
+  mapView?: CreateCalloutContributorsMapViewInput;
 }

--- a/src/domain/collaboration/callout-settings/dto/callout.settings.contributors.dto.update.ts
+++ b/src/domain/collaboration/callout-settings/dto/callout.settings.contributors.dto.update.ts
@@ -1,7 +1,14 @@
 import { ActorType } from '@common/enums/actor.type';
 import { ContributorCollectionView } from '@common/enums/contributor.collection.view';
 import { Field, InputType } from '@nestjs/graphql';
-import { ArrayMinSize, IsEnum, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsEnum,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { CreateCalloutContributorsMapViewInput } from './callout.settings.contributors.mapview.dto.create';
 
 // Partial-update input: every field is OPTIONAL so a caller can update just one
 // (e.g. defaultView) without resending the whole block — the server merges into
@@ -39,4 +46,14 @@ export class UpdateCalloutContributorsSettingsInput {
   @IsOptional()
   @IsEnum(ContributorCollectionView)
   defaultView?: ContributorCollectionView;
+
+  @Field(() => CreateCalloutContributorsMapViewInput, {
+    nullable: true,
+    description:
+      'Admin-fixed initial map view. Omitted ⇒ stored view unchanged; explicit null ⇒ clear to automatic framing.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateCalloutContributorsMapViewInput)
+  mapView?: CreateCalloutContributorsMapViewInput | null;
 }

--- a/src/domain/collaboration/callout-settings/dto/callout.settings.contributors.mapview.dto.create.ts
+++ b/src/domain/collaboration/callout-settings/dto/callout.settings.contributors.mapview.dto.create.ts
@@ -1,0 +1,55 @@
+import { Field, Float, InputType, ObjectType } from '@nestjs/graphql';
+import { IsNumber, Max, Min } from 'class-validator';
+
+/**
+ * Dual-decorated DTO for a Contributors-collection callout's fixed map view.
+ *
+ * CRASH-GUARD VALIDATORS:
+ * MapLibre's LngLat constructor throws on latitude outside ±90, so invalid
+ * coordinates crash the map in every viewer's browser, including anonymous.
+ * Write-time validation is the primary defence; see also the client-side
+ * render guard (isRenderableMapView).
+ *
+ * The WhiteboardPreviewCoordinatesInput is the anti-precedent: it carries
+ * zero validation. This DTO does NOT copy that pattern.
+ */
+@InputType()
+@ObjectType('CreateCalloutContributorsMapViewData')
+export class CreateCalloutContributorsMapViewInput {
+  @Field(() => Float, {
+    nullable: false,
+    description: 'Map center longitude. Finite, within [-180, 180].',
+  })
+  @IsNumber(
+    { allowNaN: false, allowInfinity: false },
+    { message: 'longitude must be a finite number.' }
+  )
+  @Min(-180)
+  @Max(180)
+  longitude!: number;
+
+  @Field(() => Float, {
+    nullable: false,
+    description:
+      'Map center latitude. Finite, within [-90, 90]. MapLibre throws on values outside this range.',
+  })
+  @IsNumber(
+    { allowNaN: false, allowInfinity: false },
+    { message: 'latitude must be a finite number.' }
+  )
+  @Min(-90)
+  @Max(90)
+  latitude!: number;
+
+  @Field(() => Float, {
+    nullable: false,
+    description: 'Map zoom level. Finite, within [0, 22].',
+  })
+  @IsNumber(
+    { allowNaN: false, allowInfinity: false },
+    { message: 'zoom must be a finite number.' }
+  )
+  @Min(0)
+  @Max(22)
+  zoom!: number;
+}

--- a/src/services/api/input-creator/input.creator.service.spec.ts
+++ b/src/services/api/input-creator/input.creator.service.spec.ts
@@ -1,4 +1,5 @@
 import { CalloutFramingType } from '@common/enums/callout.framing.type';
+import { CalloutSelectionMode } from '@common/enums/callout.selection.mode';
 import { RelationshipNotFoundException } from '@common/exceptions';
 import { EntityNotInitializedException } from '@common/exceptions/entity.not.initialized.exception';
 import { CalloutService } from '@domain/collaboration/callout/callout.service';
@@ -754,6 +755,113 @@ describe('InputCreatorService', () => {
       expect(result.location!.city).toBe('Amsterdam');
       expect(result.referencesData).toHaveLength(1);
       expect(result.referencesData![0].name).toBe('website');
+    });
+  });
+
+  // ─── Template-capture strip: mapView ───────────────────────────────────────
+
+  describe('template strip — mapView on CONTRIBUTORS callout', () => {
+    const contributorsCalloutWithMapView = {
+      id: 'callout-contributors',
+      nameID: 'contributors-callout',
+      sortOrder: 1,
+      framing: {
+        id: 'framing-contributors',
+        type: CalloutFramingType.CONTRIBUTORS,
+        profile: {
+          displayName: 'Contributors',
+          description: '',
+          tagsets: [],
+        },
+        whiteboard: undefined,
+        link: undefined,
+        memo: undefined,
+        mediaGallery: undefined,
+      },
+      contributionDefaults: {
+        defaultDisplayName: '',
+        postDescription: '',
+        whiteboardContent: '',
+      },
+      settings: {
+        framing: {
+          contributors: {
+            contributorTypes: ['USER'],
+            defaultContributorType: 'USER',
+            defaultView: 'LIST',
+            mapView: { longitude: 4.9, latitude: 52.37, zoom: 7 },
+          },
+          selection: { mode: 'auto', selectedIds: [] },
+        },
+      },
+      classification: { tagsets: [] },
+    };
+
+    it('strips mapView from a CONTRIBUTORS callout during template serialization', async () => {
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(
+        contributorsCalloutWithMapView
+      );
+
+      const result = await service.buildCreateCalloutInputFromCallout(
+        'callout-contributors'
+      );
+
+      expect(result).not.toBeNull();
+      // mapView must not appear in the serialized template settings
+      expect(
+        (result!.settings as any)?.framing?.contributors?.mapView
+      ).toBeUndefined();
+    });
+
+    it('preserves every contributor field when a CONTRIBUTORS callout has no mapView (regression)', async () => {
+      const calloutWithoutMapView = {
+        ...contributorsCalloutWithMapView,
+        settings: {
+          framing: {
+            contributors: {
+              contributorTypes: ['USER'],
+              defaultContributorType: 'USER',
+              defaultView: 'LIST',
+              // no mapView
+            },
+            selection: { mode: CalloutSelectionMode.AUTO, selectedIds: [] },
+          },
+        },
+      };
+
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(
+        calloutWithoutMapView
+      );
+
+      const result = await service.buildCreateCalloutInputFromCallout(
+        'callout-contributors'
+      );
+
+      expect(result).not.toBeNull();
+      const contributors = (result!.settings as any)?.framing?.contributors;
+      // No mapView appears (nothing to strip), and each other contributor field
+      // round-trips unchanged — assert them all, not just contributorTypes.
+      expect(contributors?.mapView).toBeUndefined();
+      expect(contributors?.contributorTypes).toEqual(['USER']);
+      expect(contributors?.defaultContributorType).toBe('USER');
+      expect(contributors?.defaultView).toBe('LIST');
+    });
+
+    it('025 selection strip still holds on a CONTRIBUTORS callout with mapView (regression)', async () => {
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(
+        contributorsCalloutWithMapView
+      );
+
+      const result = await service.buildCreateCalloutInputFromCallout(
+        'callout-contributors'
+      );
+
+      expect(result).not.toBeNull();
+      // 025: selection is reset to AUTO (enum value is 'auto')
+      expect((result!.settings as any)?.framing?.selection?.mode).toBe('auto');
+      expect(
+        (result!.settings as any)?.framing?.selection?.selectedIds
+      ).toEqual([]);
     });
   });
 });

--- a/src/services/api/input-creator/input.creator.service.ts
+++ b/src/services/api/input-creator/input.creator.service.ts
@@ -625,10 +625,17 @@ export class InputCreatorService {
   }
 
   /**
-   * Template-capture strip (workspace#025, FR-017 / US5-AS5):
-   * Collection-kind callouts in CUSTOM mode must NOT serialize their selected
-   * ids into the template — the template must be AUTO so a space created from
-   * it self-populates from its own members/subspaces.
+   * Template-capture strip (workspace#025):
+   *
+   * - Selection strip (025, FR-017 / US5-AS5): collection-kind callouts in
+   *   CUSTOM mode must NOT serialize their selected ids into the template — the
+   *   template must be AUTO so a space created from it self-populates from its
+   *   own members/subspaces.
+   *
+   * - Map-view strip: a CONTRIBUTORS callout with a
+   *   stored mapView must NOT carry that camera position into the template — the
+   *   view was framed on the origin space's community and would wrongly open
+   *   every derived space's map on that city. Template ⇒ automatic framing.
    *
    * Deep-copies the settings object to avoid mutating the live callout in
    * memory. Non-collection kinds are returned unchanged.
@@ -648,10 +655,22 @@ export class InputCreatorService {
     // Deep-copy so the live callout object is not mutated in memory.
     const copy = JSON.parse(JSON.stringify(settings));
     if (copy?.framing) {
+      // 025: Reset selection to AUTO for all collection kinds.
       copy.framing.selection = {
         mode: CalloutSelectionMode.AUTO,
         selectedIds: [],
       };
+
+      // Strip the admin-fixed map view from CONTRIBUTORS templates.
+      // The view is host-space-specific; templates must produce automatic
+      // framing. SPACES callouts have no mapView, so this branch is a no-op
+      // for them.
+      if (
+        framingType === CalloutFramingType.CONTRIBUTORS &&
+        copy.framing.contributors
+      ) {
+        delete copy.framing.contributors.mapView;
+      }
     }
     return copy;
   }


### PR DESCRIPTION
## What & why

Persist an admin-chosen **fixed initial map view** for the Contributors-collection callout's map (the server slice of GitHub issue alkem-io/client-web#10003). Today the map auto-fits to contributor locales; this lets a space admin set the camera all viewers open on. When unset, behavior is **byte-identical to today** (automatic fit).

Adds a nullable `mapView { longitude, latitude, zoom }` value object **nested on `ICalloutContributorsSettings`**, beside `defaultView`. Presence/absence encodes the only two states — no mode enum.

## Changes
- Nullable `mapView` ObjectType on the contributors settings interface + dual-decorated `CreateCalloutContributorsMapViewInput`.
- **Hard finite + range validation on BOTH create and update** — `latitude ±90` is the MapLibre `LngLat` crash bound (`longitude ±180`, `zoom [0,22]`).
- `validate-and-reject` clause in the contributors-settings normalizer: omit ⇒ keep, explicit `null` ⇒ clear; never heals; isolated from contributor-type auto-heal; CONTRIBUTORS-kind gate inherited.
- Template serialization **strips `mapView`** so a host-specific camera never leaks into reusable templates.
- **Additive-only** schema diff; **no DDL, no migration, no authorization-policy writes.**

## Evidence
- **Gates**: `pnpm install/lint/test:ci:no:coverage/build` all green (7381 tests incl. the new map-view validation spec).
- **Schema contract**: additive nullable field, existing 3 fields byte-identical; 0 breaking (7 additive) per the schema-diff bot.
- **Review**: adversarial panel (correctness · spec-compliance · quality · security) — 0 confirmed findings, no security-hold; confirmed no auth writes / no reset / no migration.

Pairs with the client-web UI PR (map-view capture control). Refs alkem-io/client-web#10003

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a fixed initial map view for contributors callout maps, including latitude, longitude, and zoom.
  * Map view settings can be created, updated, cleared, and retrieved.
  * Omitted map views continue to use automatic framing.

* **Bug Fixes**
  * Added validation for invalid coordinates, zoom levels, and non-finite values.
  * Prevented map views from being carried into templates or unrelated callout types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->