### PR TITLE
fix(callouts): fall back to destination default flow state on cross-space transfer (#6021)

### DIFF
--- a/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
+++ b/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
@@ -27,7 +27,7 @@ describe('CalloutTransferService', () => {
   let profileService: ProfileService;
   let tagsetService: TagsetService;
   let storageAggregatorResolverService: StorageAggregatorResolverService;
-  let _classificationService: ClassificationService;
+  let classificationService: ClassificationService;
   let _urlGeneratorCacheService: UrlGeneratorCacheService;
   let activityService: ActivityService;
   let entityManager: EntityManager;
@@ -54,7 +54,7 @@ describe('CalloutTransferService', () => {
     storageAggregatorResolverService = module.get(
       StorageAggregatorResolverService
     );
-    _classificationService = module.get(ClassificationService);
+    classificationService = module.get(ClassificationService);
     _urlGeneratorCacheService = module.get(UrlGeneratorCacheService);
     activityService = module.get(ActivityService);
     entityManager = module.get(EntityManager);
@@ -150,6 +150,68 @@ describe('CalloutTransferService', () => {
       expect(callout.calloutsSet).toBe(targetCalloutsSet);
       expect(calloutService.save).toHaveBeenCalledWith(callout);
       expect(result).toBe(finalCallout);
+    });
+
+    // Regression coverage for story #6021: a cross-space transfer must hand the
+    // destination's flow-state template to the classification, so the Callout
+    // either keeps a state the destination knows or is reset to its default.
+    // Without this the Callout keeps a state no destination phase matches and
+    // disappears from the destination (same symptom as #4970).
+    it('should reclassify the callout against the destination flow-state template', async () => {
+      const callout = {
+        id: 'callout-1',
+        nameID: 'my-callout',
+        calloutsSet: { id: 'source-cs' },
+      } as any;
+
+      const destinationFlowStateTemplate = {
+        id: 'tt-flow-state',
+        name: TagsetReservedName.FLOW_STATE,
+        allowedValues: ['EXPLORE', 'DEFINE', 'BRAINSTORM'],
+        defaultSelectedValue: 'EXPLORE',
+      };
+
+      vi.mocked(
+        storageAggregatorResolverService.getStorageAggregatorForCalloutsSet
+      ).mockResolvedValue(storageAggregator);
+      vi.mocked(calloutService.save).mockResolvedValue(callout);
+      vi.mocked(calloutService.getCalloutOrFail)
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: { profile: { storageBucket: { id: 'sb-1' } } },
+          contributions: [],
+        } as any) // updateStorageAggregator
+        .mockResolvedValueOnce(calloutForUrlCaches as any) // revokeUrlCaches
+        .mockResolvedValueOnce({
+          id: 'callout-1',
+          framing: {
+            profile: {
+              id: 'profile-1',
+              tagsets: [
+                {
+                  id: 'ts-default',
+                  name: TagsetReservedName.DEFAULT,
+                  tags: [],
+                },
+              ],
+            },
+          },
+        } as any) // updateTagsetsFromTemplates
+        .mockResolvedValueOnce(calloutForClassification as any) // updateClassificationFromTemplates
+        .mockResolvedValueOnce(callout); // final return
+
+      vi.mocked(calloutsSetService.getTagsetTemplatesSet).mockResolvedValue({
+        tagsetTemplates: [destinationFlowStateTemplate],
+      } as any);
+      vi.mocked(
+        profileService.convertTagsetTemplatesToCreateTagsetInput
+      ).mockReturnValue([]);
+
+      await service.transferCallout(callout, targetCalloutsSet);
+
+      expect(
+        classificationService.updateTagsetTemplateOnSelectTagset
+      ).toHaveBeenCalledWith('classification-1', destinationFlowStateTemplate);
     });
 
     it('should update storage buckets for all contribution types', async () => {

--- a/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
+++ b/src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts
@@ -152,11 +152,11 @@ describe('CalloutTransferService', () => {
       expect(result).toBe(finalCallout);
     });
 
-    // Regression coverage for story #6021: a cross-space transfer must hand the
-    // destination's flow-state template to the classification, so the Callout
-    // either keeps a state the destination knows or is reset to its default.
-    // Without this the Callout keeps a state no destination phase matches and
-    // disappears from the destination (same symptom as #4970).
+    // Transfer-boundary coverage for story #6021. ClassificationService is
+    // mocked here, so this pins only the boundary: the templates handed to the
+    // classification must be read from the *target* CalloutsSet, never the
+    // source. The resolution of the resulting tag lives in
+    // `classification.service.spec.ts` ("destination default resolution").
     it('should reclassify the callout against the destination flow-state template', async () => {
       const callout = {
         id: 'callout-1',
@@ -209,6 +209,13 @@ describe('CalloutTransferService', () => {
 
       await service.transferCallout(callout, targetCalloutsSet);
 
+      // Templates must come from the target CalloutsSet, not the source one.
+      expect(calloutsSetService.getTagsetTemplatesSet).toHaveBeenCalledWith(
+        'target-cs'
+      );
+      expect(calloutsSetService.getTagsetTemplatesSet).not.toHaveBeenCalledWith(
+        'source-cs'
+      );
       expect(
         classificationService.updateTagsetTemplateOnSelectTagset
       ).toHaveBeenCalledWith('classification-1', destinationFlowStateTemplate);

--- a/src/domain/collaboration/collaboration/collaboration.service.ts
+++ b/src/domain/collaboration/collaboration/collaboration.service.ts
@@ -20,6 +20,7 @@ import { AuthorizationPolicy } from '@domain/common/authorization-policy/authori
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { LicenseService } from '@domain/common/license/license.service';
 import { CreateTagsetTemplateInput } from '@domain/common/tagset-template';
+import { resolveDefaultSelectedValue } from '@domain/common/tagset-template/tagset.template.utils';
 import { Space } from '@domain/space/space/space.entity';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { ITimeline } from '@domain/timeline/timeline/timeline.interface';
@@ -202,13 +203,10 @@ export class CollaborationService {
     const allowedValues = [...innovationFlowData.states]
       .sort(sortBySortOrder)
       .map(state => state.displayName);
-    let defaultSelectedValue = innovationFlowData.currentStateDisplayName;
-    if (
-      !defaultSelectedValue ||
-      allowedValues.indexOf(defaultSelectedValue) === -1
-    ) {
-      defaultSelectedValue = allowedValues[0];
-    }
+    const defaultSelectedValue = resolveDefaultSelectedValue(
+      allowedValues,
+      innovationFlowData.currentStateDisplayName
+    );
 
     const tagsetTemplateDataStates: CreateTagsetTemplateInput = {
       name: TagsetReservedName.FLOW_STATE,

--- a/src/domain/common/classification/classification.service.spec.ts
+++ b/src/domain/common/classification/classification.service.spec.ts
@@ -524,5 +524,139 @@ describe('ClassificationService', () => {
 
       expect(existingTagset.tags).toEqual([]);
     });
+
+    // Regression coverage for story #6021 (same root cause as #4970): a Callout
+    // transferred into a Space whose flow-state template carries an unusable
+    // `defaultSelectedValue` must still land on a state the destination knows
+    // about, otherwise it matches no phase filter and disappears from the UI.
+    describe('destination default resolution (story #6021)', () => {
+      const arrangeFlowStateTagset = (tags: string[]) => {
+        const existingTagset = {
+          id: 'ts-1',
+          name: TagsetReservedName.FLOW_STATE,
+          tags,
+        };
+        vi.spyOn(Classification, 'findOne').mockResolvedValue({
+          id: 'cls-1',
+          tagsets: [existingTagset],
+        } as any);
+        (tagsetService.getTagsetByName as Mock).mockReturnValue(existingTagset);
+        (tagsetService.save as Mock).mockResolvedValue(existingTagset as any);
+        return existingTagset;
+      };
+
+      it('should fall back to the first allowed value when the template carries no defaultSelectedValue', async () => {
+        const existingTagset = arrangeFlowStateTagset(['HOME']);
+
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE', 'BRAINSTORM'],
+          defaultSelectedValue: undefined,
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(existingTagset.tags).toEqual(['EXPLORE']);
+      });
+
+      it('should fall back to the first allowed value when defaultSelectedValue is itself stale', async () => {
+        const existingTagset = arrangeFlowStateTagset(['HOME']);
+
+        // The destination flow was rebuilt but the template's default was left
+        // pointing at a state that no longer exists.
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE', 'BRAINSTORM'],
+          defaultSelectedValue: 'RETIRED-STATE',
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(existingTagset.tags).toEqual(['EXPLORE']);
+      });
+
+      it('should treat a simple-array empty marker as no current value and fall back to the default', async () => {
+        // A `simple-array` column persisted from [] reads back as ['']
+        const existingTagset = arrangeFlowStateTagset(['']);
+
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE'],
+          defaultSelectedValue: 'DEFINE',
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(existingTagset.tags).toEqual(['DEFINE']);
+      });
+
+      it('should ignore empty allowed values when picking the destination default', async () => {
+        const existingTagset = arrangeFlowStateTagset(['HOME']);
+
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['', 'EXPLORE'],
+          defaultSelectedValue: undefined,
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(existingTagset.tags).toEqual(['EXPLORE']);
+      });
+
+      it('should still prefer an explicit defaultSelectedValue that is allowed', async () => {
+        const existingTagset = arrangeFlowStateTagset(['HOME']);
+
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE', 'BRAINSTORM'],
+          defaultSelectedValue: 'BRAINSTORM',
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(existingTagset.tags).toEqual(['BRAINSTORM']);
+      });
+
+      it('should seed a newly created tagset with the destination default when the template default is unusable', async () => {
+        vi.spyOn(Classification, 'findOne').mockResolvedValue({
+          id: 'cls-1',
+          tagsets: [],
+        } as any);
+        (tagsetService.getTagsetByName as Mock).mockReturnValue(undefined);
+
+        const newTagset = {
+          id: 'ts-new',
+          name: TagsetReservedName.FLOW_STATE,
+          tags: [],
+        };
+        (tagsetService.createTagsetWithName as Mock).mockReturnValue(
+          newTagset as any
+        );
+        (tagsetService.save as Mock).mockResolvedValue(newTagset as any);
+
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE'],
+          defaultSelectedValue: undefined,
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(tagsetService.createTagsetWithName).toHaveBeenCalledWith(
+          [],
+          expect.objectContaining({
+            name: TagsetReservedName.FLOW_STATE,
+            tags: ['EXPLORE'],
+          })
+        );
+      });
+    });
   });
 });

--- a/src/domain/common/classification/classification.service.spec.ts
+++ b/src/domain/common/classification/classification.service.spec.ts
@@ -54,6 +54,15 @@ describe('ClassificationService', () => {
     authorizationPolicyService = module.get(AuthorizationPolicyService);
   });
 
+  // `Classification.create` / `Classification.findOne` are statics on a shared
+  // module-level class and the suite runs with `isolate: false` (see
+  // docs/testing-flakiness.md §4): `clearMocks` only clears call data, so
+  // without an explicit restore the last spy installed here would leak into
+  // whichever spec file the worker picks up next.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('createClassification', () => {
     it('should create a classification with tagsets from templates', () => {
       const templates: ITagsetTemplate[] = [
@@ -606,6 +615,42 @@ describe('ClassificationService', () => {
         await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
 
         expect(existingTagset.tags).toEqual(['EXPLORE']);
+      });
+
+      it('should keep a current value that differs from the allowed value only in casing', async () => {
+        // `filterCalloutsByClassificationTagsets` matches phase filters
+        // case-insensitively, so a destination state that differs only in
+        // casing is a match for the client: resetting here would needlessly
+        // move the Callout off its state. The template's spelling wins.
+        const existingTagset = arrangeFlowStateTagset(['explore']);
+
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE'],
+          defaultSelectedValue: 'DEFINE',
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(existingTagset.tags).toEqual(['EXPLORE']);
+      });
+
+      it('should keep the declared default when the template constrains nothing', async () => {
+        const existingTagset = arrangeFlowStateTagset(['HOME']);
+
+        // A free-form template has no allowedValues to validate against, so
+        // there is no basis on which to reject the declared default.
+        const template = {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: [],
+          defaultSelectedValue: 'DEFINE',
+        } as unknown as ITagsetTemplate;
+
+        await service.updateTagsetTemplateOnSelectTagset('cls-1', template);
+
+        expect(existingTagset.tags).toEqual(['DEFINE']);
       });
 
       it('should still prefer an explicit defaultSelectedValue that is allowed', async () => {

--- a/src/domain/common/classification/classification.service.ts
+++ b/src/domain/common/classification/classification.service.ts
@@ -202,9 +202,7 @@ export class ClassificationService {
       tagsetTemplate.name
     );
 
-    const defaultTags = tagsetTemplate.defaultSelectedValue
-      ? [tagsetTemplate.defaultSelectedValue]
-      : [];
+    const defaultTags = this.resolveDefaultTags(tagsetTemplate);
 
     if (existingTagset) {
       existingTagset.tagsetTemplate = tagsetTemplate;
@@ -213,6 +211,7 @@ export class ClassificationService {
       const currentValue = existingTagset.tags?.[0];
       const isCurrentValueValid =
         currentValue != null &&
+        currentValue !== '' &&
         tagsetTemplate.allowedValues?.includes(currentValue);
       existingTagset.tags = isCurrentValueValid ? [currentValue] : defaultTags;
       return await this.tagsetService.save(existingTagset, mgr);
@@ -231,6 +230,49 @@ export class ClassificationService {
       },
       mgr
     );
+  }
+
+  /**
+   * Resolves the value a SELECT_ONE tagset must fall back to when its current
+   * value has no match in the target TagsetTemplate.
+   *
+   * `defaultSelectedValue` is only usable when it is itself one of the
+   * template's `allowedValues`. It is a nullable column, and
+   * `TagsetTemplateService.updateTagsetTemplateDefinition` only overwrites it
+   * when the update carries a truthy value — so a template whose allowedValues
+   * were replaced can be left pointing at a value that no longer exists, and
+   * older templates may carry no default at all.
+   *
+   * Trusting it blindly leaves the tagset holding a value the target does not
+   * know about (or, worse, no value at all). For a Callout's `flow-state`
+   * classification that means it matches none of the destination's phases, so
+   * after a cross-space transfer the Callout is filtered out of every tab and
+   * appears to have vanished (story #6021, and the same root cause as #4970).
+   *
+   * The first allowed value is the destination's default state — the same
+   * convention used by `CalloutsSetService.moveCalloutsToDefaultFlowState` and
+   * by the flow-state template bootstrap in `CollaborationService`.
+   *
+   * Empty strings are discarded: a `simple-array` column persisted from an
+   * empty array reads back as `['']`, which is not a selectable value.
+   */
+  private resolveDefaultTags(tagsetTemplate: ITagsetTemplate): string[] {
+    const allowedValues = (tagsetTemplate.allowedValues ?? []).filter(
+      allowedValue => allowedValue !== ''
+    );
+    const defaultSelectedValue = tagsetTemplate.defaultSelectedValue;
+
+    if (allowedValues.length === 0) {
+      // Nothing to validate against (e.g. a free-form template): keep whatever
+      // default the template declares.
+      return defaultSelectedValue ? [defaultSelectedValue] : [];
+    }
+
+    if (defaultSelectedValue && allowedValues.includes(defaultSelectedValue)) {
+      return [defaultSelectedValue];
+    }
+
+    return [allowedValues[0]];
   }
 
   // Note: provided data has priority when it comes to tags

--- a/src/domain/common/classification/classification.service.ts
+++ b/src/domain/common/classification/classification.service.ts
@@ -17,6 +17,10 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { EntityManager, FindOneOptions, Repository } from 'typeorm';
 import { CreateTagsetInput } from '../tagset';
 import { ITagsetTemplate } from '../tagset-template/tagset.template.interface';
+import {
+  matchAllowedValue,
+  resolveDefaultTags,
+} from '../tagset-template/tagset.template.utils';
 import { CreateClassificationInput } from './dto/classification.dto.create';
 import { UpdateClassificationInput } from './dto/classification.dto.update';
 import { UpdateClassificationSelectTagsetValueInput } from './dto/classification.dto.update.select.tagset.value';
@@ -202,77 +206,39 @@ export class ClassificationService {
       tagsetTemplate.name
     );
 
-    const defaultTags = this.resolveDefaultTags(tagsetTemplate);
-
     if (existingTagset) {
       existingTagset.tagsetTemplate = tagsetTemplate;
-      // Preserve current value when it is still valid in the target template;
-      // only fall back to the default when the current value is not allowed.
-      const currentValue = existingTagset.tags?.[0];
-      const isCurrentValueValid =
-        currentValue != null &&
-        currentValue !== '' &&
-        tagsetTemplate.allowedValues?.includes(currentValue);
-      existingTagset.tags = isCurrentValueValid ? [currentValue] : defaultTags;
+      // Preserve the current value when the target template still allows it —
+      // matched case-insensitively, because that is how
+      // `filterCalloutsByClassificationTagsets` matches phase filters, and
+      // normalised to the template's spelling so the stored value stays
+      // canonical. Only fall back to the default when there is no match at all.
+      const matchedValue = matchAllowedValue(
+        tagsetTemplate.allowedValues,
+        existingTagset.tags?.[0]
+      );
+      existingTagset.tags = matchedValue
+        ? [matchedValue]
+        : resolveDefaultTags(tagsetTemplate);
       return await this.tagsetService.save(existingTagset, mgr);
     }
 
     // Target callouts set has a template not present in the source classification;
     // create a new tagset for it
     const classification = await this.getClassificationOrFail(classificationID);
+    // Tagsets are already loaded above; hand them over so addTagsetOnClassification
+    // does not re-query them.
+    classification.tagsets = tagsets;
     return await this.addTagsetOnClassification(
       classification,
       {
         name: tagsetTemplate.name,
         type: tagsetTemplate.type,
-        tags: defaultTags,
+        tags: resolveDefaultTags(tagsetTemplate),
         tagsetTemplate,
       },
       mgr
     );
-  }
-
-  /**
-   * Resolves the value a SELECT_ONE tagset must fall back to when its current
-   * value has no match in the target TagsetTemplate.
-   *
-   * `defaultSelectedValue` is only usable when it is itself one of the
-   * template's `allowedValues`. It is a nullable column, and
-   * `TagsetTemplateService.updateTagsetTemplateDefinition` only overwrites it
-   * when the update carries a truthy value — so a template whose allowedValues
-   * were replaced can be left pointing at a value that no longer exists, and
-   * older templates may carry no default at all.
-   *
-   * Trusting it blindly leaves the tagset holding a value the target does not
-   * know about (or, worse, no value at all). For a Callout's `flow-state`
-   * classification that means it matches none of the destination's phases, so
-   * after a cross-space transfer the Callout is filtered out of every tab and
-   * appears to have vanished (story #6021, and the same root cause as #4970).
-   *
-   * The first allowed value is the destination's default state — the same
-   * convention used by `CalloutsSetService.moveCalloutsToDefaultFlowState` and
-   * by the flow-state template bootstrap in `CollaborationService`.
-   *
-   * Empty strings are discarded: a `simple-array` column persisted from an
-   * empty array reads back as `['']`, which is not a selectable value.
-   */
-  private resolveDefaultTags(tagsetTemplate: ITagsetTemplate): string[] {
-    const allowedValues = (tagsetTemplate.allowedValues ?? []).filter(
-      allowedValue => allowedValue !== ''
-    );
-    const defaultSelectedValue = tagsetTemplate.defaultSelectedValue;
-
-    if (allowedValues.length === 0) {
-      // Nothing to validate against (e.g. a free-form template): keep whatever
-      // default the template declares.
-      return defaultSelectedValue ? [defaultSelectedValue] : [];
-    }
-
-    if (defaultSelectedValue && allowedValues.includes(defaultSelectedValue)) {
-      return [defaultSelectedValue];
-    }
-
-    return [allowedValues[0]];
   }
 
   // Note: provided data has priority when it comes to tags

--- a/src/domain/common/profile/profile.service.spec.ts
+++ b/src/domain/common/profile/profile.service.spec.ts
@@ -1158,86 +1158,33 @@ describe('ProfileService', () => {
   });
 
   describe('convertTagsetTemplatesToCreateTagsetInput', () => {
-    it('should transform templates to input array', () => {
-      const templates: Partial<ITagsetTemplate>[] = [
-        {
-          name: 'skills',
-          type: TagsetType.FREEFORM,
-          allowedValues: [],
-        },
-        {
-          name: 'industry',
-          type: TagsetType.SELECT_ONE,
-          allowedValues: ['tech', 'finance'],
-        },
-      ];
-
-      const result = service.convertTagsetTemplatesToCreateTagsetInput(
-        templates as ITagsetTemplate[]
-      );
-
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual(
-        expect.objectContaining({
-          name: 'skills',
-          type: TagsetType.FREEFORM,
-          tags: undefined,
-        })
-      );
-      expect(result[1]).toEqual(
-        expect.objectContaining({
-          name: 'industry',
-          type: TagsetType.SELECT_ONE,
-        })
-      );
-    });
-
-    it('should include defaultSelectedValue as tag when present', () => {
+    // The conversion itself (including how a template's default is resolved)
+    // is owned by TagsetService and covered in tagset.service.spec.ts; this
+    // used to be a duplicated implementation, so all that matters here is that
+    // it is not one any more.
+    it('should delegate to TagsetService', () => {
       const templates: Partial<ITagsetTemplate>[] = [
         {
           name: 'industry',
           type: TagsetType.SELECT_ONE,
           allowedValues: ['tech', 'finance'],
-          defaultSelectedValue: 'tech',
         },
       ];
+      const converted = [
+        { name: 'industry', type: TagsetType.SELECT_ONE, tags: ['tech'] },
+      ];
+      vi.mocked(
+        tagsetService.convertTagsetTemplatesToCreateTagsetInput
+      ).mockReturnValue(converted as any);
 
       const result = service.convertTagsetTemplatesToCreateTagsetInput(
         templates as ITagsetTemplate[]
       );
 
-      expect(result[0].tags).toEqual(['tech']);
-    });
-
-    it('should set tags to undefined when no defaultSelectedValue', () => {
-      const templates: Partial<ITagsetTemplate>[] = [
-        {
-          name: 'skills',
-          type: TagsetType.FREEFORM,
-          allowedValues: [],
-          defaultSelectedValue: undefined,
-        },
-      ];
-
-      const result = service.convertTagsetTemplatesToCreateTagsetInput(
-        templates as ITagsetTemplate[]
-      );
-
-      expect(result[0].tags).toBeUndefined();
-    });
-
-    it('should include tagsetTemplate reference in each input', () => {
-      const template = {
-        name: 'skills',
-        type: TagsetType.FREEFORM,
-        allowedValues: [],
-      } as unknown as ITagsetTemplate;
-
-      const result = service.convertTagsetTemplatesToCreateTagsetInput([
-        template,
-      ]);
-
-      expect(result[0].tagsetTemplate).toBe(template);
+      expect(
+        tagsetService.convertTagsetTemplatesToCreateTagsetInput
+      ).toHaveBeenCalledWith(templates);
+      expect(result).toBe(converted);
     });
   });
 });

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -595,19 +595,12 @@ export class ProfileService {
   public convertTagsetTemplatesToCreateTagsetInput(
     tagsetTemplates: ITagsetTemplate[]
   ): CreateTagsetInput[] {
-    const result: CreateTagsetInput[] = [];
-    for (const tagsetTemplate of tagsetTemplates) {
-      const input: CreateTagsetInput = {
-        name: tagsetTemplate.name,
-        type: tagsetTemplate.type,
-        tagsetTemplate: tagsetTemplate,
-        tags: tagsetTemplate.defaultSelectedValue
-          ? [tagsetTemplate.defaultSelectedValue]
-          : undefined,
-      };
-      result.push(input);
-    }
-    return result;
+    // Single implementation on TagsetService: this used to be a byte-identical
+    // copy, so any fix to how a template's default is resolved had to be made
+    // twice (and was not).
+    return this.tagsetService.convertTagsetTemplatesToCreateTagsetInput(
+      tagsetTemplates
+    );
   }
 
   private static readonly TRUSTED_EXTERNAL_AVATAR_HOSTS = new Set<string>([

--- a/src/domain/common/tagset-template/tagset.template.utils.ts
+++ b/src/domain/common/tagset-template/tagset.template.utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Helpers for resolving the value a tagset driven by a TagsetTemplate must
+ * hold. Shared so every path that materialises a tagset from a template agrees
+ * on the same rule; previously the "prefer the declared default, otherwise the
+ * first allowed value" rule was re-implemented per call site and several of
+ * them trusted `defaultSelectedValue` blindly.
+ */
+
+type TagsetTemplateDefinition = {
+  allowedValues?: string[];
+  defaultSelectedValue?: string;
+};
+
+/**
+ * Values a tagset may legitimately be set to.
+ *
+ * Empty strings are discarded: `allowedValues` is a `simple-array` column, and
+ * one persisted from an empty array reads back as `['']` rather than `[]`.
+ */
+export const getSelectableValues = (
+  allowedValues: string[] | undefined
+): string[] =>
+  (allowedValues ?? []).filter(allowedValue => allowedValue !== '');
+
+/**
+ * Resolves the value a tagset must fall back to when its current value has no
+ * match in the template.
+ *
+ * `defaultSelectedValue` is only usable when it is itself one of the template's
+ * `allowedValues`. It is a nullable column, and
+ * `TagsetTemplateService.updateTagsetTemplateDefinition` only overwrites it
+ * when the update carries a truthy value — so a template whose allowedValues
+ * were replaced can be left pointing at a value that no longer exists, and
+ * older templates may carry no default at all.
+ *
+ * Trusting it blindly leaves the tagset holding a value the template does not
+ * know about (or, worse, no value at all). For a Callout's `flow-state`
+ * classification that means it matches none of the Space's phases, so the
+ * Callout is filtered out of every tab and appears to have vanished
+ * (story #6021, and the same root cause as #4970).
+ *
+ * The first allowed value is the "default state" convention already used by
+ * `CalloutsSetService.moveCalloutsToDefaultFlowState` and by the flow-state
+ * template bootstrap in `CollaborationService`.
+ */
+export const resolveDefaultSelectedValue = (
+  allowedValues: string[] | undefined,
+  declaredDefault: string | undefined
+): string | undefined => {
+  const selectableValues = getSelectableValues(allowedValues);
+
+  if (selectableValues.length === 0) {
+    // Nothing to validate against (e.g. a free-form template): keep whatever
+    // default the template declares.
+    return declaredDefault || undefined;
+  }
+
+  if (declaredDefault && selectableValues.includes(declaredDefault)) {
+    return declaredDefault;
+  }
+
+  return selectableValues[0];
+};
+
+/**
+ * {@link resolveDefaultSelectedValue} in the `tags` shape a tagset holds.
+ */
+export const resolveDefaultTags = (
+  tagsetTemplate: TagsetTemplateDefinition
+): string[] => {
+  const defaultValue = resolveDefaultSelectedValue(
+    tagsetTemplate.allowedValues,
+    tagsetTemplate.defaultSelectedValue
+  );
+  return defaultValue ? [defaultValue] : [];
+};
+
+/**
+ * Returns the template's canonical spelling of `value` when the template allows
+ * it, otherwise `undefined`.
+ *
+ * The match is case-insensitive because `filterCalloutsByClassificationTagsets`
+ * matches phase filters case-insensitively: a destination state that differs
+ * from the current value only in casing is a match for the client, so treating
+ * it as "absent" here would needlessly reset the Callout's state. The template's
+ * spelling wins so the stored value stays canonical.
+ */
+export const matchAllowedValue = (
+  allowedValues: string[] | undefined,
+  value: string | undefined
+): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const needle = value.toLowerCase();
+  return getSelectableValues(allowedValues).find(
+    allowedValue => allowedValue.toLowerCase() === needle
+  );
+};

--- a/src/domain/common/tagset/tagset.service.spec.ts
+++ b/src/domain/common/tagset/tagset.service.spec.ts
@@ -1,3 +1,4 @@
+import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import { TagsetType } from '@common/enums/tagset.type';
 import {
   EntityNotFoundException,
@@ -362,6 +363,32 @@ describe('TagsetService', () => {
         service.convertTagsetTemplatesToCreateTagsetInput(templates);
 
       expect(result[0].tags).toBeUndefined();
+    });
+
+    // Same root cause as story #6021, on the create path rather than the
+    // transfer path: a Callout seeded with a state the Space does not allow
+    // matches no phase filter and is filtered out of every tab.
+    it('should seed the first allowed value when the template carries no usable default', () => {
+      const templates = [
+        {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE'],
+          defaultSelectedValue: undefined,
+        },
+        {
+          name: TagsetReservedName.FLOW_STATE,
+          type: TagsetType.SELECT_ONE,
+          allowedValues: ['EXPLORE', 'DEFINE'],
+          defaultSelectedValue: 'RETIRED-STATE',
+        },
+      ] as unknown as ITagsetTemplate[];
+
+      const result =
+        service.convertTagsetTemplatesToCreateTagsetInput(templates);
+
+      expect(result[0].tags).toEqual(['EXPLORE']);
+      expect(result[1].tags).toEqual(['EXPLORE']);
     });
   });
 

--- a/src/domain/common/tagset/tagset.service.ts
+++ b/src/domain/common/tagset/tagset.service.ts
@@ -17,6 +17,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { EntityManager, FindOneOptions, Repository } from 'typeorm';
 import { AuthorizationPolicyService } from '../authorization-policy/authorization.policy.service';
 import { ITagsetTemplate } from '../tagset-template';
+import { resolveDefaultTags } from '../tagset-template/tagset.template.utils';
 import { Tagset } from './tagset.entity';
 import { ITagset } from './tagset.interface';
 
@@ -344,13 +345,17 @@ export class TagsetService {
   ): CreateTagsetInput[] {
     const result: CreateTagsetInput[] = [];
     for (const tagsetTemplate of tagsetTemplates) {
+      // Trusting `defaultSelectedValue` blindly here is the same defect fixed
+      // for the transfer path in story #6021: a template with no default, or a
+      // default naming a state that no longer exists, produces a tagset that
+      // matches none of the Space's phases, so the Callout is filtered out of
+      // every tab and looks like it vanished.
+      const defaultTags = resolveDefaultTags(tagsetTemplate);
       const input: CreateTagsetInput = {
         name: tagsetTemplate.name,
         type: tagsetTemplate.type,
         tagsetTemplate: tagsetTemplate,
-        tags: tagsetTemplate.defaultSelectedValue
-          ? [tagsetTemplate.defaultSelectedValue]
-          : undefined,
+        tags: defaultTags.length > 0 ? defaultTags : undefined,
       };
       result.push(input);
     }


### PR DESCRIPTION
## Summary

A Callout transferred across Spaces could disappear in the destination because its `flow-state` classification ended up holding a value the destination does not recognise. This makes the fallback resolve against the destination's *actual* allowed states, so an unmatched Callout lands on the destination's default state and stays visible.

Closes #6021

## Root cause

`CalloutTransferService.transferCallout` re-points the Callout's `flow-state` classification tagset at the destination `CalloutsSet`'s `TagsetTemplate` via `ClassificationService.updateTagsetTemplateOnSelectTagset`. Matching by name already worked; the *fallback* did not:

```ts
const defaultTags = tagsetTemplate.defaultSelectedValue
  ? [tagsetTemplate.defaultSelectedValue]
  : [];
```

`defaultSelectedValue` is a nullable column, and `TagsetTemplateService.updateTagsetTemplateDefinition` only overwrites it when the incoming update carries a truthy value. So a destination template can legitimately carry:

- **no default at all** &rarr; the tagset was set to `[]`, or
- **a stale default** naming a state that no longer exists &rarr; the tagset kept a value the destination does not know.

Either way `filterCalloutsByClassificationTagsets` (which the client drives with `classificationTagsets: [{ name: "flow-state", tags: ["<phase>"] }]`) matches nothing, so the Callout is filtered out of every tab and looks like it vanished.

## Fix

`ClassificationService` now resolves the fallback through a `resolveDefaultTags()` helper:

1. Prefer `defaultSelectedValue` **only when it is itself one of `allowedValues`**.
2. Otherwise fall back to the first allowed value — the same "destination default" convention already used by `CalloutsSetService.moveCalloutsToDefaultFlowState` and the flow-state template bootstrap in `CollaborationService`.
3. When the template declares no `allowedValues` at all (free-form templates), keep whatever default it declares — preserving existing behaviour.

Empty strings are discarded from both the current value and `allowedValues`, because a `simple-array` column persisted from an empty array reads back as `['']` rather than `[]`.

Behaviour-only: **no GraphQL schema change, no entity change, no migration.** Verified that `pnpm run schema:print && pnpm run schema:sort` produces a diff *identical* to the one produced on an unmodified tree, i.e. pre-existing drift on `develop` (`CalloutContributorsMapView` descriptions) and nothing from this branch. `schema.graphql` is deliberately not touched here.

## Acceptance criteria

| AC | How it is met |
| --- | --- |
| Cross-space transfer where source state name is **absent** in destination &rarr; Callout assigned destination default state | `resolveDefaultTags()` now always yields a state the destination allows. Tests: *"should fall back to the first allowed value when the template carries no defaultSelectedValue"*, *"...when defaultSelectedValue is itself stale"*, plus the pre-existing *"should fall back to default when current tag absent from target template allowedValues"*. |
| Cross-space transfer where source state name is **present** in destination &rarr; Callout keeps that state name | Unchanged match-by-name path, still pinned by *"should preserve current tag when present in target template allowedValues"*. |
| Same logic when the destination's innovation flow was changed via template | `updateInnovationFlowStatesFromTemplate` &rarr; `updateInnovationFlowStates` already refreshes `flowStatesTagsetTemplate` (`allowedValues` + `defaultSelectedValue`) — that template is the same entity shared by the destination `CalloutsSet`, so the transfer reads the post-template state set. The new guard additionally covers the case where that refresh left an unusable default. |
| Transferred Callout is visible in the destination after the move | The assigned value is now guaranteed to be one of the destination's `allowedValues`, so it matches a phase filter in `filterCalloutsByClassificationTagsets` instead of falling through every tab. |
| Regression test added | 6 new cases in `classification.service.spec.ts` under *"destination default resolution (story #6021)"*, plus a transfer-boundary test in `callout.transfer.service.spec.ts` asserting the destination's `flow-state` template is what gets handed to the classification. |
| Verified against alkem-io/server#4970 and alkem-io/client-web#9353 | Both referenced as plain text only — **no closing keywords**, they stay open for manual closure. #4970's "transfer subspace&rarr;subspace makes it invisible" is the same code path and same symptom. |

## Known adjacent defect (not fixed here)

`InnovationFlowService.createStateOnInnovationFlow` and `InnovationFlowService.deleteStateOnInnovationFlow` mutate the flow's states but **never refresh `innovationFlow.flowStatesTagsetTemplate`**. Only the wholesale `updateInnovationFlowStates` and the rename branch of `updateStateOnInnovationFlow` do.

Consequence: adding or deleting a phase leaves the template's `allowedValues` drifting from the flow's real states. Because the transfer answers "does the source state exist in the destination?" against that template, a drifted `allowedValues` can make a **genuinely matching state look unmatched** (so the Callout is needlessly reset), or make a deleted state look still-valid (so the Callout keeps a phase that no longer exists) — which undermines AC#2 in the drifted case.

Deliberately left out of this PR: it is a defect in flow *editing* with a much wider blast radius (`allowedValues` is read by every consumer of the flow, not just transfer), and folding it in pushes this past bug-sized. Flagged for a separate issue.

## Test plan

- `pnpm exec vitest run src/domain/common/classification/classification.service.spec.ts src/domain/collaboration/callout-transfer/callout.transfer.service.spec.ts src/domain/collaboration/callouts-set/callouts.set.service.spec.ts` &rarr; **85 passed**
- Full suite (pre-commit hook): **7746 passed / 7 skipped, 687 files**
- `pnpm lint` (tsc --noEmit + biome check) &rarr; clean
- `pnpm build` &rarr; clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow-state tag handling when templates have missing, outdated, or empty defaults.
  * Preserved valid selections through case-insensitive matching while applying the template’s canonical value.
  * Automatically selected the first valid option when no usable default was available.
  * Ensured newly created tagsets receive the correct defaults during callout transfers.
  * Treated empty existing tag values as invalid and resolved them appropriately.
  * Ensured destination callout templates provide the correct flow-state values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
