### PR TITLE
fix: stop RabbitMQ dev volume from growing unbounded

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -358,6 +358,11 @@ services:
 
   rabbitmq:
     container_name: alkemio_dev_rabbitmq
+    # The Erlang node name is derived from the hostname, and the node name is
+    # the mnesia sub-directory name. Without pinning it, Docker uses the random
+    # container id, so every `compose up` orphans the previous node directory
+    # under ~/.docker-conf/rabbitmq/data and that directory is never reclaimed.
+    hostname: rmq
     image: rabbitmq:3.9.13-management
     restart: always
     networks:
@@ -369,6 +374,9 @@ services:
       - RABBITMQ_SECURE_PASSWORD=yes
       - RABBITMQ_DEFAULT_USER=alkemio-admin
       - RABBITMQ_DEFAULT_PASS=alkemio!
+      # Ra (Raft) pre-allocates its write-ahead log at boot, ~280MB by default.
+      # The dev stack only declares classic queues, so cap it at 32MB.
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-ra wal_max_size_bytes 33554432
     healthcheck:
       test: rabbitmq-diagnostics check_port_connectivity
       interval: 30s
@@ -382,7 +390,7 @@ services:
       [
         'bash',
         '-c',
-        'chmod 400 /var/lib/rabbitmq/.erlang.cookie; rabbitmq-server --hostname rmq',
+        'chmod 400 /var/lib/rabbitmq/.erlang.cookie; rabbitmq-server',
       ]
 
   notification:


### PR DESCRIPTION
## Problem

The `rabbitmq` service in `quickstart-services.yml` sets `container_name` but not `hostname`.

RabbitMQ derives its Erlang node name from the container hostname (`rabbit@$HOSTNAME`), and **the node name is the directory name** under `/var/lib/rabbitmq/mnesia`. Without a pinned hostname Docker assigns the random container id, so every `compose up --force-recreate` (or `down` + `up`) starts a brand-new node with a brand-new directory and orphans the previous one. Nothing ever reclaims them.

On my machine that had accumulated **659 directories totalling 68GB** since January, all bind-mounted into `~/.docker-conf/rabbitmq/data`.

The `--hostname rmq` already present in the `command` looks like it addresses this, but `rabbitmq-server` has no `--hostname` flag — it is silently ignored. That is likely why this went unnoticed.

## Changes

- **`hostname: rmq`** — pins the node name to `rabbit@rmq` so it is stable across recreates. This is the actual fix.
- **`RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-ra wal_max_size_bytes 33554432`** — Ra (Raft) pre-allocates its write-ahead log at boot, ~280MB per node, whether or not quorum queues exist. The dev stack declares only `classic` queues, so this is pure fixed overhead; capped at 32MB.
- **Dropped `--hostname rmq` from the `command`** — a no-op flag that misleadingly appeared to pin the node name.

## Verification

`docker compose config` renders cleanly; container recreated and healthy in 11s; all queues redeclared by the services on reconnect.

| | before | after |
|---|---|---|
| fresh node directory | 341MB | **76MB** |
| node directories | 659, one per recreate | **1, stable** |

## Note for reviewers

This only stops future growth. Existing orphans have to be deleted by hand, once per developer:

```bash
docker compose -f quickstart-services.yml down
find ~/.docker-conf/rabbitmq/data -maxdepth 1 -name 'rabbit@*' ! -name 'rabbit@rmq' -exec rm -rf {} +
```

Dev-only change — `quickstart-services.yml` is not used in any deployed environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RabbitMQ restart behavior by using a consistent hostname.
  * Reduced the risk of leftover data directories after restarts.
  * Limited Raft log growth to 32 MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->