### PR TITLE
fix: parse JSON for MCP API key routes

### DIFF
--- a/src/core/middleware/json-body-parser.middleware.spec.ts
+++ b/src/core/middleware/json-body-parser.middleware.spec.ts
@@ -1,0 +1,45 @@
+import express from 'express';
+import request from 'supertest';
+import { createJsonBodyParserMiddleware } from './json-body-parser.middleware';
+
+describe('createJsonBodyParserMiddleware', () => {
+  it('parses JSON for MCP API key management routes', async () => {
+    const app = express();
+    app.use(createJsonBodyParserMiddleware('1mb'));
+    app.post('/rest/mcp/api-keys', (req, res) => {
+      res.json(req.body);
+    });
+
+    const payload = {
+      name: 'codex-valentin',
+      scopes: [{ operations: ['read', 'tools'] }],
+    };
+
+    await request(app)
+      .post('/rest/mcp/api-keys')
+      .send(payload)
+      .expect(200, payload);
+  });
+
+  it.each([
+    '/rest/mcp',
+    '/rest/mcp/',
+  ])('leaves the MCP transport request body unconsumed for %s', async path => {
+    const app = express();
+    app.use(createJsonBodyParserMiddleware('1mb'));
+    app.post(path, (req, res) => {
+      let rawBody = '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => {
+        rawBody += chunk;
+      });
+      req.on('end', () => {
+        res.type('application/json').send(rawBody);
+      });
+    });
+
+    const payload = { jsonrpc: '2.0', method: 'tools/list', id: 1 };
+
+    await request(app).post(path).send(payload).expect(200, payload);
+  });
+});

--- a/src/core/middleware/json-body-parser.middleware.ts
+++ b/src/core/middleware/json-body-parser.middleware.ts
@@ -1,0 +1,20 @@
+import { json } from 'body-parser';
+import { RequestHandler } from 'express';
+
+/**
+ * The MCP transport parses its own request body. Other routes under the MCP
+ * prefix, such as API key management, use Nest's regular JSON DTO handling.
+ */
+export const createJsonBodyParserMiddleware = (
+  limit: string
+): RequestHandler => {
+  const jsonBodyParser = json({ limit });
+
+  return (req, res, next) => {
+    if (req.path === '/rest/mcp' || req.path === '/rest/mcp/') {
+      return next();
+    }
+
+    return jsonBodyParser(req, res, next);
+  };
+};

--- a/src/main.server.ts
+++ b/src/main.server.ts
@@ -4,10 +4,9 @@ import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { AlkemioConfig } from '@src/types';
-import { json } from 'body-parser';
 import { useContainer } from 'class-validator';
 import cookieParser from 'cookie-parser';
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 import session from 'express-session';
 import { renderGraphiQL } from 'graphql-helix';
 import { graphqlUploadExpress } from 'graphql-upload';
@@ -23,6 +22,7 @@ import {
 } from './core/auth/oidc/session-store.redis';
 import { BootstrapService } from './core/bootstrap/bootstrap.service';
 import { faviconMiddleware } from './core/middleware/favicon.middleware';
+import { createJsonBodyParserMiddleware } from './core/middleware/json-body-parser.middleware';
 
 /**
  * Bootstrap the full Alkemio API server (AppModule): GraphQL/Apollo, REST,
@@ -150,13 +150,7 @@ export const bootstrapServer = async () => {
   const { max_json_payload_size, port } = configService.get('hosting', {
     infer: true,
   });
-  // JSON body parsing - skip for MCP routes (MCP SDK handles its own parsing)
-  app.use((req: Request, res: Response, next: NextFunction) => {
-    if (req.path.startsWith('/rest/mcp')) {
-      return next();
-    }
-    json({ limit: max_json_payload_size })(req, res, next);
-  });
+  app.use(createJsonBodyParserMiddleware(max_json_payload_size));
 
   // Serve the GraphiQL interface at '/graphiql'
   app.use('/graphiql', (_req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

- bypass the application JSON parser only for the exact MCP transport endpoint
- keep JSON parsing enabled for MCP management routes such as `POST /rest/mcp/api-keys`
- add regression coverage proving API-key payloads are parsed while MCP transport bodies remain untouched

## Why

The server disabled Nest body parsing globally and then skipped the custom JSON parser for every path beginning with `/rest/mcp`. As a result, the API-key controller received an empty body and rejected valid requests with DTO errors such as `name should not be empty`.

## Testing

- `pnpm exec vitest run src/core/middleware/json-body-parser.middleware.spec.ts`
- `pnpm run typecheck:native`
- `pnpm exec biome check src/main.server.ts src/core/middleware/json-body-parser.middleware.ts src/core/middleware/json-body-parser.middleware.spec.ts`
- `git diff --check`

## Schema Contract Checklist

Not applicable: this change does not alter the GraphQL schema.

## Risk and rollback

Low and limited to HTTP request-body routing. The MCP transport behavior is explicitly preserved and tested. Roll back the single commit to restore the previous parser selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MCP transport requests so their raw request bodies remain available to route handlers.
  * Preserved JSON parsing for API key management and other standard requests.
  * Applied the configured JSON payload size limit consistently across requests.

* **Tests**
  * Added coverage for JSON parsing and raw-body handling on MCP transport paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->