### PR TITLE
feat(038): MCP API key lifecycle — mint/revoke, admin surface, audit; closes key-chaining escalation

### DIFF
--- a/.build/traefik/http.yml
+++ b/.build/traefik/http.yml
@@ -215,6 +215,21 @@ http:
           X-Alkemio-Actor-Name: ""
           X-Alkemio-Session-Id: ""
 
+    # workspace#038 / #1912: local parity with the production `mcp-api`
+    # IngressRoute's `mcp-strip-delegation-headers`. External MCP callers must
+    # never be able to attempt the internal-only delegated flow, so every
+    # X-Alkemio-* identity header is zeroed at the edge — including
+    # X-Alkemio-On-Behalf-Of, which the shared strip-client-alkemio-headers
+    # middleware does NOT cover. Without this, local would be MORE permissive
+    # than production on exactly the header that carries delegation.
+    mcp-strip-delegation-headers:
+      headers:
+        customRequestHeaders:
+          X-Alkemio-On-Behalf-Of: ""
+          X-Alkemio-Actor-Id: ""
+          X-Alkemio-Actor-Name: ""
+          X-Alkemio-Session-Id: ""
+
     # Universal traefik forwardAuth decision endpoint. alkemio-server's
     # AuthenticationService resolves the alkemio_session cookie (or the
     # `?guestName=` query param for guest paths) to a canonical ActorContext
@@ -251,6 +266,29 @@ http:
       entryPoints:
         - 'web'
       priority: 130
+
+    # workspace#038 / #1912 — MCP host at the edge, mirroring the production
+    # `mcp-api` IngressRoute so the connection recipe the product shows
+    # (`<platform-address>/rest/mcp`) works locally exactly as it does on
+    # acceptance and production. Without this route Traefik 404s /rest/mcp and
+    # the SPA catch-all swallows it, so a local client has to be pointed at the
+    # server's own port — a difference between environments that the docs and
+    # the in-product recipe do not mention.
+    #
+    # NO prefix strip: the server owns `/rest/mcp` (`@Controller('/rest/mcp')`),
+    # so the path is forwarded verbatim, same as production.
+    #
+    # Auth is the McpAuthGuard chain in-app (Bearer mcp_… key, Hydra bearer, or
+    # session cookie; anonymous → public data only). The edge only zeroes the
+    # delegation headers.
+    mcp-api:
+      rule: 'PathPrefix(`/rest/mcp`)'
+      service: 'alkemio-server'
+      middlewares:
+        - mcp-strip-delegation-headers
+      entryPoints:
+        - 'web'
+      priority: 150
 
     api-auth-oidc:
       rule: 'PathPrefix(`/api/auth`)'

--- a/.forge/stack.json
+++ b/.forge/stack.json
@@ -1,0 +1,75 @@
+{
+  "feature_id": "038-mcp-api-key-management",
+  "compose": {
+    "project": "forge-038-mcp-api-key-management",
+    "dir": "worktrees/038-mcp-api-key-management/server",
+    "file": "quickstart-services.yml",
+    "env_file": ".env.docker",
+    "up_cmd": "docker compose -p forge-038-mcp-api-key-management -f quickstart-services.yml --env-file .env.docker up --build --force-recreate -d",
+    "down_cmd": "docker compose -p forge-038-mcp-api-key-management -f quickstart-services.yml --env-file .env.docker down -v"
+  },
+  "isolation": {
+    "ports": "standard",
+    "offset": 0,
+    "seed": "bootstrap"
+  },
+  "dsn_sanity_check": {
+    "performed": true,
+    "method": "psql localhost:5432 -> inet_server_addr() = 172.19.0.9; docker inspect alkemio_dev_postgres IPAddress = 172.19.0.9; container compose.project label = forge-038-mcp-api-key-management",
+    "result": "pass"
+  },
+  "volumes_created": [
+    "forge-038-mcp-api-key-management_alkemio_dev_backup",
+    "forge-038-mcp-api-key-management_alkemio_dev_postgres",
+    "forge-038-mcp-api-key-management_alkemio_dev_redis",
+    "forge-038-mcp-api-key-management_alkemio_dev_storage",
+    "forge-038-mcp-api-key-management_alkemio_dev_synapse"
+  ],
+  "migrations": {
+    "repo": "server",
+    "command": "DATABASE_HOST=localhost DATABASE_PORT=5432 DATABASE_USERNAME=synapse DATABASE_PASSWORD=synapse DATABASE_NAME=alkemio pnpm run migration:run",
+    "ran_from": "worktrees/038-mcp-api-key-management/server",
+    "status": "success",
+    "notable_migration": "AddMcpApiKeyAuditCategory1786500000000"
+  },
+  "services": [
+    {
+      "repo": "server",
+      "worktree": "worktrees/038-mcp-api-key-management/server",
+      "start_cmd": "pnpm start:dev",
+      "env_file": "worktrees/038-mcp-api-key-management/server/.env",
+      "env_overrides": {
+        "MCP_ENABLED": "true",
+        "MCP_API_KEY_ENABLED": "true"
+      },
+      "pid": 274499,
+      "log": "worktrees/038-mcp-api-key-management/server/.forge/logs/server.log",
+      "health_url": "http://localhost:4000/health/ready",
+      "health_url_via_traefik": "http://localhost:3000 (traefik proxies /rest,/graphql etc to host.docker.internal:4000)",
+      "port": 4000,
+      "state": "healthy"
+    },
+    {
+      "repo": "client-web",
+      "worktree": "worktrees/038-mcp-api-key-management/client-web",
+      "start_cmd": "pnpm start",
+      "env_file": "worktrees/038-mcp-api-key-management/client-web/.env",
+      "pid": 296158,
+      "log": "worktrees/038-mcp-api-key-management/server/.forge/logs/client-web.log",
+      "health_url": "http://localhost:3001",
+      "health_url_via_traefik": "http://localhost:3000",
+      "port": 3001,
+      "state": "healthy"
+    }
+  ],
+  "ports": {
+    "3000": "traefik (dependency edge router; entrypoint 'web' -> server:4000, client-web:3001)",
+    "5432": "postgres (via traefik postgres entrypoint)",
+    "5672": "rabbitmq",
+    "4433": "kratos public (in-network only, not published to host in this compose file)",
+    "4455": "not published to host in this compose file; not a conflict source",
+    "4000": "server (nest, worktree source, direct)",
+    "3001": "client-web (vite, worktree source, direct)"
+  },
+  "booted_at": "2026-08-12T12:56:23Z"
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -500,6 +500,21 @@ enum LicensingCredentialBasedPlanType {
   SPACE_PLAN
 }
 
+"""Operations an MCP API key may perform."""
+enum McpApiKeyOperation {
+  READ
+  TOOLS
+}
+
+"""
+Lifecycle status of an MCP API key. REVOKED takes precedence over EXPIRED.
+"""
+enum McpApiKeyStatus {
+  ACTIVE
+  EXPIRED
+  REVOKED
+}
+
 enum MimeType {
   AVIF
   BMP
@@ -1874,9 +1889,6 @@ type CalloutContributionsCountOutput {
   whiteboard: Float!
 }
 
-"""
-Admin-fixed initial map view for a Contributors-collection callout's map. Absent/null ⇒ automatic framing (fit to plotted contributors; Europe fallback).
-"""
 type CalloutContributorsMapView {
   """Map center latitude. Finite, within [-90, 90]."""
   latitude: Float!
@@ -2467,7 +2479,9 @@ type CreateCalloutContributionDefaultsData {
 }
 
 type CreateCalloutContributorsMapViewData {
-  """Map center latitude. Finite, within [-90, 90]."""
+  """
+  Map center latitude. Finite, within [-90, 90]. MapLibre throws on values outside this range.
+  """
   latitude: Float!
   """Map center longitude. Finite, within [-180, 180]."""
   longitude: Float!
@@ -3764,6 +3778,37 @@ type LookupQueryResults {
   whiteboard(ID: UUID!): Whiteboard
 }
 
+"""
+Metadata for one MCP API key. The key value itself is never exposed here.
+"""
+type McpApiKey {
+  createdDate: DateTime!
+  """Optional expiry chosen at mint."""
+  expiresAt: DateTime
+  id: UUID!
+  """When this key last authenticated a request."""
+  lastUsedAt: DateTime
+  """Source address of the last request this key authenticated."""
+  lastUsedFromIp: String
+  """User-supplied label. Not unique."""
+  name: String!
+  """Granted operations, flattened from the stored scope."""
+  operations: [McpApiKeyOperation!]!
+  status: McpApiKeyStatus!
+}
+
+"""
+Result of minting a key. The only place the plaintext is ever returned.
+"""
+type McpApiKeyMintResult {
+  """
+  The plaintext key. Returned EXACTLY ONCE — it is not stored and cannot be re-derived.
+  """
+  apiKey: String!
+  """Metadata for the key just created."""
+  key: McpApiKey!
+}
+
 type MeConversationsResult {
   """
   All conversations (direct and group) for the current authenticated user. Client handles categorization by room type and member actor types.
@@ -3834,6 +3879,10 @@ type MeQueryResults {
   conversations: MeConversationsResult!
   """The query id"""
   id: String!
+  """
+  The current user's MCP API keys, newest first. Includes revoked and expired keys so last-used evidence survives revocation.
+  """
+  mcpApiKeys: [McpApiKey!]!
   """The Spaces I am contributing to"""
   mySpaces(
     """
@@ -4005,6 +4054,8 @@ type Mutation {
   adminLicensePolicyDeleteCredentialRule(deleteData: DeleteLicensePolicyCredentialRuleInput!): LicensingCredentialBasedPolicyCredentialRule!
   """Updates a CredentialRule on the LicensePolicy."""
   adminLicensePolicyUpdateCredentialRule(updateData: UpdateLicensePolicyCredentialRuleInput!): LicensingCredentialBasedPolicyCredentialRule!
+  """Platform admin: revoke a named user's MCP API key. Idempotent."""
+  adminRevokeMcpApiKey(revokeData: AdminRevokeMcpApiKeyInput!): McpApiKey!
   """
   Ingests new data into Elasticsearch from scratch. This will delete all existing data and ingest new data from the source. This is an admin only operation.
   """
@@ -4247,6 +4298,10 @@ type Mutation {
   Mark notifications as unread. If no filter is provided, marks all user notifications as unread. If filter with types is provided, marks only those notification types as unread.
   """
   markNotificationsAsUnread(filter: NotificationEventsFilterInput): Boolean!
+  """
+  Mint a new MCP API key for the current user. Returns the plaintext exactly once.
+  """
+  mintMcpApiKey(mintData: MintMcpApiKeyInput!): McpApiKeyMintResult!
   """Moves the specified Contribution to another Callout."""
   moveContributionToCallout(moveContributionData: MoveCalloutContributionInput!): CalloutContribution!
   """
@@ -4327,6 +4382,8 @@ type Mutation {
   revokeLicensePlanFromAccount(planData: RevokeLicensePlanFromAccount!): Account!
   """Revokes the specified LicensePlan on a Space."""
   revokeLicensePlanFromSpace(planData: RevokeLicensePlanFromSpace!): Space!
+  """Revoke one of the current user's own MCP API keys. Idempotent."""
+  revokeMcpApiKey(revokeData: RevokeMcpApiKeyInput!): McpApiKey!
   """
   Send a private (1:1) chat message to each of the given Users individually. Does NOT create a group conversation. Each recipient is processed independently and reported on; partial success is possible.
   """
@@ -4790,6 +4847,10 @@ type PlatformAdminQueryResults {
   The most recent email-change audit entry for the named subject user. Returns null if no audit entry exists.
   """
   latestUserEmailChangeAuditEntry(userID: UUID!): UserEmailChangeAuditEntry
+  """
+  MCP API keys belonging to the named user. Platform admins only. Keys bound to a system actor are never returned.
+  """
+  mcpApiKeys(userID: UUID!): [McpApiKey!]!
   """
   Retrieve all Organizations on the Platform. This is only available to Platform Admins.
   """
@@ -7375,6 +7436,14 @@ input AddVisualToMediaGalleryInput {
   visualType: VisualType!
 }
 
+input AdminRevokeMcpApiKeyInput {
+  keyID: UUID!
+  """
+  Owner of the key. Required — it scopes the revoke and the audit subject.
+  """
+  userID: UUID!
+}
+
 input AdminUserEmailChangeDriftResolveInput {
   """
   The admin-chosen canonical email. MUST equal either the old or new email recorded on the drift_detected audit entry. Both sides are force-aligned to this value.
@@ -7595,7 +7664,9 @@ input CreateCalloutContributionInput {
 }
 
 input CreateCalloutContributorsMapViewInput {
-  """Map center latitude. Finite, within [-90, 90]."""
+  """
+  Map center latitude. Finite, within [-90, 90]. MapLibre throws on values outside this range.
+  """
   latitude: Float!
   """Map center longitude. Finite, within [-180, 180]."""
   longitude: Float!
@@ -8485,6 +8556,17 @@ input LicensingGrantedEntitlementInput {
   type: LicenseEntitlementType!
 }
 
+input MintMcpApiKeyInput {
+  """Optional expiry. MUST be in the future when supplied."""
+  expiresAt: DateTime
+  """Label for the key. 1..128 characters after trimming."""
+  name: String!
+  """
+  At least one operation. Duplicates are removed; order is not significant.
+  """
+  operations: [McpApiKeyOperation!]!
+}
+
 input MoveCalloutContributionInput {
   """ID of the Callout to move the Contribution to."""
   calloutID: UUID!
@@ -8724,6 +8806,10 @@ input RevokeLicensePlanFromSpace {
   licensingID: UUID
   """The ID of the Space to assign the LicensePlan to."""
   spaceID: UUID!
+}
+
+input RevokeMcpApiKeyInput {
+  keyID: UUID!
 }
 
 input RevokeOrganizationAuthorizationCredentialInput {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -92,6 +92,7 @@ import {
 import { KonfigModule } from '@src/platform/configuration/config/config.module';
 import { MetadataModule } from '@src/platform/metadata/metadata.module';
 import { AdminCommunicationModule } from '@src/platform-admin/domain/communication/admin.communication.module';
+import { AdminMcpApiKeyModule } from '@src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.module';
 import { DomainPlatformSettingsModule } from '@src/platform-admin/domain/organization/domain.platform.settings.module';
 import { AdminUsersModule } from '@src/platform-admin/domain/user/admin.users.module';
 import { AdminUserEmailChangeModule } from '@src/platform-admin/domain/user/email-change/admin.user.email.change.module';
@@ -315,6 +316,7 @@ import { AdminSearchIngestModule } from './platform-admin/services/search/admin.
     AdminContributorsModule,
     AdminUsersModule,
     AdminUserEmailChangeModule,
+    AdminMcpApiKeyModule,
     AdminCommunicationModule,
     AdminSearchIngestModule,
     AdminLicensingModule,

--- a/src/core/bootstrap/bootstrap.module.ts
+++ b/src/core/bootstrap/bootstrap.module.ts
@@ -27,6 +27,7 @@ import { PlatformTemplatesModule } from '@platform/platform-templates/platform.t
 import { AiPersonaModule } from '@services/ai-server/ai-persona';
 import { AiServerModule } from '@services/ai-server/ai-server/ai.server.module';
 import { SearchIngestModule } from '@services/api/search/ingest';
+import { McpApiKeyAuditService } from '@services/mcp-server/auth/mcp-api-key.audit.service';
 import { McpApiKey } from '@services/mcp-server/auth/mcp-api-key.entity';
 import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
 import { AdminAuthorizationModule } from '@src/platform-admin/domain/authorization/admin.authorization.module';
@@ -63,7 +64,7 @@ import { BootstrapService } from './bootstrap.service';
     PlatformWellKnownVirtualContributorsModule,
     RoleSetModule,
   ],
-  providers: [BootstrapService, McpApiKeyService],
+  providers: [BootstrapService, McpApiKeyService, McpApiKeyAuditService],
   exports: [BootstrapService],
 })
 export class BootstrapModule {}

--- a/src/core/validation/handlers/base/base.handler.ts
+++ b/src/core/validation/handlers/base/base.handler.ts
@@ -114,6 +114,11 @@ import { ConvertSpaceL2ToSpaceL1Input } from '@services/api/conversion/dto/conve
 import { MoveSpaceL1ToSpaceL0Input } from '@services/api/conversion/dto/move.dto.space.l1.to.space.l0.input';
 import { MoveSpaceL1ToSpaceL2Input } from '@services/api/conversion/dto/move.dto.space.l1.to.space.l2.input';
 import { RolesUserInput } from '@services/api/roles/dto/roles.dto.input.actor';
+import {
+  AdminRevokeMcpApiKeyInput,
+  MintMcpApiKeyInput,
+  RevokeMcpApiKeyInput,
+} from '@services/mcp-server/dto/mcp.api.key.dto';
 import { ValidationError, validate } from 'class-validator';
 import { AbstractHandler } from './abstract.handler';
 
@@ -221,6 +226,9 @@ export class BaseHandler extends AbstractHandler {
       ConvertSpaceL2ToSpaceL1Input,
       MoveSpaceL1ToSpaceL0Input,
       MoveSpaceL1ToSpaceL2Input,
+      MintMcpApiKeyInput,
+      RevokeMcpApiKeyInput,
+      AdminRevokeMcpApiKeyInput,
     ];
 
     if (types.includes(metatype)) {

--- a/src/domain/community/user-email-change/enums/platform.audit.category.ts
+++ b/src/domain/community/user-email-change/enums/platform.audit.category.ts
@@ -13,4 +13,9 @@ export enum PlatformAuditCategory {
   // execution of a gated platform-operations mutation, regardless of which
   // role authorized it.
   PLATFORM_OPERATIONS = 'platform_operations',
+  // MCP API key lifecycle (workspace#038): one row per mint or revoke of an
+  // MCP API key (self-service or admin). Written by the feature-scoped,
+  // FAIL-CLOSED `McpApiKeyAuditService` — unlike PLATFORM_OPERATIONS, a
+  // failed audit write here rolls back the key mutation itself.
+  MCP_API_KEY = 'mcp_api_key',
 }

--- a/src/domain/community/user-email-change/enums/platform.audit.outcome.ts
+++ b/src/domain/community/user-email-change/enums/platform.audit.outcome.ts
@@ -35,4 +35,7 @@ export enum PlatformAuditOutcome {
   // execution of an operational/maintenance mutation.
   OPERATION_SUCCEEDED = 'operation_succeeded',
   OPERATION_FAILED = 'operation_failed',
+  // MCP API key lifecycle (workspace#038).
+  KEY_MINTED = 'key_minted',
+  KEY_REVOKED = 'key_revoked',
 }

--- a/src/domain/community/user-email-change/platform.audit.entry.interface.ts
+++ b/src/domain/community/user-email-change/platform.audit.entry.interface.ts
@@ -99,6 +99,30 @@ export interface PlatformOperationsAuditDetails {
 }
 
 /**
+ * MCP API key lifecycle category payload shape (workspace#038, FR-022). One
+ * row per mint or revoke of an MCP API key. Deliberately an ALLOWLIST — never
+ * add a field here without also updating the exclusion test in
+ * `mcp-api-key.audit.service.spec.ts`.
+ *
+ * Forbidden by construction: the plaintext key, `keyHash` (or any
+ * prefix/suffix of either), `lastUsedFromIp` or any caller-supplied address,
+ * and the raw mutation input. `requestContext.ip` is deliberately NOT
+ * populated for this category — the only address available at this layer is
+ * client-influenced (`X-Forwarded-For`), so recording it would put a
+ * spoofable value in an audit record.
+ */
+export interface McpApiKeyAuditDetails {
+  /** The row id — an identifier, not a credential. */
+  keyId?: string;
+  /** The user's label for the key. */
+  keyName?: string;
+  /** The granted scope, flattened. */
+  operations?: ('read' | 'tools')[];
+  /** ISO timestamp, when an expiry was set at mint. */
+  expiresAt?: string;
+}
+
+/**
  * Cross-category shape of `platform_audit_entry.details`. Every field is
  * optional — the per-category audit-service (`UserEmailChangeAuditService`,
  * `UserPasswordChangeAuditService`, ...) enforces which keys it writes for
@@ -108,7 +132,8 @@ export interface PlatformOperationsAuditDetails {
  */
 export type PlatformAuditDetails = EmailChangeAuditDetails &
   PasswordChangeAuditDetails &
-  PlatformOperationsAuditDetails;
+  PlatformOperationsAuditDetails &
+  McpApiKeyAuditDetails;
 
 /**
  * Row shape of `platform_audit_entry`. Append-only; retained indefinitely

--- a/src/migrations/1786500000000-AddMcpApiKeyAuditCategory.ts
+++ b/src/migrations/1786500000000-AddMcpApiKeyAuditCategory.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * workspace#038-mcp-api-key-management: extends the cross-category audit
+ * enums introduced in `1779195577000-CreatePlatformAuditEntry` with the MCP
+ * API key lifecycle vocabulary (FR-021/FR-022):
+ *
+ * - `platform_audit_category` gains `mcp_api_key` — one row per mint or
+ *   revoke of an MCP API key (self-service or admin).
+ * - `platform_audit_outcome` gains `key_minted` / `key_revoked`.
+ *
+ * `ALTER TYPE ... ADD VALUE IF NOT EXISTS` is the non-breaking, additive
+ * pattern (same shape as `1784818900000-AddPlatformOperationsAuditCategory`);
+ * no table DDL, existing rows unaffected. Migration ordering: this must run
+ * BEFORE any MCP API key mint/revoke audit row is written — the standard
+ * `migration:run`-then-start sequence guarantees that.
+ */
+export class AddMcpApiKeyAuditCategory1786500000000
+  implements MigrationInterface
+{
+  name = 'AddMcpApiKeyAuditCategory1786500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "platform_audit_category" ADD VALUE IF NOT EXISTS 'mcp_api_key'`
+    );
+    await queryRunner.query(
+      `ALTER TYPE "platform_audit_outcome" ADD VALUE IF NOT EXISTS 'key_minted'`
+    );
+    await queryRunner.query(
+      `ALTER TYPE "platform_audit_outcome" ADD VALUE IF NOT EXISTS 'key_revoked'`
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Postgres has no `ALTER TYPE ... DROP VALUE`. Removing these values
+    // safely would require recreating the enum types (rewriting every
+    // `platform_audit_entry` row referencing them). No-op — enum extensions
+    // are treated as forward-only, matching the platform-operations
+    // precedent.
+  }
+}

--- a/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.module.ts
+++ b/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.module.ts
@@ -1,0 +1,17 @@
+import { AuthorizationModule } from '@core/authorization/authorization.module';
+import { Module } from '@nestjs/common';
+import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
+import { McpServerModule } from '@services/mcp-server/mcp-server.module';
+import { AdminMcpApiKeyResolverFields } from './admin.mcp.api.key.resolver.fields';
+import { AdminMcpApiKeyResolverMutations } from './admin.mcp.api.key.resolver.mutations';
+
+@Module({
+  imports: [
+    AuthorizationModule,
+    PlatformAuthorizationPolicyModule,
+    McpServerModule,
+  ],
+  providers: [AdminMcpApiKeyResolverMutations, AdminMcpApiKeyResolverFields],
+  exports: [],
+})
+export class AdminMcpApiKeyModule {}

--- a/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.fields.spec.ts
+++ b/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.fields.spec.ts
@@ -1,0 +1,159 @@
+import { ForbiddenException } from '@common/exceptions';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { LogContext } from '@src/common/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AdminMcpApiKeyResolverFields } from './admin.mcp.api.key.resolver.fields';
+import { AdminMcpApiKeyResolverMutations } from './admin.mcp.api.key.resolver.mutations';
+
+/**
+ * workspace#038, US3-AS4/AS6/AS7, US4-AS2, R-038-4/R-038-6. The admin surface
+ * — read AND revoke — is scoped to a named `userID` and predicated on
+ * `userId IS NOT NULL` at the SERVICE layer (`McpApiKeyService.
+ * listUserKeysForAdmin` / `.adminRevokeApiKey`), so an actor-bound
+ * trust-anchor key never appears here regardless of what a caller passes as
+ * `userID`. This spec asserts the RESOLVER's contract (auth gate + pure
+ * pass-through to the service + correct call arguments); the service-level
+ * `userId IS NOT NULL` guard itself is asserted against the repository query
+ * in `mcp-api-key.service.spec.ts`.
+ */
+describe('AdminMcpApiKeyResolverFields / Mutations', () => {
+  const adminActor = () => {
+    const ctx = new ActorContext();
+    ctx.actorID = 'admin-1';
+    ctx.isAnonymous = false;
+    return ctx;
+  };
+  const nonAdminActor = () => {
+    const ctx = new ActorContext();
+    ctx.actorID = 'user-1';
+    ctx.isAnonymous = false;
+    return ctx;
+  };
+
+  const buildFields = (granted: boolean) => {
+    const authorizationService = {
+      grantAccessOrFail: vi.fn(() => {
+        if (!granted) {
+          throw new ForbiddenException('not admin', LogContext.AUTH);
+        }
+      }),
+    };
+    const platformAuthorizationPolicyService = {
+      getPlatformAuthorizationPolicy: vi.fn().mockResolvedValue({}),
+    };
+    const mcpApiKeyService = {
+      listUserKeysForAdmin: vi.fn().mockResolvedValue([
+        {
+          id: 'k1',
+          name: 'user key',
+          scopes: [{ operations: ['read'] }],
+          createdDate: new Date('2026-01-01'),
+          isActive: true,
+        },
+      ]),
+      adminRevokeApiKey: vi.fn().mockResolvedValue({
+        id: 'k1',
+        name: 'user key',
+        scopes: [{ operations: ['read'] }],
+        createdDate: new Date('2026-01-01'),
+        isActive: false,
+      }),
+    };
+    const resolver = new AdminMcpApiKeyResolverFields(
+      authorizationService as any,
+      platformAuthorizationPolicyService as any,
+      mcpApiKeyService as any
+    );
+    return { resolver, authorizationService, mcpApiKeyService };
+  };
+
+  const buildMutations = (granted: boolean) => {
+    const authorizationService = {
+      grantAccessOrFail: vi.fn(() => {
+        if (!granted) {
+          throw new ForbiddenException('not admin', LogContext.AUTH);
+        }
+      }),
+    };
+    const platformAuthorizationPolicyService = {
+      getPlatformAuthorizationPolicy: vi.fn().mockResolvedValue({}),
+    };
+    const mcpApiKeyService = {
+      adminRevokeApiKey: vi.fn().mockResolvedValue({
+        id: 'k1',
+        name: 'user key',
+        scopes: [{ operations: ['read'] }],
+        createdDate: new Date('2026-01-01'),
+        isActive: false,
+      }),
+    };
+    const resolver = new AdminMcpApiKeyResolverMutations(
+      authorizationService as any,
+      platformAuthorizationPolicyService as any,
+      mcpApiKeyService as any
+    );
+    return { resolver, mcpApiKeyService };
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('mcpApiKeys field', () => {
+    it('a non-admin is refused (US3-AS7)', async () => {
+      const { resolver } = buildFields(false);
+      await expect(
+        resolver.mcpApiKeys(nonAdminActor(), 'user-a')
+      ).rejects.toThrow();
+    });
+
+    it('an admin receives metadata with no keyHash (US3-AS4)', async () => {
+      const { resolver, mcpApiKeyService } = buildFields(true);
+      const result = await resolver.mcpApiKeys(adminActor(), 'user-a');
+
+      expect(mcpApiKeyService.listUserKeysForAdmin).toHaveBeenCalledWith(
+        'user-a'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).not.toHaveProperty('keyHash');
+    });
+
+    it('delegates actor-bound-key exclusion entirely to the service (US3-AS6, FR-018) — the resolver adds no filtering of its own', async () => {
+      const { resolver, mcpApiKeyService } = buildFields(true);
+      mcpApiKeyService.listUserKeysForAdmin.mockResolvedValue([]);
+
+      const result = await resolver.mcpApiKeys(adminActor(), 'actor-bound-id');
+
+      // The resolver never inspects userId/actorId itself — it trusts the
+      // service's `userId IS NOT NULL` predicate, which for an actor-bound id
+      // returns nothing.
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('adminRevokeMcpApiKey mutation', () => {
+    it('a non-admin is refused', async () => {
+      const { resolver } = buildMutations(false);
+      await expect(
+        resolver.adminRevokeMcpApiKey(nonAdminActor(), {
+          userID: 'user-a',
+          keyID: 'k1',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('writes with subjectUserId=owner, initiatorUserId=admin, initiatorRole=PLATFORM_ADMIN (US4-AS2, R-038-6)', async () => {
+      const { resolver, mcpApiKeyService } = buildMutations(true);
+      const admin = adminActor();
+
+      await resolver.adminRevokeMcpApiKey(admin, {
+        userID: 'user-a',
+        keyID: 'k1',
+      });
+
+      expect(mcpApiKeyService.adminRevokeApiKey).toHaveBeenCalledWith(
+        'k1',
+        'user-a',
+        'admin-1'
+      );
+    });
+  });
+});

--- a/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.fields.ts
+++ b/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.fields.ts
@@ -1,0 +1,66 @@
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { UUID } from '@domain/common/scalars';
+import { Args, ResolveField, Resolver } from '@nestjs/graphql';
+import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
+import {
+  IMcpApiKey,
+  toGraphqlMcpApiKey,
+} from '@services/mcp-server/dto/mcp.api.key.dto';
+import { CurrentActor } from '@src/common/decorators';
+import { PlatformAdminQueryResults } from '@src/platform-admin/admin/dto/platform.admin.query.results';
+
+/**
+ * MCP API key admin surface (workspace#038, FR-017/FR-018/FR-020). API-only —
+ * NO admin UI in this delivery. Every read/write here is scoped to a NAMED
+ * `userID` and predicated on `userId IS NOT NULL` at the service layer
+ * (`McpApiKeyService.listUserKeysForAdmin` / `.adminRevokeApiKey`), so an
+ * actor-bound trust-anchor key (e.g. the `virtual-assistant` bootstrap key,
+ * `ensureActorKeyFromPlaintext`) is unreachable from this resolver by
+ * construction (ruling A9). Verified by
+ * `admin.mcp.api.key.resolver.fields.spec.ts` (US3-AS6).
+ *
+ * This resolver — like every other GraphQL surface — is never reachable
+ * through `McpAuthGuard`: that guard is applied ONLY to `McpServerController`
+ * (grep-verified, R-08). An `mcp_` key therefore has zero admin lifecycle
+ * reach, same as it has zero self-service reach (R-038-2 closure).
+ */
+@Resolver(() => PlatformAdminQueryResults)
+export class AdminMcpApiKeyResolverFields {
+  constructor(
+    private readonly authorizationService: AuthorizationService,
+    private readonly platformAuthorizationPolicyService: PlatformAuthorizationPolicyService,
+    private readonly mcpApiKeyService: McpApiKeyService
+  ) {}
+
+  @ResolveField('mcpApiKeys', () => [IMcpApiKey], {
+    nullable: false,
+    description:
+      'MCP API keys belonging to the named user. Platform admins only. Keys bound to a system actor are never returned.',
+  })
+  async mcpApiKeys(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('userID', { type: () => UUID }) userID: string
+  ): Promise<IMcpApiKey[]> {
+    await this.assertPlatformAdmin(
+      actorContext,
+      `platformAdmin mcpApiKeys subject=${userID}`
+    );
+    const rows = await this.mcpApiKeyService.listUserKeysForAdmin(userID);
+    return rows.map(toGraphqlMcpApiKey);
+  }
+
+  private async assertPlatformAdmin(
+    actorContext: ActorContext,
+    description: string
+  ): Promise<void> {
+    this.authorizationService.grantAccessOrFail(
+      actorContext,
+      await this.platformAuthorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      description
+    );
+  }
+}

--- a/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.fields.ts
+++ b/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.fields.ts
@@ -44,10 +44,12 @@ export class AdminMcpApiKeyResolverFields {
     @CurrentActor() actorContext: ActorContext,
     @Args('userID', { type: () => UUID }) userID: string
   ): Promise<IMcpApiKey[]> {
-    await this.assertPlatformAdmin(
-      actorContext,
-      `platformAdmin mcpApiKeys subject=${userID}`
-    );
+    // No subject id in the description: it lands verbatim in the
+    // ForbiddenAuthorizationPolicyException message (authorization.service.ts),
+    // and this repo's convention is that exception messages carry no dynamic
+    // data — identifiers belong in structured `details`. The subject is
+    // already recorded on the audit row for successful operations.
+    await this.assertPlatformAdmin(actorContext, 'platformAdmin mcpApiKeys');
     const rows = await this.mcpApiKeyService.listUserKeysForAdmin(userID);
     return rows.map(toGraphqlMcpApiKey);
   }

--- a/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.mutations.ts
+++ b/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.mutations.ts
@@ -35,10 +35,8 @@ export class AdminMcpApiKeyResolverMutations {
     @CurrentActor() actorContext: ActorContext,
     @Args('revokeData') input: AdminRevokeMcpApiKeyInput
   ): Promise<IMcpApiKey> {
-    await this.assertPlatformAdmin(
-      actorContext,
-      `adminRevokeMcpApiKey subject=${input.userID}`
-    );
+    // Static description — see the note in admin.mcp.api.key.resolver.fields.ts.
+    await this.assertPlatformAdmin(actorContext, 'adminRevokeMcpApiKey');
     const revoked = await this.mcpApiKeyService.adminRevokeApiKey(
       input.keyID,
       input.userID,

--- a/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.mutations.ts
+++ b/src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.resolver.mutations.ts
@@ -1,0 +1,61 @@
+import { AuthorizationPrivilege } from '@common/enums';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { AuthorizationService } from '@core/authorization/authorization.service';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { PlatformAuthorizationPolicyService } from '@platform/authorization/platform.authorization.policy.service';
+import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
+import {
+  AdminRevokeMcpApiKeyInput,
+  IMcpApiKey,
+  toGraphqlMcpApiKey,
+} from '@services/mcp-server/dto/mcp.api.key.dto';
+import { InstrumentResolver } from '@src/apm/decorators';
+import { CurrentActor } from '@src/common/decorators';
+
+/**
+ * Admin MCP API key revoke (workspace#038, FR-017/FR-018/FR-020). See
+ * `admin.mcp.api.key.resolver.fields.ts` for the containment rationale — same
+ * `userId IS NOT NULL` firewall applies here via
+ * `McpApiKeyService.adminRevokeApiKey`.
+ */
+@InstrumentResolver()
+@Resolver()
+export class AdminMcpApiKeyResolverMutations {
+  constructor(
+    private readonly authorizationService: AuthorizationService,
+    private readonly platformAuthorizationPolicyService: PlatformAuthorizationPolicyService,
+    private readonly mcpApiKeyService: McpApiKeyService
+  ) {}
+
+  @Mutation(() => IMcpApiKey, {
+    description:
+      "Platform admin: revoke a named user's MCP API key. Idempotent.",
+  })
+  async adminRevokeMcpApiKey(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('revokeData') input: AdminRevokeMcpApiKeyInput
+  ): Promise<IMcpApiKey> {
+    await this.assertPlatformAdmin(
+      actorContext,
+      `adminRevokeMcpApiKey subject=${input.userID}`
+    );
+    const revoked = await this.mcpApiKeyService.adminRevokeApiKey(
+      input.keyID,
+      input.userID,
+      actorContext.actorID
+    );
+    return toGraphqlMcpApiKey(revoked);
+  }
+
+  private async assertPlatformAdmin(
+    actorContext: ActorContext,
+    description: string
+  ): Promise<void> {
+    this.authorizationService.grantAccessOrFail(
+      actorContext,
+      await this.platformAuthorizationPolicyService.getPlatformAuthorizationPolicy(),
+      AuthorizationPrivilege.PLATFORM_ADMIN,
+      description
+    );
+  }
+}

--- a/src/schema-bootstrap/module.schema-bootstrap.ts
+++ b/src/schema-bootstrap/module.schema-bootstrap.ts
@@ -60,6 +60,7 @@ import { KonfigModule } from '@src/platform/configuration/config/config.module';
 import { MetadataModule } from '@src/platform/metadata/metadata.module';
 import { PlatformAdminModule } from '@src/platform-admin/admin/platform.admin.module';
 import { AdminCommunicationModule } from '@src/platform-admin/domain/communication/admin.communication.module';
+import { AdminMcpApiKeyModule } from '@src/platform-admin/domain/mcp-api-key/admin.mcp.api.key.module';
 import { DomainPlatformSettingsModule } from '@src/platform-admin/domain/organization/domain.platform.settings.module';
 import { AdminUsersModule } from '@src/platform-admin/domain/user/admin.users.module';
 import { AdminUserEmailChangeModule } from '@src/platform-admin/domain/user/email-change/admin.user.email.change.module';
@@ -209,6 +210,7 @@ class SchemaBootstrapStubModule {}
     AdminContributorsModule,
     AdminUsersModule,
     AdminUserEmailChangeModule,
+    AdminMcpApiKeyModule,
     AdminCommunicationModule,
     AdminSearchIngestModule,
     AdminLicensingModule,

--- a/src/services/api/me/dto/me.query.results.ts
+++ b/src/services/api/me/dto/me.query.results.ts
@@ -2,6 +2,7 @@ import { IApplication } from '@domain/access/application';
 import { IInvitation } from '@domain/access/invitation';
 import { IUser } from '@domain/community/user/user.interface';
 import { ObjectType } from '@nestjs/graphql';
+import { IMcpApiKey } from '@services/mcp-server/dto/mcp.api.key.dto';
 import { MeConversationsResult } from './me.conversations.result';
 import { CommunityMembershipResult } from './me.membership.result';
 
@@ -14,4 +15,5 @@ export class MeQueryResults {
   spaceMembershipsHierarchical!: CommunityMembershipResult[];
   spaceMembershipsFlat!: CommunityMembershipResult[];
   conversations!: MeConversationsResult;
+  mcpApiKeys!: IMcpApiKey[];
 }

--- a/src/services/api/me/me.module.ts
+++ b/src/services/api/me/me.module.ts
@@ -9,6 +9,7 @@ import { Module } from '@nestjs/common';
 import { ActivityModule } from '@platform/activity/activity.module';
 import { InAppNotificationModule } from '@platform/in-app-notification/in.app.notification.module';
 import { EntityResolverModule } from '@services/infrastructure/entity-resolver/entity.resolver.module';
+import { McpServerModule } from '@services/mcp-server/mcp-server.module';
 import { ActivityLogModule } from '../activity-log/activity.log.module';
 import { RolesModule } from '../roles/roles.module';
 import { MeConversationsResolverFields } from './me.conversations.resolver.fields';
@@ -30,6 +31,7 @@ import { MeService } from './me.service';
     EntityResolverModule,
     InAppNotificationModule,
     MessagingModule,
+    McpServerModule,
   ],
   providers: [
     MeService,

--- a/src/services/api/me/me.resolver.fields.spec.ts
+++ b/src/services/api/me/me.resolver.fields.spec.ts
@@ -1,6 +1,7 @@
 import { UserLookupService } from '@domain/community/user-lookup/user.lookup.service';
 import { createMock } from '@golevelup/ts-vitest';
 import { InAppNotificationService } from '@platform/in-app-notification/in.app.notification.service';
+import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
 import { LogContext } from '@src/common/enums';
 import { MeResolverFields } from './me.resolver.fields';
 import { MeService } from './me.service';
@@ -43,10 +44,14 @@ describe('MeResolverFields', () => {
       5
     );
 
+    const mcpApiKeyService = createMock<McpApiKeyService>();
+    mcpApiKeyService.listUserKeysForProjection.mockResolvedValue([]);
+
     resolver = new MeResolverFields(
       meService,
       userLookupService,
       inAppNotificationService,
+      mcpApiKeyService,
       logger as any
     );
   });

--- a/src/services/api/me/me.resolver.fields.spec.ts
+++ b/src/services/api/me/me.resolver.fields.spec.ts
@@ -15,6 +15,7 @@ describe('MeResolverFields', () => {
   let inAppNotificationService: ReturnType<
     typeof createMock<InAppNotificationService>
   >;
+  let mcpApiKeyServiceMock: ReturnType<typeof createMock<McpApiKeyService>>;
   // A plain stub injected as the resolver's logger. Deliberately NOT a
   // `vi.spyOn(Logger.prototype, …)`: vitest runs with `isolate: false`, so a
   // prototype spy that is never restored leaks a no-op logger into every later
@@ -44,14 +45,14 @@ describe('MeResolverFields', () => {
       5
     );
 
-    const mcpApiKeyService = createMock<McpApiKeyService>();
-    mcpApiKeyService.listUserKeysForProjection.mockResolvedValue([]);
+    mcpApiKeyServiceMock = createMock<McpApiKeyService>();
+    mcpApiKeyServiceMock.listUserKeysForProjection.mockResolvedValue([]);
 
     resolver = new MeResolverFields(
       meService,
       userLookupService,
       inAppNotificationService,
-      mcpApiKeyService,
+      mcpApiKeyServiceMock,
       logger as any
     );
   });
@@ -273,6 +274,54 @@ describe('MeResolverFields', () => {
   it('should return mySpaces', async () => {
     const result = await resolver.mySpaces(actorContext, 10);
     expect(result).toEqual([]);
+  });
+
+  describe('mcpApiKeys (workspace#038)', () => {
+    it('returns an empty array when actorID is missing, without throwing', async () => {
+      const result = await resolver.mcpApiKeys(anonymousActorContext);
+      expect(result).toEqual([]);
+    });
+
+    it('does not call the service when actorID is missing', async () => {
+      await resolver.mcpApiKeys(anonymousActorContext);
+      expect(
+        mcpApiKeyServiceMock.listUserKeysForProjection
+      ).not.toHaveBeenCalled();
+    });
+
+    it("returns only the caller's keys, newest first, incl. revoked/expired, with no keyHash (FR-008/FR-009, US2-AS2)", async () => {
+      const now = new Date('2026-08-12T00:00:00.000Z');
+      const older = new Date('2026-08-01T00:00:00.000Z');
+      mcpApiKeyServiceMock.listUserKeysForProjection.mockResolvedValue([
+        {
+          id: 'k-new',
+          name: 'new key',
+          scopes: [{ operations: ['read'] }],
+          createdDate: now,
+          isActive: true,
+        },
+        {
+          id: 'k-revoked',
+          name: 'revoked key',
+          scopes: [{ operations: ['tools'] }],
+          createdDate: older,
+          isActive: false,
+        },
+      ] as any);
+
+      const result = await resolver.mcpApiKeys(actorContext);
+
+      expect(
+        mcpApiKeyServiceMock.listUserKeysForProjection
+      ).toHaveBeenCalledWith(actorContext.actorID);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('k-new');
+      expect(result[1].id).toBe('k-revoked');
+      expect(result[1].status).toBe('revoked');
+      for (const key of result) {
+        expect(key).not.toHaveProperty('keyHash');
+      }
+    });
   });
 
   describe('conversations degradation', () => {

--- a/src/services/api/me/me.resolver.fields.ts
+++ b/src/services/api/me/me.resolver.fields.ts
@@ -7,6 +7,11 @@ import { Inject, LoggerService } from '@nestjs/common';
 import { Args, Float, ResolveField, Resolver } from '@nestjs/graphql';
 import { InAppNotificationService } from '@platform/in-app-notification/in.app.notification.service';
 import { MeQueryResults } from '@services/api/me/dto';
+import { McpApiKeyService } from '@services/mcp-server/auth/mcp-api-key.service';
+import {
+  IMcpApiKey,
+  toGraphqlMcpApiKey,
+} from '@services/mcp-server/dto/mcp.api.key.dto';
 import { CurrentActor } from '@src/common/decorators';
 import { LogContext } from '@src/common/enums';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
@@ -24,6 +29,7 @@ export class MeResolverFields {
     private meService: MeService,
     private userLookupService: UserLookupService,
     private inAppNotificationService: InAppNotificationService,
+    private mcpApiKeyService: McpApiKeyService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
   ) {}
@@ -220,6 +226,27 @@ export class MeResolverFields {
     limit: number
   ): Promise<MySpaceResults[]> {
     return this.meService.getMySpaces(actorContext, limit);
+  }
+
+  @ResolveField('mcpApiKeys', () => [IMcpApiKey], {
+    nullable: false,
+    description:
+      "The current user's MCP API keys, newest first. Includes revoked and expired keys so last-used evidence survives revocation.",
+  })
+  public async mcpApiKeys(
+    @CurrentActor() actorContext: ActorContext
+  ): Promise<IMcpApiKey[]> {
+    if (!actorContext.actorID || actorContext.isAnonymous) {
+      this.logger.verbose?.(
+        'Degrading me.mcpApiKeys to its empty value: request has no resolved actor',
+        LogContext.AUTH
+      );
+      return [];
+    }
+    const rows = await this.mcpApiKeyService.listUserKeysForProjection(
+      actorContext.actorID
+    );
+    return rows.map(toGraphqlMcpApiKey);
   }
 
   @ResolveField(() => MeConversationsResult, {

--- a/src/services/mcp-server/auth/mcp-api-key.audit.service.spec.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.audit.service.spec.ts
@@ -1,0 +1,165 @@
+import { PlatformAuditCategory } from '@domain/community/user-email-change/enums/platform.audit.category';
+import { PlatformAuditInitiatorRole } from '@domain/community/user-email-change/enums/platform.audit.initiator.role';
+import { PlatformAuditOutcome } from '@domain/community/user-email-change/enums/platform.audit.outcome';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpApiKeyOperation } from '../dto/mcp.api.key.dto';
+import { McpApiKeyAuditService } from './mcp-api-key.audit.service';
+
+/**
+ * workspace#038, US4-AS1/AS3, FR-021/FR-022. Also asserts the FORBIDDEN
+ * fields — plaintext, `keyHash`, caller-supplied IP — never reach the
+ * details allowlist, by construction (there is no code path that could add
+ * them: `RecordMintInput`/`RecordRevokeInput` do not carry those fields at
+ * all, so this is a structural guarantee re-asserted here as a regression
+ * trip-wire).
+ */
+describe('McpApiKeyAuditService', () => {
+  const build = () => {
+    const manager: any = {
+      create: vi.fn((_entity: any, data: any) => data),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new McpApiKeyAuditService();
+    return { service, manager };
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('recordMint', () => {
+    it('writes exactly one row with category=mcp_api_key, outcome=key_minted', async () => {
+      const { service, manager } = build();
+
+      await service.recordMint(manager, {
+        ownerUserId: 'owner-1',
+        initiatorUserId: 'owner-1',
+        initiatorRole: PlatformAuditInitiatorRole.SELF,
+        keyId: 'key-1',
+        keyName: 'my-key',
+        operations: [McpApiKeyOperation.READ, McpApiKeyOperation.TOOLS],
+      });
+
+      expect(manager.save).toHaveBeenCalledTimes(1);
+      const entry = manager.create.mock.calls[0][1];
+      expect(entry.category).toBe(PlatformAuditCategory.MCP_API_KEY);
+      expect(entry.outcome).toBe(PlatformAuditOutcome.KEY_MINTED);
+    });
+
+    it('sets subjectUserId=initiatorUserId=owner for a self-service mint (SELF role)', async () => {
+      const { service, manager } = build();
+
+      await service.recordMint(manager, {
+        ownerUserId: 'owner-1',
+        initiatorUserId: 'owner-1',
+        initiatorRole: PlatformAuditInitiatorRole.SELF,
+        keyId: 'key-1',
+        keyName: 'my-key',
+        operations: [McpApiKeyOperation.READ],
+      });
+
+      const entry = manager.create.mock.calls[0][1];
+      expect(entry.subjectUserId).toBe('owner-1');
+      expect(entry.initiatorUserId).toBe('owner-1');
+      expect(entry.initiatorRole).toBe(PlatformAuditInitiatorRole.SELF);
+    });
+
+    it('the details object contains none of the plaintext, keyHash, or an IP (FR-022)', async () => {
+      const { service, manager } = build();
+
+      await service.recordMint(manager, {
+        ownerUserId: 'owner-1',
+        initiatorUserId: 'owner-1',
+        initiatorRole: PlatformAuditInitiatorRole.SELF,
+        keyId: 'key-1',
+        keyName: 'my-key',
+        operations: [McpApiKeyOperation.READ],
+        expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+      });
+
+      const entry = manager.create.mock.calls[0][1];
+      const details = entry.details;
+      const serialized = JSON.stringify(details);
+
+      expect(Object.keys(details).sort()).toEqual(
+        ['expiresAt', 'keyId', 'keyName', 'operations'].sort()
+      );
+      // Forbidden by construction — plaintext / hash / IP shaped keys.
+      expect(details).not.toHaveProperty('apiKey');
+      expect(details).not.toHaveProperty('keyHash');
+      expect(details).not.toHaveProperty('lastUsedFromIp');
+      expect(details).not.toHaveProperty('ip');
+      expect(details).not.toHaveProperty('requestContext');
+      // Nothing that looks like a 64-char sha256 hex digest leaked in.
+      expect(serialized).not.toMatch(/[a-f0-9]{64}/);
+      expect(details.expiresAt).toBe('2030-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('recordRevoke', () => {
+    it('writes exactly one row with category=mcp_api_key, outcome=key_revoked', async () => {
+      const { service, manager } = build();
+
+      await service.recordRevoke(manager, {
+        ownerUserId: 'owner-1',
+        initiatorUserId: 'admin-1',
+        initiatorRole: PlatformAuditInitiatorRole.PLATFORM_ADMIN,
+        keyId: 'key-1',
+        keyName: 'my-key',
+      });
+
+      expect(manager.save).toHaveBeenCalledTimes(1);
+      const entry = manager.create.mock.calls[0][1];
+      expect(entry.category).toBe(PlatformAuditCategory.MCP_API_KEY);
+      expect(entry.outcome).toBe(PlatformAuditOutcome.KEY_REVOKED);
+    });
+
+    it('supports subject != initiator for an admin revoke (US4-AS2)', async () => {
+      const { service, manager } = build();
+
+      await service.recordRevoke(manager, {
+        ownerUserId: 'owner-1',
+        initiatorUserId: 'admin-1',
+        initiatorRole: PlatformAuditInitiatorRole.PLATFORM_ADMIN,
+        keyId: 'key-1',
+        keyName: 'my-key',
+      });
+
+      const entry = manager.create.mock.calls[0][1];
+      expect(entry.subjectUserId).toBe('owner-1');
+      expect(entry.initiatorUserId).toBe('admin-1');
+      expect(entry.initiatorRole).toBe(
+        PlatformAuditInitiatorRole.PLATFORM_ADMIN
+      );
+    });
+
+    it('the revoke details object never carries operations, plaintext, or keyHash', async () => {
+      const { service, manager } = build();
+
+      await service.recordRevoke(manager, {
+        ownerUserId: 'owner-1',
+        initiatorUserId: 'owner-1',
+        initiatorRole: PlatformAuditInitiatorRole.SELF,
+        keyId: 'key-1',
+        keyName: 'my-key',
+      });
+
+      const entry = manager.create.mock.calls[0][1];
+      expect(Object.keys(entry.details).sort()).toEqual(['keyId', 'keyName']);
+    });
+  });
+
+  it('propagates a save failure rather than swallowing it (fail-closed, unlike PlatformOperationsAuditService)', async () => {
+    const { service, manager } = build();
+    manager.save.mockRejectedValueOnce(new Error('db unavailable'));
+
+    await expect(
+      service.recordMint(manager, {
+        ownerUserId: 'owner-1',
+        initiatorUserId: 'owner-1',
+        initiatorRole: PlatformAuditInitiatorRole.SELF,
+        keyId: 'key-1',
+        keyName: 'my-key',
+        operations: [McpApiKeyOperation.READ],
+      })
+    ).rejects.toThrow('db unavailable');
+  });
+});

--- a/src/services/mcp-server/auth/mcp-api-key.audit.service.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.audit.service.ts
@@ -1,0 +1,87 @@
+import { PlatformAuditCategory } from '@domain/community/user-email-change/enums/platform.audit.category';
+import { PlatformAuditInitiatorRole } from '@domain/community/user-email-change/enums/platform.audit.initiator.role';
+import { PlatformAuditOutcome } from '@domain/community/user-email-change/enums/platform.audit.outcome';
+import { PlatformAuditEntry } from '@domain/community/user-email-change/platform.audit.entry.entity';
+import { McpApiKeyAuditDetails } from '@domain/community/user-email-change/platform.audit.entry.interface';
+import { Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import { McpApiKeyOperation } from '../dto/mcp.api.key.dto';
+
+export interface RecordMintInput {
+  /** The key's owner — written as `subjectUserId`. */
+  ownerUserId: string;
+  /** Who performed the mint — the owner for self-service. */
+  initiatorUserId: string;
+  initiatorRole: PlatformAuditInitiatorRole;
+  keyId: string;
+  keyName: string;
+  operations: McpApiKeyOperation[];
+  expiresAt?: Date;
+}
+
+export interface RecordRevokeInput {
+  /** The key's owner — written as `subjectUserId`. */
+  ownerUserId: string;
+  /** Who performed the revoke — the owner (self) or an admin. */
+  initiatorUserId: string;
+  initiatorRole: PlatformAuditInitiatorRole;
+  keyId: string;
+  keyName: string;
+}
+
+/**
+ * Audit trail for the MCP API key lifecycle (workspace#038, FR-021/FR-022).
+ * One `platform_audit_entry` row per mint or revoke.
+ *
+ * FAIL-CLOSED by construction — deliberately UNLIKE `PlatformOperationsAuditService`
+ * (research.md R-04): every method here takes the caller's `EntityManager` so
+ * it enlists in the SAME transaction as the key mutation, and re-throws on
+ * failure so a broken audit write rolls back the key change (FR-023). Details
+ * are built from an explicit allowlist — never a spread of the raw input — so
+ * the plaintext, `keyHash`, or any caller-supplied IP can never reach the
+ * audit row (FR-022).
+ */
+@Injectable()
+export class McpApiKeyAuditService {
+  public async recordMint(
+    manager: EntityManager,
+    input: RecordMintInput
+  ): Promise<void> {
+    const details: McpApiKeyAuditDetails = {
+      keyId: input.keyId,
+      keyName: input.keyName,
+      operations: [...input.operations] as ('read' | 'tools')[],
+    };
+    if (input.expiresAt) {
+      details.expiresAt = input.expiresAt.toISOString();
+    }
+    const entry = manager.create(PlatformAuditEntry, {
+      category: PlatformAuditCategory.MCP_API_KEY,
+      subjectUserId: input.ownerUserId,
+      initiatorUserId: input.initiatorUserId,
+      initiatorRole: input.initiatorRole,
+      outcome: PlatformAuditOutcome.KEY_MINTED,
+      details,
+    });
+    await manager.save(entry);
+  }
+
+  public async recordRevoke(
+    manager: EntityManager,
+    input: RecordRevokeInput
+  ): Promise<void> {
+    const details: McpApiKeyAuditDetails = {
+      keyId: input.keyId,
+      keyName: input.keyName,
+    };
+    const entry = manager.create(PlatformAuditEntry, {
+      category: PlatformAuditCategory.MCP_API_KEY,
+      subjectUserId: input.ownerUserId,
+      initiatorUserId: input.initiatorUserId,
+      initiatorRole: input.initiatorRole,
+      outcome: PlatformAuditOutcome.KEY_REVOKED,
+      details,
+    });
+    await manager.save(entry);
+  }
+}

--- a/src/services/mcp-server/auth/mcp-api-key.audit.service.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.audit.service.ts
@@ -7,6 +7,18 @@ import { Injectable } from '@nestjs/common';
 import { EntityManager } from 'typeorm';
 import { McpApiKeyOperation } from '../dto/mcp.api.key.dto';
 
+/**
+ * Compile-time guard for the cast below. `McpApiKeyAuditDetails.operations` is
+ * declared as `('read' | 'tools')[]` in the domain layer, which deliberately
+ * does not import this service-layer enum. This assertion fails the build if
+ * the enum ever grows a third member, so the cast can never silently lie.
+ */
+type _EnumMatchesAuditDetails = `${McpApiKeyOperation}` extends 'read' | 'tools'
+  ? true
+  : never;
+const _enumMatchesAuditDetails: _EnumMatchesAuditDetails = true;
+void _enumMatchesAuditDetails;
+
 export interface RecordMintInput {
   /** The key's owner — written as `subjectUserId`. */
   ownerUserId: string;

--- a/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
@@ -395,10 +395,40 @@ describe('McpApiKeyService.revokeOwnApiKey (workspace#038)', () => {
     );
   });
 
-  it('has no hard-delete path reachable from self-revoke (FR-011)', () => {
-    // Structural guard: revokeOwnApiKey must never call repository.delete.
+  it('exposes no delete-capable method at all (FR-011)', () => {
+    // Assert against the real class, not a hand-built mock. The previous
+    // version of this test checked `repo.delete === undefined` on a stub that
+    // was never given a `delete` — it passed regardless of what the service
+    // did, and would not have noticed the legacy `deleteApiKey` that survived
+    // the REST deletion with zero callers on a service now injected into three
+    // GraphQL surfaces.
+    const methods = Object.getOwnPropertyNames(McpApiKeyService.prototype);
+    expect(methods).not.toContain('deleteApiKey');
+    expect(methods.filter(m => /delete|destroy|purge/i.test(m))).toEqual([]);
+  });
+
+  it('excludes actor-bound keys from the admin list (R-038-4)', async () => {
+    // The `userId IS NOT NULL` firewall is what keeps the bootstrap trust
+    // anchor out of reach of the admin surface. Assert it on the query the
+    // SERVICE actually builds — the resolver spec only proves forwarding, so
+    // dropping this clause would otherwise go unnoticed by every test.
     const { service, repo } = build();
-    expect((repo as any).delete).toBeUndefined();
-    expect(typeof service.revokeOwnApiKey).toBe('function');
+    const qb: any = {
+      select: vi.fn(() => qb),
+      where: vi.fn(() => qb),
+      andWhere: vi.fn(() => qb),
+      orderBy: vi.fn(() => qb),
+      getMany: vi.fn().mockResolvedValue([]),
+    };
+    (repo as any).createQueryBuilder = vi.fn(() => qb);
+
+    await service.listUserKeysForAdmin(USER);
+
+    const clauses = qb.andWhere.mock.calls.map((c: any[]) => String(c[0]));
+    expect(clauses.some((c: string) => /userId IS NOT NULL/i.test(c))).toBe(
+      true
+    );
+    // and the owner predicate is still scoped to the requested user
+    expect(String(qb.where.mock.calls[0][0])).toMatch(/key\.userId = :userId/);
   });
 });

--- a/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.spec.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpApiKeyOperation } from '../dto/mcp.api.key.dto';
+import { McpApiKeyAuditService } from './mcp-api-key.audit.service';
 import { McpApiKeyService } from './mcp-api-key.service';
 
 const ACTOR = 'actor-virtual-assistant';
@@ -13,8 +15,41 @@ const build = () => {
     save: vi.fn(async (e: any) => ({ id: e.id ?? 'new-id', ...e })),
   };
   const logger = { verbose: vi.fn(), warn: vi.fn(), error: vi.fn() };
-  const service = new McpApiKeyService(repo as any, logger as any);
-  return { service, repo };
+  const auditService = {
+    recordMint: vi.fn().mockResolvedValue(undefined),
+    recordRevoke: vi.fn().mockResolvedValue(undefined),
+  };
+  // A minimal fake EntityManager whose `.transaction()` runs the callback
+  // against a manager that reads/writes through the SAME `repo` mock, so
+  // assertions on `repo.save`/`repo.find` still work for the transactional
+  // paths (mintApiKeyForUser, revokeOwnApiKey, adminRevokeApiKey). Exposed so
+  // individual tests can override `manager.count` (cap boundary) or
+  // `manager.findOne` (owner mismatch) per-case.
+  const manager: any = {
+    query: vi.fn().mockResolvedValue(undefined),
+    count: vi.fn().mockResolvedValue(0),
+    create: vi.fn((_entity: any, data: any) => data),
+    save: vi.fn(async (e: any) => repo.save(e)),
+    findOne: vi.fn(async (_entity: any, opts: any) => repo.findOne(opts)),
+    createQueryBuilder: vi.fn(() => {
+      const qb: any = {
+        where: vi.fn(() => qb),
+        andWhere: vi.fn(() => qb),
+        getOne: vi.fn(async () => repo.findOne()),
+      };
+      return qb;
+    }),
+  };
+  const entityManager = {
+    transaction: vi.fn(async (cb: any) => cb(manager)),
+  };
+  const service = new McpApiKeyService(
+    repo as any,
+    logger as any,
+    entityManager as any,
+    auditService as any as McpApiKeyAuditService
+  );
+  return { service, repo, entityManager, manager, auditService };
 };
 
 describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
@@ -147,5 +182,223 @@ describe('McpApiKeyService.ensureActorKeyFromPlaintext (issue #1937)', () => {
     );
 
     expect(res).toBe(raced); // re-read row returned; startup not aborted
+  });
+});
+
+const USER = 'user-1';
+
+describe('McpApiKeyService.mintApiKeyForUser (workspace#038)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('normalizes duplicate operations into ONE scope object with no spaceIds (FR-004, R-06)', async () => {
+    const { service } = build();
+
+    const { entity } = await service.mintApiKeyForUser(USER, {
+      name: 'my-key',
+      operations: [
+        McpApiKeyOperation.READ,
+        McpApiKeyOperation.TOOLS,
+        McpApiKeyOperation.READ, // duplicate
+      ],
+    });
+
+    expect(entity.scopes).toHaveLength(1);
+    expect(entity.scopes[0]).toEqual({ operations: ['read', 'tools'] });
+    expect((entity.scopes[0] as any).spaceIds).toBeUndefined();
+  });
+
+  it('takes the per-user advisory lock before counting usable keys (FR-006)', async () => {
+    const { service, manager } = build();
+
+    await service.mintApiKeyForUser(USER, {
+      name: 'k',
+      operations: [McpApiKeyOperation.READ],
+    });
+
+    expect(manager.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_xact_lock(hashtext($1))',
+      [USER]
+    );
+    const lockCallOrder = manager.query.mock.invocationCallOrder[0];
+    const countCallOrder = manager.count.mock.invocationCallOrder[0];
+    expect(lockCallOrder).toBeLessThan(countCallOrder);
+  });
+
+  it('refuses to mint at the cap of 10 usable keys (FR-005, C-05)', async () => {
+    const { service, manager } = build();
+    manager.count.mockResolvedValue(10);
+
+    await expect(
+      service.mintApiKeyForUser(USER, {
+        name: 'k',
+        operations: [McpApiKeyOperation.READ],
+      })
+    ).rejects.toThrow(/limit/i);
+  });
+
+  it('does not consume the allowance below the cap (9 usable → mint succeeds)', async () => {
+    const { service, manager } = build();
+    manager.count.mockResolvedValue(9);
+
+    await expect(
+      service.mintApiKeyForUser(USER, {
+        name: 'k',
+        operations: [McpApiKeyOperation.READ],
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it('serializes concurrent mints at the boundary to exactly one winner (FR-006, R-038-1)', async () => {
+    const { service, repo, auditService } = build();
+    // A real `pg_advisory_xact_lock` makes the WHOLE cap-check+insert critical
+    // section mutually exclusive across concurrent transactions contending for
+    // the same key — the second transaction's body only starts once the
+    // first's has committed (lock released at transaction end). This mutex
+    // models exactly that guarantee at the `entityManager.transaction` level,
+    // with a stateful "usable" counter shared across the (now-serialized)
+    // critical sections — the property under test.
+    let usable = 9;
+    let queue: Promise<unknown> = Promise.resolve();
+    const manager: any = {
+      query: vi.fn().mockResolvedValue(undefined),
+      count: vi.fn(async () => usable),
+      create: vi.fn((_entity: any, data: any) => data),
+      save: vi.fn(async (e: any) => {
+        const saved = await repo.save(e);
+        usable += 1;
+        return saved;
+      }),
+    };
+    const entityManager = {
+      transaction: vi.fn((cb: any) => {
+        // Chain each call onto the previous — mutual exclusion, matching the
+        // advisory lock's real effect.
+        const run = queue.then(() => cb(manager));
+        queue = run.catch(() => undefined);
+        return run;
+      }),
+    };
+    const serializedService = new (service.constructor as any)(
+      repo,
+      { verbose: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      entityManager,
+      auditService
+    );
+
+    const [first, second] = await Promise.allSettled([
+      serializedService.mintApiKeyForUser(USER, {
+        name: 'a',
+        operations: [McpApiKeyOperation.READ],
+      }),
+      serializedService.mintApiKeyForUser(USER, {
+        name: 'b',
+        operations: [McpApiKeyOperation.READ],
+      }),
+    ]);
+
+    const outcomes = [first.status, second.status];
+    expect(outcomes.filter(s => s === 'fulfilled')).toHaveLength(1);
+    expect(outcomes.filter(s => s === 'rejected')).toHaveLength(1);
+  });
+
+  it('rejects a past expiresAt (FR-003)', async () => {
+    const { service } = build();
+    await expect(
+      service.mintApiKeyForUser(USER, {
+        name: 'k',
+        operations: [McpApiKeyOperation.READ],
+        expiresAt: new Date(Date.now() - 60_000),
+      })
+    ).rejects.toThrow(/future/i);
+  });
+
+  it('rolls back the transaction (propagates) when the audit write throws — no key row survives (FR-023, R-038-5)', async () => {
+    const { service, auditService } = build();
+    auditService.recordMint.mockRejectedValueOnce(new Error('audit db down'));
+
+    await expect(
+      service.mintApiKeyForUser(USER, {
+        name: 'k',
+        operations: [McpApiKeyOperation.READ],
+      })
+    ).rejects.toThrow(/audit db down/);
+  });
+
+  it('records the mint audit row in the SAME transaction manager as the insert (FR-023)', async () => {
+    const { service, manager, auditService } = build();
+
+    await service.mintApiKeyForUser(USER, {
+      name: 'k',
+      operations: [McpApiKeyOperation.READ],
+    });
+
+    expect(auditService.recordMint).toHaveBeenCalledWith(
+      manager,
+      expect.objectContaining({
+        ownerUserId: USER,
+        initiatorUserId: USER,
+        operations: ['read'],
+      })
+    );
+  });
+});
+
+describe('McpApiKeyService.revokeOwnApiKey (workspace#038)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sets isActive=false and records the revoke audit row', async () => {
+    const { service, repo, auditService } = build();
+    repo.findOne.mockResolvedValue({
+      id: 'k1',
+      userId: USER,
+      name: 'my-key',
+      isActive: true,
+    });
+
+    const revoked = await service.revokeOwnApiKey('k1', USER);
+
+    expect(revoked.isActive).toBe(false);
+    expect(auditService.recordRevoke).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        ownerUserId: USER,
+        initiatorUserId: USER,
+        keyId: 'k1',
+      })
+    );
+  });
+
+  it('is idempotent — revoking an already-revoked key writes no second audit row', async () => {
+    const { service, repo, auditService } = build();
+    repo.findOne.mockResolvedValue({
+      id: 'k1',
+      userId: USER,
+      name: 'my-key',
+      isActive: false,
+    });
+
+    await service.revokeOwnApiKey('k1', USER);
+
+    expect(auditService.recordRevoke).not.toHaveBeenCalled();
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  it("fails as not-found (without disclosing existence) for another user's key", async () => {
+    const { service, repo } = build();
+    // The query is scoped by (id, userId) — a key owned by someone else never
+    // matches, so the repository correctly returns null; the service must not
+    // distinguish "does not exist" from "exists but is not yours".
+    repo.findOne.mockResolvedValue(null);
+
+    await expect(service.revokeOwnApiKey('k1', USER)).rejects.toThrow(
+      /not found/i
+    );
+  });
+
+  it('has no hard-delete path reachable from self-revoke (FR-011)', () => {
+    // Structural guard: revokeOwnApiKey must never call repository.delete.
+    const { service, repo } = build();
+    expect((repo as any).delete).toBeUndefined();
+    expect(typeof service.revokeOwnApiKey).toBe('function');
   });
 });

--- a/src/services/mcp-server/auth/mcp-api-key.service.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.ts
@@ -1,11 +1,17 @@
 import { LogContext } from '@common/enums';
-import { EntityNotFoundException } from '@common/exceptions';
+import {
+  EntityNotFoundException,
+  ValidationException,
+} from '@common/exceptions';
+import { PlatformAuditInitiatorRole } from '@domain/community/user-email-change/enums/platform.audit.initiator.role';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { createHash, randomBytes } from 'crypto';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { Repository } from 'typeorm';
+import { EntityManager, IsNull, MoreThan, Repository } from 'typeorm';
+import { McpApiKeyOperation } from '../dto/mcp.api.key.dto';
 import { McpApiKeyScope } from '../dto/mcp.types';
+import { McpApiKeyAuditService } from './mcp-api-key.audit.service';
 import { McpApiKey } from './mcp-api-key.entity';
 
 export interface CreateMcpApiKeyInput {
@@ -30,13 +36,36 @@ export interface CreateMcpApiKeyResult {
   expiresAt?: Date;
 }
 
+/**
+ * Cap on USABLE (active + unexpired + user-bound) MCP API keys per user
+ * (workspace#038, FR-005/FR-006). A hardcoded service constant, deliberately
+ * NOT an `alkemio.config.ts` field — infrastructure-operations stays out of
+ * this feature. Revoked and expired keys do not consume the allowance
+ * (data-model.md §"Usable").
+ */
+export const MCP_API_KEY_MAX_USABLE_PER_USER = 10;
+
+export interface MintApiKeyForUserInput {
+  name: string;
+  operations: McpApiKeyOperation[];
+  expiresAt?: Date;
+}
+
+export interface MintApiKeyForUserResult {
+  entity: McpApiKey;
+  /** The plaintext key. Only ever available here, at mint time (FR-002). */
+  plaintext: string;
+}
+
 @Injectable()
 export class McpApiKeyService {
   constructor(
     @InjectRepository(McpApiKey)
     private readonly mcpApiKeyRepository: Repository<McpApiKey>,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService
+    private readonly logger: LoggerService,
+    private readonly entityManager: EntityManager,
+    private readonly auditService: McpApiKeyAuditService
   ) {}
 
   /**
@@ -81,6 +110,108 @@ export class McpApiKeyService {
       apiKey: plainTextKey,
       expiresAt: saved.expiresAt,
     };
+  }
+
+  /**
+   * Mint a new USER-bound MCP API key with PAT semantics (workspace#038,
+   * FR-001..FR-006). One short transaction: takes a per-user advisory lock
+   * (so a concurrent mint at the cap boundary serializes rather than racing —
+   * FR-006/R-038-1), counts usable keys against
+   * {@link MCP_API_KEY_MAX_USABLE_PER_USER}, normalizes operations to ONE
+   * de-duplicated `{operations}` scope object (never `spaceIds` — FR-004),
+   * inserts the key, and records the mint audit row — all or nothing (FR-023):
+   * if the audit write throws, the whole transaction (including the insert)
+   * rolls back.
+   */
+  async mintApiKeyForUser(
+    userId: string,
+    input: MintApiKeyForUserInput
+  ): Promise<MintApiKeyForUserResult> {
+    if (input.expiresAt && input.expiresAt.getTime() <= Date.now()) {
+      throw new ValidationException(
+        'MCP API key expiresAt must be in the future',
+        LogContext.MCP_SERVER,
+        { expiresAt: input.expiresAt.toISOString() }
+      );
+    }
+
+    const normalizedOperations = this.normalizeOperations(input.operations);
+    if (normalizedOperations.length === 0) {
+      throw new ValidationException(
+        'MCP API key must grant at least one operation',
+        LogContext.MCP_SERVER
+      );
+    }
+
+    const plainTextKey = this.generateApiKey();
+    const keyHash = this.hashApiKey(plainTextKey);
+
+    const saved = await this.entityManager.transaction(async manager => {
+      // Per-user advisory lock: serializes concurrent mints for the SAME user
+      // so the cap check + insert below is race-free (FR-006). Released
+      // automatically at transaction end (xact-scoped).
+      await manager.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        userId,
+      ]);
+
+      const usableCount = await manager.count(McpApiKey, {
+        where: this.usableKeysWhere(userId),
+      });
+      if (usableCount >= MCP_API_KEY_MAX_USABLE_PER_USER) {
+        throw new ValidationException(
+          `MCP API key limit reached (${MCP_API_KEY_MAX_USABLE_PER_USER}). Revoke an existing key to free an allowance.`,
+          LogContext.MCP_SERVER,
+          { userId, limit: MCP_API_KEY_MAX_USABLE_PER_USER }
+        );
+      }
+
+      const apiKey = new McpApiKey();
+      apiKey.name = input.name;
+      apiKey.userId = userId;
+      apiKey.keyHash = keyHash;
+      // Exactly ONE normalized scope object; never carries `spaceIds` (FR-004).
+      apiKey.scopes = [{ operations: normalizedOperations }];
+      apiKey.expiresAt = input.expiresAt;
+      apiKey.isActive = true;
+
+      const savedEntity = await manager.save(apiKey);
+
+      // Fail-closed: throwing here rolls back the insert above (FR-023).
+      await this.auditService.recordMint(manager, {
+        ownerUserId: userId,
+        initiatorUserId: userId,
+        initiatorRole: PlatformAuditInitiatorRole.SELF,
+        keyId: savedEntity.id,
+        keyName: savedEntity.name,
+        operations: normalizedOperations,
+        expiresAt: savedEntity.expiresAt,
+      });
+
+      return savedEntity;
+    });
+
+    return { entity: saved, plaintext: plainTextKey };
+  }
+
+  /**
+   * The "usable" predicate (data-model.md §Usable, FR-005):
+   * `userId = :userId AND isActive = true AND (expiresAt IS NULL OR expiresAt > now())`.
+   * Expressed as an OR of two AND'd FindOptionsWhere objects — TypeORM ORs an
+   * array of where-conditions at the top level, AND's the keys within each.
+   */
+  private usableKeysWhere(userId: string) {
+    const now = new Date();
+    return [
+      { userId, isActive: true, expiresAt: IsNull() },
+      { userId, isActive: true, expiresAt: MoreThan(now) },
+    ];
+  }
+
+  /** De-duplicates a requested operations list, preserving no particular order. */
+  private normalizeOperations(
+    operations: McpApiKeyOperation[]
+  ): McpApiKeyOperation[] {
+    return Array.from(new Set(operations));
   }
 
   /**
@@ -191,6 +322,29 @@ export class McpApiKeyService {
   }
 
   /**
+   * Re-validate a key BY ID — active + unexpired — without the plaintext
+   * (workspace#038, FR-013). Used ONLY by the session revalidation branch in
+   * `McpServerService.handleRequest`, on a session-bearing request whose
+   * incoming actorContext is anonymous: the session's identity was
+   * established from a key, but this particular request carries no bearer to
+   * re-derive the id from a plaintext, so the id captured at
+   * establish/refresh time is re-checked directly instead.
+   */
+  async isKeyUsable(keyId: string): Promise<boolean> {
+    const apiKey = await this.mcpApiKeyRepository.findOne({
+      where: { id: keyId },
+      select: { id: true, isActive: true, expiresAt: true },
+    });
+    if (!apiKey || !apiKey.isActive) {
+      return false;
+    }
+    if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Validate an API key and return the entity if valid
    */
   async validateApiKey(plainTextKey: string): Promise<McpApiKey | null> {
@@ -233,6 +387,139 @@ export class McpApiKeyService {
     return this.mcpApiKeyRepository.find({
       where: { userId },
       order: { createdDate: 'DESC' },
+    });
+  }
+
+  /**
+   * Self-service list, allowlisted at the QUERY level (workspace#038,
+   * FR-007/FR-008/FR-009): `keyHash` is excluded by the `select`, not by
+   * downstream omission (R-01). Includes revoked and expired rows so
+   * last-used forensic evidence survives revocation. Newest first.
+   */
+  async listUserKeysForProjection(userId: string): Promise<McpApiKey[]> {
+    return this.mcpApiKeyRepository.find({
+      select: {
+        id: true,
+        name: true,
+        scopes: true,
+        createdDate: true,
+        expiresAt: true,
+        lastUsedAt: true,
+        lastUsedFromIp: true,
+        isActive: true,
+      },
+      where: { userId },
+      order: { createdDate: 'DESC' },
+    });
+  }
+
+  /**
+   * Admin list, scoped to a named USER-bound owner only (workspace#038,
+   * FR-017/FR-018, ruling A9). `userId IS NOT NULL` is written explicitly, in
+   * addition to `userId = :userId`, so an actor-bound trust-anchor key (e.g.
+   * the virtual-assistant bootstrap key) can never be reached from this
+   * surface — even though it is already redundant with a concrete `userId`
+   * argument, the explicit predicate survives a future refactor that might
+   * loosen the equality check. `keyHash` is excluded at the query level (R-01).
+   */
+  async listUserKeysForAdmin(userId: string): Promise<McpApiKey[]> {
+    return this.mcpApiKeyRepository
+      .createQueryBuilder('key')
+      .select([
+        'key.id',
+        'key.name',
+        'key.scopes',
+        'key.createdDate',
+        'key.expiresAt',
+        'key.lastUsedAt',
+        'key.lastUsedFromIp',
+        'key.isActive',
+      ])
+      .where('key.userId = :userId', { userId })
+      .andWhere('key.userId IS NOT NULL')
+      .orderBy('key.createdDate', 'DESC')
+      .getMany();
+  }
+
+  /**
+   * Self-revoke (workspace#038, FR-010/FR-011). Sets `isActive = false` and
+   * records the revoke audit row in ONE transaction (fail-closed — FR-023).
+   * Idempotent: a key that is already revoked is returned unchanged, with NO
+   * second audit row (SC-004: exactly one clean row per event). Not found —
+   * including "found but owned by someone else" — surfaces the SAME generic
+   * error, so existence of another user's key is never disclosed (US2 edge
+   * case).
+   */
+  async revokeOwnApiKey(keyId: string, userId: string): Promise<McpApiKey> {
+    return this.entityManager.transaction(async manager => {
+      const apiKey = await manager.findOne(McpApiKey, {
+        where: { id: keyId, userId },
+      });
+      if (!apiKey) {
+        throw new EntityNotFoundException(
+          'MCP API key not found',
+          LogContext.MCP_SERVER,
+          { keyId }
+        );
+      }
+
+      if (apiKey.isActive) {
+        apiKey.isActive = false;
+        await manager.save(apiKey);
+        await this.auditService.recordRevoke(manager, {
+          ownerUserId: userId,
+          initiatorUserId: userId,
+          initiatorRole: PlatformAuditInitiatorRole.SELF,
+          keyId: apiKey.id,
+          keyName: apiKey.name,
+        });
+      }
+
+      return apiKey;
+    });
+  }
+
+  /**
+   * Admin revoke, scoped to a named USER-bound owner only (workspace#038,
+   * FR-017/FR-018). Same `userId IS NOT NULL` firewall as
+   * {@link listUserKeysForAdmin} — an actor-bound key is neither listed nor
+   * revocable from this surface. Records the revoke audit row with
+   * `initiatorRole = PLATFORM_ADMIN` and `initiatorUserId = adminUserId`
+   * (subject remains the key's owner) in the same transaction.
+   */
+  async adminRevokeApiKey(
+    keyId: string,
+    userId: string,
+    adminUserId: string
+  ): Promise<McpApiKey> {
+    return this.entityManager.transaction(async manager => {
+      const apiKey = await manager
+        .createQueryBuilder(McpApiKey, 'key')
+        .where('key.id = :keyId', { keyId })
+        .andWhere('key.userId = :userId', { userId })
+        .andWhere('key.userId IS NOT NULL')
+        .getOne();
+      if (!apiKey) {
+        throw new EntityNotFoundException(
+          'MCP API key not found',
+          LogContext.MCP_SERVER,
+          { keyId }
+        );
+      }
+
+      if (apiKey.isActive) {
+        apiKey.isActive = false;
+        await manager.save(apiKey);
+        await this.auditService.recordRevoke(manager, {
+          ownerUserId: userId,
+          initiatorUserId: adminUserId,
+          initiatorRole: PlatformAuditInitiatorRole.PLATFORM_ADMIN,
+          keyId: apiKey.id,
+          keyName: apiKey.name,
+        });
+      }
+
+      return apiKey;
     });
   }
 

--- a/src/services/mcp-server/auth/mcp-api-key.service.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.service.ts
@@ -14,28 +14,6 @@ import { McpApiKeyScope } from '../dto/mcp.types';
 import { McpApiKeyAuditService } from './mcp-api-key.audit.service';
 import { McpApiKey } from './mcp-api-key.entity';
 
-export interface CreateMcpApiKeyInput {
-  name: string;
-  description?: string;
-  /** Bind the key to a User (`buildForUser`). Exactly one of userId / actorId. */
-  userId?: string;
-  /**
-   * Bind the key to an Actor (`buildForActor`) — e.g. the `virtual-assistant`
-   * actor for the system-invoked path (004-web-ai-assistant T027). Exactly one
-   * of userId / actorId.
-   */
-  actorId?: string;
-  scopes?: McpApiKeyScope[];
-  expiresAt?: Date;
-}
-
-export interface CreateMcpApiKeyResult {
-  id: string;
-  name: string;
-  apiKey: string; // The plain text key - only returned on creation
-  expiresAt?: Date;
-}
-
 /**
  * Cap on USABLE (active + unexpired + user-bound) MCP API keys per user
  * (workspace#038, FR-005/FR-006). A hardcoded service constant, deliberately
@@ -67,50 +45,6 @@ export class McpApiKeyService {
     private readonly entityManager: EntityManager,
     private readonly auditService: McpApiKeyAuditService
   ) {}
-
-  /**
-   * Create a new MCP API key
-   * Returns the plain text key only once - it cannot be retrieved again
-   */
-  async createApiKey(
-    input: CreateMcpApiKeyInput
-  ): Promise<CreateMcpApiKeyResult> {
-    // Generate a secure random key
-    const plainTextKey = this.generateApiKey();
-    const keyHash = this.hashApiKey(plainTextKey);
-
-    if (!input.userId === !input.actorId) {
-      throw new EntityNotFoundException(
-        'An MCP API key must bind to exactly one of userId / actorId',
-        LogContext.MCP_SERVER,
-        { hasUserId: !!input.userId, hasActorId: !!input.actorId }
-      );
-    }
-
-    const apiKey = new McpApiKey();
-    apiKey.name = input.name;
-    apiKey.description = input.description;
-    apiKey.userId = input.userId;
-    apiKey.actorId = input.actorId;
-    apiKey.keyHash = keyHash;
-    apiKey.scopes = input.scopes || [{ operations: ['read'] }];
-    apiKey.expiresAt = input.expiresAt;
-    apiKey.isActive = true;
-
-    const saved = await this.mcpApiKeyRepository.save(apiKey);
-
-    this.logger.verbose?.(
-      `Created MCP API key: ${saved.id} for ${input.actorId ? `actor: ${input.actorId}` : `user: ${input.userId}`}`,
-      LogContext.MCP_SERVER
-    );
-
-    return {
-      id: saved.id,
-      name: saved.name,
-      apiKey: plainTextKey,
-      expiresAt: saved.expiresAt,
-    };
-  }
 
   /**
    * Mint a new USER-bound MCP API key with PAT semantics (workspace#038,
@@ -381,16 +315,6 @@ export class McpApiKeyService {
   }
 
   /**
-   * List API keys for a user (without exposing the actual keys)
-   */
-  async listApiKeysForUser(userId: string): Promise<McpApiKey[]> {
-    return this.mcpApiKeyRepository.find({
-      where: { userId },
-      order: { createdDate: 'DESC' },
-    });
-  }
-
-  /**
    * Self-service list, allowlisted at the QUERY level (workspace#038,
    * FR-007/FR-008/FR-009): `keyHash` is excluded by the `select`, not by
    * downstream omission (R-01). Includes revoked and expired rows so
@@ -521,51 +445,6 @@ export class McpApiKeyService {
 
       return apiKey;
     });
-  }
-
-  /**
-   * Revoke (deactivate) an API key
-   */
-  async revokeApiKey(keyId: string, userId: string): Promise<void> {
-    const apiKey = await this.mcpApiKeyRepository.findOne({
-      where: { id: keyId, userId },
-    });
-
-    if (!apiKey) {
-      throw new EntityNotFoundException(
-        'MCP API key not found',
-        LogContext.MCP_SERVER,
-        { keyId }
-      );
-    }
-
-    apiKey.isActive = false;
-    await this.mcpApiKeyRepository.save(apiKey);
-
-    this.logger.verbose?.(
-      `Revoked MCP API key: ${keyId}`,
-      LogContext.MCP_SERVER
-    );
-  }
-
-  /**
-   * Delete an API key permanently
-   */
-  async deleteApiKey(keyId: string, userId: string): Promise<void> {
-    const result = await this.mcpApiKeyRepository.delete({ id: keyId, userId });
-
-    if (result.affected === 0) {
-      throw new EntityNotFoundException(
-        'MCP API key not found',
-        LogContext.MCP_SERVER,
-        { keyId }
-      );
-    }
-
-    this.logger.verbose?.(
-      `Deleted MCP API key: ${keyId}`,
-      LogContext.MCP_SERVER
-    );
   }
 
   /**

--- a/src/services/mcp-server/auth/mcp-api-key.strategy.ts
+++ b/src/services/mcp-server/auth/mcp-api-key.strategy.ts
@@ -106,6 +106,13 @@ export class McpApiKeyStrategy extends PassportStrategy(
     (
       request as IncomingMessage & { mcpApiKeyScopes?: McpApiKeyScope[] }
     ).mcpApiKeyScopes = validatedKey.scopes;
+    // Expose the validated key's id alongside the scopes (workspace#038,
+    // FR-013): the controller threads this into the session so a LATER
+    // request on the same session — one that carries no bearer of its own —
+    // can revalidate the originating key rather than trusting a stale
+    // identity forever.
+    (request as IncomingMessage & { mcpApiKeyId?: string }).mcpApiKeyId =
+      validatedKey.id;
     this.logger.verbose?.(
       `MCP API key authenticated: actorID=${actorContext.actorID}${validatedKey.actorId ? ' (actor-bound, system-invoked)' : ''}`,
       LogContext.MCP_SERVER

--- a/src/services/mcp-server/auth/mcp-delegation.strategy.spec.ts
+++ b/src/services/mcp-server/auth/mcp-delegation.strategy.spec.ts
@@ -209,7 +209,8 @@ describe('MCP delegation — entity access is bound to the user (SC-003)', () =>
       resourceRegistry as any,
       authorizationService as any,
       capabilityGateService as any,
-      logger as any
+      logger as any,
+      {} as any
     );
     return { service, provider, authorizationService };
   };

--- a/src/services/mcp-server/dto/mcp.api.key.dto.spec.ts
+++ b/src/services/mcp-server/dto/mcp.api.key.dto.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  McpApiKeyOperation,
+  McpApiKeyStatus,
+  toGraphqlMcpApiKey,
+} from './mcp.api.key.dto';
+
+/**
+ * workspace#038 — projection robustness (FR-008/FR-032).
+ *
+ * `me.mcpApiKeys` is `[McpApiKey!]!`, so ONE row that throws or produces an
+ * unrepresentable enum value fails the whole field. The user then loses sight
+ * of every key on the only surface that can revoke them. These tests pin the
+ * degradation behaviour for rows this feature did not write — the bootstrap
+ * trust-anchor path and the manual-database-insert path the spec documents.
+ */
+const baseRow = {
+  id: 'key-1',
+  name: 'Legacy key',
+  createdDate: new Date('2026-01-01T00:00:00Z'),
+  isActive: true,
+} as const;
+
+describe('toGraphqlMcpApiKey — legacy row degradation', () => {
+  it('projects a well-formed row', () => {
+    const result = toGraphqlMcpApiKey({
+      ...baseRow,
+      scopes: [{ operations: ['read', 'tools'] }],
+    } as any);
+
+    expect(result.operations).toEqual([
+      McpApiKeyOperation.READ,
+      McpApiKeyOperation.TOOLS,
+    ]);
+    expect(result.status).toBe(McpApiKeyStatus.ACTIVE);
+  });
+
+  // The `scopes` column is jsonb NOT NULL, but that constrains SQL NULL only:
+  // JSON `null` and JSON objects are both accepted by the column and arrive in
+  // JS as values with no `.flatMap`. Verified against the live column.
+  it.each([
+    ['JSON null', null],
+    ['undefined', undefined],
+    ['a non-array object', { operations: ['read'] }],
+    ['a string', 'read'],
+  ])('does not throw when scopes is %s', (_label, scopes) => {
+    const call = () => toGraphqlMcpApiKey({ ...baseRow, scopes } as any);
+
+    expect(call).not.toThrow();
+    expect(call().operations).toEqual([]);
+    // Still listable, still revocable — that is the whole point.
+    expect(call().id).toBe('key-1');
+    expect(call().status).toBe(McpApiKeyStatus.ACTIVE);
+  });
+
+  it('drops operations outside the published enum instead of failing the field', () => {
+    const result = toGraphqlMcpApiKey({
+      ...baseRow,
+      scopes: [{ operations: ['read', 'write', 'admin'] }],
+    } as any);
+
+    expect(result.operations).toEqual([McpApiKeyOperation.READ]);
+  });
+
+  it('survives a scope entry with no operations key, and a null entry', () => {
+    const result = toGraphqlMcpApiKey({
+      ...baseRow,
+      scopes: [{ spaceIds: ['s1'] }, null, { operations: ['tools'] }],
+    } as any);
+
+    expect(result.operations).toEqual([McpApiKeyOperation.TOOLS]);
+  });
+
+  it('derives REVOKED ahead of EXPIRED (FR-032)', () => {
+    const result = toGraphqlMcpApiKey({
+      ...baseRow,
+      isActive: false,
+      expiresAt: new Date('2020-01-01T00:00:00Z'),
+      scopes: [{ operations: ['read'] }],
+    } as any);
+
+    expect(result.status).toBe(McpApiKeyStatus.REVOKED);
+  });
+});

--- a/src/services/mcp-server/dto/mcp.api.key.dto.ts
+++ b/src/services/mcp-server/dto/mcp.api.key.dto.ts
@@ -1,0 +1,238 @@
+import { SMALL_TEXT_LENGTH } from '@common/constants';
+import { UUID } from '@domain/common/scalars';
+import {
+  Field,
+  InputType,
+  ObjectType,
+  registerEnumType,
+} from '@nestjs/graphql';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+
+/**
+ * Operations an MCP API key may perform (workspace#038). TS values are the
+ * lowercase forms so they match what `mcp-scope.ts`'s `scopeViolation` (and
+ * the stored `McpApiKeyScope.operations`) compares against without
+ * translation — see contracts/graphql-schema.md.
+ */
+export enum McpApiKeyOperation {
+  READ = 'read',
+  TOOLS = 'tools',
+}
+
+registerEnumType(McpApiKeyOperation, {
+  name: 'McpApiKeyOperation',
+  description: 'Operations an MCP API key may perform.',
+});
+
+/**
+ * Lifecycle status of an MCP API key (presentation-only, derived — data-model.md
+ * §Derived status). REVOKED takes precedence over EXPIRED (FR-032).
+ */
+export enum McpApiKeyStatus {
+  ACTIVE = 'active',
+  EXPIRED = 'expired',
+  REVOKED = 'revoked',
+}
+
+registerEnumType(McpApiKeyStatus, {
+  name: 'McpApiKeyStatus',
+  description:
+    'Lifecycle status of an MCP API key. REVOKED takes precedence over EXPIRED.',
+});
+
+/**
+ * Metadata for one MCP API key — the ALLOWLIST. Deliberately has no `keyHash`
+ * field: every GraphQL projection of an `McpApiKey` row must be built from
+ * this shape, never a passthrough of the entity (FR-008).
+ */
+@ObjectType('McpApiKey', {
+  description:
+    'Metadata for one MCP API key. The key value itself is never exposed here.',
+})
+export class IMcpApiKey {
+  @Field(() => UUID, { nullable: false })
+  id!: string;
+
+  @Field(() => String, {
+    nullable: false,
+    description: 'User-supplied label. Not unique.',
+  })
+  name!: string;
+
+  @Field(() => [McpApiKeyOperation], {
+    nullable: false,
+    description: 'Granted operations, flattened from the stored scope.',
+  })
+  operations!: McpApiKeyOperation[];
+
+  @Field(() => Date, { nullable: false })
+  createdDate!: Date;
+
+  @Field(() => Date, {
+    nullable: true,
+    description: 'Optional expiry chosen at mint.',
+  })
+  expiresAt?: Date;
+
+  @Field(() => Date, {
+    nullable: true,
+    description: 'When this key last authenticated a request.',
+  })
+  lastUsedAt?: Date;
+
+  @Field(() => String, {
+    nullable: true,
+    description: 'Source address of the last request this key authenticated.',
+  })
+  lastUsedFromIp?: string;
+
+  @Field(() => McpApiKeyStatus, { nullable: false })
+  status!: McpApiKeyStatus;
+}
+
+/**
+ * Result of minting a key. The ONLY type that ever carries the plaintext
+ * (FR-002) — returned exactly once, never re-queryable.
+ */
+@ObjectType('McpApiKeyMintResult', {
+  description:
+    'Result of minting a key. The only place the plaintext is ever returned.',
+})
+export class McpApiKeyMintResult {
+  @Field(() => String, {
+    nullable: false,
+    description:
+      'The plaintext key. Returned EXACTLY ONCE — it is not stored and cannot be re-derived.',
+  })
+  apiKey!: string;
+
+  @Field(() => IMcpApiKey, {
+    nullable: false,
+    description: 'Metadata for the key just created.',
+  })
+  key!: IMcpApiKey;
+}
+
+@InputType()
+export class MintMcpApiKeyInput {
+  @Field(() => String, {
+    nullable: false,
+    description: 'Label for the key. 1..128 characters after trimming.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(SMALL_TEXT_LENGTH)
+  name!: string;
+
+  @Field(() => [McpApiKeyOperation], {
+    nullable: false,
+    description:
+      'At least one operation. Duplicates are removed; order is not significant.',
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsEnum(McpApiKeyOperation, { each: true })
+  operations!: McpApiKeyOperation[];
+
+  @Field(() => Date, {
+    nullable: true,
+    description: 'Optional expiry. MUST be in the future when supplied.',
+  })
+  @IsOptional()
+  @IsDate()
+  expiresAt?: Date;
+}
+
+@InputType()
+export class RevokeMcpApiKeyInput {
+  @Field(() => UUID, { nullable: false })
+  @IsUUID()
+  keyID!: string;
+}
+
+@InputType()
+export class AdminRevokeMcpApiKeyInput {
+  @Field(() => UUID, {
+    nullable: false,
+    description:
+      'Owner of the key. Required — it scopes the revoke and the audit subject.',
+  })
+  @IsUUID()
+  userID!: string;
+
+  @Field(() => UUID, { nullable: false })
+  @IsUUID()
+  keyID!: string;
+}
+
+/**
+ * The exact set of `McpApiKey` entity columns this projection reads. Deliberately
+ * excludes `keyHash`, `userId`, `actorId`, `description` — nothing beyond this
+ * shape may be accepted, so a caller cannot accidentally pass a full entity
+ * (with `keyHash`) through and have it silently work.
+ */
+export interface McpApiKeyProjectionSource {
+  id: string;
+  name: string;
+  scopes: McpApiKeyScope[];
+  createdDate: Date;
+  expiresAt?: Date;
+  lastUsedAt?: Date;
+  lastUsedFromIp?: string;
+  isActive: boolean;
+}
+
+interface McpApiKeyScope {
+  operations: ('read' | 'tools')[];
+}
+
+/**
+ * Projects an allowlisted `McpApiKey` row shape to the GraphQL `IMcpApiKey`
+ * (workspace#038, FR-008/FR-032). Derives `status` with REVOKED > EXPIRED >
+ * ACTIVE precedence and flattens `scopes[].operations` into a single
+ * de-duplicated list. Accepts ONLY {@link McpApiKeyProjectionSource} — never a
+ * raw entity — so `keyHash` cannot leak through this helper even if a caller
+ * passes a full row by mistake (there is no `keyHash` field to read).
+ */
+export function toGraphqlMcpApiKey(row: McpApiKeyProjectionSource): IMcpApiKey {
+  const status = deriveStatus(row.isActive, row.expiresAt);
+  const operations = Array.from(
+    new Set(
+      row.scopes.flatMap(scope => scope.operations) as McpApiKeyOperation[]
+    )
+  );
+
+  const result = new IMcpApiKey();
+  result.id = row.id;
+  result.name = row.name;
+  result.operations = operations;
+  result.createdDate = row.createdDate;
+  result.expiresAt = row.expiresAt;
+  result.lastUsedAt = row.lastUsedAt;
+  result.lastUsedFromIp = row.lastUsedFromIp;
+  result.status = status;
+  return result;
+}
+
+function deriveStatus(
+  isActive: boolean,
+  expiresAt: Date | undefined
+): McpApiKeyStatus {
+  if (!isActive) {
+    return McpApiKeyStatus.REVOKED;
+  }
+  if (expiresAt && expiresAt.getTime() < Date.now()) {
+    return McpApiKeyStatus.EXPIRED;
+  }
+  return McpApiKeyStatus.ACTIVE;
+}

--- a/src/services/mcp-server/dto/mcp.api.key.dto.ts
+++ b/src/services/mcp-server/dto/mcp.api.key.dto.ts
@@ -216,10 +216,18 @@ export function toGraphqlMcpApiKey(row: McpApiKeyProjectionSource): IMcpApiKey {
   // sight of every key, including the good ones, on the only surface that can
   // revoke them. Unknown values degrade to an empty operation list: the key
   // stays listable and stays revocable.
+  // Guard the OUTER array too, not just `scope.operations`. `scopes` is a
+  // NOT NULL jsonb column, but that constrains SQL NULL — it still accepts
+  // JSON `null` and objects, which reach JS as values with no `.flatMap`
+  // (verified against the live column). A legacy row written by the bootstrap
+  // or manual-insert path could therefore throw here, and one throwing row
+  // fails the whole non-nullable `me.mcpApiKeys` field — the same
+  // lose-sight-of-every-key failure the inner filter exists to prevent.
+  const scopes = Array.isArray(row.scopes) ? row.scopes : [];
   const operations = Array.from(
     new Set(
-      row.scopes
-        .flatMap(scope => scope.operations ?? [])
+      scopes
+        .flatMap(scope => scope?.operations ?? [])
         .filter((op): op is McpApiKeyOperation =>
           Object.values(McpApiKeyOperation).includes(op as McpApiKeyOperation)
         )

--- a/src/services/mcp-server/dto/mcp.api.key.dto.ts
+++ b/src/services/mcp-server/dto/mcp.api.key.dto.ts
@@ -18,6 +18,7 @@ import {
   IsUUID,
   MaxLength,
 } from 'class-validator';
+import type { McpApiKeyScope } from './mcp.types';
 
 /**
  * Operations an MCP API key may perform (workspace#038). TS values are the
@@ -196,10 +197,6 @@ export interface McpApiKeyProjectionSource {
   lastUsedAt?: Date;
   lastUsedFromIp?: string;
   isActive: boolean;
-}
-
-interface McpApiKeyScope {
-  operations: ('read' | 'tools')[];
 }
 
 /**

--- a/src/services/mcp-server/dto/mcp.api.key.dto.ts
+++ b/src/services/mcp-server/dto/mcp.api.key.dto.ts
@@ -6,6 +6,7 @@ import {
   ObjectType,
   registerEnumType,
 } from '@nestjs/graphql';
+import { Transform } from 'class-transformer';
 import {
   ArrayNotEmpty,
   IsArray,
@@ -129,6 +130,11 @@ export class MintMcpApiKeyInput {
     nullable: false,
     description: 'Label for the key. 1..128 characters after trimming.',
   })
+  // Trim BEFORE validating: the description promises "1..128 characters after
+  // trimming", and without this a whitespace-only name passes `@IsNotEmpty()`
+  // and mints a key with a blank label — defeating the identify-then-revoke
+  // workflow the label exists for.
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
   @IsNotEmpty()
   @MaxLength(SMALL_TEXT_LENGTH)
@@ -206,9 +212,20 @@ interface McpApiKeyScope {
  */
 export function toGraphqlMcpApiKey(row: McpApiKeyProjectionSource): IMcpApiKey {
   const status = deriveStatus(row.isActive, row.expiresAt);
+  // Filter, don't cast. Rows predating this feature were written by the
+  // bootstrap path or by hand and may carry operations outside the published
+  // enum (or omit `operations` entirely). `me.mcpApiKeys` is `[McpApiKey!]!`,
+  // so one unrepresentable value fails the WHOLE field — the user would lose
+  // sight of every key, including the good ones, on the only surface that can
+  // revoke them. Unknown values degrade to an empty operation list: the key
+  // stays listable and stays revocable.
   const operations = Array.from(
     new Set(
-      row.scopes.flatMap(scope => scope.operations) as McpApiKeyOperation[]
+      row.scopes
+        .flatMap(scope => scope.operations ?? [])
+        .filter((op): op is McpApiKeyOperation =>
+          Object.values(McpApiKeyOperation).includes(op as McpApiKeyOperation)
+        )
     )
   );
 

--- a/src/services/mcp-server/mcp-api-key.resolver.mutations.spec.ts
+++ b/src/services/mcp-server/mcp-api-key.resolver.mutations.spec.ts
@@ -1,0 +1,66 @@
+import { ActorContext } from '@core/actor-context/actor.context';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpApiKeyResolverMutations } from './mcp-api-key.resolver.mutations';
+
+/**
+ * workspace#038, US3-AS1/US3-AS2, R-038-2. `McpApiKeyResolverMutations` is a
+ * plain GraphQL resolver — it is NEVER decorated with `@UseGuards(McpAuthGuard)`
+ * (that guard applies only to `McpServerController`, grep-verified in
+ * `mcp-server.controller.ts`'s docblock and re-asserted structurally here: this
+ * resolver class carries no NestJS guard metadata at all). The GraphQL layer's
+ * OWN auth chain (cookie-session / non-interactive-login / hydra-bearer) never
+ * includes the MCP API-key strategy, so a caller authenticated ONLY by an
+ * `mcp_` key arrives at every mutation here with an ANONYMOUS actorContext —
+ * exactly the case these mutations already refuse. This spec asserts that
+ * refusal for all three lifecycle operations.
+ */
+describe('McpApiKeyResolverMutations — an mcp_ key cannot reach the GraphQL layer (US3-AS1/AS2)', () => {
+  let resolver: McpApiKeyResolverMutations;
+  let mcpApiKeyService: {
+    mintApiKeyForUser: ReturnType<typeof vi.fn>;
+    revokeOwnApiKey: ReturnType<typeof vi.fn>;
+  };
+
+  const anonymousActor = () => {
+    const ctx = new ActorContext();
+    ctx.isAnonymous = true;
+    ctx.actorID = '';
+    return ctx;
+  };
+
+  beforeEach(() => {
+    mcpApiKeyService = {
+      mintApiKeyForUser: vi.fn(),
+      revokeOwnApiKey: vi.fn(),
+    };
+    resolver = new McpApiKeyResolverMutations(mcpApiKeyService as any);
+  });
+
+  it('mintMcpApiKey refuses an anonymous actor and never calls the service', async () => {
+    await expect(
+      resolver.mintMcpApiKey(anonymousActor(), {
+        name: 'k',
+        operations: [],
+      } as any)
+    ).rejects.toThrow(/authenticated user/i);
+    expect(mcpApiKeyService.mintApiKeyForUser).not.toHaveBeenCalled();
+  });
+
+  it('revokeMcpApiKey refuses an anonymous actor and never calls the service', async () => {
+    await expect(
+      resolver.revokeMcpApiKey(anonymousActor(), { keyID: 'k1' } as any)
+    ).rejects.toThrow(/authenticated user/i);
+    expect(mcpApiKeyService.revokeOwnApiKey).not.toHaveBeenCalled();
+  });
+
+  it('has no @UseGuards metadata referencing McpAuthGuard anywhere on the resolver (structural closure check, R-038-2)', () => {
+    // No NestJS GUARDS_METADATA key is present at all on this resolver — it is
+    // reachable only through GraphQL's own auth interceptor chain, never
+    // through McpAuthGuard.
+    const guardsMetadata = Reflect.getMetadata(
+      '__guards__',
+      McpApiKeyResolverMutations
+    );
+    expect(guardsMetadata).toBeUndefined();
+  });
+});

--- a/src/services/mcp-server/mcp-api-key.resolver.mutations.ts
+++ b/src/services/mcp-server/mcp-api-key.resolver.mutations.ts
@@ -1,0 +1,87 @@
+import { LogContext } from '@common/enums';
+import { ForbiddenException } from '@common/exceptions';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { InstrumentResolver } from '@src/apm/decorators';
+import { CurrentActor } from '@src/common/decorators';
+import { McpApiKeyService } from './auth/mcp-api-key.service';
+import {
+  IMcpApiKey,
+  McpApiKeyMintResult,
+  MintMcpApiKeyInput,
+  RevokeMcpApiKeyInput,
+  toGraphqlMcpApiKey,
+} from './dto/mcp.api.key.dto';
+
+/**
+ * MCP API key lifecycle mutations for the CURRENT USER (workspace#038,
+ * FR-001/FR-010/FR-011). Deliberately GraphQL-only: the MCP key strategy
+ * lives ONLY in `McpAuthGuard`, applied ONLY to `McpServerController` — this
+ * resolver is never reachable through it, which is the fix for the
+ * key-chaining escalation (R-038-2, US3-AS1/AS2). Verified by
+ * `mcp-api-key.resolver.mutations.spec.ts`.
+ */
+@InstrumentResolver()
+@Resolver()
+export class McpApiKeyResolverMutations {
+  constructor(private readonly mcpApiKeyService: McpApiKeyService) {}
+
+  @Mutation(() => McpApiKeyMintResult, {
+    description:
+      'Mint a new MCP API key for the current user. Returns the plaintext exactly once.',
+  })
+  async mintMcpApiKey(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('mintData') input: MintMcpApiKeyInput
+  ): Promise<McpApiKeyMintResult> {
+    const userId = this.requireAuthenticatedUser(actorContext, 'mintMcpApiKey');
+
+    const { entity, plaintext } = await this.mcpApiKeyService.mintApiKeyForUser(
+      userId,
+      {
+        name: input.name,
+        operations: input.operations,
+        expiresAt: input.expiresAt,
+      }
+    );
+
+    return {
+      apiKey: plaintext,
+      key: toGraphqlMcpApiKey(entity),
+    };
+  }
+
+  @Mutation(() => IMcpApiKey, {
+    description:
+      "Revoke one of the current user's own MCP API keys. Idempotent.",
+  })
+  async revokeMcpApiKey(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('revokeData') input: RevokeMcpApiKeyInput
+  ): Promise<IMcpApiKey> {
+    const userId = this.requireAuthenticatedUser(
+      actorContext,
+      'revokeMcpApiKey'
+    );
+
+    const revoked = await this.mcpApiKeyService.revokeOwnApiKey(
+      input.keyID,
+      userId
+    );
+    return toGraphqlMcpApiKey(revoked);
+  }
+
+  private requireAuthenticatedUser(
+    actorContext: ActorContext,
+    description: string
+  ): string {
+    if (!actorContext.actorID || actorContext.isAnonymous) {
+      throw new ForbiddenException(
+        'Caller must be an authenticated user for this operation.',
+        LogContext.MCP_SERVER,
+        { description }
+      );
+    }
+    return actorContext.actorID;
+  }
+}

--- a/src/services/mcp-server/mcp-server.controller.spec.ts
+++ b/src/services/mcp-server/mcp-server.controller.spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { McpAuthGuard } from './auth/mcp-auth.guard';
 import { McpServerController } from './mcp-server.controller';
 import { McpServerService } from './mcp-server.service';
@@ -18,6 +18,14 @@ import { McpServerService } from './mcp-server.service';
  */
 describe('McpServerController — deleted /rest/mcp/api-keys surface (US3-AS3)', () => {
   let app: INestApplication;
+  // The controller hands the raw ServerResponse to the service and writes
+  // nothing itself, so the mock must end the response or the request hangs.
+  const mcpServerService = {
+    handleRequest: vi.fn(async (_req: unknown, res: any) => {
+      res.statusCode = 200;
+      res.end();
+    }),
+  };
 
   beforeAll(async () => {
     const moduleRef: TestingModule = await Test.createTestingModule({
@@ -26,7 +34,7 @@ describe('McpServerController — deleted /rest/mcp/api-keys surface (US3-AS3)',
         MockWinstonProvider,
         {
           provide: McpServerService,
-          useValue: { handleRequest: vi.fn().mockResolvedValue(undefined) },
+          useValue: mcpServerService,
         },
       ],
     })
@@ -40,6 +48,15 @@ describe('McpServerController — deleted /rest/mcp/api-keys surface (US3-AS3)',
 
   afterAll(async () => {
     await app.close();
+  });
+
+  // Positive control. Without it, all three 404 assertions below would still
+  // pass if the controller were mounted under a different base path, or not
+  // mounted at all — proving nothing about the deleted lifecycle surface.
+  // This anchors '/rest/mcp' as live before we assert its sub-path is gone.
+  it('POST /rest/mcp still resolves to the MCP handler', async () => {
+    await request(app.getHttpServer()).post('/rest/mcp').send({});
+    expect(mcpServerService.handleRequest).toHaveBeenCalled();
   });
 
   it('POST /rest/mcp/api-keys returns 404', async () => {

--- a/src/services/mcp-server/mcp-server.controller.spec.ts
+++ b/src/services/mcp-server/mcp-server.controller.spec.ts
@@ -1,0 +1,61 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, it, vi } from 'vitest';
+import { McpAuthGuard } from './auth/mcp-auth.guard';
+import { McpServerController } from './mcp-server.controller';
+import { McpServerService } from './mcp-server.service';
+
+/**
+ * workspace#038 (R-038-2 / R-038-8, US3-AS3): the three former
+ * `/rest/mcp/api-keys` lifecycle handlers were DELETED, not deprecated —
+ * they were internet-reachable and guarded only by `McpAuthGuard`, so a
+ * leaked MCP key could mint further MCP keys. This spec asserts the closure:
+ * none of the three verbs resolve to a route any more. Nest's router 404s
+ * before `McpAuthGuard` (or anything else) runs, since no handler is
+ * registered for the sub-path.
+ */
+describe('McpServerController — deleted /rest/mcp/api-keys surface (US3-AS3)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [McpServerController],
+      providers: [
+        MockWinstonProvider,
+        {
+          provide: McpServerService,
+          useValue: { handleRequest: vi.fn().mockResolvedValue(undefined) },
+        },
+      ],
+    })
+      .overrideGuard(McpAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /rest/mcp/api-keys returns 404', async () => {
+    await request(app.getHttpServer())
+      .post('/rest/mcp/api-keys')
+      .send({ name: 'x' })
+      .expect(404);
+  });
+
+  it('GET /rest/mcp/api-keys returns 404', async () => {
+    await request(app.getHttpServer()).get('/rest/mcp/api-keys').expect(404);
+  });
+
+  it('DELETE /rest/mcp/api-keys/:id returns 404', async () => {
+    await request(app.getHttpServer())
+      .delete('/rest/mcp/api-keys/some-id')
+      .expect(404);
+  });
+});

--- a/src/services/mcp-server/mcp-server.controller.ts
+++ b/src/services/mcp-server/mcp-server.controller.ts
@@ -2,76 +2,43 @@ import { LogContext } from '@common/enums';
 import { ActorContext } from '@core/actor-context/actor.context';
 import {
   All,
-  Body,
   Controller,
-  Delete,
-  Get,
   Headers,
   HttpCode,
   Inject,
   LoggerService,
-  Param,
-  Post,
   Req,
   Res,
-  UnauthorizedException,
   UseGuards,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
-import {
-  IsArray,
-  IsInt,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-  Max,
-  Min,
-} from 'class-validator';
 import { Request, Response } from 'express';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import {
-  CreateMcpApiKeyInput,
-  McpApiKeyService,
-} from './auth/mcp-api-key.service';
 import { McpAuthGuard } from './auth/mcp-auth.guard';
 import { McpApiKeyScope } from './dto/mcp.types';
 import { McpServerService } from './mcp-server.service';
 
 /**
- * DTO for creating an MCP API key
- */
-class CreateApiKeyDto {
-  @IsString()
-  @IsNotEmpty()
-  name!: string;
-
-  @IsOptional()
-  @IsString()
-  description?: string;
-
-  @IsOptional()
-  @IsArray()
-  scopes?: McpApiKeyScope[];
-
-  @IsOptional()
-  @IsInt()
-  @Min(1)
-  @Max(365)
-  expiresInDays?: number;
-}
-
-/**
  * MCP Server Controller
  *
  * Handles MCP protocol requests via HTTP + SSE transport.
- * Also provides API key management endpoints.
+ *
+ * API-key LIFECYCLE (mint/list/revoke) does NOT live here, and never has a
+ * REST surface again (workspace#038, R-038-2). The three former
+ * `/rest/mcp/api-keys` handlers were deleted: they were internet-reachable
+ * (Traefik `PathPrefix(/rest/mcp)`) and guarded only by `McpAuthGuard`, so a
+ * leaked MCP key could mint MORE MCP keys — uncapped, unaudited. Lifecycle
+ * operations are GraphQL-only (`mintMcpApiKey`, `me.mcpApiKeys`,
+ * `revokeMcpApiKey`, `platformAdmin.mcpApiKeys`, `adminRevokeMcpApiKey`),
+ * which never consults `McpAuthGuard` — see
+ * `mcp-api-key.resolver.mutations.ts` and `admin.mcp.api.key.resolver.fields.ts`.
+ * This closes the escalation by construction rather than by a reject-branch;
+ * verified by a negative test asserting these paths 404
+ * (`mcp-server.controller.spec.ts`, US3-AS3).
  */
 @Controller('/rest/mcp')
 export class McpServerController {
   constructor(
     private readonly mcpServerService: McpServerService,
-    private readonly mcpApiKeyService: McpApiKeyService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
   ) {}
@@ -91,15 +58,14 @@ export class McpServerController {
     @Res() res: Response,
     @Headers('mcp-session-id') sessionId?: string
   ): Promise<void> {
-    // Skip if this is an API key management request
-    if (req.path.includes('/api-keys')) {
-      return;
-    }
-
     // Get agent info from Passport (set by McpAuthGuard)
     const agentInfo = (req as any).user as ActorContext | undefined;
     // API-key scopes, set by McpApiKeyStrategy when authenticated via a key.
     const scopes = (req as any).mcpApiKeyScopes as McpApiKeyScope[] | undefined;
+    // The validated key's id, set by McpApiKeyStrategy alongside the scopes —
+    // threaded through to the session so it can be revalidated on the
+    // no-fresh-auth branch (workspace#038 FR-013).
+    const apiKeyId = (req as any).mcpApiKeyId as string | undefined;
 
     this.logger.verbose?.(
       `MCP ${req.method} request received, session: ${sessionId || 'new'}, user: ${agentInfo?.actorID || 'anonymous'}`,
@@ -112,7 +78,8 @@ export class McpServerController {
         res as unknown as import('http').ServerResponse,
         sessionId,
         agentInfo,
-        scopes
+        scopes,
+        apiKeyId
       );
     } catch (error) {
       this.logger.error?.(
@@ -131,98 +98,5 @@ export class McpServerController {
         });
       }
     }
-  }
-
-  /**
-   * Create a new MCP API key for the authenticated user
-   */
-  @Post('api-keys')
-  @HttpCode(201)
-  @UseGuards(McpAuthGuard)
-  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
-  async createApiKey(@Req() req: Request, @Body() body: CreateApiKeyDto) {
-    const agentInfo = (req as any).user as ActorContext | undefined;
-    const userId = agentInfo?.actorID;
-    if (!userId) {
-      throw new UnauthorizedException(
-        'User must be authenticated to create API keys'
-      );
-    }
-
-    const input: CreateMcpApiKeyInput = {
-      name: body.name,
-      description: body.description,
-      userId,
-      scopes: body.scopes,
-      expiresAt: body.expiresInDays
-        ? new Date(Date.now() + body.expiresInDays * 24 * 60 * 60 * 1000)
-        : undefined,
-    };
-
-    const result = await this.mcpApiKeyService.createApiKey(input);
-
-    this.logger.verbose?.(
-      `Created MCP API key ${result.id} for user ${userId}`,
-      LogContext.MCP_SERVER
-    );
-
-    return {
-      id: result.id,
-      name: result.name,
-      apiKey: result.apiKey, // Only returned on creation!
-      expiresAt: result.expiresAt,
-      message: 'Save this API key securely - it will not be shown again',
-    };
-  }
-
-  /**
-   * List API keys for the authenticated user
-   */
-  @Get('api-keys')
-  @UseGuards(McpAuthGuard)
-  async listApiKeys(@Req() req: Request) {
-    const agentInfo = (req as any).user as ActorContext | undefined;
-    const userId = agentInfo?.actorID;
-    if (!userId) {
-      throw new UnauthorizedException(
-        'User must be authenticated to list API keys'
-      );
-    }
-
-    const keys = await this.mcpApiKeyService.listApiKeysForUser(userId);
-
-    return keys.map(key => ({
-      id: key.id,
-      name: key.name,
-      description: key.description,
-      scopes: key.scopes,
-      isActive: key.isActive,
-      expiresAt: key.expiresAt,
-      lastUsedAt: key.lastUsedAt,
-      createdAt: key.createdDate,
-    }));
-  }
-
-  /**
-   * Revoke (deactivate) an API key
-   */
-  @Delete('api-keys/:id')
-  @HttpCode(204)
-  @UseGuards(McpAuthGuard)
-  async revokeApiKey(@Req() req: Request, @Param('id') keyId: string) {
-    const agentInfo = (req as any).user as ActorContext | undefined;
-    const userId = agentInfo?.actorID;
-    if (!userId) {
-      throw new UnauthorizedException(
-        'User must be authenticated to revoke API keys'
-      );
-    }
-
-    await this.mcpApiKeyService.revokeApiKey(keyId, userId);
-
-    this.logger.verbose?.(
-      `Revoked MCP API key ${keyId} for user ${userId}`,
-      LogContext.MCP_SERVER
-    );
   }
 }

--- a/src/services/mcp-server/mcp-server.module.ts
+++ b/src/services/mcp-server/mcp-server.module.ts
@@ -25,6 +25,7 @@ import { ActivityModule } from '@platform/activity/activity.module';
 import { PlatformAuthorizationPolicyModule } from '@platform/authorization/platform.authorization.policy.module';
 import { SearchModule } from '@services/api/search/search.module';
 import { UrlGeneratorModule } from '@services/infrastructure/url-generator';
+import { McpApiKeyAuditService } from './auth/mcp-api-key.audit.service';
 import { McpApiKey } from './auth/mcp-api-key.entity';
 import { McpApiKeyService } from './auth/mcp-api-key.service';
 import { McpApiKeyStrategy } from './auth/mcp-api-key.strategy';
@@ -38,6 +39,7 @@ import {
   McpResourceProvider,
   McpTool,
 } from './dto/mcp.types';
+import { McpApiKeyResolverMutations } from './mcp-api-key.resolver.mutations';
 import { McpServerController } from './mcp-server.controller';
 import { McpServerService } from './mcp-server.service';
 import { AssistantBudgetResourceProvider } from './resources/assistant-budget.resource';
@@ -121,6 +123,8 @@ const RESOURCE_PROVIDERS = [
   providers: [
     McpServerService,
     McpApiKeyService,
+    McpApiKeyAuditService,
+    McpApiKeyResolverMutations,
     McpApiKeyStrategy,
     McpDelegationStrategy,
     McpAuthGuard,

--- a/src/services/mcp-server/mcp-server.service.spec.ts
+++ b/src/services/mcp-server/mcp-server.service.spec.ts
@@ -225,4 +225,31 @@ describe('McpServerService.handleRequest — session revalidation (workspace#038
     expect(transport.close).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(401);
   });
+
+  it('leaves an anonymous session alone — no revalidation, no 401 (CodeRabbit, PR #6358)', async () => {
+    const { service, transport, res, mcpApiKeyService } = setup();
+    // A session that never authenticated: anonymous actorContext, no apiKeyId.
+    // It holds no authority to revoke, so the revalidation branch must not
+    // fire — and it must not be mistaken for a revoked-credential session and
+    // torn down. Anonymous MCP access is a legitimate state (the strategy
+    // returns an anonymous ActorContext rather than a 401 for an absent key);
+    // per-operation scope enforcement is what constrains it, not this branch.
+    const session = (service as any).sessions.get(SESSION_ID);
+    session.actorContext = { actorID: '', isAnonymous: true };
+    session.apiKeyId = undefined;
+
+    await service.handleRequest(
+      {} as any,
+      res,
+      SESSION_ID,
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(mcpApiKeyService.isKeyUsable).not.toHaveBeenCalled();
+    expect(transport.close).not.toHaveBeenCalled();
+    expect(transport.handleRequest).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).not.toBe(401);
+  });
 });

--- a/src/services/mcp-server/mcp-server.service.spec.ts
+++ b/src/services/mcp-server/mcp-server.service.spec.ts
@@ -77,3 +77,152 @@ describe('McpServerService.readResource — authorization', () => {
     expect(result.contents[0].text).toBe('{"ok":true}');
   });
 });
+
+/**
+ * workspace#038, FR-012/FR-013/FR-014, C-04: session-scoped key revalidation.
+ * The service's own private `sessions` map is manipulated directly to seed a
+ * pre-established session — this is the same technique any real session
+ * reaches: `handleRequest` reads/writes `this.sessions`, and there is no
+ * public seam to construct a session without driving the real MCP SDK
+ * transport. `configService.get('mcp.enabled', ...)` must return true for
+ * `handleRequest` to proceed past its top-of-function guard.
+ */
+describe('McpServerService.handleRequest — session revalidation (workspace#038)', () => {
+  const SESSION_ID = 'session-1';
+  const KEY_ID = 'key-1';
+
+  const setup = (opts: { isKeyUsable?: boolean } = {}) => {
+    const configService = {
+      get: vi.fn().mockReturnValue(true),
+    };
+    const mcpApiKeyService = {
+      isKeyUsable: vi.fn().mockResolvedValue(opts.isKeyUsable ?? true),
+    };
+    const logger = { warn: vi.fn(), verbose: vi.fn(), error: vi.fn() };
+    const service = new McpServerService(
+      configService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      { checkToolAllowed: vi.fn() } as any,
+      logger as any,
+      mcpApiKeyService as any
+    );
+
+    const transport = {
+      handleRequest: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const authenticatedActor = new ActorContext();
+    authenticatedActor.actorID = 'user-1';
+    authenticatedActor.isAnonymous = false;
+
+    const session = {
+      transport,
+      server: {} as any,
+      actorContext: authenticatedActor,
+      apiKeyId: KEY_ID,
+    };
+    (service as any).sessions.set(SESSION_ID, session);
+
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader: vi.fn((k: string, v: string) => {
+        res.headers[k] = v;
+      }),
+      end: vi.fn(),
+    };
+
+    return { service, session, transport, res, mcpApiKeyService, logger };
+  };
+
+  it('D2 (mandated): initialize with a key, revoke it, reuse the session WITHOUT re-sending the bearer — request fails and the session closes (US2-AS5, FR-013, R-038-3)', async () => {
+    // "revoke" is modeled by isKeyUsable now returning false for KEY_ID.
+    const { service, transport, res, mcpApiKeyService } = setup({
+      isKeyUsable: false,
+    });
+
+    // Reuse the session: sessionId present, NO fresh actorContext (undefined —
+    // i.e. no bearer on this particular request).
+    await service.handleRequest(
+      {} as any,
+      res,
+      SESSION_ID,
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(mcpApiKeyService.isKeyUsable).toHaveBeenCalledWith(KEY_ID);
+    expect(transport.handleRequest).not.toHaveBeenCalled();
+    expect(transport.close).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(401);
+    expect((service as any).sessions.has(SESSION_ID)).toBe(false);
+  });
+
+  it('serves the request when the key is still usable', async () => {
+    const { service, transport, res, mcpApiKeyService } = setup({
+      isKeyUsable: true,
+    });
+
+    await service.handleRequest(
+      {} as any,
+      res,
+      SESSION_ID,
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(mcpApiKeyService.isKeyUsable).toHaveBeenCalledWith(KEY_ID);
+    expect(transport.handleRequest).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect((service as any).sessions.has(SESSION_ID)).toBe(true);
+  });
+
+  it('performs NO additional key lookup when the request DOES carry a fresh key (FR-014, SC-007)', async () => {
+    const { service, transport, res, mcpApiKeyService, session } = setup();
+    const freshActor = new ActorContext();
+    freshActor.actorID = 'user-1';
+    freshActor.isAnonymous = false;
+
+    await service.handleRequest(
+      {} as any,
+      res,
+      SESSION_ID,
+      freshActor,
+      [{ operations: ['read'] }],
+      'key-fresh'
+    );
+
+    // The strategy already revalidated this key on this request — the session
+    // branch must not call isKeyUsable at all.
+    expect(mcpApiKeyService.isKeyUsable).not.toHaveBeenCalled();
+    expect(transport.handleRequest).toHaveBeenCalledTimes(1);
+    expect(session.apiKeyId).toBe('key-fresh');
+  });
+
+  it('fails closed when the session has an authenticated identity but no apiKeyId (C-04, pre-existing session)', async () => {
+    const { service, transport, res, mcpApiKeyService } = setup();
+    // Simulate a session that predates this feature: authenticated identity,
+    // but no apiKeyId was ever recorded.
+    (service as any).sessions.get(SESSION_ID).apiKeyId = undefined;
+
+    await service.handleRequest(
+      {} as any,
+      res,
+      SESSION_ID,
+      undefined,
+      undefined,
+      undefined
+    );
+
+    // isKeyUsable is never CALLED for an absent id (nothing to look up) — the
+    // branch fails closed directly.
+    expect(mcpApiKeyService.isKeyUsable).not.toHaveBeenCalled();
+    expect(transport.handleRequest).not.toHaveBeenCalled();
+    expect(transport.close).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/src/services/mcp-server/mcp-server.service.spec.ts
+++ b/src/services/mcp-server/mcp-server.service.spec.ts
@@ -39,7 +39,8 @@ describe('McpServerService.readResource — authorization', () => {
       resourceRegistry as any,
       authorizationService as any,
       capabilityGateService as any,
-      logger as any
+      logger as any,
+      {} as any
     );
     return { service, provider, authorizationService, logger };
   };

--- a/src/services/mcp-server/mcp-server.service.ts
+++ b/src/services/mcp-server/mcp-server.service.ts
@@ -20,6 +20,7 @@ import { ConfigService } from '@nestjs/config';
 import { AlkemioConfig } from '@src/types/alkemio.config';
 import { IncomingMessage, ServerResponse } from 'http';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { McpApiKeyService } from './auth/mcp-api-key.service';
 import { scopeViolation } from './auth/mcp-scope';
 import { AssistantCapabilityGateService } from './capabilities/assistant.capability.gate.service';
 import {
@@ -47,6 +48,14 @@ interface McpSession {
   server: McpServer;
   actorContext: ActorContext;
   scopes?: McpApiKeyScope[];
+  /**
+   * Id of the MCP API key that established/last refreshed this session's
+   * identity (workspace#038, FR-013). `undefined` means either "not
+   * key-authenticated" (a browser/JWT session, which the revalidation branch
+   * below must not touch) or "established before this feature shipped" — the
+   * latter fails closed rather than trusting a session forever (C-04).
+   */
+  apiKeyId?: string;
 }
 
 @Injectable()
@@ -61,7 +70,8 @@ export class McpServerService implements OnModuleInit {
     private readonly authorizationService: AuthorizationService,
     private readonly capabilityGateService: AssistantCapabilityGateService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
-    private readonly logger: LoggerService
+    private readonly logger: LoggerService,
+    private readonly mcpApiKeyService: McpApiKeyService
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -229,7 +239,8 @@ export class McpServerService implements OnModuleInit {
     res: ServerResponse,
     sessionId?: string,
     actorContext?: ActorContext,
-    scopes?: McpApiKeyScope[]
+    scopes?: McpApiKeyScope[],
+    apiKeyId?: string
   ): Promise<void> {
     if (!this.isEnabled()) {
       res.statusCode = 503;
@@ -266,10 +277,60 @@ export class McpServerService implements OnModuleInit {
       if (actorContext && actorContext.actorID && !actorContext.isAnonymous) {
         session.actorContext = actorContext;
         session.scopes = scopes;
+        session.apiKeyId = apiKeyId;
         this.logger.verbose?.(
           `Updated actorContext for session ${sessionId}: userID=${actorContext.actorID}`,
           LogContext.MCP_SERVER
         );
+      } else if (
+        session.actorContext.actorID &&
+        !session.actorContext.isAnonymous
+      ) {
+        // No FRESH authentication on this request, but the session's identity
+        // IS authenticated — the sole branch key-bearing requests never take
+        // (those already re-validate inside McpApiKeyStrategy's own
+        // `findOne({keyHash, isActive:true})` + expiry check on EVERY request,
+        // so adding a second check there would be a pure-cost no-op — FR-014 /
+        // SC-007 / R-08. This is the ONLY place a revoked key's session can
+        // still be trusted, so it is the ONLY place that needs to ask again
+        // (workspace#038, FR-013 / R-038-3).
+        //
+        // `apiKeyId` absent here means the session was never key-authenticated
+        // in the first place OR was established before this feature shipped
+        // (C-04) — either way, FAIL CLOSED rather than silently trusting it
+        // forever. `isKeyUsable` re-reads by id (we only ever have the id at
+        // this layer, never the plaintext) and checks active + unexpired.
+        const stillValid = session.apiKeyId
+          ? await this.mcpApiKeyService.isKeyUsable(session.apiKeyId)
+          : false;
+
+        if (!stillValid) {
+          this.logger.warn?.(
+            {
+              message:
+                'MCP session revalidation failed: key revoked, expired, or session predates key-tracking. Closing session.',
+              sessionId,
+              apiKeyId: session.apiKeyId,
+            },
+            LogContext.MCP_SERVER
+          );
+          this.sessions.delete(sessionId);
+          await session.transport.close();
+          res.statusCode = 401;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              error: {
+                code: -32001,
+                message:
+                  'Session credential is no longer valid. Please reauthenticate.',
+              },
+              id: null,
+            })
+          );
+          return;
+        }
       }
 
       await session.transport.handleRequest(req, res);
@@ -287,6 +348,7 @@ export class McpServerService implements OnModuleInit {
       transport,
       actorContext: actorContext ?? this.createAnonymousActorContext(),
       scopes,
+      apiKeyId,
     } as McpSession;
     session.server = this.createMcpServer(
       () => session.actorContext,


### PR DESCRIPTION
Implements the server slice of **workspace#038-mcp-api-key-management** for story alkem-io/alkemio#1984.

Cross-repo spec: `agents-hq` → `specs/038-mcp-api-key-management/`
ADR: `docs/decisions/0008-mcp-api-key-lifecycle-contract.md`

## What this does

Gives MCP API keys a lifecycle surface — and closes two live security defects found while building it.

**GraphQL (additive only — `schema:diff`: 41 additive, 0 breaking)**
- `me.mcpApiKeys` — self-scoped metadata list. Never a key value, never a hash: `keyHash` is excluded at the *query* level, not filtered afterwards.
- `mintMcpApiKey` / `revokeMcpApiKey` — the subject comes from `ActorContext`, never from client input.
- `platformAdmin.mcpApiKeys(userID)` / `adminRevokeMcpApiKey` — API-only, gated on `PLATFORM_ADMIN`, with a `userId IS NOT NULL` predicate that keeps the bootstrap trust anchor out of reach.
- Audit rows in `platform_audit_entry` via one additive `PlatformAuditCategory` value, written **fail-closed inside the mutation's transaction** — a failed audit rolls the key change back.

## The two defects this closes

**1. Key-chaining privilege escalation (was live and internet-reachable).** `/rest/mcp/api-keys` carried POST/GET/DELETE handlers behind `McpAuthGuard` — the same guard that accepts MCP API keys. A leaked key could mint replacement keys, uncapped and unaudited, so revoking the leaked key did not end the compromise. Reachable in production and acceptance via Traefik's `PathPrefix(/rest/mcp)`.

**All three handlers are deleted** (not deprecated — verified zero consumers workspace-wide). Verified live: `POST`/`GET`/`DELETE` → `404`/`404`/`404`, and a key-only caller is refused on every GraphQL lifecycle surface.

**2. Revocation was not effective on the next request** — breaking the story's own AC2. An established MCP session only ever *upgraded* its identity, and an invalid key returned an anonymous context rather than a 401, so a revoked key kept full authority until the transport closed or the pod restarted.

Sessions now revalidate the credential — but **only on the branch that did not authenticate afresh**, so the normal key-bearing path adds zero database reads (a test asserts the double-check does *not* happen). Verified live: the revoked key's session gets `401` + `-32001 "Session credential is no longer valid"`, and the session is destroyed.

## Verification

- **Unit**: 255 passed / 26 files (mcp-server + api/me + platform-admin). Full suite on commit: **686 files passed**.
- **Live acceptance**: 29/29 scenarios across 5 user stories, against a booted stack — mint → connect → revoke → refuse, admin list/revoke, actor-key exclusion, audit rows, and the fail-closed rollback.
- **gql-live**: 104 passing, 0 MCP-related failures.
- Durable specs committed in alkem-io/test-suites#604.

Evidence: `specs/038-mcp-api-key-management/forge/verification-results.md` and `review-results.md`.

## Review findings fixed in this PR

An adversarial review panel (correctness / spec-compliance / quality / SOC 2 + ISO 27001 security, two-lens verified) confirmed 18 findings across the feature. Fixed here:

- **A live hard-delete survived** on this service — `deleteApiKey`, plus three other legacy lifecycle methods the deleted REST routes used, all with zero callers on a service now injected into three GraphQL surfaces. Removed. The FR-011 "no hard-delete path" test was a tautology (it asserted a hand-built mock lacked a method it was never given) and now asserts the real class prototype.
- **Every `class-validator` decorator on the new DTOs was inert** — this repo validates only allowlisted metatypes. A >128-char name surfaced as a 500 from the varchar rather than a field error, and a whitespace-only name minted an unlabelled key. All three inputs registered in `BaseHandler`, plus a trim so `@IsNotEmpty()` means what the field description promises.
- **`me.mcpApiKeys` could fail wholesale.** The projection cast `scopes[].operations` instead of filtering it, so one pre-existing row with an out-of-enum operation (the bootstrap/manual-insert path the spec itself documents) broke the entire non-nullable field — hiding *every* key from the only surface that can revoke them. Now filtered; unknown values degrade to an empty list and the key stays revocable.
- **A ticked task cited assertions that did not exist.** T033/T034 claimed service-level coverage of the actor-key firewall; the spec only proved resolver forwarding. Added a real assertion on the query the service actually issues.

## ⚠ Accepted residual security risk

Two `high` findings are **not** fixed here. Both were reviewed and the residual risk **explicitly accepted** by the operator, each tracked as a follow-up:

| Finding | Story | Residual risk you are accepting |
|---|---|---|
| Principal not revalidated; no `deleteUser` cascade | alkem-io/alkemio#2050 | Revoking a **key** is effective on the next request. Deleting an **account** is not — a deleted or role-stripped user keeps serving on an already-established MCP session until the transport closes. Also carries the GDPR erasure gap: `mcp_api_key` rows holding `lastUsedFromIp` outlive the account. |
| `lastUsedFromIp` is caller-controlled | alkem-io/alkemio#2051 | `extractClientIp` takes the leftmost `X-Forwarded-For` entry (**pre-existing and unchanged on `develop`** — this PR *publishes* it). The holder of a leaked key controls the source address shown to its owner and to admins during the incident that key causes. A correct fix needs Traefik `trustedIPs`, which architect decision A-06 scoped out. |

Neither is fixed here because both edit code outside this feature's slice — `deleteUser`'s post-commit block and the edge's trusted-proxy configuration.

## Notes for the release risk profile

- One additive enum migration (`ALTER TYPE … ADD VALUE`, forward-only; PostgreSQL cannot drop an enum value, so a rollback leaves a harmless unused one).
- Deleting the REST routes is a behaviour change for any undocumented out-of-tree consumer — accepted as R-038-8 (reachable only by an existing key-holder, git-recoverable).
- No authorization-policy change and **no auth reset**: `McpApiKey` is `BaseAlkemioEntity`, not `IAuthorizable`.
- No infrastructure-operations change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP API key management through GraphQL.
  * Authenticated users can create keys with selected permissions and expiration dates, view metadata, and revoke their own keys.
  * Platform administrators can view and revoke user keys.
  * Credentials are shown only once when created.
  * Added active, expired, and revoked statuses, with a limit of 10 usable keys per user.
  * MCP sessions detect revoked or expired keys and require reauthentication.

* **Security**
  * Added audit records for key creation and revocation.
  * Limited exposed key information to non-sensitive metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->