### PR TITLE
fix(notifications): build payload for collabora document contributions

### DIFF
--- a/src/services/adapters/notification-external-adapter/notification.external.adapter.spec.ts
+++ b/src/services/adapters/notification-external-adapter/notification.external.adapter.spec.ts
@@ -356,6 +356,50 @@ describe('NotificationExternalAdapter', () => {
         CalloutContributionType.MEMO
       );
     });
+
+    it('should build payload for collabora document contribution (regression: server crash on document response)', async () => {
+      mockSetup();
+
+      const result = await adapter.buildSpaceCollaborationCreatedPayload(
+        NotificationEvent.SPACE_COLLABORATION_CALLOUT_CONTRIBUTION,
+        'user-1',
+        [],
+        {
+          id: 'space-1',
+          level: 1,
+          about: { profile: { displayName: 'Space' } },
+        } as any,
+        {
+          callout: {
+            id: 'callout-1',
+            framing: {
+              id: 'framing-1',
+              profile: { displayName: 'Callout', description: 'desc' },
+              type: 'POST_COLLECTION',
+            },
+            settings: {
+              contribution: { allowedTypes: ['collabora_document'] },
+            },
+          },
+          contribution: {
+            id: 'contrib-1',
+            createdBy: 'user-1',
+            collaboraDocument: {
+              id: 'collabora-1',
+              createdBy: 'user-1',
+              profile: { displayName: 'Doc', description: 'desc' },
+            },
+          },
+        } as any
+      );
+
+      expect(result.callout.contribution?.type).toBe(
+        CalloutContributionType.COLLABORA_DOCUMENT
+      );
+      expect(result.callout.contribution?.id).toBe('collabora-1');
+      // Collabora documents have no deep link — the URL is the containing callout.
+      expect(result.callout.contribution?.url).toBe('/callout/1');
+    });
   });
 
   describe('buildPlatformUserRemovedNotificationPayload', () => {

--- a/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
+++ b/src/services/adapters/notification-external-adapter/notification.external.adapter.ts
@@ -392,9 +392,25 @@ export class NotificationExternalAdapter {
           contribution.memo.nameID
         ),
       };
+    } else if (contribution.collaboraDocument) {
+      contributionPayload = {
+        id: contribution.collaboraDocument.id,
+        type: CalloutContributionType.COLLABORA_DOCUMENT,
+        createdBy: await this.getContributorPayloadOrFail(
+          contribution.createdBy ||
+            contribution.collaboraDocument.createdBy ||
+            ''
+        ),
+        displayName: contribution.collaboraDocument.profile?.displayName ?? '',
+        description: contribution.collaboraDocument.profile?.description ?? '',
+        // Collabora documents have no client deep-link route — the client opens
+        // them in a dialog from the callout page — so the canonical URL is the
+        // containing callout (mirrors UrlGeneratorService + the link branch).
+        url: calloutURL,
+      };
     } else {
       throw new RelationshipNotFoundException(
-        'No valid contribution type found (post, whiteboard, or link)',
+        'No valid contribution type found (post, whiteboard, link, memo, or collabora document)',
         LogContext.NOTIFICATIONS,
         {
           contribution: contribution.id,


### PR DESCRIPTION
## Problem

Adding a **Collabora document as a callout response** crashed the server. Symptom reported: the first document create succeeds on the client, then the server process dies before the next request.

```
RelationshipNotFoundException: No valid contribution type found (post, whiteboard, or link)
  at NotificationExternalAdapter.buildSpaceCollaborationCreatedPayload (notification.external.adapter.ts:396)
  at NotificationSpaceAdapter.spaceCollaborationCalloutContributionCreated (notification.space.adapter.ts:381)
  at CalloutResolverMutations.processActivityCollaboraDocumentCreated (callout.resolver.mutations.ts:775)
```

## Root cause

`createContributionOnCallout` fires `spaceCollaborationCalloutContributionCreated` for the new document, but `buildSpaceCollaborationCreatedPayload` only had branches for **post / whiteboard / link / memo**. A `collabora_document` contribution fell through to the `else` and threw `RelationshipNotFoundException`.

Because `processActivityCollaboraDocumentCreated` is dispatched **fire-and-forget** (not awaited), the throw surfaced as an **unhandled promise rejection** and took the Node process down — hence "first succeeds, then the server crashes."

This is a regression from the document-responses work in #6350.

## Fix

- Add the missing `collaboraDocument` branch to `buildSpaceCollaborationCreatedPayload`, mirroring the memo/link branches. Collabora documents have **no client deep-link route** (the client opens them in a dialog from the callout page), so the payload URL is the containing **callout URL** — exactly what `UrlGeneratorService` resolves for them and what the `link` branch already does.
- The just-created contribution already carries `collaboraDocument.profile.displayName` and `.createdBy` (set in `createCollaboraDocument`), so no extra DB load is needed.
- Correct the now-stale `else`-branch message to list every handled type.

## Tests

- New unit test in `notification.external.adapter.spec.ts`: builds the payload for a collabora document contribution, asserting `type === COLLABORA_DOCUMENT`, the contribution id, and the callout URL.
- Full suite green via the pre-commit hook (**8032 passed / 7 skipped**); typecheck + Biome clean.

## Notes

- Scope is limited to unblocking the server crash. The dispatched payload is well-formed with `type: COLLABORA_DOCUMENT`; whether the notifications-service template renders a bespoke string for this type is a separate, non-crashing concern.
- Commits are unsigned (headless runner can't reach the hardware signing key) — re-sign on merge if branch protection requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Collabora document contributions in space collaboration notifications.
  - Notifications now include the document ID, type, creator, optional name and description, and the containing callout link.

- **Bug Fixes**
  - Improved invalid-contribution error messages to recognize memo and Collabora document types.

- **Tests**
  - Added regression coverage to verify Collabora document notification payloads and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->