### PR TITLE
feat(dco): PR-template sign-off reminder, signed-off baseline commits, CLA→DCO docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,6 +43,13 @@ If BREAKING changes are intentional:
 
 <!-- Testing strategy, migration notes, docs follow-up, etc. -->
 
+### DCO sign-off
+
+> All commits must carry a `Signed-off-by` trailer matching your Git
+> identity ([DCO 1.1](https://developercertificate.org/)). Use
+> `git commit -s`; fix existing commits with
+> `git rebase --signoff HEAD~N` and push with `--force-with-lease`.
+
 ---
 
 Reference docs: `specs/002-schema-contract-diffing/quickstart.md` for full workflow and troubleshooting.

--- a/.github/workflows/schema-baseline.yml
+++ b/.github/workflows/schema-baseline.yml
@@ -149,7 +149,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: update schema baseline" -S
+          git commit -m "chore: update schema baseline" -S -s
           branch="schema-baseline/${GITHUB_RUN_ID}"
           git branch --force "$branch"
           echo "BASELINE_FAILURE_PHASE=push" >> "$GITHUB_ENV"

--- a/docs/Developing.md
+++ b/docs/Developing.md
@@ -48,7 +48,7 @@ The registration and the recovery flows include sending emails to the registered
 
 - The `Schema Baseline` GitHub Action writes a summary with diff counts and links to artifacts after every `develop` push; inspect the job summary first when a baseline pull request is missing.
 - If the run fails before publishing a commit, check the appended summary section for the `BASELINE_FAILURE_CONTEXT` note and download the `schema-baseline-<run>` artifact bundle for `schema.graphql`, `tmp/prev.schema.graphql`, and `change-report.json`.
-- Signing issues typically surface during the "Commit baseline update" or branch push steps. Confirm the `ALKEMIO_INFRASTRUCTURE_BOT_GPG_*` secrets match the key uploaded to the automation bot and that the key is marked as trusted in GitHub. If the PR fails to open, confirm the `ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN` secret still has `repo` scope and the bot account retains CLA privileges.
+- Signing issues typically surface during the "Commit baseline update" or branch push steps. Confirm the `ALKEMIO_INFRASTRUCTURE_BOT_GPG_*` secrets match the key uploaded to the automation bot and that the key is marked as trusted in GitHub. If the PR fails to open, confirm the `ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN` secret still has `repo` scope; the workflow signs commits and adds the DCO-required `Signed-off-by` trailer.
 - To regenerate locally, follow `specs/012-generate-schema-baseline/quickstart.md` and push the resulting `schema-baseline.graphql` if automation is blocked.
 - Owners automatically receive a commit comment on failure; if the automation remains red after remediation, re-run the job from the Actions UI with `workflow_dispatch` to verify the fix.
 

--- a/docs/Running.md
+++ b/docs/Running.md
@@ -187,6 +187,6 @@ Note: You may need multiple repositories cloned in order for this command to run
   - `ALKEMIO_INFRASTRUCTURE_BOT_GPG_PRIVATE_KEY`: ASCII-armored private key for the automation identity.
   - `ALKEMIO_INFRASTRUCTURE_BOT_GPG_PASSPHRASE`: Passphrase for the key (set to an empty string when the key is unprotected).
 - - `ALKEMIO_INFRASTRUCTURE_BOT_GPG_KEY_ID`: Fingerprint uploaded to GitHub so commits appear as verified.
-- - `ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN`: Classic PAT with at least `repo` scope issued for the automation account; used to push the baseline branch and create the PR (also satisfies CLA requirements).
+- - `ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN`: Classic PAT with at least `repo` scope issued for the automation account; used to push the baseline branch and create the PR (commits are signed and signed off per DCO — see CONTRIBUTING).
 - Grant the automation key push access via the PAT and verify the public key is registered with the bot account that owns the commits.
 - After updating secrets, trigger the workflow manually (`workflow_dispatch`) to confirm the baseline branch/PR path succeeds before relying on automatic runs.


### PR DESCRIPTION
Docs + workflow slice of the CLA→DCO migration (`workspace#035-dco-migration`, story `alkem-io/infrastructure-operations#2186`).

`server` is the only surveyed repo with its **own** `PULL_REQUEST_TEMPLATE.md`, so the org-default template change doesn't reach it — it needs this one-line addition of its own.

## Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`** — DCO sign-off reminder added. The existing **Schema Contract Checklist is preserved verbatim** (a repo gate asserts this).
- **`.github/workflows/schema-baseline.yml`** — the automated baseline commit now signs off (`-s`). Under `require.members: true` an unsigned-off CI commit would fail the required DCO check.
- **`docs/Developing.md`, `docs/Running.md`** — stale CLA wording replaced.

Docs and workflow only; no runtime code, no schema change.

---

## Evidence

Full run ledger: [`specs/035-dco-migration/forge-run.md`](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/forge-run.md) · [spec](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/spec.md) · [plan](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/plan.md) · [runbook](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/specs/035-dco-migration/runbook.md) · [ADR 0008](https://github.com/alkem-io/agents-hq/blob/feat/035-dco-migration/docs/decisions/0008-dco-enforcement-contract.md)

**Review**: 4 dimensions (correctness · spec-compliance · quality · security) over **7 security rounds**. Every round found something real; rounds 4–7 found defects in the *previous round's remediation*. Two criticals were confirmed by adversarial reproduction against live payloads.

**All commits GPG-signed and DCO signed-off** — this feature's own policy applied to itself.

### Residuals the reviewer ruled trackable (not blockers)

| # | Residual | Severity |
|---|---|---|
| S7-1 | A local actor with evidence-write access can forge a rollback bundle **legally indistinguishable** from a genuine one. Not patchable by comparison — a discriminating guard was built, found to break legitimate recovery, and reverted. Interim control: the H4/H6 human gates. | high |
| D1 | remove-CLA evidence not artifact-bound beyond journals + live pinned-DCO verification | medium |
| D6 | Installer lacks a signed-revision provenance anchor | medium |
| D7 | H5 sweep omits immutable check-run id/URL fields | low |

⚠️ **The round-7 remediation is unreviewed** — it landed after the last review's pinned SHAs.

**This PR changes no live GitHub setting.** All enforcement happens at human gates H1a–H8 per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DCO sign-off guidance for commits, including commands to sign or amend commits.
  * Updated schema baseline troubleshooting instructions to verify signed commits and bot token permissions.
  * Clarified that infrastructure bot commits must follow DCO signing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->