### PR TITLE
Feat/move contributions between callouts

### DIFF
--- a/src/domain/collaboration/callout-contribution/callout.contribution.move.module.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.move.module.ts
@@ -1,5 +1,6 @@
 import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { Callout } from '@domain/collaboration/callout/callout.entity';
+import { ClassificationModule } from '@domain/common/classification/classification.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UrlGeneratorModule } from '@services/infrastructure/url-generator';
@@ -15,6 +16,7 @@ import { CalloutContributionMoveService } from './callout.contribution.move.serv
     CalloutModule,
     AuthorizationModule,
     CalloutContributionModule,
+    ClassificationModule,
     CollaborationLicenseModule,
     UrlGeneratorModule,
     TypeOrmModule.forFeature([CalloutContribution, Callout]),

--- a/src/domain/collaboration/callout-contribution/callout.contribution.move.service.spec.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.move.service.spec.ts
@@ -1,8 +1,10 @@
 import { CalloutContributionType } from '@common/enums/callout.contribution.type';
+import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import {
   EntityNotFoundException,
   NotSupportedException,
 } from '@common/exceptions';
+import { ClassificationService } from '@domain/common/classification/classification.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
@@ -21,6 +23,7 @@ describe('CalloutContributionMoveService', () => {
   let calloutRepository: Repository<Callout>;
   let contributionRepository: Repository<CalloutContribution>;
   let contributionService: CalloutContributionService;
+  let classificationService: ClassificationService;
   let urlGeneratorCacheService: UrlGeneratorCacheService;
 
   beforeEach(async () => {
@@ -44,6 +47,7 @@ describe('CalloutContributionMoveService', () => {
       getRepositoryToken(CalloutContribution)
     );
     contributionService = module.get(CalloutContributionService);
+    classificationService = module.get(ClassificationService);
     urlGeneratorCacheService = module.get(UrlGeneratorCacheService);
   });
 
@@ -109,6 +113,112 @@ describe('CalloutContributionMoveService', () => {
         'post-profile-id'
       );
       expect(contributionRepository.save).toHaveBeenCalledWith(contribution);
+    });
+
+    // A Tasks board target callout: its classification carries the reserved
+    // `task` tagset whose template lists the board's columns.
+    function createBoardTargetCallout(columns: string[]) {
+      return {
+        id: 'target-board',
+        calloutsSet: { id: calloutsSetId },
+        settings: {
+          contribution: { allowedTypes: [CalloutContributionType.POST] },
+        },
+        classification: {
+          tagsets: [
+            {
+              name: TagsetReservedName.TASK,
+              tagsetTemplate: { allowedValues: columns },
+            },
+          ],
+        },
+      } as any;
+    }
+
+    it('seeds a task-column classification (first column) when moving a post INTO a Tasks board', async () => {
+      const contribution = createContribution({
+        post: { profile: { id: 'post-profile-id' } },
+      });
+      const targetBoard = createBoardTargetCallout(['To Do', 'In Progress']);
+
+      vi.mocked(
+        contributionService.getCalloutContributionOrFail
+      ).mockResolvedValue(contribution);
+      vi.mocked(calloutRepository.findOne).mockResolvedValue(targetBoard);
+      vi.mocked(classificationService.createClassification).mockReturnValue({
+        id: 'new-classification',
+      } as any);
+      vi.mocked(contributionRepository.save).mockImplementation(
+        async (c: any) => c
+      );
+
+      await service.moveContributionToCallout('contribution-1', 'target-board');
+
+      expect(classificationService.createClassification).toHaveBeenCalledWith(
+        [{ allowedValues: ['To Do', 'In Progress'] }],
+        { tagsets: [{ name: TagsetReservedName.TASK, tags: ['To Do'] }] }
+      );
+      // No previous classification to delete.
+      expect(classificationService.deleteClassification).not.toHaveBeenCalled();
+      expect((contribution as any).classification).toEqual({
+        id: 'new-classification',
+      });
+    });
+
+    it('drops the task classification when moving a task OUT to an ordinary callout', async () => {
+      const contribution = {
+        ...createContribution({ post: { profile: { id: 'post-profile-id' } } }),
+        classification: { id: 'old-classification' },
+      } as any;
+      const targetCallout = createTargetCallout([CalloutContributionType.POST]);
+
+      vi.mocked(
+        contributionService.getCalloutContributionOrFail
+      ).mockResolvedValue(contribution);
+      vi.mocked(calloutRepository.findOne).mockResolvedValue(targetCallout);
+      vi.mocked(contributionRepository.save).mockImplementation(
+        async (c: any) => c
+      );
+
+      await service.moveContributionToCallout(
+        'contribution-1',
+        'target-callout'
+      );
+
+      expect(contribution.classification).toBeNull();
+      expect(classificationService.createClassification).not.toHaveBeenCalled();
+      expect(classificationService.deleteClassification).toHaveBeenCalledWith(
+        'old-classification'
+      );
+    });
+
+    it('re-seeds the classification when moving a task between two Tasks boards', async () => {
+      const contribution = {
+        ...createContribution({ post: { profile: { id: 'post-profile-id' } } }),
+        classification: { id: 'old-classification' },
+      } as any;
+      const targetBoard = createBoardTargetCallout(['Backlog', 'Done']);
+
+      vi.mocked(
+        contributionService.getCalloutContributionOrFail
+      ).mockResolvedValue(contribution);
+      vi.mocked(calloutRepository.findOne).mockResolvedValue(targetBoard);
+      vi.mocked(classificationService.createClassification).mockReturnValue({
+        id: 'new-classification',
+      } as any);
+      vi.mocked(contributionRepository.save).mockImplementation(
+        async (c: any) => c
+      );
+
+      await service.moveContributionToCallout('contribution-1', 'target-board');
+
+      expect(classificationService.createClassification).toHaveBeenCalledWith(
+        [{ allowedValues: ['Backlog', 'Done'] }],
+        { tagsets: [{ name: TagsetReservedName.TASK, tags: ['Backlog'] }] }
+      );
+      expect(classificationService.deleteClassification).toHaveBeenCalledWith(
+        'old-classification'
+      );
     });
 
     it('should throw EntityNotFoundException when target callout is not found', async () => {

--- a/src/domain/collaboration/callout-contribution/callout.contribution.move.service.ts
+++ b/src/domain/collaboration/callout-contribution/callout.contribution.move.service.ts
@@ -1,9 +1,12 @@
 import { LogContext } from '@common/enums';
 import { CalloutContributionType } from '@common/enums/callout.contribution.type';
+import { TagsetReservedName } from '@common/enums/tagset.reserved.name';
 import {
   EntityNotFoundException,
   NotSupportedException,
 } from '@common/exceptions';
+import { Classification } from '@domain/common/classification/classification.entity';
+import { ClassificationService } from '@domain/common/classification/classification.service';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UrlGeneratorCacheService } from '@services/infrastructure/url-generator/url.generator.service.cache';
@@ -21,6 +24,7 @@ export class CalloutContributionMoveService {
     @InjectRepository(CalloutContribution)
     private calloutContributionRepository: Repository<CalloutContribution>,
     private calloutContributionService: CalloutContributionService,
+    private classificationService: ClassificationService,
     private urlGeneratorCacheService: UrlGeneratorCacheService
   ) {}
 
@@ -35,6 +39,11 @@ export class CalloutContributionMoveService {
           relations: {
             callout: {
               calloutsSet: true,
+            },
+            // The task-column classification (present only for a task on a board)
+            // is reconciled with the destination below.
+            classification: {
+              tagsets: true,
             },
             post: {
               profile: true,
@@ -59,6 +68,14 @@ export class CalloutContributionMoveService {
       where: { id: calloutID },
       relations: {
         calloutsSet: true,
+        // Needed to detect whether the destination is a Tasks board and, if so,
+        // to read its column template (allowedValues) when seeding the moved
+        // post's task column.
+        classification: {
+          tagsets: {
+            tagsetTemplate: true,
+          },
+        },
       },
     });
 
@@ -134,6 +151,41 @@ export class CalloutContributionMoveService {
 
     contribution.callout = targetCallout;
 
+    // Reconcile the task-column classification with the destination callout. A
+    // task's column is a per-contribution classification, and only POST
+    // contributions can be tasks (Tasks boards are POST-only). Moving a post INTO
+    // a board makes it a task in the board's first column; moving a task OUT to an
+    // ordinary callout drops the column classification (it becomes a plain post);
+    // moving between two boards re-seeds it on the destination board's first
+    // column. Any previous classification is deleted after the save below.
+    const previousClassificationId = contribution.classification?.id;
+    if (contribution.post) {
+      const targetBoardTemplate = targetCallout.classification?.tagsets?.find(
+        tagset => tagset.name === TagsetReservedName.TASK
+      )?.tagsetTemplate;
+      if (targetBoardTemplate) {
+        contribution.classification =
+          this.classificationService.createClassification(
+            [targetBoardTemplate],
+            {
+              tagsets: [
+                {
+                  name: TagsetReservedName.TASK,
+                  tags: [targetBoardTemplate.allowedValues[0]],
+                },
+              ],
+              // createClassification returns the IClassification interface; the
+              // entity relation is typed as the concrete class (mirrors the create
+              // path in CalloutContributionService).
+            }
+          ) as Classification;
+      } else {
+        // Detach the task classification. The relation is typed optional, but
+        // TypeORM needs an explicit null to null the FK on save.
+        (contribution as { classification: unknown }).classification = null;
+      }
+    }
+
     if (contribution?.post?.profile.id) {
       await this.urlGeneratorCacheService.revokeUrlCache(
         contribution?.post?.profile.id
@@ -160,6 +212,20 @@ export class CalloutContributionMoveService {
       );
     }
 
-    return await this.calloutContributionRepository.save(contribution);
+    const movedContribution =
+      await this.calloutContributionRepository.save(contribution);
+
+    // The contribution now points at its new classification (or null), so the
+    // pre-move classification is orphaned — delete it to leave no orphan behind.
+    if (
+      previousClassificationId &&
+      previousClassificationId !== contribution.classification?.id
+    ) {
+      await this.classificationService.deleteClassification(
+        previousClassificationId
+      );
+    }
+
+    return movedContribution;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Moving a contribution into a task board now automatically assigns it to the board’s first available column.
  * Moving a contribution out of a task board now removes its task-board classification.
  * Moving contributions between task boards now replaces the previous board classification with the appropriate destination classification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->