### PR TITLE
feat(006): Release B legacy collaboration content drop

### DIFF
--- a/src/config/release-a.migrations.spec.ts
+++ b/src/config/release-a.migrations.spec.ts
@@ -1,5 +1,3 @@
-import { readdirSync } from 'fs';
-import { join } from 'path';
 import type { QueryRunner } from 'typeorm';
 import { vi } from 'vitest';
 import { AddContentPointer1781802081405 } from '../migrations/1781802081405-AddContentPointer';
@@ -14,8 +12,6 @@ import { DefaultLegacyWhiteboardContent1781950000000 } from '../migrations/17819
 // fails before the default and succeeds after — while an explicit NULL still
 // fails — is a runtime transcript against a throwaway table (the repo has no
 // DB-backed test harness); see the Release A report's evidence path.
-
-const MIGRATIONS_DIR = join(__dirname, '..', 'migrations');
 
 const mockRunner = () => {
   const query = vi.fn(async () => undefined);
@@ -67,8 +63,15 @@ describe('006 Release A content migrations', () => {
     });
   });
 
-  it('the destructive DropMemoAndWhiteboardContent migration is ABSENT in Release A', () => {
-    const files = readdirSync(MIGRATIONS_DIR);
-    expect(files.some(f => /DropMemoAndWhiteboardContent/.test(f))).toBe(false);
+  it('Release A itself never drops the legacy content columns', async () => {
+    const { runner, query } = mockRunner();
+    await new AddContentPointer1781802081405().up(runner);
+    await new DefaultLegacyWhiteboardContent1781950000000().up(runner);
+
+    expect(
+      statementsOf(query).some(s =>
+        /ALTER TABLE "(?:memo|whiteboard)" DROP COLUMN "content"/i.test(s)
+      )
+    ).toBe(false);
   });
 });

--- a/src/config/release-b.migrations.spec.ts
+++ b/src/config/release-b.migrations.spec.ts
@@ -1,0 +1,97 @@
+import type { QueryRunner } from 'typeorm';
+import { vi } from 'vitest';
+import { DropLegacyMemoWhiteboardContent1787551200000 } from '../migrations/1787551200000-DropLegacyMemoWhiteboardContent';
+
+type Counts = {
+  memoUnmigrated: number;
+  whiteboardUnmigrated: number;
+};
+
+const mockRunner = (counts: Counts) => {
+  const query = vi.fn(async (statement: string) => {
+    if (/SELECT[\s\S]+memoUnmigrated/.test(statement)) {
+      return [counts];
+    }
+    return undefined;
+  });
+  return { runner: { query } as unknown as QueryRunner, query };
+};
+
+const statementsOf = (query: ReturnType<typeof vi.fn>): string[] =>
+  query.mock.calls.map(call => String(call[0]));
+
+describe('006 Release B legacy content-column drop', () => {
+  it('locks both owner tables, proves zero NULL/blank pointers, then drops only the legacy content columns', async () => {
+    const { runner, query } = mockRunner({
+      memoUnmigrated: 0,
+      whiteboardUnmigrated: 0,
+    });
+
+    await new DropLegacyMemoWhiteboardContent1787551200000().up(runner);
+
+    const statements = statementsOf(query);
+    expect(statements).toHaveLength(4);
+    expect(statements[0]).toMatch(
+      /LOCK TABLE "memo", "whiteboard" IN ACCESS EXCLUSIVE MODE/
+    );
+    expect(statements[1]).toMatch(
+      /FROM "memo"[\s\S]+"contentPointer" IS NULL[\s\S]+btrim\("contentPointer"\) = ''/
+    );
+    expect(statements[1]).toMatch(
+      /FROM "whiteboard"[\s\S]+"contentPointer" IS NULL[\s\S]+btrim\("contentPointer"\) = ''/
+    );
+    expect(statements.slice(2)).toEqual([
+      `ALTER TABLE "memo" DROP COLUMN "content"`,
+      `ALTER TABLE "whiteboard" DROP COLUMN "content"`,
+    ]);
+    expect(statements.some(s => /ALTER COLUMN "contentPointer"/i.test(s))).toBe(
+      false
+    );
+  });
+
+  it.each([
+    {
+      type: 'memo',
+      counts: { memoUnmigrated: 1, whiteboardUnmigrated: 0 },
+    },
+    {
+      type: 'whiteboard',
+      counts: { memoUnmigrated: 0, whiteboardUnmigrated: 1 },
+    },
+  ] as const)('fails closed before either DROP when $type has an unmigrated row', async ({
+    counts,
+  }) => {
+    const { runner, query } = mockRunner(counts);
+
+    await expect(
+      new DropLegacyMemoWhiteboardContent1787551200000().up(runner)
+    ).rejects.toThrow(/refused.*NULL or blank contentPointer/i);
+
+    expect(statementsOf(query)).toHaveLength(2);
+    expect(
+      statementsOf(query).some(s => /DROP COLUMN "content"/i.test(s))
+    ).toBe(false);
+  });
+
+  it('fails closed when the preflight result is missing or malformed', async () => {
+    const query = vi.fn(async () => []);
+    const runner = { query } as unknown as QueryRunner;
+
+    await expect(
+      new DropLegacyMemoWhiteboardContent1787551200000().up(runner)
+    ).rejects.toThrow(/invalid preflight result/i);
+    expect(statementsOf(query)).toHaveLength(2);
+  });
+
+  it('has no dishonest down migration after destroying the legacy bytes', async () => {
+    const { runner, query } = mockRunner({
+      memoUnmigrated: 0,
+      whiteboardUnmigrated: 0,
+    });
+
+    await expect(
+      new DropLegacyMemoWhiteboardContent1787551200000().down(runner)
+    ).rejects.toThrow(/irreversible.*backup/i);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/src/migrations/1787551200000-DropLegacyMemoWhiteboardContent.ts
+++ b/src/migrations/1787551200000-DropLegacyMemoWhiteboardContent.ts
@@ -1,0 +1,82 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+type PreflightRow = {
+  memoUnmigrated?: unknown;
+  whiteboardUnmigrated?: unknown;
+};
+
+const parseCount = (value: unknown): number | undefined => {
+  if (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 0
+  ) {
+    return value;
+  }
+  if (typeof value === 'string' && /^(0|[1-9]\d*)$/.test(value)) {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+/**
+ * Release B for 006-collab-content-unification.
+ *
+ * This migration is intentionally separate from additive Release A. Operators
+ * first hold the memo/whiteboard write fence, migrate every legacy row, and run
+ * the Release-A verifier. The ACCESS EXCLUSIVE lock then closes the residual
+ * count-to-DDL race: even a mistakenly undrained writer cannot insert a fresh
+ * NULL pointer between this migration's preflight and the column drops.
+ *
+ * Only the legacy recovery sources are removed. `contentPointer` remains
+ * nullable because a newly-created document legitimately has a short interval
+ * between its row insert and initial snapshot attachment.
+ */
+export class DropLegacyMemoWhiteboardContent1787551200000
+  implements MigrationInterface
+{
+  name = 'DropLegacyMemoWhiteboardContent1787551200000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `LOCK TABLE "memo", "whiteboard" IN ACCESS EXCLUSIVE MODE`
+    );
+
+    const rows = (await queryRunner.query(`
+      SELECT
+        (SELECT COUNT(*)::integer
+           FROM "memo"
+          WHERE "contentPointer" IS NULL
+             OR btrim("contentPointer") = '') AS "memoUnmigrated",
+        (SELECT COUNT(*)::integer
+           FROM "whiteboard"
+          WHERE "contentPointer" IS NULL
+             OR btrim("contentPointer") = '') AS "whiteboardUnmigrated"
+    `)) as PreflightRow[];
+    const memoUnmigrated = parseCount(rows[0]?.memoUnmigrated);
+    const whiteboardUnmigrated = parseCount(
+      rows[0]?.whiteboardUnmigrated
+    );
+
+    if (memoUnmigrated === undefined || whiteboardUnmigrated === undefined) {
+      throw new Error(
+        'Release B refused: invalid preflight result while counting unmigrated memo/whiteboard rows'
+      );
+    }
+    if (memoUnmigrated > 0 || whiteboardUnmigrated > 0) {
+      throw new Error(
+        `Release B refused: memo/whiteboard rows still have NULL or blank contentPointer (memo=${memoUnmigrated}, whiteboard=${whiteboardUnmigrated})`
+      );
+    }
+
+    await queryRunner.query(`ALTER TABLE "memo" DROP COLUMN "content"`);
+    await queryRunner.query(`ALTER TABLE "whiteboard" DROP COLUMN "content"`);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    throw new Error(
+      'Release B is irreversible: dropped legacy content bytes cannot be reconstructed; restore the coordinated database and file-storage backup or forward-fix'
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Stacked Release B for 006 collaboration-content unification. This PR must merge only after Release A (#6193) is merged and the write-fenced migration worker reports zero failures plus a clean enhanced `--verify`.

- take ACCESS EXCLUSIVE locks on `memo` and `whiteboard` to close the preflight-to-DDL writer race
- fail closed if any `contentPointer` is NULL or blank
- drop only `memo.content` and `whiteboard.content`; keep `contentPointer` nullable for the legitimate new-row snapshot window
- refuse a dishonest down migration because dropped legacy bytes require coordinated DB + file-storage backup restoration

## Validation

- Node 22 `pnpm lint`
- focused Release A/B migration specs: 9 passed
- full pre-commit suite: 722 files / 8318 tests passed / 0 failed
- PostgreSQL 17.5 temporary-table transcript: zero-row preflight dropped only the two content columns; whitespace pointer produced an unmigrated count and no DROP

## Rollout gate

Do not retarget this PR to `develop` until Release A merges. Do not run it outside maintenance/write-fence. The point of no return is applying this migration.