### PR TITLE
feat(039): add Application.user nullable resolver field (applications export)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1643,6 +1643,8 @@ type Application {
   state: String!
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
+  """The User who submitted this Application."""
+  user: User
 }
 
 type AssistantCapability {

--- a/src/domain/access/application/application.resolver.fields.spec.ts
+++ b/src/domain/access/application/application.resolver.fields.spec.ts
@@ -60,4 +60,27 @@ describe('ApplicationResolverFields', () => {
       );
     });
   });
+
+  describe('user', () => {
+    it('S1 delegation — should return the user from applicationService.getUser and call it with application.id', async () => {
+      const mockUser = { id: 'user-1' } as any;
+      const mockApplication = { id: 'app-1' } as any;
+      (applicationService.getUser as Mock).mockResolvedValue(mockUser);
+
+      const result = await resolver.user(mockApplication);
+
+      expect(result).toBe(mockUser);
+      expect(applicationService.getUser).toHaveBeenCalledWith('app-1');
+    });
+
+    it('S2 null-on-missing — should return null without throwing when service resolves null', async () => {
+      const mockApplication = { id: 'app-1' } as any;
+      (applicationService.getUser as Mock).mockResolvedValue(null);
+
+      const result = await resolver.user(mockApplication);
+
+      expect(result).toBeNull();
+      expect(applicationService.getUser).toHaveBeenCalledWith('app-1');
+    });
+  });
 });

--- a/src/domain/access/application/application.resolver.fields.ts
+++ b/src/domain/access/application/application.resolver.fields.ts
@@ -3,6 +3,7 @@ import { GraphqlGuard } from '@core/authorization';
 import { Application, IApplication } from '@domain/access/application';
 import { IActor } from '@domain/actor/actor/actor.interface';
 import { IQuestion } from '@domain/common/question/question.interface';
+import { IUser } from '@domain/community/user/user.interface';
 import { UseGuards } from '@nestjs/common';
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import {
@@ -35,5 +36,16 @@ export class ApplicationResolverFields {
   @Profiling.api
   async questions(@Parent() application: Application): Promise<IQuestion[]> {
     return await this.applicationService.getQuestionsSorted(application);
+  }
+
+  @AuthorizationActorHasPrivilege(AuthorizationPrivilege.READ)
+  @UseGuards(GraphqlGuard)
+  @ResolveField('user', () => IUser, {
+    nullable: true,
+    description: 'The User who submitted this Application.',
+  })
+  @Profiling.api
+  async user(@Parent() application: Application): Promise<IUser | null> {
+    return await this.applicationService.getUser(application.id);
   }
 }

--- a/src/domain/access/application/application.service.spec.ts
+++ b/src/domain/access/application/application.service.spec.ts
@@ -272,6 +272,42 @@ describe('ApplicationService', () => {
     });
   });
 
+  describe('getUser', () => {
+    it('should return the user when the relation is present', async () => {
+      const mockUser = { id: 'user-1' } as any;
+      const mockApplication = {
+        id: 'app-1',
+        user: mockUser,
+      } as Application;
+
+      vi.spyOn(service, 'getApplicationOrFail').mockResolvedValue(
+        mockApplication
+      );
+
+      const result = await service.getUser('app-1');
+
+      expect(result).toBe(mockUser);
+      expect(service.getApplicationOrFail).toHaveBeenCalledWith('app-1', {
+        relations: { user: true },
+      });
+    });
+
+    it('should return null when the user relation is missing', async () => {
+      const mockApplication = {
+        id: 'app-1',
+        user: undefined,
+      } as Application;
+
+      vi.spyOn(service, 'getApplicationOrFail').mockResolvedValue(
+        mockApplication
+      );
+
+      const result = await service.getUser('app-1');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('getActor', () => {
     it('should return user when application has a loaded user relation', async () => {
       const mockUser = { id: 'user-1', email: 'user@test.com' } as any;

--- a/src/domain/access/application/application.service.ts
+++ b/src/domain/access/application/application.service.ts
@@ -16,6 +16,7 @@ import { AuthorizationPolicyService } from '@domain/common/authorization-policy/
 import { LifecycleService } from '@domain/common/lifecycle/lifecycle.service';
 import { NVPService } from '@domain/common/nvp/nvp.service';
 import { IQuestion } from '@domain/common/question/question.interface';
+import { IUser } from '@domain/community/user/user.interface';
 import { UserService } from '@domain/community/user/user.service';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -124,6 +125,13 @@ export class ApplicationService {
         { applicationID }
       );
     return user;
+  }
+
+  async getUser(applicationID: string): Promise<IUser | null> {
+    const application = await this.getApplicationOrFail(applicationID, {
+      relations: { user: true },
+    });
+    return application.user ?? null;
   }
 
   async findExistingApplications(


### PR DESCRIPTION
## What

Adds ONE additive, nullable GraphQL field `Application.user: User` (delegation-only resolver
+ a service accessor). This lets the client read an applicant's email through the **existing
`READ_USER_PII` field gate** on `User.email` — no new authorization logic, no email handling
in this resolver.

Part of the cross-repo feature **`workspace#039-membership-csv-export`** — the client-web
slice adds the two CSV export buttons (issue alkem-io/client-web#10030).

## Why

The "Export All Submitted Applications" CSV needs a **privilege-gated** applicant email
column. Rather than add a new email path (and a new leak surface), the applicant email nests
through the platform's existing `User.email` resolver, which already returns the `not accessible`
sentinel to unauthorized callers. This resolver is pure delegation: `application → user`.

## Changes

- `application.resolver.fields.ts` — new `@ResolveField('user')` returning the related `User`
  (nullable); no email logic.
- `application.service.ts` — `getUser(application)` accessor.
- `schema.graphql` — `Application.user: User` (nullable, **ADDED-only**; schema baseline diff
  has zero breaking entries).

**No DDL, no migration** — `application.user` ManyToOne already exists (`application.entity.ts`).

## Testing

- Full server suite green (**8084 tests**), incl. new `Application.user` resolver + service specs
  (delegation returns the related user; null-on-missing).
- gql-live probes against a booted stack: privileged caller → real address; **unprivileged
  caller → `not accessible` sentinel, never an address** (R-1); null-user branch by unit spec.

## Contract

`contracts/graphql-application-user.md` — §1 additive-only, §4 consumer codegen check, §5 live
probes. Verified additive with zero breaking budget.

## Risk / tracked debt

The only elevated risk is **R-1 (PII leak via the new read path)** — fully mitigated: the
resolver delegates to the pre-existing `READ_USER_PII` gate and never touches `email`. No
security-hold. No unresolved security residual. (Client-side product/UX residual **R-3** —
blank-cell ambiguity — is tracked on the client-web PR and the Release NN risk profile.)

Cross-ref: `workspace#039-membership-csv-export`. Relates to alkem-io/client-web#10030.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applications now expose the user who submitted them.
  * The submitting user is optional and may be unavailable when no user is associated with the application.

* **Tests**
  * Added coverage for loading associated users and handling applications without one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->