### PR TITLE
chore: bump virtual-contributor to v0.2.0 in the local AI stack

### DIFF
--- a/overlays/ai-stack.yml
+++ b/overlays/ai-stack.yml
@@ -34,7 +34,7 @@ services:
   virtual_contributor_engine_guidance:
     container_name: alkemio_dev_virtual_contributor_engine_guidance
     hostname: virtual-contributor-engine-guidance
-    image: alkemio/virtual-contributor:v0.1.3
+    image: alkemio/virtual-contributor:v0.2.0
     restart: always
     networks:
       - alkemio_dev_net
@@ -67,7 +67,7 @@ services:
   virtual-contributor-engine-expert:
     container_name: alkemio_dev_virtual_contributor_engine_expert
     hostname: virtual-contributor-engine-expert
-    image: alkemio/virtual-contributor:v0.1.3
+    image: alkemio/virtual-contributor:v0.2.0
     restart: always
     networks:
       - alkemio_dev_net
@@ -102,7 +102,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_virtual_contributor_ingest_website
     hostname: virtual-contributor-ingest-website
-    image: alkemio/virtual-contributor:v0.1.3
+    image: alkemio/virtual-contributor:v0.2.0
     restart: always
     networks:
       - alkemio_dev_net
@@ -195,7 +195,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_virtual_contributor_ingest_space
     hostname: virtual-contributor-ingest-space
-    image: alkemio/virtual-contributor:v0.1.3
+    image: alkemio/virtual-contributor:v0.2.0
     restart: always
     depends_on:
       rabbitmq:
@@ -241,7 +241,7 @@ services:
   virtual_contributor_engine_generic:
     container_name: alkemio_dev_virtual_contributor_engine_generic
     hostname: virtual-contributor-engine-generic
-    image: alkemio/virtual-contributor:v0.1.3
+    image: alkemio/virtual-contributor:v0.2.0
     restart: always
     networks:
       - alkemio_dev_net
@@ -265,7 +265,7 @@ services:
   virtual_contributor_engine_openai_assistant:
     container_name: alkemio_dev_virtual_contributor_engine_openai_assistant
     hostname: virtual-contributor-engine-openai-assistant
-    image: alkemio/virtual-contributor:v0.1.3
+    image: alkemio/virtual-contributor:v0.2.0
     restart: always
     networks:
       - alkemio_dev_net


### PR DESCRIPTION
Bumps the six unified VC services in `overlays/ai-stack.yml` (guidance/expert/generic/openai-assistant/ingest-website/ingest-space) from `v0.1.3` to `v0.2.0` — the first release carrying the distroless non-root runtime image (alkem-io/virtual-contributor#105, workspace#026-distroless-runtime-images): UID 65532, shell-less, Python 3.13, 56% smaller, 0 fixable HIGH/CRITICAL CVEs.

Local dev compose stack only — no cluster impact. Companion to alkem-io/dev-orchestration#73 (the k8s manifest bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)