### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -652,6 +652,14 @@ input AddVisualToMediaGalleryInput {
   visualType: VisualType!
 }
 
+input AdminRevokeMcpApiKeyInput {
+  keyID: UUID!
+  """
+  Owner of the key. Required — it scopes the revoke and the audit subject.
+  """
+  userID: UUID!
+}
+
 input AdminUserEmailChangeDriftResolveInput {
   """
   The admin-chosen canonical email. MUST equal either the old or new email recorded on the drift_detected audit entry. Both sides are force-aligned to this value.
@@ -794,6 +802,28 @@ input AssignRoleOnRoleSetInput {
 input AssignUserGroupMemberInput {
   groupID: UUID!
   userID: UUID!
+}
+
+type AssistantCapability {
+  """What the capability does (for the settings UI)."""
+  description: String!
+  """Human-readable label for the capability toggle."""
+  displayName: String!
+  """
+  READ | WRITE_ADDITIVE | WRITE_DESTRUCTIVE — drives the default (READ enabled, WRITE_* disabled) and confirmation behaviour.
+  """
+  kind: AssistantCapabilityKind!
+  """The MCP tool name, e.g. "search_content"."""
+  name: String!
+}
+
+"""
+The kind of an assistant capability — READ is enabled by default; WRITE_* are disabled by default and confirmation-gated.
+"""
+enum AssistantCapabilityKind {
+  READ
+  WRITE_ADDITIVE
+  WRITE_DESTRUCTIVE
 }
 
 type AssistantCapabilityToggle {
@@ -4394,6 +4424,52 @@ type LookupQueryResults {
 """A markdown string."""
 scalar Markdown
 
+"""
+Metadata for one MCP API key. The key value itself is never exposed here.
+"""
+type McpApiKey {
+  createdDate: DateTime!
+  """Optional expiry chosen at mint."""
+  expiresAt: DateTime
+  id: UUID!
+  """When this key last authenticated a request."""
+  lastUsedAt: DateTime
+  """Source address of the last request this key authenticated."""
+  lastUsedFromIp: String
+  """User-supplied label. Not unique."""
+  name: String!
+  """Granted operations, flattened from the stored scope."""
+  operations: [McpApiKeyOperation!]!
+  status: McpApiKeyStatus!
+}
+
+"""
+Result of minting a key. The only place the plaintext is ever returned.
+"""
+type McpApiKeyMintResult {
+  """
+  The plaintext key. Returned EXACTLY ONCE — it is not stored and cannot be re-derived.
+  """
+  apiKey: String!
+  """Metadata for the key just created."""
+  key: McpApiKey!
+}
+
+"""Operations an MCP API key may perform."""
+enum McpApiKeyOperation {
+  READ
+  TOOLS
+}
+
+"""
+Lifecycle status of an MCP API key. REVOKED takes precedence over EXPIRED.
+"""
+enum McpApiKeyStatus {
+  ACTIVE
+  EXPIRED
+  REVOKED
+}
+
 type MeConversationsResult {
   """
   All conversations (direct and group) for the current authenticated user. Client handles categorization by room type and member actor types.
@@ -4421,6 +4497,10 @@ type MeQueryResults {
   conversations: MeConversationsResult!
   """The query id"""
   id: String!
+  """
+  The current user's MCP API keys, newest first. Includes revoked and expired keys so last-used evidence survives revocation.
+  """
+  mcpApiKeys: [McpApiKey!]!
   """The Spaces I am contributing to"""
   mySpaces(
     """
@@ -4597,6 +4677,17 @@ enum MimeType {
   XPNG
 }
 
+input MintMcpApiKeyInput {
+  """Optional expiry. MUST be in the future when supplied."""
+  expiresAt: DateTime
+  """Label for the key. 1..128 characters after trimming."""
+  name: String!
+  """
+  At least one operation. Duplicates are removed; order is not significant.
+  """
+  operations: [McpApiKeyOperation!]!
+}
+
 type ModelCardAiEngineResult {
   """Access to detailed information on the underlying models specifications"""
   additionalTechnicalDetails: String!
@@ -4721,6 +4812,8 @@ type Mutation {
   adminLicensePolicyDeleteCredentialRule(deleteData: DeleteLicensePolicyCredentialRuleInput!): LicensingCredentialBasedPolicyCredentialRule!
   """Updates a CredentialRule on the LicensePolicy."""
   adminLicensePolicyUpdateCredentialRule(updateData: UpdateLicensePolicyCredentialRuleInput!): LicensingCredentialBasedPolicyCredentialRule!
+  """Platform admin: revoke a named user's MCP API key. Idempotent."""
+  adminRevokeMcpApiKey(revokeData: AdminRevokeMcpApiKeyInput!): McpApiKey!
   """
   Ingests new data into Elasticsearch from scratch. This will delete all existing data and ingest new data from the source. This is an admin only operation.
   """
@@ -4963,6 +5056,10 @@ type Mutation {
   Mark notifications as unread. If no filter is provided, marks all user notifications as unread. If filter with types is provided, marks only those notification types as unread.
   """
   markNotificationsAsUnread(filter: NotificationEventsFilterInput): Boolean!
+  """
+  Mint a new MCP API key for the current user. Returns the plaintext exactly once.
+  """
+  mintMcpApiKey(mintData: MintMcpApiKeyInput!): McpApiKeyMintResult!
   """Moves the specified Contribution to another Callout."""
   moveContributionToCallout(moveContributionData: MoveCalloutContributionInput!): CalloutContribution!
   """
@@ -5043,6 +5140,8 @@ type Mutation {
   revokeLicensePlanFromAccount(planData: RevokeLicensePlanFromAccount!): Account!
   """Revokes the specified LicensePlan on a Space."""
   revokeLicensePlanFromSpace(planData: RevokeLicensePlanFromSpace!): Space!
+  """Revoke one of the current user's own MCP API keys. Idempotent."""
+  revokeMcpApiKey(revokeData: RevokeMcpApiKeyInput!): McpApiKey!
   """
   Send a private (1:1) chat message to each of the given Users individually. Does NOT create a group conversation. Each recipient is processed independently and reported on; partial success is possible.
   """
@@ -5691,6 +5790,10 @@ type PlatformAdminQueryResults {
   The most recent email-change audit entry for the named subject user. Returns null if no audit entry exists.
   """
   latestUserEmailChangeAuditEntry(userID: UUID!): UserEmailChangeAuditEntry
+  """
+  MCP API keys belonging to the named user. Platform admins only. Keys bound to a system actor are never returned.
+  """
+  mcpApiKeys(userID: UUID!): [McpApiKey!]!
   """
   Retrieve all Organizations on the Platform. This is only available to Platform Admins.
   """
@@ -6375,6 +6478,10 @@ type Query {
   platform: Platform!
   """Allow looking up of information for Platform administration."""
   platformAdmin: PlatformAdminQueryResults!
+  """
+  The enumerable assistant capability surface (one per MCP tool), with each tool classified READ / WRITE_ADDITIVE / WRITE_DESTRUCTIVE.
+  """
+  platformCapabilities: [AssistantCapability!]!
   """Get the list of restricted space names."""
   restrictedSpaceNames: [String!]!
   """The roles that the specified Organization has."""
@@ -6686,6 +6793,10 @@ input RevokeLicensePlanFromSpace {
   licensingID: UUID
   """The ID of the Space to assign the LicensePlan to."""
   spaceID: UUID!
+}
+
+input RevokeMcpApiKeyInput {
+  keyID: UUID!
 }
 
 input RevokeOrganizationAuthorizationCredentialInput {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 326337 bytes
Snapshot md5: 0b98eec062cee1d1f595a20fd2644299

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP API-key management, including minting, revoking, expiration, names, and operation permissions.
  * Added views for current users and platform administrators to review API keys.
  * Added assistant capability discovery through platform capability metadata.
  * Added API-key status, operation, and capability information, including one-time mint results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->