### PR TITLE
fix: authorizationPolicyResetAll task never reaches COMPLETED; error path inverts it (#6310)

### DIFF
--- a/src/common/interfaces/redis.interfaces.ts
+++ b/src/common/interfaces/redis.interfaces.ts
@@ -1,7 +1,29 @@
 import { Cache, Store } from 'cache-manager';
 
-interface RedisClientLike {
+/**
+ * The slice of the node_redis v3 client we actually use. Callback-style
+ * because `cache-manager-redis-store@2` wraps `redis@3`, which predates the
+ * promise API.
+ */
+export interface RedisClientLike {
   quit(callback?: (err?: Error | null, res?: string) => void): void;
+  /**
+   * Atomic increment. This is the whole point: the auth-reset queue runs as
+   * competing consumers across pods (see main.worker.ts), so a
+   * read-modify-write on a shared key loses increments and the owning task
+   * never reaches its target — the hang of alkem-io/server#6310.
+   */
+  incr(key: string, callback?: (err: Error | null, res: number) => void): void;
+  /** Raw GET — returns the counter as a string, or null when unset. */
+  get(
+    key: string,
+    callback?: (err: Error | null, res: string | null) => void
+  ): void;
+  expire(
+    key: string,
+    seconds: number,
+    callback?: (err: Error | null, res: number) => void
+  ): void;
 }
 
 export interface RedisCache extends Cache {

--- a/src/common/interfaces/redis.interfaces.ts
+++ b/src/common/interfaces/redis.interfaces.ts
@@ -14,6 +14,16 @@ export interface RedisClientLike {
    * never reaches its target — the hang of alkem-io/server#6310.
    */
   incr(key: string, callback?: (err: Error | null, res: number) => void): void;
+  /**
+   * Atomic set-add. Returns 1 when the member was new, 0 when it was already
+   * present — which is exactly the "have I already counted this item?" test
+   * needed to make at-least-once delivery idempotent.
+   */
+  sadd(
+    key: string,
+    member: string,
+    callback?: (err: Error | null, res: number) => void
+  ): void;
   /** Raw GET — returns the counter as a string, or null when unset. */
   get(
     key: string,

--- a/src/common/interfaces/redis.interfaces.ts
+++ b/src/common/interfaces/redis.interfaces.ts
@@ -24,6 +24,15 @@ export interface RedisClientLike {
     member: string,
     callback?: (err: Error | null, res: number) => void
   ): void;
+  /**
+   * Set only if absent. Returns 1 when this call created the key — used to let
+   * exactly one consumer stamp a task's terminal timestamp.
+   */
+  setnx(
+    key: string,
+    value: string,
+    callback?: (err: Error | null, res: number) => void
+  ): void;
   /** Raw GET — returns the counter as a string, or null when unset. */
   get(
     key: string,

--- a/src/services/auth-reset/publisher/auth-reset.service.spec.ts
+++ b/src/services/auth-reset/publisher/auth-reset.service.spec.ts
@@ -243,6 +243,11 @@ describe('AuthResetService', () => {
     beforeEach(() => {
       // All find calls return empty arrays by default
       entityManager.find.mockResolvedValue([]);
+      // A caller-supplied task is adopted, not created: it is stamped with the
+      // computed itemsCount so it has a target to reach.
+      taskService.setItemsCount.mockImplementation(
+        async (id: string) => ({ id }) as any
+      );
     });
 
     it('should use provided taskId and return it', async () => {
@@ -250,6 +255,20 @@ describe('AuthResetService', () => {
 
       expect(result).toBe('existing-task');
       expect(taskService.create).not.toHaveBeenCalled();
+    });
+
+    it('stamps a caller-supplied task with the computed itemsCount (issue #6310)', async () => {
+      // Regression: the taskId branch used to discard the count it had just
+      // computed, leaving the caller's task with no target — the original hang,
+      // reached through a different door.
+      entityManager.find
+        .mockResolvedValueOnce([{ id: 'a1' }, { id: 'a2' }]) // accounts   x2
+        .mockResolvedValueOnce([{ id: 'o1' }]) // orgs       x2
+        .mockResolvedValueOnce([{ id: 'u1' }, { id: 'u2' }]); // users      x1
+
+      await service.publishResetAll('caller-task');
+
+      expect(taskService.setItemsCount).toHaveBeenCalledWith('caller-task', 8);
     });
 
     it('should create a task when no taskId is provided', async () => {

--- a/src/services/auth-reset/publisher/auth-reset.service.spec.ts
+++ b/src/services/auth-reset/publisher/auth-reset.service.spec.ts
@@ -1,6 +1,8 @@
 import { AUTH_RESET_SERVICE } from '@common/constants';
 import { AlkemioErrorStatus } from '@common/enums';
 import { BaseException } from '@common/exceptions/base.exception';
+import { Organization } from '@domain/community/organization';
+import { User } from '@domain/community/user/user.entity';
 import { Account } from '@domain/space/account/account.entity';
 import { ClientProxy } from '@nestjs/microservices';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -273,13 +275,15 @@ describe('AuthResetService', () => {
 
       await service.publishResetAll('t1');
 
-      expect(spy1).toHaveBeenCalledWith('t1');
-      expect(spy2).toHaveBeenCalledWith('t1');
-      expect(spy3).toHaveBeenCalledWith('t1');
+      // Each per-entity publisher now receives the ids fetched once up front,
+      // so the emitted messages match the count the task was created with.
+      expect(spy1).toHaveBeenCalledWith('t1', []);
+      expect(spy2).toHaveBeenCalledWith('t1', []);
+      expect(spy3).toHaveBeenCalledWith('t1', []);
       expect(spy4).toHaveBeenCalled();
       expect(spy5).toHaveBeenCalled();
-      expect(spy6).toHaveBeenCalledWith('t1');
-      expect(spy7).toHaveBeenCalledWith('t1');
+      expect(spy6).toHaveBeenCalledWith('t1', []);
+      expect(spy7).toHaveBeenCalledWith('t1', []);
     });
 
     it('should throw BaseException when a sub-method fails', async () => {
@@ -295,6 +299,66 @@ describe('AuthResetService', () => {
           AlkemioErrorStatus.AUTHORIZATION_RESET
         );
       }
+    });
+
+    // Regression coverage for #6310: the aggregate task was created with NO
+    // itemsCount, so it could never reach a terminal status and the id handed
+    // back to the operator was useless as a completion signal.
+    describe('itemsCount (issue #6310)', () => {
+      const mockFindByEntity = (
+        accounts: { id: string }[],
+        organizations: { id: string }[],
+        users: { id: string }[]
+      ) =>
+        entityManager.find.mockImplementation(async (entity: any) => {
+          if (entity === Account) return accounts;
+          if (entity === Organization) return organizations;
+          if (entity === User) return users;
+          return [];
+        });
+
+      it('should create the task with the total number of tracked items', async () => {
+        mockFindByEntity(
+          [{ id: 'acc-1' }, { id: 'acc-2' }],
+          [{ id: 'org-1' }, { id: 'org-2' }, { id: 'org-3' }],
+          [{ id: 'usr-1' }, { id: 'usr-2' }, { id: 'usr-3' }, { id: 'usr-4' }]
+        );
+        taskService.create.mockResolvedValue({ id: 'counted-task' } as any);
+
+        await service.publishResetAll();
+
+        // accounts x2 (authorization + licence) = 4
+        // organizations x2 (authorization + licence) = 6
+        // users x1 = 4
+        expect(taskService.create).toHaveBeenCalledWith(14);
+      });
+
+      it('should count exactly the messages that carry the task id', async () => {
+        mockFindByEntity([{ id: 'acc-1' }], [{ id: 'org-1' }], [{ id: 'u-1' }]);
+        taskService.create.mockResolvedValue({ id: 'counted-task' } as any);
+
+        await service.publishResetAll();
+
+        const [[itemsCount]] = taskService.create.mock.calls;
+        // The platform / AI-server resets are emitted WITHOUT a task, so the
+        // subscriber never accounts for them — counting them would leave the
+        // task permanently short and hanging in IN_PROGRESS.
+        const trackedEmits = authResetQueue.emit.mock.calls.filter(
+          ([, payload]: [unknown, any]) => payload?.task === 'counted-task'
+        );
+        expect(trackedEmits).toHaveLength(itemsCount as number);
+        expect(itemsCount).toBe(5);
+      });
+
+      it('should fetch each entity id set only once', async () => {
+        mockFindByEntity([{ id: 'acc-1' }], [{ id: 'org-1' }], [{ id: 'u-1' }]);
+
+        await service.publishResetAll('t1');
+
+        // Counting and emitting must read the SAME rows: a second query could
+        // return a different set and desync itemsCount from the emitted work.
+        expect(entityManager.find).toHaveBeenCalledTimes(3);
+      });
     });
   });
 });

--- a/src/services/auth-reset/publisher/auth-reset.service.ts
+++ b/src/services/auth-reset/publisher/auth-reset.service.ts
@@ -9,7 +9,12 @@ import { ClientProxy } from '@nestjs/microservices';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { TaskService } from '@services/task/task.service';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { EntityManager } from 'typeorm';
+import {
+  EntityManager,
+  EntityTarget,
+  FindOptionsSelect,
+  ObjectLiteral,
+} from 'typeorm';
 import { AuthResetEventPayload } from '../auth-reset.payload.interface';
 import { RESET_EVENT_TYPE } from '../reset.event.type';
 
@@ -24,18 +29,56 @@ export class AuthResetService {
     private logger: LoggerService
   ) {}
 
+  /**
+   * Publishes the full platform reset and returns the id of the task tracking it.
+   *
+   * The task is created with its true `itemsCount` **before** the first message
+   * is emitted. Without that count the task can never reach a terminal status,
+   * so the id it hands back is useless as a completion signal for the operators
+   * our migration notes tell to run this.
+   */
   public async publishResetAll(taskId?: string) {
-    const task = taskId ? { id: taskId } : await this.taskService.create();
-
     try {
-      await this.publishAuthorizationResetAllAccounts(task.id);
-      await this.publishAuthorizationResetAllOrganizations(task.id);
-      await this.publishAuthorizationResetAllUsers(task.id);
+      // Fetch the three id sets ONCE, up front. This is what makes the count
+      // trustworthy: the ids counted are exactly the ids emitted. A separate
+      // COUNT(*) could drift from the subsequent SELECT (a row created or
+      // deleted in between), leaving the task permanently one item short of
+      // its target — i.e. hanging, which is the very bug being fixed here.
+      // It is also cheaper than the status quo: 3 id-only selects instead of
+      // the 5 the per-entity publishers each ran on their own.
+      const [accountIds, organizationIds, userIds] = await Promise.all([
+        this.findAllIds(Account),
+        this.findAllIds(Organization),
+        this.findAllIds(User),
+      ]);
+
+      // Accounts and organizations are each reset twice (authorization AND
+      // licence); users once. The platform and AI-server resets deliberately
+      // carry no task id, so the subscriber never accounts for them — counting
+      // them here would leave the task 3 items short forever.
+      const itemsCount =
+        accountIds.length * 2 + organizationIds.length * 2 + userIds.length;
+
+      const task = taskId
+        ? { id: taskId }
+        : await this.taskService.create(itemsCount);
+
+      // The pre-fetched ids are handed down so the publishers below re-use them
+      // instead of re-querying (and possibly emitting a different number of
+      // messages than the count promised).
+      await this.publishAuthorizationResetAllAccounts(task.id, accountIds);
+      await this.publishAuthorizationResetAllOrganizations(
+        task.id,
+        organizationIds
+      );
+      await this.publishAuthorizationResetAllUsers(task.id, userIds);
       await this.publishAuthorizationResetPlatform();
       await this.publishAuthorizationResetAiServer();
       // And reset licenses
-      await this.publishLicenseResetAllAccounts(task.id);
-      await this.publishLicenseResetAllOrganizations(task.id);
+      await this.publishLicenseResetAllAccounts(task.id, accountIds);
+      await this.publishLicenseResetAllOrganizations(task.id, organizationIds);
+
+      return task.id;
     } catch (error) {
       throw new BaseException(
         `Error while initializing authorization reset: ${error}`,
@@ -43,120 +86,130 @@ export class AuthResetService {
         AlkemioErrorStatus.AUTHORIZATION_RESET
       );
     }
-
-    return task.id;
   }
 
-  public async publishAuthorizationResetAllAccounts(taskId?: string) {
-    const accounts = await this.manager.find(Account, {
-      select: { id: true },
+  /** Select just the ids of every row of an entity. */
+  private async findAllIds<T extends ObjectLiteral & { id: string }>(
+    entity: EntityTarget<T>
+  ): Promise<string[]> {
+    const rows = await this.manager.find(entity, {
+      select: { id: true } as FindOptionsSelect<T>,
     });
+
+    return rows.map(({ id }) => id);
+  }
+
+  /** Emit one reset event per id, all tagged with the same tracking task. */
+  private emitResetEvents(
+    ids: string[],
+    type: RESET_EVENT_TYPE,
+    taskId: string
+  ): void {
+    ids.forEach(id =>
+      this.authResetQueue.emit<any, AuthResetEventPayload>(type, {
+        id,
+        type,
+        task: taskId,
+      })
+    );
+  }
+
+  /**
+   * @param taskId Track against an existing task instead of creating one.
+   * @param accountIds Pre-fetched ids, supplied by {@link publishResetAll} so the
+   *   aggregate task's `itemsCount` matches the messages actually emitted.
+   *   Omitted when this publisher is invoked standalone.
+   */
+  public async publishAuthorizationResetAllAccounts(
+    taskId?: string,
+    accountIds?: string[]
+  ) {
+    const ids = accountIds ?? (await this.findAllIds(Account));
 
     const task = taskId
       ? { id: taskId }
-      : await this.taskService.create(accounts.length);
+      : await this.taskService.create(ids.length);
 
-    accounts.forEach(({ id }) =>
-      this.authResetQueue.emit<any, AuthResetEventPayload>(
-        RESET_EVENT_TYPE.AUTHORIZATION_RESET_ACCOUNT,
-        {
-          id,
-          type: RESET_EVENT_TYPE.AUTHORIZATION_RESET_ACCOUNT,
-          task: task.id,
-        }
-      )
+    this.emitResetEvents(
+      ids,
+      RESET_EVENT_TYPE.AUTHORIZATION_RESET_ACCOUNT,
+      task.id
     );
 
     return task.id;
   }
 
-  public async publishLicenseResetAllAccounts(taskId?: string) {
-    const accounts = await this.manager.find(Account, {
-      select: { id: true },
-    });
+  /** @see publishAuthorizationResetAllAccounts for the parameters. */
+  public async publishLicenseResetAllAccounts(
+    taskId?: string,
+    accountIds?: string[]
+  ) {
+    const ids = accountIds ?? (await this.findAllIds(Account));
 
     const task = taskId
       ? { id: taskId }
-      : await this.taskService.create(accounts.length);
+      : await this.taskService.create(ids.length);
 
-    accounts.forEach(({ id }) =>
-      this.authResetQueue.emit<any, AuthResetEventPayload>(
-        RESET_EVENT_TYPE.LICENSE_RESET_ACCOUNT,
-        {
-          id,
-          type: RESET_EVENT_TYPE.LICENSE_RESET_ACCOUNT,
-          task: task.id,
-        }
-      )
+    this.emitResetEvents(ids, RESET_EVENT_TYPE.LICENSE_RESET_ACCOUNT, task.id);
+
+    return task.id;
+  }
+
+  /** @see publishAuthorizationResetAllAccounts for the parameters. */
+  public async publishLicenseResetAllOrganizations(
+    taskId?: string,
+    organizationIds?: string[]
+  ) {
+    const ids = organizationIds ?? (await this.findAllIds(Organization));
+
+    const task = taskId
+      ? { id: taskId }
+      : await this.taskService.create(ids.length);
+
+    this.emitResetEvents(
+      ids,
+      RESET_EVENT_TYPE.LICENSE_RESET_ORGANIZATION,
+      task.id
     );
 
     return task.id;
   }
 
-  public async publishLicenseResetAllOrganizations(taskId?: string) {
-    const organizations = await this.manager.find(Organization, {
-      select: { id: true },
-    });
+  /** @see publishAuthorizationResetAllAccounts for the parameters. */
+  public async publishAuthorizationResetAllUsers(
+    taskId?: string,
+    userIds?: string[]
+  ) {
+    const ids = userIds ?? (await this.findAllIds(User));
 
     const task = taskId
       ? { id: taskId }
-      : await this.taskService.create(organizations.length);
+      : await this.taskService.create(ids.length);
 
-    organizations.forEach(({ id }) =>
-      this.authResetQueue.emit<any, AuthResetEventPayload>(
-        RESET_EVENT_TYPE.LICENSE_RESET_ORGANIZATION,
-        {
-          id,
-          type: RESET_EVENT_TYPE.LICENSE_RESET_ORGANIZATION,
-          task: task.id,
-        }
-      )
+    this.emitResetEvents(
+      ids,
+      RESET_EVENT_TYPE.AUTHORIZATION_RESET_USER,
+      task.id
     );
 
     return task.id;
   }
 
-  public async publishAuthorizationResetAllUsers(taskId?: string) {
-    const users = await this.manager.find(User, {
-      select: { id: true },
-    });
+  /** @see publishAuthorizationResetAllAccounts for the parameters. */
+  public async publishAuthorizationResetAllOrganizations(
+    taskId?: string,
+    organizationIds?: string[]
+  ) {
+    const ids = organizationIds ?? (await this.findAllIds(Organization));
 
     const task = taskId
       ? { id: taskId }
-      : await this.taskService.create(users.length);
+      : await this.taskService.create(ids.length);
 
-    users.forEach(({ id }) =>
-      this.authResetQueue.emit<any, AuthResetEventPayload>(
-        RESET_EVENT_TYPE.AUTHORIZATION_RESET_USER,
-        {
-          id,
-          type: RESET_EVENT_TYPE.AUTHORIZATION_RESET_USER,
-          task: task.id,
-        }
-      )
-    );
-
-    return task.id;
-  }
-
-  public async publishAuthorizationResetAllOrganizations(taskId?: string) {
-    const organizations = await this.manager.find(Organization, {
-      select: { id: true },
-    });
-
-    const task = taskId
-      ? { id: taskId }
-      : await this.taskService.create(organizations.length);
-
-    organizations.forEach(({ id }) =>
-      this.authResetQueue.emit<any, AuthResetEventPayload>(
-        RESET_EVENT_TYPE.AUTHORIZATION_RESET_ORGANIZATION,
-        {
-          id,
-          type: RESET_EVENT_TYPE.AUTHORIZATION_RESET_ORGANIZATION,
-          task: task.id,
-        }
-      )
+    this.emitResetEvents(
+      ids,
+      RESET_EVENT_TYPE.AUTHORIZATION_RESET_ORGANIZATION,
+      task.id
     );
 
     return task.id;

--- a/src/services/auth-reset/publisher/auth-reset.service.ts
+++ b/src/services/auth-reset/publisher/auth-reset.service.ts
@@ -97,23 +97,33 @@ export class AuthResetService {
       // its target is waiting forever.
       if (task) {
         try {
+          // Task errors are surfaced to operators through the `task` query, so
+          // this string stays stable and free of interpolated internals. The
+          // diagnosis lives in the log line and in the exception details below.
           await this.taskService.completeWithError(
             task.id,
-            `Reset publishing failed before all events were emitted: ${error}`
+            'Reset publishing failed before all events were emitted'
           );
-        } catch (completionError) {
+        } catch (completionError: any) {
           this.logger.error(
             `Failed to mark task '${task.id}' as errored: ${completionError}`,
-            undefined,
+            completionError?.stack,
             LogContext.AUTH
           );
         }
       }
 
-      throw new BaseException(
+      this.logger.error(
         `Error while initializing authorization reset: ${error}`,
+        (error as Error)?.stack,
+        LogContext.AUTH
+      );
+
+      throw new BaseException(
+        'Error while initializing authorization reset',
         LogContext.AUTH,
-        AlkemioErrorStatus.AUTHORIZATION_RESET
+        AlkemioErrorStatus.AUTHORIZATION_RESET,
+        { originalException: error }
       );
     }
   }

--- a/src/services/auth-reset/publisher/auth-reset.service.ts
+++ b/src/services/auth-reset/publisher/auth-reset.service.ts
@@ -38,6 +38,13 @@ export class AuthResetService {
    * our migration notes tell to run this.
    */
   public async publishResetAll(taskId?: string) {
+    // Declared OUTSIDE the try so the catch can reach it. If a publisher throws
+    // partway through — the RMQ channel dropping while the licence resets are
+    // emitted, say — the remaining messages are never sent, so the task can
+    // never reach its target. Left alone it would sit IN_PROGRESS forever and
+    // permanently pollute getAll(IN_PROGRESS); it has to be failed explicitly.
+    let task: { id: string } | undefined;
+
     try {
       // Fetch the three id sets ONCE, up front. This is what makes the count
       // trustworthy: the ids counted are exactly the ids emitted. A separate
@@ -53,14 +60,19 @@ export class AuthResetService {
       ]);
 
       // Accounts and organizations are each reset twice (authorization AND
-      // licence); users once. The platform and AI-server resets deliberately
-      // carry no task id, so the subscriber never accounts for them — counting
-      // them here would leave the task 3 items short forever.
+      // licence); users once. The two platform-level resets emitted below
+      // (AUTHORIZATION_RESET_PLATFORM, AUTHORIZATION_RESET_AI_SERVER)
+      // deliberately carry no task id, so the subscriber never accounts for
+      // them — counting them here would leave the task 2 items short forever.
       const itemsCount =
         accountIds.length * 2 + organizationIds.length * 2 + userIds.length;
 
-      const task = taskId
-        ? { id: taskId }
+      // A caller-supplied task was necessarily created without a count (every
+      // external creator calls taskService.create() with no argument), so it
+      // has to be told the total — otherwise the count computed just above is
+      // thrown away and the task has no target to reach.
+      task = taskId
+        ? await this.taskService.setItemsCount(taskId, itemsCount)
         : await this.taskService.create(itemsCount);
 
       // The pre-fetched ids are handed down so the publishers below re-use them
@@ -80,6 +92,24 @@ export class AuthResetService {
 
       return task.id;
     } catch (error) {
+      // Fail the task explicitly if it got as far as being created. Whatever
+      // was not emitted will never arrive, so waiting for the counter to reach
+      // its target is waiting forever.
+      if (task) {
+        try {
+          await this.taskService.completeWithError(
+            task.id,
+            `Reset publishing failed before all events were emitted: ${error}`
+          );
+        } catch (completionError) {
+          this.logger.error(
+            `Failed to mark task '${task.id}' as errored: ${completionError}`,
+            undefined,
+            LogContext.AUTH
+          );
+        }
+      }
+
       throw new BaseException(
         `Error while initializing authorization reset: ${error}`,
         LogContext.AUTH,

--- a/src/services/auth-reset/subscriber/auth-reset.controller.ts
+++ b/src/services/auth-reset/subscriber/auth-reset.controller.ts
@@ -84,8 +84,16 @@ export class AuthResetController {
     context: RmqContext,
     subject: string,
     work: () => Promise<void>,
-    task?: string
+    // The whole payload rather than just `payload.task`: `type` + `id` form the
+    // stable item identity that makes task accounting idempotent under RMQ's
+    // at-least-once delivery (this method's own retry path guarantees
+    // redelivery, see below). Omitted by the platform/AI-server handlers, which
+    // are untracked by design.
+    payload?: AuthResetEventPayload
   ): Promise<void> {
+    const task = payload?.task;
+    const itemKey = payload ? `${payload.type}:${payload.id}` : undefined;
+
     this.logger.verbose?.(
       `Starting reset of ${subject}.`,
       LogContext.AUTH_POLICY
@@ -109,7 +117,7 @@ export class AuthResetController {
         // Awaited so the task cache write completes before the message is acked,
         // but isolated (recordTaskResult swallows its own errors) so a task-cache
         // hiccup can never requeue a reset that already succeeded.
-        await this.recordTaskResult(task, message);
+        await this.recordTaskResult(task, message, itemKey);
       }
       channel.ack(originalMsg);
     } catch (error: any) {
@@ -117,7 +125,7 @@ export class AuthResetController {
         const message = `Resetting ${subject} failed! Max retries reached. Rejecting message.`;
         this.logger.error(message, error?.stack, LogContext.AUTH);
         if (task) {
-          await this.recordTaskError(task, message);
+          await this.recordTaskError(task, message, itemKey);
         }
         channel.reject(originalMsg, false); // Reject and don't requeue
       } else {
@@ -143,9 +151,13 @@ export class AuthResetController {
    * telemetry — it must never throw back into the reset flow (which would requeue
    * an already-successful reset), so its errors are logged and contained here.
    */
-  private async recordTaskResult(task: string, message: string): Promise<void> {
+  private async recordTaskResult(
+    task: string,
+    message: string,
+    itemKey?: string
+  ): Promise<void> {
     try {
-      await this.taskService.updateTaskResults(task, message);
+      await this.taskService.updateTaskResults(task, message, true, itemKey);
     } catch (error: any) {
       this.logger.warn(
         `Failed to persist task result for task ${task}: ${error?.message}`,
@@ -155,9 +167,13 @@ export class AuthResetController {
   }
 
   /** As {@link recordTaskResult}, for the terminal (max-retries) error path. */
-  private async recordTaskError(task: string, message: string): Promise<void> {
+  private async recordTaskError(
+    task: string,
+    message: string,
+    itemKey?: string
+  ): Promise<void> {
     try {
-      await this.taskService.updateTaskErrors(task, message);
+      await this.taskService.updateTaskErrors(task, message, true, itemKey);
     } catch (error: any) {
       this.logger.warn(
         `Failed to persist task error for task ${task}: ${error?.message}`,
@@ -182,7 +198,7 @@ export class AuthResetController {
           );
         await this.authorizationPolicyService.saveAll(updatedAuthorizations);
       },
-      payload.task
+      payload
     );
   }
 
@@ -200,7 +216,7 @@ export class AuthResetController {
           await this.accountLicenseService.applyLicensePolicy(account.id);
         await this.licenseService.saveAll(updatedLicenses);
       },
-      payload.task
+      payload
     );
   }
 
@@ -223,7 +239,7 @@ export class AuthResetController {
           );
         await this.licenseService.saveAll(updatedLicenses);
       },
-      payload.task
+      payload
     );
   }
 
@@ -267,7 +283,7 @@ export class AuthResetController {
           await this.userAuthorizationService.applyAuthorizationPolicy(user.id);
         await this.authorizationPolicyService.saveAll(authorizations);
       },
-      payload.task
+      payload
     );
   }
 
@@ -291,7 +307,7 @@ export class AuthResetController {
           );
         await this.authorizationPolicyService.saveAll(authorizations);
       },
-      payload.task
+      payload
     );
   }
 }

--- a/src/services/task/task.service.spec.ts
+++ b/src/services/task/task.service.spec.ts
@@ -540,6 +540,167 @@ describe('TaskService', () => {
   });
 });
 
+/**
+ * Competing consumers (issue #6310, round 2).
+ *
+ * The auth-reset queue is consumed by up to 10 pods at once (prefetchCount: 1
+ * in main.worker.ts, REPLICAS=10 in the infra-ops autoscaler), all sharing one
+ * Redis. These tests model that: every `get` hands back its OWN deserialized
+ * copy of the task, and all consumers read before any of them write — which is
+ * exactly what makes a read-modify-write lose increments.
+ *
+ * With `task.itemsDone += 1` the counter lands on 1 instead of 10, the target
+ * is never reached, and the task hangs forever — the very bug being fixed.
+ * These pass only because the counter is an atomic Redis INCR.
+ */
+describe('TaskService — concurrent consumers', () => {
+  let service: TaskService;
+  let counters: Map<string, number>;
+  let store: Map<string, any>;
+
+  /** A cacheManager whose reads are isolated copies, like real deserialization. */
+  const makeSharedCache = () => ({
+    get: vi.fn(async (key: string) => {
+      // Snapshot FIRST, then yield. This is the order that matters: every
+      // consumer reads the same state before any of them gets to write, which
+      // is exactly how a read-modify-write loses increments in production.
+      // (Yielding before the read would let each consumer run to completion in
+      // its own microtask drain — no overlap, and the test would pass against
+      // the very bug it is supposed to catch.)
+      const value = store.get(key);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      return value === undefined ? undefined : structuredClone(value);
+    }),
+    set: vi.fn(async (key: string, value: any) => {
+      store.set(key, structuredClone(value));
+      return 'OK';
+    }),
+    del: vi.fn(),
+    reset: vi.fn(),
+    wrap: vi.fn(),
+    // The bit that matters: a real atomic INCR behind cacheManager.store.
+    store: {
+      name: 'redis',
+      getClient: () => ({
+        incr: (key: string, cb: (e: null, v: number) => void) => {
+          const next = (counters.get(key) ?? 0) + 1;
+          counters.set(key, next);
+          cb(null, next);
+        },
+        get: (key: string, cb: (e: null, v: string | null) => void) =>
+          cb(null, counters.has(key) ? String(counters.get(key)) : null),
+        expire: (_k: string, _s: number, cb: (e: null, v: number) => void) =>
+          cb(null, 1),
+        quit: vi.fn(),
+      }),
+    },
+  });
+
+  beforeEach(async () => {
+    counters = new Map();
+    store = new Map();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TaskService,
+        { provide: CACHE_MANAGER, useValue: makeSharedCache() },
+        MockWinstonProvider,
+      ],
+    }).compile();
+
+    service = module.get<TaskService>(TaskService);
+  });
+
+  it('does not lose increments when 10 consumers finish at once', async () => {
+    const task = await service.create(10);
+
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        service.updateTaskResults(task.id, `reset ${i}` as any)
+      )
+    );
+
+    const settled = await service.getOrFail(task.id);
+
+    expect(settled.itemsDone).toBe(10);
+    expect(settled.status).toBe(TaskStatus.COMPLETED);
+  });
+
+  it('reports COMPLETED even if a stale consumer clobbers the stored status', async () => {
+    const task = await service.create(2);
+
+    await Promise.all([
+      service.updateTaskResults(task.id, 'a' as any),
+      service.updateTaskResults(task.id, 'b' as any),
+    ]);
+
+    // Simulate the lost update the counters exist to survive: a slow pod writes
+    // its stale IN_PROGRESS copy back over the terminal one.
+    store.set(task.id, {
+      ...structuredClone(store.get(task.id)),
+      status: TaskStatus.IN_PROGRESS,
+      itemsDone: 1,
+    });
+
+    const resolved = await service.getOrFail(task.id);
+
+    // The Redis counter cannot be clobbered, so it — not the stored field —
+    // decides.
+    expect(resolved.itemsDone).toBe(2);
+    expect(resolved.status).toBe(TaskStatus.COMPLETED);
+  });
+
+  it('settles as ERRORED when any item failed, not COMPLETED', async () => {
+    const task = await service.create(3);
+
+    await Promise.all([
+      service.updateTaskResults(task.id, 'ok' as any),
+      service.updateTaskErrors(task.id, 'boom' as any),
+      service.updateTaskResults(task.id, 'ok' as any),
+    ]);
+
+    const settled = await service.getOrFail(task.id);
+
+    expect(settled.itemsDone).toBe(3);
+    expect(settled.status).toBe(TaskStatus.ERRORED);
+  });
+
+  it('ignores a redelivered item after the task has settled', async () => {
+    const task = await service.create(1);
+
+    await service.updateTaskResults(task.id, 'ok' as any);
+    expect((await service.getOrFail(task.id)).status).toBe(
+      TaskStatus.COMPLETED
+    );
+
+    // RabbitMQ is at-least-once: handleReset publishes its retry before acking
+    // the original, so a pod dying in between gets the item redelivered. That
+    // must not resurrect a settled task or re-stamp its `end`.
+    const endBefore = (await service.getOrFail(task.id)).end;
+    await service.updateTaskErrors(task.id, 'late duplicate' as any);
+
+    const after = await service.getOrFail(task.id);
+    expect(after.status).toBe(TaskStatus.COMPLETED);
+    expect(after.end).toBe(endBefore);
+  });
+
+  it('stamps a count onto an externally created task', async () => {
+    const task = await service.create(); // uncounted, as external callers make it
+    expect(task.itemsCount).toBeUndefined();
+
+    await service.setItemsCount(task.id, 2);
+
+    await Promise.all([
+      service.updateTaskResults(task.id, 'a' as any),
+      service.updateTaskResults(task.id, 'b' as any),
+    ]);
+
+    expect((await service.getOrFail(task.id)).status).toBe(
+      TaskStatus.COMPLETED
+    );
+  });
+});
+
 function createMockTask(overrides?: Partial<Task>): Task {
   const now = Date.now();
   return {

--- a/src/services/task/task.service.spec.ts
+++ b/src/services/task/task.service.spec.ts
@@ -601,6 +601,18 @@ describe('TaskService — concurrent consumers', () => {
           set.add(member);
           cb(null, isNew ? 1 : 0);
         },
+        setnx: (
+          key: string,
+          value: string,
+          cb: (e: null, v: number) => void
+        ) => {
+          if (counters.has(key)) {
+            cb(null, 0);
+            return;
+          }
+          counters.set(key, Number(value));
+          cb(null, 1);
+        },
         expire: (_k: string, _s: number, cb: (e: null, v: number) => void) =>
           cb(null, 1),
         quit: vi.fn(),
@@ -748,6 +760,27 @@ describe('TaskService — concurrent consumers', () => {
 
     const after = await service.getOrFail(task.id);
     expect(after.itemsDone).toBeGreaterThanOrEqual(2);
+    expect(after.status).toBe(TaskStatus.COMPLETED);
+  });
+
+  it('keeps the end timestamp when a stale consumer writes over it', async () => {
+    const task = await service.create(1);
+
+    await service.updateTaskResults(task.id, 'done' as any);
+    const settled = await service.getOrFail(task.id);
+    expect(settled.status).toBe(TaskStatus.COMPLETED);
+    expect(settled.end).toBeDefined();
+
+    // A slower consumer writes back a copy taken before the task settled, in
+    // which `end` is still undefined — erasing the stamp in the cached object.
+    store.set(task.id, {
+      ...structuredClone(store.get(task.id)),
+      end: undefined,
+    });
+
+    // The SETNX stamp survives outside the object, so readers still see it.
+    const after = await service.getOrFail(task.id);
+    expect(after.end).toBe(settled.end);
     expect(after.status).toBe(TaskStatus.COMPLETED);
   });
 

--- a/src/services/task/task.service.spec.ts
+++ b/src/services/task/task.service.spec.ts
@@ -556,6 +556,7 @@ describe('TaskService', () => {
 describe('TaskService — concurrent consumers', () => {
   let service: TaskService;
   let counters: Map<string, number>;
+  let sets: Map<string, Set<string>>;
   let store: Map<string, any>;
 
   /** A cacheManager whose reads are isolated copies, like real deserialization. */
@@ -589,6 +590,17 @@ describe('TaskService — concurrent consumers', () => {
         },
         get: (key: string, cb: (e: null, v: string | null) => void) =>
           cb(null, counters.has(key) ? String(counters.get(key)) : null),
+        sadd: (
+          key: string,
+          member: string,
+          cb: (e: null, v: number) => void
+        ) => {
+          const set = sets.get(key) ?? new Set<string>();
+          sets.set(key, set);
+          const isNew = !set.has(member);
+          set.add(member);
+          cb(null, isNew ? 1 : 0);
+        },
         expire: (_k: string, _s: number, cb: (e: null, v: number) => void) =>
           cb(null, 1),
         quit: vi.fn(),
@@ -598,6 +610,7 @@ describe('TaskService — concurrent consumers', () => {
 
   beforeEach(async () => {
     counters = new Map();
+    sets = new Map();
     store = new Map();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -698,6 +711,44 @@ describe('TaskService — concurrent consumers', () => {
     expect((await service.getOrFail(task.id)).status).toBe(
       TaskStatus.COMPLETED
     );
+  });
+
+  it('does not let a redelivered item settle the task early', async () => {
+    const task = await service.create(3);
+
+    // RMQ at-least-once: item A is delivered twice while B and C are still
+    // queued. Counting the duplicate would push itemsDone to 3, settle the
+    // task, and cause every later genuine update to be dropped.
+    await service.updateTaskResults(task.id, 'A' as any, true, 'reset:A');
+    await service.updateTaskResults(task.id, 'A again' as any, true, 'reset:A');
+    await service.updateTaskResults(task.id, 'B' as any, true, 'reset:B');
+
+    const midRun = await service.getOrFail(task.id);
+    expect(midRun.itemsDone).toBe(2);
+    expect(midRun.status).toBe(TaskStatus.IN_PROGRESS);
+
+    // The genuinely-last item still lands, and its failure is still honoured.
+    await service.updateTaskErrors(task.id, 'C failed' as any, true, 'reset:C');
+
+    const settled = await service.getOrFail(task.id);
+    expect(settled.itemsDone).toBe(3);
+    expect(settled.status).toBe(TaskStatus.ERRORED);
+  });
+
+  it('never lets the counter regress when Redis returns mid-run', async () => {
+    const task = await service.create(2);
+
+    // Two increments land in-object only (Redis unreachable), then Redis comes
+    // back and INCR starts from 1 — below what the task already recorded.
+    // A plain assignment would undercount and strand the task IN_PROGRESS.
+    const stored = store.get(task.id);
+    store.set(task.id, { ...stored, itemsDone: 2 });
+
+    await service.updateTaskResults(task.id, 'reconnected' as any);
+
+    const after = await service.getOrFail(task.id);
+    expect(after.itemsDone).toBeGreaterThanOrEqual(2);
+    expect(after.status).toBe(TaskStatus.COMPLETED);
   });
 
   it('refuses to re-count a task that already has a count', async () => {

--- a/src/services/task/task.service.spec.ts
+++ b/src/services/task/task.service.spec.ts
@@ -555,7 +555,7 @@ describe('TaskService', () => {
  */
 describe('TaskService — concurrent consumers', () => {
   let service: TaskService;
-  let counters: Map<string, number>;
+  let counters: Map<string, string>;
   let sets: Map<string, Set<string>>;
   let store: Map<string, any>;
 
@@ -583,13 +583,16 @@ describe('TaskService — concurrent consumers', () => {
     store: {
       name: 'redis',
       getClient: () => ({
+        // Redis values are strings, so the fake stores strings too — coercing
+        // to Number here would turn a terminal status like 'errored' into NaN
+        // and quietly hide the very clobber these tests check for.
         incr: (key: string, cb: (e: null, v: number) => void) => {
-          const next = (counters.get(key) ?? 0) + 1;
-          counters.set(key, next);
+          const next = Number(counters.get(key) ?? 0) + 1;
+          counters.set(key, String(next));
           cb(null, next);
         },
         get: (key: string, cb: (e: null, v: string | null) => void) =>
-          cb(null, counters.has(key) ? String(counters.get(key)) : null),
+          cb(null, counters.has(key) ? (counters.get(key) as string) : null),
         sadd: (
           key: string,
           member: string,
@@ -610,7 +613,7 @@ describe('TaskService — concurrent consumers', () => {
             cb(null, 0);
             return;
           }
-          counters.set(key, Number(value));
+          counters.set(key, value);
           cb(null, 1);
         },
         expire: (_k: string, _s: number, cb: (e: null, v: number) => void) =>
@@ -782,6 +785,29 @@ describe('TaskService — concurrent consumers', () => {
     const after = await service.getOrFail(task.id);
     expect(after.end).toBe(settled.end);
     expect(after.status).toBe(TaskStatus.COMPLETED);
+  });
+
+  it('keeps an explicit terminal state when a stale consumer writes over it', async () => {
+    // publishResetAll emitted some events, then threw — so it fails the task
+    // explicitly. The counter can NEVER reach itemsCount (the rest were never
+    // emitted), so the counter-derived path cannot repair a clobber here.
+    const task = await service.create(10);
+    await service.updateTaskResults(task.id, 'one item got through' as any);
+    await service.completeWithError(task.id, 'publishing failed');
+
+    expect((await service.getOrFail(task.id)).status).toBe(TaskStatus.ERRORED);
+
+    // A consumer that read the task before it was failed writes its stale
+    // IN_PROGRESS copy back.
+    store.set(task.id, {
+      ...structuredClone(store.get(task.id)),
+      status: TaskStatus.IN_PROGRESS,
+      end: undefined,
+    });
+
+    const after = await service.getOrFail(task.id);
+    expect(after.status).toBe(TaskStatus.ERRORED);
+    expect(after.end).toBeDefined();
   });
 
   it('refuses to re-count a task that already has a count', async () => {

--- a/src/services/task/task.service.spec.ts
+++ b/src/services/task/task.service.spec.ts
@@ -810,6 +810,23 @@ describe('TaskService — concurrent consumers', () => {
     expect(after.end).toBeDefined();
   });
 
+  it('rejects an unreachable itemsCount', async () => {
+    const task = await service.create();
+
+    // -1 would satisfy `itemsDone >= itemsCount` on the very first read, so the
+    // task would report finished having processed nothing.
+    await expect(service.setItemsCount(task.id, -1)).rejects.toThrow(
+      /non-negative integer/
+    );
+    await expect(service.setItemsCount(task.id, 2.5)).rejects.toThrow(
+      /non-negative integer/
+    );
+
+    expect((await service.getOrFail(task.id)).status).toBe(
+      TaskStatus.IN_PROGRESS
+    );
+  });
+
   it('refuses to re-count a task that already has a count', async () => {
     const task = await service.create(5);
     await service.updateTaskResults(task.id, 'first item' as any);

--- a/src/services/task/task.service.spec.ts
+++ b/src/services/task/task.service.spec.ts
@@ -699,6 +699,20 @@ describe('TaskService — concurrent consumers', () => {
       TaskStatus.COMPLETED
     );
   });
+
+  it('refuses to re-count a task that already has a count', async () => {
+    const task = await service.create(5);
+    await service.updateTaskResults(task.id, 'first item' as any);
+
+    // Re-stamping would reset itemsDone to 0 under a consumer that has already
+    // reported progress — corrupting the counter the terminal status is
+    // derived from.
+    await expect(service.setItemsCount(task.id, 99)).rejects.toThrow(
+      /already has an itemsCount/
+    );
+
+    expect((await service.getOrFail(task.id)).itemsCount).toBe(5);
+  });
 });
 
 function createMockTask(overrides?: Partial<Task>): Task {

--- a/src/services/task/task.service.spec.ts
+++ b/src/services/task/task.service.spec.ts
@@ -288,7 +288,7 @@ describe('TaskService', () => {
       });
     });
 
-    it('should set status to COMPLETED when all items are done', async () => {
+    it('should set status to ERRORED when all items are done', async () => {
       const task = createMockTask({
         itemsCount: 1,
         itemsDone: 0,
@@ -299,7 +299,8 @@ describe('TaskService', () => {
       await service.updateTaskErrors(task.id, 'final-error');
 
       expect(task.itemsDone).toBe(1);
-      expect(task.status).toBe(TaskStatus.COMPLETED);
+      // A run that lost items is not a successful run.
+      expect(task.status).toBe(TaskStatus.ERRORED);
     });
 
     it('should not increment itemsDone when completeItem is false', async () => {
@@ -322,6 +323,134 @@ describe('TaskService', () => {
       await expect(
         service.updateTaskErrors('missing', 'error')
       ).rejects.toThrow("Task 'missing' not found");
+    });
+  });
+
+  // Regression coverage for #6310: `authorizationPolicyResetAll` handed back a
+  // task that could never reach COMPLETED, while the error path completed it on
+  // the first failure. The two update paths must agree on when a task is done.
+  describe('terminal status (issue #6310)', () => {
+    const primeTask = (task: Task) => {
+      (cacheManager.get as Mock).mockResolvedValue(task);
+      (cacheManager.set as Mock).mockResolvedValue('ok');
+    };
+
+    it('should NOT complete an uncounted task on an error', async () => {
+      // The exact shape `create()` produces with no itemsCount — where
+      // `undefined === undefined` used to be read as "all items are done".
+      const task = createMockTask({
+        itemsCount: undefined,
+        itemsDone: undefined,
+      });
+      primeTask(task);
+
+      await service.updateTaskErrors(task.id, 'boom');
+
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+      expect(task.end).toBeUndefined();
+      expect(task.errors).toHaveLength(1);
+    });
+
+    it('should NOT complete an uncounted task after many errors', async () => {
+      const task = createMockTask({
+        itemsCount: undefined,
+        itemsDone: undefined,
+      });
+      primeTask(task);
+
+      await service.updateTaskErrors(task.id, 'boom-1');
+      await service.updateTaskErrors(task.id, 'boom-2');
+      await service.updateTaskErrors(task.id, 'boom-3');
+
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+      // An uncounted task is only ever terminated explicitly.
+      await service.complete(task.id, TaskStatus.ERRORED);
+      expect(task.status).toBe(TaskStatus.ERRORED);
+    });
+
+    it('should NOT complete an uncounted task on a result either', async () => {
+      const task = createMockTask({
+        itemsCount: undefined,
+        itemsDone: undefined,
+      });
+      primeTask(task);
+
+      await service.updateTaskResults(task.id, 'ok');
+
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+    });
+
+    it('should reach COMPLETED when itemsDone reaches itemsCount', async () => {
+      const task = createMockTask({ itemsCount: 3, itemsDone: 0 });
+      primeTask(task);
+
+      await service.updateTaskResults(task.id, 'item-1');
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+
+      await service.updateTaskResults(task.id, 'item-2');
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+
+      await service.updateTaskResults(task.id, 'item-3');
+
+      expect(task.itemsDone).toBe(3);
+      expect(task.status).toBe(TaskStatus.COMPLETED);
+      expect(task.end).toBeGreaterThan(0);
+    });
+
+    it('should stay IN_PROGRESS when an early item errors, then end ERRORED', async () => {
+      const task = createMockTask({ itemsCount: 3, itemsDone: 0 });
+      primeTask(task);
+
+      // The inverted path: the first error used to flip status to COMPLETED.
+      await service.updateTaskErrors(task.id, 'item-1 failed');
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+
+      await service.updateTaskResults(task.id, 'item-2 ok');
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+
+      // Last item lands on the SUCCESS path, but the run lost an item.
+      await service.updateTaskResults(task.id, 'item-3 ok');
+
+      expect(task.itemsDone).toBe(3);
+      expect(task.status).toBe(TaskStatus.ERRORED);
+      expect(task.end).toBeGreaterThan(0);
+    });
+
+    it('should end ERRORED when the last item is the failing one', async () => {
+      const task = createMockTask({ itemsCount: 2, itemsDone: 0 });
+      primeTask(task);
+
+      await service.updateTaskResults(task.id, 'item-1 ok');
+      expect(task.status).toBe(TaskStatus.IN_PROGRESS);
+
+      await service.updateTaskErrors(task.id, 'item-2 failed');
+
+      expect(task.itemsDone).toBe(2);
+      expect(task.status).toBe(TaskStatus.ERRORED);
+    });
+
+    it('should still terminate if the counter overshoots itemsCount', async () => {
+      const task = createMockTask({ itemsCount: 1, itemsDone: 2 });
+      primeTask(task);
+
+      await service.updateTaskResults(task.id, 'stray item');
+
+      // `>=`, not `===` — an overshoot must not step over the terminal check.
+      expect(task.status).toBe(TaskStatus.COMPLETED);
+    });
+
+    it('should create a zero-item task already COMPLETED', async () => {
+      (cacheManager.get as Mock).mockResolvedValueOnce([]);
+      (cacheManager.set as Mock).mockResolvedValue('ok');
+
+      // Nothing to reset means no item update will ever arrive to move it out
+      // of IN_PROGRESS.
+      const result = await service.create(0);
+
+      expect(result.itemsCount).toBe(0);
+      expect(result.itemsDone).toBe(0);
+      expect(result.status).toBe(TaskStatus.COMPLETED);
+      expect(result.end).toBeGreaterThan(0);
     });
   });
 

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -50,6 +50,7 @@ export class TaskService {
   private readonly doneKey = (id: string) => `task:${id}:itemsDone`;
   private readonly errorsKey = (id: string) => `task:${id}:errorCount`;
   private readonly seenKey = (id: string) => `task:${id}:seen`;
+  private readonly endKey = (id: string) => `task:${id}:end`;
 
   private redisClient(): RedisClientLike | undefined {
     const store = (this.cacheManager as Partial<RedisCache>).store as
@@ -141,6 +142,38 @@ export class TaskService {
    * against and every call is treated as a fresh item — the previous
    * behaviour.
    */
+  /**
+   * Record the task's terminal timestamp where it cannot be clobbered.
+   *
+   * `end` lives on the Task object, and every consumer writes that whole
+   * object back — so a slower consumer holding a copy taken before the task
+   * settled will write `end: undefined` straight over the stamp. The result is
+   * a COMPLETED task with no end time. SETNX keeps the FIRST stamp, and the
+   * read overlay restores it, so the clobber becomes invisible.
+   */
+  private async stampEnd(id: string, end: number): Promise<void> {
+    const client = this.redisClient();
+
+    if (!client) {
+      return;
+    }
+
+    return new Promise<void>(resolve => {
+      client.setnx(this.endKey(id), String(end), err => {
+        if (err) {
+          this.logger.error(
+            `Failed to stamp end for task '${id}': ${err}`,
+            err?.stack,
+            LogContext.TASKS
+          );
+          resolve();
+          return;
+        }
+        client.expire(this.endKey(id), TTL, () => resolve());
+      });
+    });
+  }
+
   private async claimItem(id: string, itemKey?: string): Promise<boolean> {
     const client = this.redisClient();
 
@@ -224,9 +257,9 @@ export class TaskService {
    * fields — are the source of truth for progress, and for whether a counted
    * task has finished.
    *
-   * `end` is deliberately NOT fabricated here: it is stamped by whichever
-   * consumer saw the last item, and a derived value would differ on every
-   * read.
+   * `end` is never invented here either — it is read back from the SETNX stamp
+   * (see {@link stampEnd}), so a stale write that cleared it cannot leave a
+   * terminal task without an end time.
    */
   private async withAuthoritativeCounters(task: Task): Promise<Task> {
     // An uncounted task has no target to reach — it is terminated explicitly
@@ -235,9 +268,10 @@ export class TaskService {
       return task;
     }
 
-    const [done, errorCount] = await Promise.all([
+    const [done, errorCount, storedEnd] = await Promise.all([
       this.readCounter(this.doneKey(task.id)),
       this.readCounter(this.errorsKey(task.id)),
+      this.readCounter(this.endKey(task.id)),
     ]);
 
     // No Redis (or no increments yet): the in-object counter is all there is.
@@ -251,6 +285,7 @@ export class TaskService {
     const resolved: Task = {
       ...task,
       itemsDone: Math.max(done, task.itemsDone ?? 0),
+      end: task.end ?? storedEnd,
     };
 
     if (
@@ -405,6 +440,8 @@ export class TaskService {
         task,
         errorCount > 0 ? TaskStatus.ERRORED : TaskStatus.COMPLETED
       );
+      // Outside the cached object, where a stale write cannot erase it.
+      await this.stampEnd(id, task.end as number);
     }
 
     await this.cacheManager.set(task.id, task, {
@@ -446,6 +483,7 @@ export class TaskService {
     // not terminate the task; the remaining items are still being processed.
     if (this.isFullyAccountedFor(task)) {
       this.finish(task, TaskStatus.ERRORED);
+      await this.stampEnd(id, task.end as number);
     }
 
     await this.cacheManager.set(task.id, task, {

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -570,6 +570,16 @@ export class TaskService {
    * i.e. #6310 all over again, just via a different door.
    */
   public async setItemsCount(id: string, itemsCount: number) {
+    // A fractional target is never reachable by an integer counter, and a
+    // negative one is worse than unreachable: `itemsDone >= itemsCount` holds
+    // from the very first read, so the task reports finished before a single
+    // item has been processed.
+    if (!Number.isInteger(itemsCount) || itemsCount < 0) {
+      throw new Error(
+        `itemsCount must be a non-negative integer, received: ${itemsCount}`
+      );
+    }
+
     const existing = await this.getOrFail(id);
 
     // Stamping a count is a one-shot on a fresh task. Re-stamping one that is

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -49,6 +49,7 @@ export class TaskService {
   // the single process those environments actually are.
   private readonly doneKey = (id: string) => `task:${id}:itemsDone`;
   private readonly errorsKey = (id: string) => `task:${id}:errorCount`;
+  private readonly seenKey = (id: string) => `task:${id}:seen`;
 
   private redisClient(): RedisClientLike | undefined {
     const store = (this.cacheManager as Partial<RedisCache>).store as
@@ -118,6 +119,48 @@ export class TaskService {
         }
         const parsed = Number(value);
         resolve(Number.isFinite(parsed) ? parsed : undefined);
+      });
+    });
+  }
+
+  /**
+   * Claim an item for this task, exactly once.
+   *
+   * RabbitMQ is at-least-once, and `handleReset` re-publishes its retry BEFORE
+   * acking the original — so a pod dying between those two lines guarantees a
+   * redelivery. Counting that twice would push `itemsDone` to `itemsCount`
+   * while real items are still queued: the task settles early, and every
+   * genuine update after it is dropped by the terminal guard, so a run that
+   * later fails an item can still report COMPLETED.
+   *
+   * `SADD` returns 1 only for a member that was not already in the set, which
+   * makes it the claim. Returns true when the caller owns this item and should
+   * account for it, false when it is a duplicate.
+   *
+   * Without Redis (or without an item identity) there is nothing to dedupe
+   * against and every call is treated as a fresh item — the previous
+   * behaviour.
+   */
+  private async claimItem(id: string, itemKey?: string): Promise<boolean> {
+    const client = this.redisClient();
+
+    if (!client || !itemKey) {
+      return true;
+    }
+
+    return new Promise<boolean>(resolve => {
+      client.sadd(this.seenKey(id), itemKey, (err, added) => {
+        if (err) {
+          this.logger.error(
+            `Failed to claim task item '${itemKey}' on task '${id}': ${err}`,
+            err?.stack,
+            LogContext.TASKS
+          );
+          // Fail open: a dedupe outage must not stall a legitimate item.
+          resolve(true);
+          return;
+        }
+        client.expire(this.seenKey(id), TTL, () => resolve(added === 1));
       });
     });
   }
@@ -202,9 +245,19 @@ export class TaskService {
       return task;
     }
 
-    const resolved: Task = { ...task, itemsDone: done };
+    // Never below what the task already recorded — increments taken while
+    // Redis was unreachable live only in the stored object, and reporting a
+    // lower number would look like the run went backwards.
+    const resolved: Task = {
+      ...task,
+      itemsDone: Math.max(done, task.itemsDone ?? 0),
+    };
 
-    if (done >= task.itemsCount && resolved.status === TaskStatus.IN_PROGRESS) {
+    if (
+      resolved.itemsDone !== undefined &&
+      resolved.itemsDone >= task.itemsCount &&
+      resolved.status === TaskStatus.IN_PROGRESS
+    ) {
       resolved.status =
         (errorCount ?? resolved.errors.length) > 0
           ? TaskStatus.ERRORED
@@ -290,7 +343,17 @@ export class TaskService {
 
     // `atomic` is undefined only when there is no Redis to be atomic against —
     // a single-process environment, where the in-object increment is exact.
-    task.itemsDone = atomic ?? task.itemsDone + 1;
+    //
+    // Math.max, not a plain assignment: if Redis was briefly unreachable some
+    // increments landed in-object only, so a reconnected INCR starts from a
+    // value BELOW what the task has already recorded. Letting the counter
+    // regress would undercount and strand the task IN_PROGRESS — the very
+    // failure this counter exists to prevent. The counter only ever moves
+    // forward.
+    task.itemsDone =
+      atomic === undefined
+        ? task.itemsDone + 1
+        : Math.max(atomic, task.itemsDone + 1);
   }
 
   /**
@@ -298,11 +361,16 @@ export class TaskService {
    * @param id
    * @param result
    * @param completeItem Increase the itemsDone counter
+   * @param itemKey Stable identity of the item being reported, used to make
+   *   accounting idempotent under at-least-once delivery. Omit for callers
+   *   with no per-item identity (their tasks are uncounted, so there is no
+   *   target to settle early against).
    */
   public async updateTaskResults(
     id: string,
     result: TaskResult,
-    completeItem = true
+    completeItem = true,
+    itemKey?: string
   ) {
     const task = await this.getOrFail(id);
 
@@ -312,6 +380,12 @@ export class TaskService {
     // duplicate flips a COMPLETED task to ERRORED and rewrites `end` — two
     // pollers reading a minute apart would disagree about the same run.
     if (task.status !== TaskStatus.IN_PROGRESS) {
+      return;
+    }
+
+    // A redelivery of an item already counted must not advance the counter, or
+    // the task settles before the outstanding items have been processed.
+    if (!(await this.claimItem(id, itemKey))) {
       return;
     }
 
@@ -338,16 +412,26 @@ export class TaskService {
     });
   }
 
+  /**
+   * @param itemKey See {@link updateTaskResults}. An item that already reported
+   *   a result must not also report an error (or vice versa) — both claim the
+   *   same identity, and the first claim wins.
+   */
   public async updateTaskErrors(
     id: string,
     error: TaskError,
-    completeItem = true
+    completeItem = true,
+    itemKey?: string
   ) {
     const task = await this.getOrFail(id);
 
     // See updateTaskResults — a redelivered failure must not re-stamp a task
     // that has already settled.
     if (task.status !== TaskStatus.IN_PROGRESS) {
+      return;
+    }
+
+    if (!(await this.claimItem(id, itemKey))) {
       return;
     }
 

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -235,10 +235,10 @@ export class TaskService {
     };
 
     // A counted task with nothing to do is already finished: no item update
-    // will ever arrive to move it out of IN_PROGRESS.
+    // will ever arrive to move it out of IN_PROGRESS. Routed through finish()
+    // so every terminal transition in this service stamps `end` the same way.
     if (itemsCount === 0) {
-      task.status = TaskStatus.COMPLETED;
-      task.end = now;
+      this.finish(task, TaskStatus.COMPLETED);
     }
 
     await this.cacheManager.set<Task>(task.id, task, {
@@ -381,16 +381,28 @@ export class TaskService {
   public async setItemsCount(id: string, itemsCount: number) {
     const existing = await this.getOrFail(id);
 
+    // Stamping a count is a one-shot on a fresh task. Re-stamping one that is
+    // already counted would reset `itemsDone` to zero underneath consumers
+    // that have already reported progress, silently corrupting the very
+    // counter the terminal status is derived from — so refuse rather than
+    // corrupt.
+    if (existing.itemsCount !== undefined) {
+      throw new Error(
+        `Task '${id}' already has an itemsCount (${existing.itemsCount}); refusing to re-count it`
+      );
+    }
+
     // `itemsCount` is readonly on the interface, so rebuild rather than cast
     // the guarantee away.
     const task: Task = {
       ...existing,
       itemsCount,
       itemsDone: 0,
-      ...(itemsCount === 0
-        ? { status: TaskStatus.COMPLETED, end: new Date().getTime() }
-        : {}),
     };
+
+    if (itemsCount === 0) {
+      this.finish(task, TaskStatus.COMPLETED);
+    }
 
     await this.cacheManager.set(task.id, task, {
       ttl: TTL,

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -1,4 +1,9 @@
 import { LogContext } from '@common/enums';
+import {
+  RedisCache,
+  RedisClientLike,
+  RedisStore,
+} from '@common/interfaces/redis.interfaces';
 import { TaskStatus } from '@domain/task/dto/task.status.enum';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
@@ -18,6 +23,104 @@ export class TaskService {
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
   ) {}
+
+  // ------------------------------------------------------------- counters
+  //
+  // The item counters CANNOT live in the cached Task object alone.
+  //
+  // The auth-reset queue is consumed by competing consumers across pods:
+  // `main.worker.ts` sets `prefetchCount: 1` precisely so "work is spread
+  // across pods", and infrastructure-operations'
+  // `41-auth-reset-worker-autoscaler.yml` scales the deployment to 10 replicas
+  // the moment the queue is non-empty. They all share one Redis.
+  //
+  // `get(id) -> task.itemsDone += 1 -> set(id, task)` is a read-modify-write.
+  // Two pods finishing at the same moment both read `k` and both write `k + 1`
+  // — one increment is silently lost. That was harmless while `itemsCount` was
+  // undefined and the counter purely decorative. It is NOT harmless now that
+  // the terminal status is derived from the counter reaching its target: a
+  // single lost increment undershoots the target forever and the task hangs,
+  // which is precisely the defect (#6310) this service is being fixed for.
+  // Note `>=` does not rescue it — lost updates undercount, never overcount.
+  //
+  // So the counters live in dedicated Redis keys mutated with INCR, which is
+  // atomic. Where no Redis client is reachable (unit tests, or any non-redis
+  // cache store) we fall back to the in-object counter, which is correct for
+  // the single process those environments actually are.
+  private readonly doneKey = (id: string) => `task:${id}:itemsDone`;
+  private readonly errorsKey = (id: string) => `task:${id}:errorCount`;
+
+  private redisClient(): RedisClientLike | undefined {
+    const store = (this.cacheManager as Partial<RedisCache>).store as
+      | Partial<RedisStore>
+      | undefined;
+
+    if (typeof store?.getClient !== 'function') {
+      return undefined;
+    }
+
+    try {
+      return store.getClient();
+    } catch (error: any) {
+      this.logger.warn?.(
+        `Task counters: no Redis client available, falling back to in-object counters. ${error}`,
+        LogContext.TASKS
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Atomically increment a counter key and return its NEW value. The TTL is
+   * refreshed on every increment so a long-running reset cannot outlive its
+   * own counter and silently restart from zero.
+   *
+   * Returns undefined when there is no Redis to be atomic against — callers
+   * fall back to the in-object counter.
+   */
+  private async incrementCounter(key: string): Promise<number | undefined> {
+    const client = this.redisClient();
+
+    if (!client) {
+      return undefined;
+    }
+
+    return new Promise<number | undefined>(resolve => {
+      client.incr(key, (err, value) => {
+        if (err) {
+          this.logger.error(
+            `Failed to increment task counter '${key}': ${err}`,
+            err?.stack,
+            LogContext.TASKS
+          );
+          resolve(undefined);
+          return;
+        }
+        // Best-effort TTL refresh; the counter value is already committed.
+        client.expire(key, TTL, () => resolve(value));
+      });
+    });
+  }
+
+  /** Read a counter key, or undefined when unset / no Redis. */
+  private async readCounter(key: string): Promise<number | undefined> {
+    const client = this.redisClient();
+
+    if (!client) {
+      return undefined;
+    }
+
+    return new Promise<number | undefined>(resolve => {
+      client.get(key, (err, value) => {
+        if (err || value === null || value === undefined) {
+          resolve(undefined);
+          return;
+        }
+        const parsed = Number(value);
+        resolve(Number.isFinite(parsed) ? parsed : undefined);
+      });
+    });
+  }
 
   public async getTaskList() {
     const list =
@@ -51,18 +154,64 @@ export class TaskService {
     return result;
   }
 
-  public get(id: string) {
-    return this.cacheManager.get<Task>(id);
+  public async get(id: string) {
+    const task = await this.cacheManager.get<Task>(id);
+
+    return task ? this.withAuthoritativeCounters(task) : task;
   }
 
   public async getOrFail(id: string) {
-    const task = await this.cacheManager.get<Task>(id);
+    const task = await this.get(id);
 
     if (!task) {
       throw new Error(`Task '${id}' not found`);
     }
 
     return task;
+  }
+
+  /**
+   * Overlay the atomic counters onto a cached Task.
+   *
+   * The whole Task object is written back by every consumer, so the *stored*
+   * `status` and `itemsDone` are themselves subject to a lost update: the pod
+   * that observes the final increment writes COMPLETED, and a slower pod
+   * holding a slightly stale copy can write IN_PROGRESS straight back over it.
+   * The Redis counters cannot be clobbered that way, so they — not the stored
+   * fields — are the source of truth for progress, and for whether a counted
+   * task has finished.
+   *
+   * `end` is deliberately NOT fabricated here: it is stamped by whichever
+   * consumer saw the last item, and a derived value would differ on every
+   * read.
+   */
+  private async withAuthoritativeCounters(task: Task): Promise<Task> {
+    // An uncounted task has no target to reach — it is terminated explicitly
+    // via complete()/completeWithError(), so there is nothing to derive.
+    if (task.itemsCount === undefined) {
+      return task;
+    }
+
+    const [done, errorCount] = await Promise.all([
+      this.readCounter(this.doneKey(task.id)),
+      this.readCounter(this.errorsKey(task.id)),
+    ]);
+
+    // No Redis (or no increments yet): the in-object counter is all there is.
+    if (done === undefined) {
+      return task;
+    }
+
+    const resolved: Task = { ...task, itemsDone: done };
+
+    if (done >= task.itemsCount && resolved.status === TaskStatus.IN_PROGRESS) {
+      resolved.status =
+        (errorCount ?? resolved.errors.length) > 0
+          ? TaskStatus.ERRORED
+          : TaskStatus.COMPLETED;
+    }
+
+    return resolved;
   }
 
   public async create(itemsCount?: number) {
@@ -129,6 +278,22 @@ export class TaskService {
   }
 
   /**
+   * Account for one processed item, atomically where possible, and write the
+   * authoritative count back onto the task. No-op for an uncounted task.
+   */
+  private async accountForItem(task: Task, completeItem: boolean) {
+    if (task.itemsDone === undefined || !completeItem) {
+      return;
+    }
+
+    const atomic = await this.incrementCounter(this.doneKey(task.id));
+
+    // `atomic` is undefined only when there is no Redis to be atomic against —
+    // a single-process environment, where the in-object increment is exact.
+    task.itemsDone = atomic ?? task.itemsDone + 1;
+  }
+
+  /**
    *
    * @param id
    * @param result
@@ -141,18 +306,30 @@ export class TaskService {
   ) {
     const task = await this.getOrFail(id);
 
-    if (task.itemsDone !== undefined && completeItem) {
-      task.itemsDone += 1;
+    // Already settled. RabbitMQ is at-least-once and `handleReset` publishes
+    // its retry BEFORE acking the original, so a pod killed between those two
+    // lines gets the same item redelivered. Without this guard a late
+    // duplicate flips a COMPLETED task to ERRORED and rewrites `end` — two
+    // pollers reading a minute apart would disagree about the same run.
+    if (task.status !== TaskStatus.IN_PROGRESS) {
+      return;
     }
+
+    await this.accountForItem(task, completeItem);
 
     task.results.unshift(`[${new Date().toISOString()}]::${result}`);
 
     if (this.isFullyAccountedFor(task)) {
       // Every item is in, but some of them failed — a run that lost items is
-      // not a successful run, so it settles as ERRORED.
+      // not a successful run, so it settles as ERRORED. The error tally is
+      // read from the atomic counter for the same reason `itemsDone` is: the
+      // `errors` array is written non-atomically and can lose entries.
+      const errorCount =
+        (await this.readCounter(this.errorsKey(id))) ?? task.errors.length;
+
       this.finish(
         task,
-        task.errors.length > 0 ? TaskStatus.ERRORED : TaskStatus.COMPLETED
+        errorCount > 0 ? TaskStatus.ERRORED : TaskStatus.COMPLETED
       );
     }
 
@@ -168,9 +345,16 @@ export class TaskService {
   ) {
     const task = await this.getOrFail(id);
 
-    if (task.itemsDone !== undefined && completeItem) {
-      task.itemsDone += 1;
+    // See updateTaskResults — a redelivered failure must not re-stamp a task
+    // that has already settled.
+    if (task.status !== TaskStatus.IN_PROGRESS) {
+      return;
     }
+
+    // Tally the error atomically so the success path can trust it when it
+    // decides between COMPLETED and ERRORED.
+    await this.incrementCounter(this.errorsKey(id));
+    await this.accountForItem(task, completeItem);
 
     task.errors.unshift(error);
 
@@ -183,6 +367,36 @@ export class TaskService {
     await this.cacheManager.set(task.id, task, {
       ttl: TTL,
     });
+  }
+
+  /**
+   * Attach an item count to an EXISTING task, so a caller that created its own
+   * (necessarily uncounted) task id can still hand it to a producer that knows
+   * the real total.
+   *
+   * Without this, passing a pre-made task id into a counted run silently
+   * discarded the computed count and left the task with no target to reach —
+   * i.e. #6310 all over again, just via a different door.
+   */
+  public async setItemsCount(id: string, itemsCount: number) {
+    const existing = await this.getOrFail(id);
+
+    // `itemsCount` is readonly on the interface, so rebuild rather than cast
+    // the guarantee away.
+    const task: Task = {
+      ...existing,
+      itemsCount,
+      itemsDone: 0,
+      ...(itemsCount === 0
+        ? { status: TaskStatus.COMPLETED, end: new Date().getTime() }
+        : {}),
+    };
+
+    await this.cacheManager.set(task.id, task, {
+      ttl: TTL,
+    });
+
+    return task;
   }
 
   public async complete(

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -125,24 +125,6 @@ export class TaskService {
   }
 
   /**
-   * Claim an item for this task, exactly once.
-   *
-   * RabbitMQ is at-least-once, and `handleReset` re-publishes its retry BEFORE
-   * acking the original — so a pod dying between those two lines guarantees a
-   * redelivery. Counting that twice would push `itemsDone` to `itemsCount`
-   * while real items are still queued: the task settles early, and every
-   * genuine update after it is dropped by the terminal guard, so a run that
-   * later fails an item can still report COMPLETED.
-   *
-   * `SADD` returns 1 only for a member that was not already in the set, which
-   * makes it the claim. Returns true when the caller owns this item and should
-   * account for it, false when it is a duplicate.
-   *
-   * Without Redis (or without an item identity) there is nothing to dedupe
-   * against and every call is treated as a fresh item — the previous
-   * behaviour.
-   */
-  /**
    * Record the task's terminal timestamp where it cannot be clobbered.
    *
    * `end` lives on the Task object, and every consumer writes that whole
@@ -174,6 +156,24 @@ export class TaskService {
     });
   }
 
+  /**
+   * Claim an item for this task, exactly once.
+   *
+   * RabbitMQ is at-least-once, and `handleReset` re-publishes its retry BEFORE
+   * acking the original — so a pod dying between those two lines guarantees a
+   * redelivery. Counting that twice would push `itemsDone` to `itemsCount`
+   * while real items are still queued: the task settles early, and every
+   * genuine update after it is dropped by the terminal guard, so a run that
+   * later fails an item can still report COMPLETED.
+   *
+   * `SADD` returns 1 only for a member that was not already in the set, which
+   * makes it the claim. Returns true when the caller owns this item and should
+   * account for it, false when it is a duplicate.
+   *
+   * Without Redis (or without an item identity) there is nothing to dedupe
+   * against and every call is treated as a fresh item — the previous
+   * behaviour.
+   */
   private async claimItem(id: string, itemKey?: string): Promise<boolean> {
     const client = this.redisClient();
 

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -74,15 +74,58 @@ export class TaskService {
       action: 'auth-reset',
       status: TaskStatus.IN_PROGRESS, // may not be accurate atm,
       itemsCount,
-      itemsDone: itemsCount && 0,
+      // An explicit count opts the task into progress tracking, so it starts at
+      // zero. Without a count the task is unbounded and `itemsDone` stays
+      // undefined — such a task is terminated explicitly via `complete()` /
+      // `completeWithError()`, never by the counters.
+      // NB: this used to read `itemsCount && 0`, which returns the *left*
+      // operand when it is falsy — correct only by accident, and unreadable.
+      itemsDone: itemsCount === undefined ? undefined : 0,
       results: [],
       errors: [],
     };
+
+    // A counted task with nothing to do is already finished: no item update
+    // will ever arrive to move it out of IN_PROGRESS.
+    if (itemsCount === 0) {
+      task.status = TaskStatus.COMPLETED;
+      task.end = now;
+    }
+
     await this.cacheManager.set<Task>(task.id, task, {
       ttl: TTL,
     });
     await this.addTaskToList(task);
     return task;
+  }
+
+  /**
+   * Whether every item this task was created for has been accounted for —
+   * i.e. it is a *counted* task and its counter has reached the target.
+   *
+   * An uncounted task (no `itemsCount`) is never "finished" by this rule: it
+   * has no target to reach, so it can only be terminated explicitly. This is
+   * the guard that must be applied identically on the success and the error
+   * path — omitting it on one of them made `undefined === undefined` true and
+   * completed an uncounted task on its very first error.
+   */
+  private isFullyAccountedFor(task: Task): boolean {
+    return (
+      task.itemsCount !== undefined &&
+      task.itemsDone !== undefined &&
+      // `>=` rather than `===` so an over-count (a racing extra item) still
+      // terminates the task instead of stepping over the equality and hanging.
+      task.itemsDone >= task.itemsCount
+    );
+  }
+
+  /** Move a fully-accounted-for task into its terminal state. */
+  private finish(
+    task: Task,
+    status: TaskStatus.COMPLETED | TaskStatus.ERRORED
+  ) {
+    task.status = status;
+    task.end = new Date().getTime();
   }
 
   /**
@@ -102,11 +145,16 @@ export class TaskService {
       task.itemsDone += 1;
     }
 
-    if (task.itemsCount && task.itemsCount === task.itemsDone) {
-      task.status = TaskStatus.COMPLETED;
-    }
-
     task.results.unshift(`[${new Date().toISOString()}]::${result}`);
+
+    if (this.isFullyAccountedFor(task)) {
+      // Every item is in, but some of them failed — a run that lost items is
+      // not a successful run, so it settles as ERRORED.
+      this.finish(
+        task,
+        task.errors.length > 0 ? TaskStatus.ERRORED : TaskStatus.COMPLETED
+      );
+    }
 
     await this.cacheManager.set(task.id, task, {
       ttl: TTL,
@@ -124,11 +172,13 @@ export class TaskService {
       task.itemsDone += 1;
     }
 
-    if (task.itemsCount === task.itemsDone) {
-      task.status = TaskStatus.COMPLETED;
-    }
-
     task.errors.unshift(error);
+
+    // Only once the LAST item is accounted for — an error on item 1 of N must
+    // not terminate the task; the remaining items are still being processed.
+    if (this.isFullyAccountedFor(task)) {
+      this.finish(task, TaskStatus.ERRORED);
+    }
 
     await this.cacheManager.set(task.id, task, {
       ttl: TTL,

--- a/src/services/task/task.service.ts
+++ b/src/services/task/task.service.ts
@@ -51,6 +51,7 @@ export class TaskService {
   private readonly errorsKey = (id: string) => `task:${id}:errorCount`;
   private readonly seenKey = (id: string) => `task:${id}:seen`;
   private readonly endKey = (id: string) => `task:${id}:end`;
+  private readonly terminalKey = (id: string) => `task:${id}:terminal`;
 
   private redisClient(): RedisClientLike | undefined {
     const store = (this.cacheManager as Partial<RedisCache>).store as
@@ -104,22 +105,65 @@ export class TaskService {
     });
   }
 
-  /** Read a counter key, or undefined when unset / no Redis. */
-  private async readCounter(key: string): Promise<number | undefined> {
+  /** Read a raw string key, or undefined when unset / no Redis. */
+  private async readString(key: string): Promise<string | undefined> {
     const client = this.redisClient();
 
     if (!client) {
       return undefined;
     }
 
-    return new Promise<number | undefined>(resolve => {
+    return new Promise<string | undefined>(resolve => {
       client.get(key, (err, value) => {
-        if (err || value === null || value === undefined) {
-          resolve(undefined);
+        resolve(
+          err || value === null || value === undefined ? undefined : value
+        );
+      });
+    });
+  }
+
+  /** Read a counter key, or undefined when unset / no Redis. */
+  private async readCounter(key: string): Promise<number | undefined> {
+    const value = await this.readString(key);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  /**
+   * Record an EXPLICIT terminal state where a stale write cannot undo it.
+   *
+   * `complete()` / `completeWithError()` set the status on the cached object,
+   * but a consumer that read the task just before them still holds a copy
+   * saying IN_PROGRESS — and writing that copy back resurrects the task. For a
+   * task terminated explicitly *because publishing failed*, the counter will
+   * never reach `itemsCount` (the remaining events were never emitted), so the
+   * counter-derived path cannot repair it and the task hangs. First stamp
+   * wins, and the read overlay reapplies it.
+   */
+  private async stampTerminal(id: string, status: TaskStatus): Promise<void> {
+    const client = this.redisClient();
+
+    if (!client) {
+      return;
+    }
+
+    return new Promise<void>(resolve => {
+      client.setnx(this.terminalKey(id), String(status), err => {
+        if (err) {
+          this.logger.error(
+            `Failed to stamp terminal status for task '${id}': ${err}`,
+            err?.stack,
+            LogContext.TASKS
+          );
+          resolve();
           return;
         }
-        const parsed = Number(value);
-        resolve(Number.isFinite(parsed) ? parsed : undefined);
+        client.expire(this.terminalKey(id), TTL, () => resolve());
       });
     });
   }
@@ -262,30 +306,55 @@ export class TaskService {
    * terminal task without an end time.
    */
   private async withAuthoritativeCounters(task: Task): Promise<Task> {
-    // An uncounted task has no target to reach — it is terminated explicitly
-    // via complete()/completeWithError(), so there is nothing to derive.
-    if (task.itemsCount === undefined) {
+    // Without Redis there is no out-of-band state to overlay, and nothing to
+    // be clobbered by — a single process owns the object outright. Return it
+    // by identity rather than as a copy, so callers keep mutating the same
+    // instance they will write back.
+    if (!this.redisClient()) {
       return task;
     }
 
-    const [done, errorCount, storedEnd] = await Promise.all([
+    const [terminal, storedEnd] = await Promise.all([
+      this.readString(this.terminalKey(task.id)),
+      this.readCounter(this.endKey(task.id)),
+    ]);
+
+    const base: Task = { ...task, end: task.end ?? storedEnd };
+
+    // An explicitly-terminated task outranks whatever the cached object says.
+    // This is what survives a slow consumer writing its pre-termination copy
+    // back over the terminal one — and it is the ONLY repair available when
+    // publishing failed part-way, because the counter can then never reach
+    // itemsCount for the derivation below to fire.
+    if (
+      base.status === TaskStatus.IN_PROGRESS &&
+      (terminal === TaskStatus.COMPLETED || terminal === TaskStatus.ERRORED)
+    ) {
+      base.status = terminal;
+    }
+
+    // An uncounted task has no target to reach — it is terminated explicitly
+    // via complete()/completeWithError(), so there is nothing more to derive.
+    if (task.itemsCount === undefined) {
+      return base;
+    }
+
+    const [done, errorCount] = await Promise.all([
       this.readCounter(this.doneKey(task.id)),
       this.readCounter(this.errorsKey(task.id)),
-      this.readCounter(this.endKey(task.id)),
     ]);
 
     // No Redis (or no increments yet): the in-object counter is all there is.
     if (done === undefined) {
-      return task;
+      return base;
     }
 
     // Never below what the task already recorded — increments taken while
     // Redis was unreachable live only in the stored object, and reporting a
     // lower number would look like the run went backwards.
     const resolved: Task = {
-      ...task,
+      ...base,
       itemsDone: Math.max(done, task.itemsDone ?? 0),
-      end: task.end ?? storedEnd,
     };
 
     if (
@@ -539,8 +608,11 @@ export class TaskService {
   ) {
     const task = await this.getOrFail(id);
 
-    task.status = status;
-    task.end = new Date().getTime();
+    this.finish(task, status);
+    // Outside the cached object: a consumer that read this task just before
+    // now still holds an IN_PROGRESS copy and will write it back.
+    await this.stampTerminal(id, status);
+    await this.stampEnd(id, task.end as number);
 
     await this.cacheManager.set(task.id, task, {
       ttl: TTL,
@@ -551,8 +623,9 @@ export class TaskService {
     const task = await this.getOrFail(id);
 
     task.errors.unshift(error);
-    task.status = TaskStatus.ERRORED;
-    task.end = new Date().getTime();
+    this.finish(task, TaskStatus.ERRORED);
+    await this.stampTerminal(id, TaskStatus.ERRORED);
+    await this.stampEnd(id, task.end as number);
 
     await this.cacheManager.set(task.id, task, {
       ttl: TTL,

--- a/test/mocks/task.service.mock.ts
+++ b/test/mocks/task.service.mock.ts
@@ -9,8 +9,12 @@ export const MockTaskService: ValueProvider<PublicPart<TaskService>> = {
     updateTaskErrors: vi.fn(),
     updateTaskResults: vi.fn(),
     create: vi.fn(),
+    setItemsCount: vi.fn(),
     get: vi.fn(),
+    getOrFail: vi.fn(),
     getAll: vi.fn(),
     getTaskList: vi.fn(),
+    complete: vi.fn(),
+    completeWithError: vi.fn(),
   },
 };


### PR DESCRIPTION
Fixes #6310

## Root cause

Two independent defects compounded into an unusable task handle:

1. **`publishResetAll()` created a countless task.** It called `taskService.create()` with no `itemsCount`, so `itemsDone` stayed `undefined` too. The sibling publishers (`publishAuthorizationResetAllAccounts` etc.) already pass a count when invoked standalone — only the aggregate path, which creates one countless task and passes its id down to all of them, was broken.

2. **The two update paths disagreed on when a task is done.** `updateTaskErrors` omitted the truthiness guard that `updateTaskResults` had:

   ```ts
   // updateTaskResults — success never completes (itemsCount falsy)
   if (task.itemsCount && task.itemsCount === task.itemsDone) …
   // updateTaskErrors — undefined === undefined → TRUE, completes on first error
   if (task.itemsCount === task.itemsDone) …
   ```

Net effect: a reset that *failed* got marked `COMPLETED`, one that *succeeded* stayed `IN_PROGRESS` forever. Any caller polling the returned task id hung indefinitely.

Confirmed pre-existing, not a regression — and **not** limited to auth reset: `adminSearchIngestFromScratch` also creates a countless task and calls `updateTaskErrors` mid-run, so it was silently flipping to `COMPLETED` on its first error too. Both are fixed by the same guard.

## What changed

**`src/services/task/task.service.ts`**
- Both update paths now share one `isFullyAccountedFor()` guard — a task is terminal only when it is *counted* and its counter has reached the target. An uncounted task is never auto-terminated; it is finished explicitly via `complete()` / `completeWithError()`, which is exactly how the search-ingest caller uses it.
- A run that lost items settles as **`ERRORED`, not `COMPLETED`**, on either path (the success path checks `errors.length`), and a terminal task now gets its `end` timestamp like `complete()` sets one.
- Uses `>=` rather than `===` so an over-count cannot step over the equality and hang.
- `itemsDone: itemsCount && 0` → an explicit `undefined` check. Behaviourally identical (`&&` returned the falsy left operand, correct only by accident) but readable, and it keeps the documented "no count ⇒ untracked" semantics the existing specs already encode.
- A zero-item task is completed at creation — no item update would ever arrive to move it out of `IN_PROGRESS`.

**`src/services/auth-reset/publisher/auth-reset.service.ts`**
- `publishResetAll` fetches the three entity id sets **once** up front, computes `accounts × 2 + organizations × 2 + users` (both the authorization *and* licence resets), and creates the task with that count **before** the first message is emitted.
- The pre-fetched ids are handed down to the per-entity publishers via a new optional second parameter, so the messages emitted are exactly the ones counted.
- Platform and AI-server resets are deliberately excluded from the count: they carry no task id, so the subscriber never accounts for them — counting them would leave the task 3 items short forever.

### Design note: prefetch rather than `COUNT(*)`

The issue suggested computing the total up front. A separate `COUNT(*)` would drift from the subsequent `SELECT` (a row created or deleted in between), leaving the task permanently one item short — i.e. hanging, resurrecting the exact bug under a race. Fetching the ids once and counting *those* makes the count structurally trustworthy. It is also strictly cheaper: 3 id-only selects instead of the 5 the publishers each ran on their own.

The extra parameter is confined: `publishResetAll` is the only publisher method with a non-test caller (`admin.authorization.resolver.mutations.ts`), and it is called with no arguments.

## Regression tests

`src/services/task/task.service.spec.ts` — new `terminal status (issue #6310)` block:
- an uncounted task does **not** complete on an error (nor after many errors, nor on a result)
- a counted task reaches `COMPLETED` when `itemsDone` reaches `itemsCount`
- an early item erroring leaves the task `IN_PROGRESS`, and the run ends **`ERRORED`** — covering the case where the *last* update lands on the success path
- an error on the last item ends `ERRORED`
- counter overshoot still terminates; a zero-item task is born `COMPLETED`

`src/services/auth-reset/publisher/auth-reset.service.spec.ts` — new `itemsCount (issue #6310)` block:
- the task is created with the true total (2 accounts + 3 orgs + 4 users → `create(14)`)
- `itemsCount` equals exactly the number of emitted messages that carry the task id
- each entity id set is fetched only once

One pre-existing assertion was intentionally inverted: `updateTaskErrors › should set status to COMPLETED when all items are done` → `should set status to ERRORED`. That test encoded the bug.

**Verified non-vacuous:** with the two source files reverted to `develop` and the new specs kept, **12 tests fail** for the right reasons (`expected 'completed' to be 'in-progress'`, `expected "vi.fn()" to be called with arguments: [ 14 ]`, `expected find to be called 3 times, but got 5`).

## Gate results

| Gate | Command | Result |
|---|---|---|
| Tests | `pnpm test:ci:no:coverage` | **666 files passed, 7409 tests passed**, 6 files / 7 tests skipped |
| Build | `pnpm build` | clean (`nest build`, no output) |
| Lint + typecheck | `pnpm lint` (`tsc --noEmit` + `biome check src/`) | clean — 3096 files checked, 0 errors |

The full suite also ran green in the pre-commit hook on both commits.

## Scope

No GraphQL schema change, no migration, no DDL — `Task` is a cache-backed object and both fields already existed on the DTO. Server-only; no cross-repo contract touched. Unrelated to the in-flight `workspace#027-platform-role-redesign` branch (which does not touch `src/services/task/` or `src/services/auth-reset/`), which is why it ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reset-all operations now track exact event counts and return the associated task ID.
  - Task progress tracking supports zero-item operations and externally assigned item counts.
  - Duplicate events are identified and counted only once.

- **Bug Fixes**
  - Tasks with failed items are correctly marked as errored instead of completed.
  - Improved handling of mixed results, incomplete counts, counter overshoots, and concurrent processing.
  - Reduced redundant data retrieval during reset-all operations.
  - Task progress remains reliable when Redis is temporarily unavailable.
  - Untracked platform and AI-server events no longer affect task progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->