### PR TITLE
fix: server's own in-repo dev/test/sandbox manifests missed the distroless migration entrypoint (workspace#026)

### DIFF
--- a/manifests/25-server-deployment-dev.yaml
+++ b/manifests/25-server-deployment-dev.yaml
@@ -16,9 +16,20 @@ spec:
       labels:
         app: alkemio-server
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: alkemio-server
           image: rg.nl-ams.scw.cloud/alkemio/alkemio-server:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: RABBITMQ_HOST
               valueFrom:

--- a/manifests/26-server-migration.yaml
+++ b/manifests/26-server-migration.yaml
@@ -12,11 +12,31 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: alkemio-server
               image: rg.nl-ams.scw.cloud/alkemio/alkemio-server:latest
-              command: ["pnpm", "run", "migration:run"]
+              # Requires alkemio/server images built from feature 026 (distroless era) or later —
+              # pnpm/ts-node no longer exist in the runtime image; this command works only against
+              # images containing compiled dist/ output.
+              # NOTE: `command:` fully replaces the image's OCI Entrypoint, so k8s does a raw exec
+              # lookup of argv[0] on $PATH — the distroless nodejs runtime's ENTRYPOINT
+              # (/nodejs/bin/node) lives outside $PATH by design, so a bare "node" argv[0] fails with
+              # `exec: "node": executable file not found in $PATH`. Use the absolute binary path
+              # instead (matches server/.docker/distroless-migration-smoke.sh's
+              # `--entrypoint /nodejs/bin/node`).
+              command: ["/nodejs/bin/node", "./node_modules/typeorm/cli.js", "migration:run", "--dataSource", "dist/config/migration.config.js"]
               imagePullPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               env:
                 # Map POSTGRES_USER/PASSWORD to DATABASE_USERNAME/PASSWORD for the server
                 - name: DATABASE_USERNAME


### PR DESCRIPTION
## What broke

workspace#026 (distroless server image, #6300) patched `dev-orchestration`'s
kustomize base (`01-migration-cron-job.yml`, `11-server-deployment.yml`) to the
compiled migration entrypoint + securityContext. It missed that
`build-deploy-k8s-{dev,test,sandbox}-hetzner.yml` apply **this repo's own**
`manifests/{25,26}-*.yaml` on every push via `azure/k8s-deploy` — a third,
separate copy that dev-orchestration's PR never touched. Same 'two apply paths'
pattern workspace#033 already found and fixed for client-web (R-5).

## Live incident (k8s-hetzner-dev, current)

`server-migration-job` has been `StartError` for 80+ minutes since #6300/#6333
auto-deployed to dev:

```
exec: "pnpm": executable file not found in $PATH: unknown
```

The distroless runtime has no shell/pnpm; `manifests/26-server-migration.yaml`
still ran `command: ["pnpm", "run", "migration:run"]`. The server Deployment
itself (`manifests/25-server-deployment-dev.yaml`) also ran with an empty pod
`securityContext` (no `runAsNonRoot`/65532/seccomp), unlike the kustomize-base
copy.

## Fix

Mirrors dev-orchestration#70's already-validated shape exactly:

- `manifests/26-server-migration.yaml`: compiled entrypoint
  (`/nodejs/bin/node ./node_modules/typeorm/cli.js migration:run --dataSource
  dist/config/migration.config.js`, matching
  `.docker/distroless-migration-smoke.sh`) + pod/container securityContext.
- `manifests/25-server-deployment-dev.yaml`: pod/container securityContext
  (this one file is shared by the dev/test/sandbox deploy workflows).

## Verified

- Both files parse as valid YAML.
- Command + securityContext block are copy-identical to dev-orchestration's
  already-live-verified kustomize base for the same image family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced security enforcement for deployments and migrations, including non-root execution, seccomp profile enforcement, and Linux capability restrictions.

* **Infrastructure**
  * Updated migration execution to use optimized TypeORM CLI with distroless Node.js runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->