### PR TITLE
fix: temporarily disable Collabora document analytics attribution (hotfix for ~8s open latency)

### DIFF
--- a/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
@@ -574,7 +574,13 @@ describe('CalloutResolverMutations', () => {
   });
 
   describe('importCollaboraDocument', () => {
-    it('should report COLLABORA_DOCUMENT_UPLOADED for the uploading actor', async () => {
+    // TEMP hotfix: COLLABORA_DOCUMENT_UPLOADED analytics attribution is disabled
+    // to remove the ~8s getCommunityForCollaboraDocumentOrFail penalty on the
+    // upload path, so the reporter is no longer called here. Re-enabled by the
+    // proper fix (a cheap leaf-first space lookup) in the
+    // collabora-editor-url-latency follow-up PR referenced in this PR's
+    // description.
+    it.skip('should report COLLABORA_DOCUMENT_UPLOADED for the uploading actor', async () => {
       const callout = {
         id: 'callout-1',
         authorization: { id: 'auth-1' },

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -604,41 +604,46 @@ export class CalloutResolverMutations {
       );
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
 
-    // Lifecycle analytics (US4 / FR-013): record the upload as a single-actor
+    // TEMP hotfix: analytics attribution disabled to remove the ~8s
+    // getCommunityForCollaboraDocumentOrFail penalty on the document-upload
+    // path. The proper fix (a cheap leaf-first space lookup) restores this
+    // reporting; see the collabora-editor-url-latency follow-up PR referenced in
+    // this PR's description.
+    // Lifecycle analytics: record the upload as a single-actor
     // COLLABORA_DOCUMENT_UPLOADED event for the uploading user. Resolve the
     // level-zero space by the freshly-created CollaboraDocument the same way
     // the open path does (via the community resolver), then report.
-    // Best-effort (FR-008): the contribution is already persisted above, so a
+    // Best-effort: the contribution is already persisted above, so a
     // failure here must NOT fail the import — that would prompt a client retry
     // and a duplicate document. Catch and log; never re-throw.
-    if (contribution.collaboraDocument) {
-      try {
-        const collaboraDocument = contribution.collaboraDocument;
-        const community =
-          await this.communityResolverService.getCommunityForCollaboraDocumentOrFail(
-            collaboraDocument.id
-          );
-        const levelZeroSpaceID =
-          await this.communityResolverService.getLevelZeroSpaceIdForCommunity(
-            community.id
-          );
-        this.contributionReporter.calloutCollaboraDocumentUploaded(
-          {
-            id: collaboraDocument.id,
-            name:
-              collaboraDocument.profile?.displayName ?? collaboraDocument.id,
-            space: levelZeroSpaceID,
-          },
-          actorContext
-        );
-      } catch (e: any) {
-        this.logger.error(
-          `Failed to report COLLABORA_DOCUMENT_UPLOADED analytics for contribution ${contribution.id}: ${e?.message}`,
-          e?.stack,
-          LogContext.COLLABORATION
-        );
-      }
-    }
+    // if (contribution.collaboraDocument) {
+    //   try {
+    //     const collaboraDocument = contribution.collaboraDocument;
+    //     const community =
+    //       await this.communityResolverService.getCommunityForCollaboraDocumentOrFail(
+    //         collaboraDocument.id
+    //       );
+    //     const levelZeroSpaceID =
+    //       await this.communityResolverService.getLevelZeroSpaceIdForCommunity(
+    //         community.id
+    //       );
+    //     this.contributionReporter.calloutCollaboraDocumentUploaded(
+    //       {
+    //         id: collaboraDocument.id,
+    //         name:
+    //           collaboraDocument.profile?.displayName ?? collaboraDocument.id,
+    //         space: levelZeroSpaceID,
+    //       },
+    //       actorContext
+    //     );
+    //   } catch (e: any) {
+    //     this.logger.error(
+    //       `Failed to report COLLABORA_DOCUMENT_UPLOADED analytics for contribution ${contribution.id}: ${e?.message}`,
+    //       e?.stack,
+    //       LogContext.COLLABORATION
+    //     );
+    //   }
+    // }
 
     return await this.calloutContributionService.getCalloutContributionOrFail(
       contribution.id

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.mutations.spec.ts
@@ -111,16 +111,22 @@ describe('CollaboraDocumentResolverMutations', () => {
         collaboraDocumentService.updateCollaboraDocument
       ).toHaveBeenCalledWith('collab-doc-1', 'A New Title');
 
-      expect(
-        contributionReporter.calloutCollaboraDocumentReplaced
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'collab-doc-1',
-          name: 'A New Title',
-          space: 'space-root',
-        }),
-        actorContext
-      );
+      // TEMP hotfix: COLLABORA_DOCUMENT_REPLACED analytics attribution is disabled
+      // to remove the ~8s getCommunityForCollaboraDocumentOrFail penalty, so the
+      // reporter is no longer called on the replace path. The auth check, file
+      // swap, and rename above are unaffected. Re-enabled by the proper fix (a
+      // cheap leaf-first space lookup) in the collabora-editor-url-latency
+      // follow-up PR referenced in this PR's description.
+      // expect(
+      //   contributionReporter.calloutCollaboraDocumentReplaced
+      // ).toHaveBeenCalledWith(
+      //   expect.objectContaining({
+      //     id: 'collab-doc-1',
+      //     name: 'A New Title',
+      //     space: 'space-root',
+      //   }),
+      //   actorContext
+      // );
 
       expect(result.id).toBe('collab-doc-1');
     });

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.mutations.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.mutations.ts
@@ -155,37 +155,42 @@ export class CollaboraDocumentResolverMutations {
       }
     }
 
-    // FR-014 lifecycle analytics: record the swap as a single-actor
+    // TEMP hotfix: analytics attribution disabled to remove the ~8s
+    // getCommunityForCollaboraDocumentOrFail penalty on the document-replace
+    // path. The proper fix (a cheap leaf-first space lookup) restores this
+    // reporting; see the collabora-editor-url-latency follow-up PR referenced in
+    // this PR's description.
+    // Lifecycle analytics: record the swap as a single-actor
     // COLLABORA_DOCUMENT_REPLACED event. Resolve the level-zero space via the
     // community resolver exactly as the upload path does. Best-effort: the
     // swap is already committed, so a failure here must NOT fail the mutation
     // (a retry would double-swap). Catch and log; never re-throw.
-    try {
-      const community =
-        await this.communityResolverService.getCommunityForCollaboraDocumentOrFail(
-          updated.id
-        );
-      const levelZeroSpaceID =
-        await this.communityResolverService.getLevelZeroSpaceIdForCommunity(
-          community.id
-        );
-      this.contributionReporter.calloutCollaboraDocumentReplaced(
-        {
-          id: updated.id,
-          name: updated.profile?.displayName ?? updated.id,
-          space: levelZeroSpaceID,
-        },
-        actorContext
-      );
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      const details = e instanceof Error ? e.stack : String(e);
-      this.logger.error(
-        `Failed to report COLLABORA_DOCUMENT_REPLACED analytics for CollaboraDocument ${updated.id}: ${message}`,
-        details,
-        LogContext.COLLABORATION
-      );
-    }
+    // try {
+    //   const community =
+    //     await this.communityResolverService.getCommunityForCollaboraDocumentOrFail(
+    //       updated.id
+    //     );
+    //   const levelZeroSpaceID =
+    //     await this.communityResolverService.getLevelZeroSpaceIdForCommunity(
+    //       community.id
+    //     );
+    //   this.contributionReporter.calloutCollaboraDocumentReplaced(
+    //     {
+    //       id: updated.id,
+    //       name: updated.profile?.displayName ?? updated.id,
+    //       space: levelZeroSpaceID,
+    //     },
+    //     actorContext
+    //   );
+    // } catch (e) {
+    //   const message = e instanceof Error ? e.message : String(e);
+    //   const details = e instanceof Error ? e.stack : String(e);
+    //   this.logger.error(
+    //     `Failed to report COLLABORA_DOCUMENT_REPLACED analytics for CollaboraDocument ${updated.id}: ${message}`,
+    //     details,
+    //     LogContext.COLLABORATION
+    //   );
+    // }
 
     return updated;
   }

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.spec.ts
@@ -42,7 +42,12 @@ describe('CollaboraDocumentResolverQueries', () => {
   });
 
   describe('collaboraEditorUrl', () => {
-    it('should report COLLABORA_DOCUMENT_OPENED for the opening actor and return the editor URL', async () => {
+    // TEMP hotfix: COLLABORA_DOCUMENT_OPENED analytics attribution is disabled to
+    // remove the ~8s getCommunityForCollaboraDocumentOrFail penalty on the open
+    // path, so the reporter is no longer called here. Re-enabled by the proper
+    // fix (a cheap leaf-first space lookup) in the collabora-editor-url-latency
+    // follow-up PR referenced in this PR's description.
+    it.skip('should report COLLABORA_DOCUMENT_OPENED for the opening actor and return the editor URL', async () => {
       const collaboraDocument = {
         id: 'collab-doc-1',
         authorization: { id: 'auth-1' },

--- a/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
+++ b/src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts
@@ -75,36 +75,41 @@ export class CollaboraDocumentResolverQueries {
       lang
     );
 
-    // Lifecycle analytics (US4 / FR-014): one COLLABORA_DOCUMENT_OPENED record
-    // per editor-URL fetch, attributed to the opening actor (like spaceJoined).
-    // Resolve the level-zero space the same way the upload path does.
-    // Best-effort (FR-008): reported AFTER the editor URL is resolved and
-    // wrapped so a community/space resolution or reporting failure can never
-    // block the user from opening the document.
-    try {
-      const community =
-        await this.communityResolverService.getCommunityForCollaboraDocumentOrFail(
-          collaboraDocument.id
-        );
-      const levelZeroSpaceID =
-        await this.communityResolverService.getLevelZeroSpaceIdForCommunity(
-          community.id
-        );
-      this.contributionReporter.collaboraDocumentOpened(
-        {
-          id: collaboraDocument.id,
-          name: collaboraDocument.profile?.displayName ?? collaboraDocument.id,
-          space: levelZeroSpaceID,
-        },
-        actorContext
-      );
-    } catch (e: any) {
-      this.logger.error(
-        `Failed to report COLLABORA_DOCUMENT_OPENED analytics for document ${collaboraDocument.id}: ${e?.message}`,
-        e?.stack,
-        LogContext.COLLABORATION
-      );
-    }
+    // TEMP hotfix: analytics attribution disabled to remove the ~8s
+    // getCommunityForCollaboraDocumentOrFail penalty on the document-open path.
+    // The proper fix (a cheap leaf-first space lookup) restores this reporting;
+    // see the collabora-editor-url-latency follow-up PR referenced in this PR's
+    // description.
+    // Lifecycle analytics: one COLLABORA_DOCUMENT_OPENED record per editor-URL
+    // fetch, attributed to the opening actor (like spaceJoined). Resolve the
+    // level-zero space the same way the upload path does. Best-effort: reported
+    // AFTER the editor URL is resolved and wrapped so a community/space
+    // resolution or reporting failure can never block the user from opening the
+    // document.
+    // try {
+    //   const community =
+    //     await this.communityResolverService.getCommunityForCollaboraDocumentOrFail(
+    //       collaboraDocument.id
+    //     );
+    //   const levelZeroSpaceID =
+    //     await this.communityResolverService.getLevelZeroSpaceIdForCommunity(
+    //       community.id
+    //     );
+    //   this.contributionReporter.collaboraDocumentOpened(
+    //     {
+    //       id: collaboraDocument.id,
+    //       name: collaboraDocument.profile?.displayName ?? collaboraDocument.id,
+    //       space: levelZeroSpaceID,
+    //     },
+    //     actorContext
+    //   );
+    // } catch (e: any) {
+    //   this.logger.error(
+    //     `Failed to report COLLABORA_DOCUMENT_OPENED analytics for document ${collaboraDocument.id}: ${e?.message}`,
+    //     e?.stack,
+    //     LogContext.COLLABORATION
+    //   );
+    // }
 
     return editorUrl;
   }

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.spec.ts
@@ -309,7 +309,13 @@ describe('CollaborativeDocumentIntegrationService', () => {
     });
   });
 
-  describe('officeDocumentContributions', () => {
+  // TEMP hotfix: the background office-document window reporting path is disabled
+  // to remove the ~8s getCommunityForCollaboraDocumentOrFail penalty it paid per
+  // event (reportOfficeDocumentWindow now returns early). The whole reporting
+  // behavior these blocks verify is suppressed until the proper fix restores it
+  // with a cheap leaf-first space lookup — see the collabora-editor-url-latency
+  // follow-up PR referenced in this PR's description.
+  describe.skip('officeDocumentContributions', () => {
     // The event carries the STORAGE Document id (= collaboraDocument.document.id),
     // NOT the CollaboraDocument id. The service reverse-resolves the
     // CollaboraDocument by its document.id, then indexes under CollaboraDocument.id.
@@ -751,7 +757,12 @@ describe('CollaborativeDocumentIntegrationService', () => {
 
   // FR-012: companion VIEW consumer — same reverse-resolution path as the
   // contribution consumer, differing ONLY in the reporter method invoked.
-  describe('officeDocumentViews', () => {
+  // TEMP hotfix: office-document window reporting is disabled to remove the ~8s
+  // getCommunityForCollaboraDocumentOrFail penalty (reportOfficeDocumentWindow
+  // now returns early). Re-enabled by the proper fix (a cheap leaf-first space
+  // lookup) in the collabora-editor-url-latency follow-up PR referenced in this
+  // PR's description.
+  describe.skip('officeDocumentViews', () => {
     const STORAGE_DOCUMENT_ID = 'storage-doc-1';
     const COLLABORA_DOCUMENT_ID = 'collabora-doc-1';
 

--- a/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
+++ b/src/services/collaborative-document-integration/collaborative-document-integration.service.ts
@@ -331,60 +331,71 @@ export class CollaborativeDocumentIntegrationService {
       alkemio: boolean;
     }) => void
   ): Promise<void> {
-    try {
-      // documentId is the storage Document id — reverse-resolve the domain
-      // CollaboraDocument that is backed by it.
-      const collaboraDocument =
-        await this.collaboraDocumentService.getCollaboraDocumentByStorageDocumentId(
-          documentId,
-          { relations: { profile: true } }
-        );
-      if (!collaboraDocument) {
-        this.logger.warn?.(
-          {
-            message: `Discarding Collabora document ${kind} event: no CollaboraDocument for storage document id`,
-            documentId,
-          },
-          LogContext.COLLAB_DOCUMENT_INTEGRATION
-        );
-        return;
-      }
-
-      const community =
-        await this.communityResolver.getCommunityForCollaboraDocumentOrFail(
-          collaboraDocument.id
-        );
-      const levelZeroSpaceID =
-        await this.communityResolver.getLevelZeroSpaceIdForCommunity(
-          community.id
-        );
-      const displayName = collaboraDocument.profile?.displayName ?? '';
-
-      // Resolve actor types ONCE for the union of both sets (tolerant batch
-      // lookup — unresolvable ids are simply absent and fall to `unknown`),
-      // then partition each set by type. The set of ids is unchanged (SC-006);
-      // only their shape changes (flat array → type-keyed object).
-      const allIds = [...new Set([...writeActors, ...readonlyActors])];
-      const typeById = await this.actorLookupService.getActorTypesByIds(allIds);
-
-      report({
-        id: collaboraDocument.id,
-        name: displayName,
-        space: levelZeroSpaceID,
-        writeActors: this.groupActorsByType(writeActors, typeById),
-        readonlyActors: this.groupActorsByType(readonlyActors, typeById),
-        alkemio: await this.isAlkemioTeamWindow(allIds, typeById),
-      });
-    } catch (e: any) {
-      this.logger.warn?.(
-        {
-          message: `Discarding unresolvable Collabora document ${kind} event`,
-          documentId,
-          error: e?.message,
-        },
-        LogContext.COLLAB_DOCUMENT_INTEGRATION
-      );
-    }
+    // TEMP hotfix: analytics attribution disabled to remove the ~8s
+    // getCommunityForCollaboraDocumentOrFail penalty. This is the BACKGROUND
+    // RabbitMQ consumer path — no user waits on it, but it paid the same
+    // expensive getCommunityForCollaboraDocumentOrFail query per
+    // contribution/view event. Whole best-effort report body suppressed (the
+    // `report`/`kind`/`documentId`/actor params are now unreferenced while this
+    // is off; restored by the proper fix — a cheap leaf-first space lookup — in
+    // the collabora-editor-url-latency follow-up PR referenced in this PR's
+    // description). Return early so the consumer still ACKs the event without
+    // firing the query.
+    return;
+    // try {
+    //   // documentId is the storage Document id — reverse-resolve the domain
+    //   // CollaboraDocument that is backed by it.
+    //   const collaboraDocument =
+    //     await this.collaboraDocumentService.getCollaboraDocumentByStorageDocumentId(
+    //       documentId,
+    //       { relations: { profile: true } }
+    //     );
+    //   if (!collaboraDocument) {
+    //     this.logger.warn?.(
+    //       {
+    //         message: `Discarding Collabora document ${kind} event: no CollaboraDocument for storage document id`,
+    //         documentId,
+    //       },
+    //       LogContext.COLLAB_DOCUMENT_INTEGRATION
+    //     );
+    //     return;
+    //   }
+    //
+    //   const community =
+    //     await this.communityResolver.getCommunityForCollaboraDocumentOrFail(
+    //       collaboraDocument.id
+    //     );
+    //   const levelZeroSpaceID =
+    //     await this.communityResolver.getLevelZeroSpaceIdForCommunity(
+    //       community.id
+    //     );
+    //   const displayName = collaboraDocument.profile?.displayName ?? '';
+    //
+    //   // Resolve actor types ONCE for the union of both sets (tolerant batch
+    //   // lookup — unresolvable ids are simply absent and fall to `unknown`),
+    //   // then partition each set by type. The set of ids is unchanged;
+    //   // only their shape changes (flat array → type-keyed object).
+    //   const allIds = [...new Set([...writeActors, ...readonlyActors])];
+    //   const typeById = await this.actorLookupService.getActorTypesByIds(allIds);
+    //
+    //   report({
+    //     id: collaboraDocument.id,
+    //     name: displayName,
+    //     space: levelZeroSpaceID,
+    //     writeActors: this.groupActorsByType(writeActors, typeById),
+    //     readonlyActors: this.groupActorsByType(readonlyActors, typeById),
+    //     alkemio: await this.isAlkemioTeamWindow(allIds, typeById),
+    //   });
+    // } catch (e: any) {
+    //   this.logger.warn?.(
+    //     {
+    //       message: `Discarding unresolvable Collabora document ${kind} event`,
+    //       documentId,
+    //       error: e?.message,
+    //     },
+    //     LogContext.COLLAB_DOCUMENT_INTEGRATION
+    //   );
+    // }
   }
 
   /**


### PR DESCRIPTION
## Temporary hotfix

Opening or attributing a Collabora document made the user wait ~8s. Root cause: a best-effort lifecycle-analytics step `await`s `communityResolverService.getCommunityForCollaboraDocumentOrFail(...)` **inline before the response returns**. That method is a TypeORM `findOne(Space)` OR-ing two five-level relation paths — it took **7,917 ms** in a measured production trace. The reporter call itself is cheap; the expensive part is resolving the space to attribute the record to.

This PR **comments out** (does not delete) the four best-effort analytics `try/catch` blocks that call `getCommunityForCollaboraDocumentOrFail`, removing the ~8s penalty. `getCommunityForCollaboraDocumentOrFail` itself is left untouched.

### Sites disabled
1. `src/domain/collaboration/collabora-document/collabora.document.resolver.queries.ts` — `collaboraEditorUrl` query, `COLLABORA_DOCUMENT_OPENED`. **This is the primary user-facing ~8s penalty.** Still returns `editorUrl`.
2. `src/domain/collaboration/collabora-document/collabora.document.resolver.mutations.ts` — `replaceCollaboraDocument`, `COLLABORA_DOCUMENT_REPLACED`. Still returns the swapped document.
3. `src/domain/collaboration/callout/callout.resolver.mutations.ts` — `importCollaboraDocument`, `COLLABORA_DOCUMENT_UPLOADED` (the whole `if (contribution.collaboraDocument) { ... }` block). Still returns via `getCalloutContributionOrFail`.
4. `src/services/collaborative-document-integration/collaborative-document-integration.service.ts` — `reportOfficeDocumentWindow`, the **background RabbitMQ consumer** path (contribution + view events). **No user waits on this one**, but it paid the same expensive query per contribution/view event, so it's disabled here too (the method now returns early so the consumer still ACKs the event without firing the query).

### Effect
Analytics records for `COLLABORA_DOCUMENT_OPENED` / `COLLABORA_DOCUMENT_REPLACED` / `COLLABORA_DOCUMENT_UPLOADED` (and the background office-document contribution/view window records) are **temporarily suppressed**. All user-facing behavior — auth checks, editor-URL return, file swap, rename, contribution return values — is unchanged.

### Follow-up (restores analytics)
The proper fix restores/replaces this logic with a cheap leaf-first space lookup on branch `fix/110-collabora-editor-url-latency` (spec draft PR #6350, feature `110-collabora-editor-url-latency`). The blocks are commented rather than deleted so that follow-up can restore them in place.

### Tests
Existing unit assertions that the reporter is called on these paths would now fail, so the analytics-specific assertions have been skipped/narrowed (each with a comment pointing to the follow-up). Unrelated assertions were not weakened:
- `collabora.document.resolver.queries.spec.ts` — `it.skip` on the "report COLLABORA_DOCUMENT_OPENED … and return the editor URL" test (its purpose is the reporter assertion; return-URL behavior is covered by other tests in the file).
- `collabora.document.resolver.mutations.spec.ts` — commented out only the `calloutCollaboraDocumentReplaced` assertion inside the replace happy-path test; the auth / file-swap / rename / return assertions still run.
- `callout.resolver.mutations.spec.ts` — `it.skip` on the "report COLLABORA_DOCUMENT_UPLOADED" test.
- `collaborative-document-integration.service.spec.ts` — `describe.skip` on `officeDocumentContributions` and `officeDocumentViews` (they verify the now-suppressed window reporting).

Gates: `pnpm lint` (tsc native + biome) clean; `pnpm build` clean; `pnpm test` — 7759 passed, 30 skipped, 0 failed.

### Comments convention
This diff touches comments. Per the workspace convention (`docs/conventions/code-comments.md`), the added comments carry **no** spec/feature/issue/PR numeric references — the follow-up is described in prose and cross-referenced here in the PR instead.

No schema change, no migration, no new dependency.