### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -1056,6 +1056,7 @@ enum AuthorizationPrivilege {
   LICENSE_RESET
   MOVE_CONTRIBUTION
   MOVE_POST
+  MOVE_TASK
   PLATFORM_ADMIN
   PLATFORM_OPERATIONS_ADMIN
   PLATFORM_SETTINGS_ADMIN
@@ -1213,6 +1214,10 @@ type Callout {
   settings: CalloutSettings!
   """The sorting order for this Callout."""
   sortOrder: Float!
+  """
+  Per-column task counts for a Tasks board callout, in the board-defined column order and zero-filled; null when the callout is not a Tasks board.
+  """
+  taskColumnCounts: [TaskColumnCount!]
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
 }
@@ -1226,6 +1231,10 @@ enum CalloutAllowedActors {
 type CalloutContribution {
   """The authorization rules for the entity"""
   authorization: Authorization
+  """
+  The Classification of this Contribution, present only for a task on a Tasks board (carries the task column).
+  """
+  classification: Classification
   """The CollaboraDocument that was contributed."""
   collaboraDocument: CollaboraDocument
   """The user that created this Document"""
@@ -1654,6 +1663,20 @@ type Collaboration {
   timeline: Timeline!
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
+}
+
+type CollaborationMigrationIssue {
+  id: String!
+  reason: String!
+}
+
+type CollaborationMigrationResult {
+  failed: Int!
+  failedDocuments: [CollaborationMigrationIssue!]!
+  flagged: Int!
+  flaggedDocuments: [CollaborationMigrationIssue!]!
+  migrated: Int!
+  total: Int!
 }
 
 type Communication {
@@ -2150,6 +2173,10 @@ type CreateCalloutContributionData {
   post: CreatePostData
   """The sort order to assign to this Contribution."""
   sortOrder: Float
+  """
+  The Tasks board column this task starts in. Only valid when the parent Callout is a Tasks board; defaults to the first column.
+  """
+  taskColumn: String
   type: CalloutContributionType!
   whiteboard: CreateWhiteboardData
 }
@@ -2177,6 +2204,10 @@ input CreateCalloutContributionInput {
   post: CreatePostInput
   """The sort order to assign to this Contribution."""
   sortOrder: Float
+  """
+  The Tasks board column this task starts in. Only valid when the parent Callout is a Tasks board; defaults to the first column.
+  """
+  taskColumn: String
   type: CalloutContributionType!
   whiteboard: CreateWhiteboardInput
 }
@@ -2252,6 +2283,10 @@ type CreateCalloutData {
   settings: CreateCalloutSettingsData
   """The sort order to assign to this Callout."""
   sortOrder: Float
+  """
+  When present, creates this Callout as a Tasks board. Requires a POST-only contribution type.
+  """
+  taskBoard: CreateCalloutTaskBoardData
 }
 
 type CreateCalloutFramingData {
@@ -2305,6 +2340,10 @@ input CreateCalloutInput {
   settings: CreateCalloutSettingsInput
   """The sort order to assign to this Callout."""
   sortOrder: Float
+  """
+  When present, creates this Callout as a Tasks board. Requires a POST-only contribution type.
+  """
+  taskBoard: CreateCalloutTaskBoardInput
 }
 
 input CreateCalloutOnCalloutsSetInput {
@@ -2323,6 +2362,10 @@ input CreateCalloutOnCalloutsSetInput {
   settings: CreateCalloutSettingsInput
   """The sort order to assign to this Callout."""
   sortOrder: Float
+  """
+  When present, creates this Callout as a Tasks board. Requires a POST-only contribution type.
+  """
+  taskBoard: CreateCalloutTaskBoardInput
 }
 
 type CreateCalloutSelectionSettingsData {
@@ -2407,6 +2450,20 @@ input CreateCalloutSettingsInput {
   framing: CreateCalloutSettingsFramingInput
   """Visibility of the Callout. Defaults to PUBLISHED."""
   visibility: CalloutVisibility
+}
+
+type CreateCalloutTaskBoardData {
+  """
+  The ordered columns of the Tasks board. The first is the default column. Omit to seed the default set.
+  """
+  columns: [String!]
+}
+
+input CreateCalloutTaskBoardInput {
+  """
+  The ordered columns of the Tasks board. The first is the default column. Omit to seed the default set.
+  """
+  columns: [String!]
 }
 
 type CreateCalloutsSetData {
@@ -2515,6 +2572,10 @@ input CreateContributionOnCalloutInput {
   post: CreatePostInput
   """The sort order to assign to this Contribution."""
   sortOrder: Float
+  """
+  The Tasks board column this task starts in. Only valid when the parent Callout is a Tasks board; defaults to the first column.
+  """
+  taskColumn: String
   type: CalloutContributionType!
   whiteboard: CreateWhiteboardInput
 }
@@ -2948,6 +3009,13 @@ input CreateTagsetOnProfileInput {
   type: TagsetType
 }
 
+input CreateTaskColumnOnCalloutInput {
+  """The Tasks board Callout to add a column to."""
+  calloutID: UUID!
+  """The name of the new column. Appended after the last column."""
+  name: String!
+}
+
 input CreateTemplateContentSpaceInput {
   about: CreateSpaceAboutInput!
   collaborationData: CreateCollaborationInput!
@@ -3060,6 +3128,10 @@ type CreateWhiteboardData {
   """The preview settings for the whiteboard."""
   previewSettings: CreateWhiteboardPreviewSettingsData
   profile: CreateProfileData
+  """
+  Seed the new Whiteboard from the stored content of an existing Whiteboard (server-side copy). Mutually exclusive with `content` — supply exactly one.
+  """
+  sourceWhiteboardID: UUID
 }
 
 input CreateWhiteboardInput {
@@ -3069,6 +3141,10 @@ input CreateWhiteboardInput {
   """The preview settings for the whiteboard."""
   previewSettings: CreateWhiteboardPreviewSettingsInput
   profile: CreateProfileInput
+  """
+  Seed the new Whiteboard from the stored content of an existing Whiteboard (server-side copy). Mutually exclusive with `content` — supply exactly one.
+  """
+  sourceWhiteboardID: UUID
 }
 
 type CreateWhiteboardPreviewSettingsData {
@@ -3246,6 +3322,15 @@ input DeleteStateOnInnovationFlowInput {
 
 input DeleteStorageBuckeetInput {
   ID: UUID!
+}
+
+input DeleteTaskColumnOnCalloutInput {
+  """The Tasks board Callout to remove a column from."""
+  calloutID: UUID!
+  """
+  The column to remove. Matched case-insensitively. The first (default) column cannot be removed; removing any other column reflows its tasks onto the first column.
+  """
+  name: String!
 }
 
 input DeleteTemplateInput {
@@ -4714,10 +4799,6 @@ type MediaGallery {
 type Memo {
   """The authorization rules for the entity"""
   authorization: Authorization
-  """
-  The last saved binary stateV2 of the Yjs document, used to collaborate on the Memo, represented in base64.
-  """
-  content: String
   """The policy governing who can update the Memo content."""
   contentUpdatePolicy: ContentUpdatePolicy!
   """The user that created this Memo"""
@@ -4931,6 +5012,15 @@ input MoveSpaceL2ToSpaceL1Input {
   targetSpaceL1ID: UUID!
 }
 
+input MoveTaskToColumnInput {
+  """
+  The destination column on the Tasks board. Matched case-insensitively to an existing column.
+  """
+  column: String!
+  """The task (Callout Contribution) to move."""
+  contributionID: UUID!
+}
+
 type Mutation {
   """
   Adds a Classification to a Space by copying a Classification Template (Step A).
@@ -5110,6 +5200,8 @@ type Mutation {
   createSubspace(subspaceData: CreateSubspaceInput!): Space!
   """Creates a new Tagset on the specified Profile"""
   createTagsetOnProfile(tagsetData: CreateTagsetOnProfileInput!): Tagset!
+  """Add a column to a Tasks board Callout."""
+  createTaskColumnOnCallout(columnData: CreateTaskColumnOnCalloutInput!): Callout!
   """Creates a new Template on the specified TemplatesSet."""
   createTemplate(templateData: CreateTemplateOnTemplatesSetInput!): Template!
   """
@@ -5174,6 +5266,8 @@ type Mutation {
   deleteStateOnInnovationFlow(stateData: DeleteStateOnInnovationFlowInput!): InnovationFlowState!
   """Deletes a Storage Bucket"""
   deleteStorageBucket(deleteData: DeleteStorageBuckeetInput!): StorageBucket!
+  """Remove a column from a Tasks board Callout."""
+  deleteTaskColumnOnCallout(columnData: DeleteTaskColumnOnCalloutInput!): Callout!
   """Deletes the specified Template."""
   deleteTemplate(deleteData: DeleteTemplateInput!): Template!
   """Deletes the specified User."""
@@ -5231,6 +5325,14 @@ type Mutation {
   """
   markNotificationsAsUnread(filter: NotificationEventsFilterInput): Boolean!
   """
+  Migrates all pending legacy memo content. Idempotent: repeated calls process only rows whose migrated marker is false.
+  """
+  migrateLegacyMemoContent: CollaborationMigrationResult!
+  """
+  Migrates all pending legacy whiteboard content. Idempotent: repeated calls process only rows whose migrated marker is false.
+  """
+  migrateLegacyWhiteboardContent: CollaborationMigrationResult!
+  """
   Mint a new MCP API key for the current user. Returns the plaintext exactly once.
   """
   mintMcpApiKey(mintData: MintMcpApiKeyInput!): McpApiKeyMintResult!
@@ -5248,6 +5350,10 @@ type Mutation {
   Move an L2 sub-subspace to become an L2 subspace under a target L1 in a different L0 space.       The subspace stays at level 2 but changes both its parent L1 and its top-level L0.       All community roles (including admins) are cleared and pending invitations dropped.       Platform access rules are recomputed from the new parent hierarchy.       Requires platform admin privileges.
   """
   moveSpaceL2ToSpaceL1(moveData: MoveSpaceL2ToSpaceL1Input!): Space!
+  """
+  Moves a task to another column on its Tasks board. Authorized as MOVE_TASK on the parent Callout, so a board member can move any task.
+  """
+  moveTaskToColumn(moveData: MoveTaskToColumnInput!): CalloutContribution!
   """Refresh the Bodies of Knowledge on All VCs"""
   refreshAllBodiesOfKnowledge: Boolean!
   """
@@ -5472,6 +5578,10 @@ type Mutation {
   updateSubspacesSortOrder(sortOrderData: UpdateSubspacesSortOrderInput!): [Space!]!
   """Updates the specified Tagset."""
   updateTagset(updateData: UpdateTagsetInput!): Tagset!
+  """Rename a column on a Tasks board Callout."""
+  updateTaskColumnOnCallout(columnData: UpdateTaskColumnOnCalloutInput!): Callout!
+  """Reorder the columns of a Tasks board Callout."""
+  updateTaskColumnsSortOrderOnCallout(sortOrderData: UpdateTaskColumnsSortOrderOnCalloutInput!): Callout!
   """Updates the specified Template."""
   updateTemplate(updateData: UpdateTemplateInput!): Template!
   """Updates the TemplateContentSpace."""
@@ -8145,6 +8255,7 @@ enum TagsetReservedName {
   FLOW_STATE
   KEYWORDS
   SKILLS
+  TASK
 }
 
 type TagsetTemplate {
@@ -8190,6 +8301,13 @@ type Task {
   status: TaskStatus!
   """TBD"""
   type: String
+}
+
+type TaskColumnCount {
+  """The Tasks board column, in the board-defined order."""
+  column: String!
+  """The number of tasks currently in this column."""
+  count: Int!
 }
 
 """The current status of the task"""
@@ -9101,6 +9219,26 @@ input UpdateTagsetInput {
   ID: UUID!
   name: String
   tags: [String!]!
+}
+
+input UpdateTaskColumnOnCalloutInput {
+  """The Tasks board Callout whose column is being renamed."""
+  calloutID: UUID!
+  """
+  The current column name. Matched case-insensitively to an existing column.
+  """
+  currentName: String!
+  """The new column name. Tasks in the column follow the rename."""
+  newName: String!
+}
+
+input UpdateTaskColumnsSortOrderOnCalloutInput {
+  """The Tasks board Callout whose columns are being reordered."""
+  calloutID: UUID!
+  """
+  Every existing column exactly once, in the new left-to-right order. Matched case-insensitively.
+  """
+  columnNames: [String!]!
 }
 
 input UpdateTemplateContentSpaceInput {
@@ -10278,8 +10416,6 @@ input VisualUploadImageInput {
 type Whiteboard {
   """The authorization rules for the entity"""
   authorization: Authorization
-  """The visual content of the Whiteboard."""
-  content: WhiteboardContent!
   """The policy governing who can update the Whiteboard content."""
   contentUpdatePolicy: ContentUpdatePolicy!
   """The user that created this Whiteboard"""
@@ -10304,7 +10440,9 @@ type Whiteboard {
   updatedDate: DateTime!
 }
 
-"""Content of a Whiteboard, as JSON."""
+"""
+Content of a Whiteboard as a base64-encoded Yjs-V2 document snapshot (CRDT state, not an Excalidraw scene).
+"""
 scalar WhiteboardContent
 
 type WhiteboardPreviewCoordinates {


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 339277 bytes
Snapshot md5: d847602925484c37fa43db0f12754e98

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task boards to Callouts, including customizable columns, task assignment, movement, counts, and sorting.
  * Added task classification and support for assigning tasks when creating contributions.
  * Added the ability to create new whiteboards from existing whiteboard content.
* **Improvements**
  * Added tools to migrate legacy memo and whiteboard content while reporting any migration issues.
  * Updated collaboration content handling for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->