### PR TITLE
Story/10132 increase limit of organization admins to 6

### DIFF
--- a/src/domain/community/organization/definitions/organization.role.definitions.spec.ts
+++ b/src/domain/community/organization/definitions/organization.role.definitions.spec.ts
@@ -1,0 +1,23 @@
+import { RoleName } from '@common/enums/role.name';
+import { organizationRoleDefinitions } from './organization.role.definitions';
+
+describe('organizationRoleDefinitions', () => {
+  const getRole = (name: RoleName) => {
+    const role = organizationRoleDefinitions.find(r => r.name === name);
+    if (!role) {
+      throw new Error(`Role definition not found: ${name}`);
+    }
+    return role;
+  };
+
+  // Regression for alkem-io/client-web#10132 (AC1): the organization admin
+  // limit was raised from 3 to 6. The cap is enforced in RoleSetService via
+  // userPolicyData.maximum for the ADMIN role.
+  it('allows up to 6 organization admins', () => {
+    expect(getRole(RoleName.ADMIN).userPolicyData.maximum).toBe(6);
+  });
+
+  it('keeps the organization owner limit at 3 (unchanged by #10132)', () => {
+    expect(getRole(RoleName.OWNER).userPolicyData.maximum).toBe(3);
+  });
+});

--- a/src/domain/community/organization/definitions/organization.role.definitions.ts
+++ b/src/domain/community/organization/definitions/organization.role.definitions.ts
@@ -36,7 +36,9 @@ export const organizationRoleDefinitions: CreateRoleInput[] = [
     parentCredentialsData: [],
     userPolicyData: {
       minimum: 0,
-      maximum: 3,
+      // AC1 of alkem-io/client-web#10132: raise the organization admin cap
+      // from 3 to 6. Enforced in RoleSetService via userPolicyData.maximum.
+      maximum: 6,
     },
     organizationPolicyData: {
       minimum: 0,

--- a/src/migrations/1785700000000-RaiseOrganizationAdminLimit.ts
+++ b/src/migrations/1785700000000-RaiseOrganizationAdminLimit.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RaiseOrganizationAdminLimit1785700000000
+  implements MigrationInterface
+{
+  // AC1 of alkem-io/client-web#10132: raise the organization admin cap from
+  // 3 to 6. The cap is enforced in RoleSetService from each role row's
+  // persisted `userPolicy.maximum`, not from the code constant — the constant
+  // change only affects newly created organizations. This backfill lifts the
+  // limit for organizations that already exist. Server-only; the OWNER role is
+  // deliberately left untouched.
+  //
+  // Idempotent and tightly scoped: the credential type predicate keeps this to
+  // organization ADMIN roles, so space/platform roles that also carry
+  // name = 'admin' are never touched, and the maximum = '3' guard means a
+  // re-run (or rows already lifted, e.g. newly created orgs) is a no-op.
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "role"
+      SET "userPolicy" = jsonb_set("userPolicy", '{maximum}', '6')
+      WHERE name = 'admin'
+        AND "credential"->>'type' = 'organization-admin'
+        AND "userPolicy"->>'maximum' = '3'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "role"
+      SET "userPolicy" = jsonb_set("userPolicy", '{maximum}', '3')
+      WHERE name = 'admin'
+        AND "credential"->>'type' = 'organization-admin'
+        AND "userPolicy"->>'maximum' = '6'
+    `);
+  }
+}

--- a/src/migrations/1785700000000-RaiseOrganizationAdminLimit.ts
+++ b/src/migrations/1785700000000-RaiseOrganizationAdminLimit.ts
@@ -25,6 +25,16 @@ export class RaiseOrganizationAdminLimit1785700000000
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // Rollback note: this reverts EVERY organization ADMIN role still at
+    // maximum = 6 back to 3 — not only the rows `up` touched. That is the
+    // intended semantics: a rollback withdraws the raised-limit feature, so all
+    // organizations return to the previous cap of 3 (organizations created
+    // after deploy with the new default of 6 are included by design, and are
+    // reverted alongside the code constant). It is non-destructive —
+    // userPolicy.maximum only gates NEW admin assignments and never removes
+    // admins already granted, so no membership is lost. Reverting to the prior
+    // uniform value is therefore both correct and idempotent, so no
+    // migration-owned row-state tracking is needed.
     await queryRunner.query(`
       UPDATE "role"
       SET "userPolicy" = jsonb_set("userPolicy", '{maximum}', '3')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum number of organization administrators from 3 to 6.
  * Organization owners remain limited to 3 users.

* **Tests**
  * Added coverage to verify administrator and owner role limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->