### PR TITLE
chore(k8s): scale the test server deployment to 4 replicas

### DIFF
--- a/manifests/26-server-deployment-test.yaml
+++ b/manifests/26-server-deployment-test.yaml
@@ -7,7 +7,7 @@ metadata:
     app: alkemio-server
 
 spec:
-  replicas: 3
+  replicas: 4
   selector:
     matchLabels:
       app: alkemio-server


### PR DESCRIPTION
## Change

Raises `alkemio-server-deployment` on **test** from **3 → 4 replicas**, for additional headroom under the parallelised nightly `server-api` suite (`workspace#040-parallel-nightly-server-api`).

## Safety

Safe at 4 replicas: database migrations run in the separate `server-migration` **CronJob**, not in the deployment, so there is no migration race on scale-out. The deployment declares no `resources` block, so there is no per-pod CPU/memory ceiling to reconsider.

## Sequencing — please read before merging

More server replicas mean **more concurrent notification events** published to the `alkemio-notifications` queue.

That queue is currently the subject of alkem-io/notifications#581, which fixes a liveness-probe death spiral triggered by exactly this kind of event volume. **Land #581 first.** Merging this ahead of it increases the event rate into a consumer that cannot yet survive a backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the deployment capacity from three to four instances for improved availability and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->