### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -5211,7 +5211,9 @@ type Mutation {
   updateVirtualContributorPlatformSettings(settingsData: UpdateVirtualContributorPlatformSettingsInput!): VirtualContributor!
   """Updates one of the Setting on an Virtual Contributor"""
   updateVirtualContributorSettings(settingsData: UpdateVirtualContributorSettingsInput!): VirtualContributor!
-  """Updates the image URI for the specified Visual."""
+  """
+  Updates the image URI, alternative text and/or display aspect ratio for the specified Visual.
+  """
   updateVisual(updateData: UpdateVisualInput!): Visual!
   """Updates the specified Whiteboard."""
   updateWhiteboard(whiteboardData: UpdateWhiteboardEntityInput!): Whiteboard!
@@ -6508,6 +6510,10 @@ type RelayPaginatedSpace implements ActorFull {
   account: Account!
   """The "highest" subscription active for this Space."""
   activeSubscription: SpaceSubscription
+  """
+  Count of visible activity events on this Space over the last 7 days, across all actors (excludes whiteboard-content-modified). Used to rank Spaces on the dashboard.
+  """
+  activityScore: Int!
   """The Actor representing this Space."""
   actor: Actor!
   """The authorization rules for the Actor"""
@@ -7372,6 +7378,10 @@ type Space implements ActorFull {
   account: Account!
   """The "highest" subscription active for this Space."""
   activeSubscription: SpaceSubscription
+  """
+  Count of visible activity events on this Space over the last 7 days, across all actors (excludes whiteboard-content-modified). Used to rank Spaces on the dashboard.
+  """
+  activityScore: Int!
   """The Actor representing this Space."""
   actor: Actor!
   """The authorization rules for the Actor"""
@@ -8831,11 +8841,20 @@ input UpdateUserSettingsCommunicationInput {
   allowOtherUsersToSendMessages: Boolean
 }
 
+input UpdateUserSettingsDashboardInput {
+  """
+  Whether the activity-feed view is shown on the home dashboard (true) or the non-activity Spaces view (false).
+  """
+  activityView: Boolean
+}
+
 input UpdateUserSettingsEntityInput {
   """Settings related to the AI assistant authority for this User."""
   assistant: UpdateUserSettingsAssistantInput
   """Settings related to this users Communication preferences."""
   communication: UpdateUserSettingsCommunicationInput
+  """Settings related to the home dashboard view."""
+  dashboard: UpdateUserSettingsDashboardInput
   """
   Update the user's design version. Any integer accepted (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).
   """
@@ -9066,6 +9085,10 @@ input UpdateVirtualContributorSettingsPrivacyInput {
 
 input UpdateVisualInput {
   alternativeText: String
+  """
+  The width / height ratio to display this visual at. Must fall within the visual type’s minAspectRatio - maxAspectRatio range; types with a fixed shape accept only their single allowed value.
+  """
+  aspectRatio: Float
   uri: String!
   visualID: String!
 }
@@ -9413,6 +9436,8 @@ type UserSettings {
   communication: UserSettingsCommunication!
   """The date at which the entity was created."""
   createdDate: DateTime!
+  """The home-dashboard view settings for this User."""
+  dashboard: UserSettingsDashboard!
   """
   The design version this User has selected (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).
   """
@@ -9451,6 +9476,13 @@ type UserSettingsCommunication {
   allowOtherUsersToContactViaEmail: Boolean!
   """Allow Users to send messages to this User."""
   allowOtherUsersToSendMessages: Boolean!
+}
+
+type UserSettingsDashboard {
+  """
+  Whether the activity-feed view is shown on the home dashboard (true) or the non-activity Spaces view (false). Default true preserves the historical behaviour.
+  """
+  activityView: Boolean!
 }
 
 type UserSettingsHomeSpace {
@@ -9843,10 +9875,18 @@ type VisualConstraints {
   allowedTypes: [String!]!
   """Dimensions ratio width / height."""
   aspectRatio: Float!
+  """
+  Maximum dimensions ratio width / height that this visual may be set to. Equal to minAspectRatio when the shape is fixed.
+  """
+  maxAspectRatio: Float!
   """Maximum height resolution."""
   maxHeight: Float!
   """Maximum width resolution."""
   maxWidth: Float!
+  """
+  Minimum dimensions ratio width / height that this visual may be set to. Equal to maxAspectRatio when the shape is fixed.
+  """
+  minAspectRatio: Float!
   """Minimum height resolution."""
   minHeight: Float!
   """Minimum width resolution."""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 321080 bytes
Snapshot md5: 6f99ebec20c10a0db1409beb126d5c33

This PR was generated by the schema-baseline workflow.