### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -1224,6 +1224,15 @@ type CalloutContributionsCountOutput {
   whiteboard: Float!
 }
 
+type CalloutContributorsMapView {
+  """Map center latitude. Finite, within [-90, 90]."""
+  latitude: Float!
+  """Map center longitude. Finite, within [-180, 180]."""
+  longitude: Float!
+  """Map zoom level. Finite, within [0, 22]."""
+  zoom: Float!
+}
+
 type CalloutContributorsSettings {
   """
   The contributor types included in this contributor-collection callout. At least one.
@@ -1235,6 +1244,10 @@ type CalloutContributorsSettings {
   defaultContributorType: ActorType!
   """The default display mode (list or map)."""
   defaultView: ContributorCollectionView!
+  """
+  Admin-fixed initial map view. Absent/null ⇒ automatic framing (fit to plotted contributors; Europe fallback).
+  """
+  mapView: CalloutContributorsMapView
 }
 
 enum CalloutDescriptionDisplayMode {
@@ -2024,6 +2037,28 @@ input CreateCalloutContributionInput {
   whiteboard: CreateWhiteboardInput
 }
 
+type CreateCalloutContributorsMapViewData {
+  """
+  Map center latitude. Finite, within [-90, 90]. MapLibre throws on values outside this range.
+  """
+  latitude: Float!
+  """Map center longitude. Finite, within [-180, 180]."""
+  longitude: Float!
+  """Map zoom level. Finite, within [0, 22]."""
+  zoom: Float!
+}
+
+input CreateCalloutContributorsMapViewInput {
+  """
+  Map center latitude. Finite, within [-90, 90]. MapLibre throws on values outside this range.
+  """
+  latitude: Float!
+  """Map center longitude. Finite, within [-180, 180]."""
+  longitude: Float!
+  """Map zoom level. Finite, within [0, 22]."""
+  zoom: Float!
+}
+
 type CreateCalloutContributorsSettingsData {
   """The contributor types to include. At least one type is required."""
   contributorTypes: [ActorType!]!
@@ -2035,6 +2070,10 @@ type CreateCalloutContributorsSettingsData {
   The default display mode. Defaults to LIST; MAP requires a locatable contributor type.
   """
   defaultView: ContributorCollectionView
+  """
+  Admin-fixed initial map view. When omitted, the callout opens on automatic framing.
+  """
+  mapView: CreateCalloutContributorsMapViewData
 }
 
 input CreateCalloutContributorsSettingsInput {
@@ -2048,6 +2087,10 @@ input CreateCalloutContributorsSettingsInput {
   The default display mode. Defaults to LIST; MAP requires a locatable contributor type.
   """
   defaultView: ContributorCollectionView
+  """
+  Admin-fixed initial map view. When omitted, the callout opens on automatic framing.
+  """
+  mapView: CreateCalloutContributorsMapViewInput
 }
 
 type CreateCalloutData {
@@ -8099,6 +8142,10 @@ input UpdateCalloutContributorsSettingsInput {
   The default display mode. Defaults to LIST; MAP requires a locatable contributor type.
   """
   defaultView: ContributorCollectionView
+  """
+  Admin-fixed initial map view. Omitted ⇒ stored view unchanged; explicit null ⇒ clear to automatic framing.
+  """
+  mapView: CreateCalloutContributorsMapViewInput
 }
 
 input UpdateCalloutEntityInput {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 319465 bytes
Snapshot md5: 0d4505323913e76f67c7567f3e3e180a

This PR was generated by the schema-baseline workflow.