### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -5211,7 +5211,9 @@ type Mutation {
   updateVirtualContributorPlatformSettings(settingsData: UpdateVirtualContributorPlatformSettingsInput!): VirtualContributor!
   """Updates one of the Setting on an Virtual Contributor"""
   updateVirtualContributorSettings(settingsData: UpdateVirtualContributorSettingsInput!): VirtualContributor!
-  """Updates the image URI for the specified Visual."""
+  """
+  Updates the image URI, alternative text and/or display aspect ratio for the specified Visual.
+  """
   updateVisual(updateData: UpdateVisualInput!): Visual!
   """Updates the specified Whiteboard."""
   updateWhiteboard(whiteboardData: UpdateWhiteboardEntityInput!): Whiteboard!
@@ -9066,6 +9068,10 @@ input UpdateVirtualContributorSettingsPrivacyInput {
 
 input UpdateVisualInput {
   alternativeText: String
+  """
+  The width / height ratio to display this visual at. Must fall within the visual type’s minAspectRatio - maxAspectRatio range; types with a fixed shape accept only their single allowed value.
+  """
+  aspectRatio: Float
   uri: String!
   visualID: String!
 }
@@ -9843,10 +9849,18 @@ type VisualConstraints {
   allowedTypes: [String!]!
   """Dimensions ratio width / height."""
   aspectRatio: Float!
+  """
+  Maximum dimensions ratio width / height that this visual may be set to. Equal to minAspectRatio when the shape is fixed.
+  """
+  maxAspectRatio: Float!
   """Maximum height resolution."""
   maxHeight: Float!
   """Maximum width resolution."""
   maxWidth: Float!
+  """
+  Minimum dimensions ratio width / height that this visual may be set to. Equal to maxAspectRatio when the shape is fixed.
+  """
+  minAspectRatio: Float!
   """Minimum height resolution."""
   minHeight: Float!
   """Minimum width resolution."""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 320065 bytes
Snapshot md5: f4bb4c11f2fa98be9873cb288ef17184

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Visual updates now support an optional display aspect ratio.
  - Aspect ratios are validated against each visual type’s supported minimum and maximum values.
  - Visual constraint details now include the required minimum and maximum aspect ratios.
  - Visual updates can document and manage image URI, alternative text, and display aspect ratio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->