### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -2360,7 +2360,7 @@ input CreateConversationInput {
   """
   displayName: String
   """
-  IDs of members to add. For DIRECT: exactly 1 ID. For GROUP: 1+ IDs. Creator is auto-included.
+  IDs of members to add. For DIRECT: exactly 1 ID. For GROUP: 1+ IDs, up to 100. Creator is auto-included.
   """
   memberIDs: [UUID!]!
   """
@@ -4948,7 +4948,7 @@ type Mutation {
   """
   joinRoleSet(joinData: JoinAsEntryRoleOnRoleSetInput!): RoleSet!
   """
-  Leave a group conversation. Returns true when the RPC is sent. Actual membership change arrives via MEMBER_REMOVED subscription event. If the last member leaves, the conversation is auto-deleted and a CONVERSATION_DELETED event follows.
+  Leave a group conversation. Awaits the Matrix kick rather than reporting success merely because the RPC was sent: true means the kick was accepted, and the membership is then removed asynchronously — observe MEMBER_REMOVED for completion. If Matrix rejects the kick this still returns true, because Alkemio is authoritative for its own membership and applies the removal locally instead; on that path the Matrix-side room membership may diverge until an operator reconciles it. If the last member leaves, the conversation is auto-deleted and a CONVERSATION_DELETED event follows.
   """
   leaveConversation(leaveData: LeaveConversationInput!): Boolean!
   """Reset the License with Entitlements on the specified Account."""
@@ -4986,7 +4986,7 @@ type Mutation {
   """Empties the CommunityGuidelines."""
   removeCommunityGuidelinesContent(communityGuidelinesData: RemoveCommunityGuidelinesContentInput!): CommunityGuidelines!
   """
-  Remove a member from a group conversation. Returns true when the RPC is sent. Actual membership change arrives via MEMBER_REMOVED subscription event.
+  Remove a member from a group conversation. Awaits the Matrix kick rather than reporting success merely because the RPC was sent: true means the kick was accepted, and the membership is then removed asynchronously — observe MEMBER_REMOVED for completion. If Matrix rejects the kick (e.g. insufficient permissions) this still returns true, because Alkemio is authoritative for its own membership and applies the removal locally instead; on that path the Matrix-side room membership may diverge until an operator reconciles it.
   """
   removeConversationMember(memberData: RemoveConversationMemberInput!): Boolean!
   """Remove the default callout template from an InnovationFlowState."""
@@ -5211,7 +5211,9 @@ type Mutation {
   updateVirtualContributorPlatformSettings(settingsData: UpdateVirtualContributorPlatformSettingsInput!): VirtualContributor!
   """Updates one of the Setting on an Virtual Contributor"""
   updateVirtualContributorSettings(settingsData: UpdateVirtualContributorSettingsInput!): VirtualContributor!
-  """Updates the image URI for the specified Visual."""
+  """
+  Updates the image URI, alternative text and/or display aspect ratio for the specified Visual.
+  """
   updateVisual(updateData: UpdateVisualInput!): Visual!
   """Updates the specified Whiteboard."""
   updateWhiteboard(whiteboardData: UpdateWhiteboardEntityInput!): Whiteboard!
@@ -5293,6 +5295,8 @@ enum NotificationEvent {
   SPACE_COMMUNITY_INVITATION_USER_PLATFORM
   SPACE_LEAD_COMMUNICATION_MESSAGE
   USER_COMMENT_REPLY
+  USER_CONVERSATION_MESSAGE_DIRECT
+  USER_CONVERSATION_MESSAGE_GROUP
   USER_EMAIL_CHANGE_GLOBAL_ADMIN_NOTIFICATION
   USER_EMAIL_CHANGE_NEW_ADDRESS_NOTIFICATION
   USER_EMAIL_CHANGE_SECURITY_SIGNAL
@@ -5380,6 +5384,10 @@ input NotificationRecipientsInput {
   The ID of the specific user recipient for user-related notifications (e.g., invitations, mentions).
   """
   userID: UUID
+  """
+  Plural recipient user IDs (e.g. conversation-message events) — resolved via a single OR-combined credentials query. Bounded to at most 100 entries; larger conversations must be fanned out by the caller in bounded batches.
+  """
+  userIDs: [UUID!]
   """The ID of the Virtual Contributor to use to determine recipients."""
   virtualContributorID: UUID
 }
@@ -6508,6 +6516,10 @@ type RelayPaginatedSpace implements ActorFull {
   account: Account!
   """The "highest" subscription active for this Space."""
   activeSubscription: SpaceSubscription
+  """
+  Count of visible activity events on this Space over the last 7 days, across all actors (excludes whiteboard-content-modified). Used to rank Spaces on the dashboard.
+  """
+  activityScore: Int!
   """The Actor representing this Space."""
   actor: Actor!
   """The authorization rules for the Actor"""
@@ -7372,6 +7384,10 @@ type Space implements ActorFull {
   account: Account!
   """The "highest" subscription active for this Space."""
   activeSubscription: SpaceSubscription
+  """
+  Count of visible activity events on this Space over the last 7 days, across all actors (excludes whiteboard-content-modified). Used to rank Spaces on the dashboard.
+  """
+  activityScore: Int!
   """The Actor representing this Space."""
   actor: Actor!
   """The authorization rules for the Actor"""
@@ -8831,11 +8847,20 @@ input UpdateUserSettingsCommunicationInput {
   allowOtherUsersToSendMessages: Boolean
 }
 
+input UpdateUserSettingsDashboardInput {
+  """
+  Whether the activity-feed view is shown on the home dashboard (true) or the non-activity Spaces view (false).
+  """
+  activityView: Boolean
+}
+
 input UpdateUserSettingsEntityInput {
   """Settings related to the AI assistant authority for this User."""
   assistant: UpdateUserSettingsAssistantInput
   """Settings related to this users Communication preferences."""
   communication: UpdateUserSettingsCommunicationInput
+  """Settings related to the home dashboard view."""
+  dashboard: UpdateUserSettingsDashboardInput
   """
   Update the user's design version. Any integer accepted (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).
   """
@@ -8904,7 +8929,7 @@ input UpdateUserSettingsNotificationPlatformAdminInput {
   """
   userEmailChanged: NotificationSettingInput
   """
-  [Admin] Receive a notification user is assigned or removed from a global role
+  [Admin] Receive a notification when a user is assigned to or removed from a global role
   """
   userGlobalRoleChanged: NotificationSettingInput
   """[Admin] Receive notification when a new user signs up"""
@@ -8980,6 +9005,14 @@ input UpdateUserSettingsNotificationSpaceInput {
 input UpdateUserSettingsNotificationUserInput {
   """Receive a notification when someone replies to a comment I made."""
   commentReply: NotificationSettingInput
+  """
+  Receive a notification when someone sends me a direct (1:1) chat message. Note: the inApp channel is permanently OFF regardless of the stored value.
+  """
+  conversationMessageDirect: NotificationSettingInput
+  """
+  Receive a notification when someone posts in a group chat I am a member of. Note: the inApp channel is permanently OFF regardless of the stored value.
+  """
+  conversationMessageGroup: NotificationSettingInput
   """Settings related to User Membership Notifications."""
   membership: UpdateUserSettingsNotificationUserMembershipInput
   """Receive a notification you are mentioned"""
@@ -9066,6 +9099,10 @@ input UpdateVirtualContributorSettingsPrivacyInput {
 
 input UpdateVisualInput {
   alternativeText: String
+  """
+  The width / height ratio to display this visual at. Must fall within the visual type’s minAspectRatio - maxAspectRatio range; types with a fixed shape accept only their single allowed value.
+  """
+  aspectRatio: Float
   uri: String!
   visualID: String!
 }
@@ -9413,6 +9450,8 @@ type UserSettings {
   communication: UserSettingsCommunication!
   """The date at which the entity was created."""
   createdDate: DateTime!
+  """The home-dashboard view settings for this User."""
+  dashboard: UserSettingsDashboard!
   """
   The design version this User has selected (1 = legacy design generation, deprecated and scheduled for removal; 2 = current default design generation; 3+ reserved for future generations).
   """
@@ -9451,6 +9490,13 @@ type UserSettingsCommunication {
   allowOtherUsersToContactViaEmail: Boolean!
   """Allow Users to send messages to this User."""
   allowOtherUsersToSendMessages: Boolean!
+}
+
+type UserSettingsDashboard {
+  """
+  Whether the activity-feed view is shown on the home dashboard (true) or the non-activity Spaces view (false). Default true preserves the historical behaviour.
+  """
+  activityView: Boolean!
 }
 
 type UserSettingsHomeSpace {
@@ -9579,6 +9625,14 @@ type UserSettingsNotificationSpaceAdmin {
 type UserSettingsNotificationUser {
   """Receive a notification when someone replies to a comment I made."""
   commentReply: UserSettingsNotificationChannels!
+  """
+  Receive a notification when someone sends me a direct (1:1) chat message. The inApp channel is permanently OFF (enforced platform-wide) — the stored value is retained for row-shape symmetry only.
+  """
+  conversationMessageDirect: UserSettingsNotificationChannels!
+  """
+  Receive a notification when someone posts in a group chat I am a member of. The inApp channel is permanently OFF (enforced platform-wide) — the stored value is retained for row-shape symmetry only.
+  """
+  conversationMessageGroup: UserSettingsNotificationChannels!
   """The notifications settings for membership events for this User"""
   membership: UserSettingsNotificationUserMembership!
   """Receive a notification you are mentioned"""
@@ -9843,10 +9897,18 @@ type VisualConstraints {
   allowedTypes: [String!]!
   """Dimensions ratio width / height."""
   aspectRatio: Float!
+  """
+  Maximum dimensions ratio width / height that this visual may be set to. Equal to minAspectRatio when the shape is fixed.
+  """
+  maxAspectRatio: Float!
   """Maximum height resolution."""
   maxHeight: Float!
   """Maximum width resolution."""
   maxWidth: Float!
+  """
+  Minimum dimensions ratio width / height that this visual may be set to. Equal to maxAspectRatio when the shape is fixed.
+  """
+  minAspectRatio: Float!
   """Minimum height resolution."""
   minHeight: Float!
   """Minimum width resolution."""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 323135 bytes
Snapshot md5: 64bdd94c0a5e5a568bd09583df4cac60

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for direct and group conversation message notification settings.
  * Added dashboard activity-view settings for user preferences.
  * Added activity scores for Spaces.
  * Added visual aspect-ratio settings and constraints.
  * Added support for specifying multiple notification recipients.
* **Improvements**
  * Clarified the 100-member limit for group conversations.
  * Improved documentation for leaving or removing conversation members, including asynchronous handling and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->