### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -1268,8 +1268,10 @@ type CalloutContributionDefaults {
   postDescription: Markdown
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
-  """The default whiteboard content for whiteboard responses."""
-  whiteboardContent: WhiteboardContent
+  """
+  Whether this Callout has a non-empty default for Whiteboard contributions.
+  """
+  whiteboardContentAvailable: Boolean!
 }
 
 enum CalloutContributionType {
@@ -1677,6 +1679,10 @@ type CollaborationMigrationResult {
   flaggedDocuments: [CollaborationMigrationIssue!]!
   migrated: Int!
   total: Int!
+  """
+  Legacy Whiteboard contribution defaults without a complete owning Callout path.
+  """
+  unattached: Int!
 }
 
 type Communication {
@@ -2186,7 +2192,14 @@ type CreateCalloutContributionDefaultsData {
   defaultDisplayName: String
   """The default description to use for new Post contributions."""
   postDescription: Markdown
-  whiteboardContent: WhiteboardContent
+  """
+  Copy the internal Whiteboard contribution default from this source Callout. Mutually exclusive with sourceWhiteboardID.
+  """
+  sourceCalloutID: UUID
+  """
+  Seed the default from an existing Whiteboard. The server copies its content and media into the owning Callout bucket; the source id is not persisted.
+  """
+  sourceWhiteboardID: UUID
 }
 
 input CreateCalloutContributionDefaultsInput {
@@ -2194,7 +2207,14 @@ input CreateCalloutContributionDefaultsInput {
   defaultDisplayName: String
   """The default description to use for new Post contributions."""
   postDescription: Markdown
-  whiteboardContent: WhiteboardContent
+  """
+  Copy the internal Whiteboard contribution default from this source Callout. Mutually exclusive with sourceWhiteboardID.
+  """
+  sourceCalloutID: UUID
+  """
+  Seed the default from an existing Whiteboard. The server copies its content and media into the owning Callout bucket; the source id is not persisted.
+  """
+  sourceWhiteboardID: UUID
 }
 
 input CreateCalloutContributionInput {
@@ -3130,27 +3150,25 @@ input CreateVisualOnProfileInput {
 }
 
 type CreateWhiteboardData {
-  content: WhiteboardContent
   """A readable identifier, unique within the containing scope."""
   nameID: NameID
   """The preview settings for the whiteboard."""
   previewSettings: CreateWhiteboardPreviewSettingsData
   profile: CreateProfileData
   """
-  Seed the new Whiteboard from the stored content of an existing Whiteboard (server-side copy). Mutually exclusive with `content` — supply exactly one.
+  Seed the new Whiteboard from the stored content of an existing Whiteboard through a server-side authorized copy. Omission creates an empty Whiteboard.
   """
   sourceWhiteboardID: UUID
 }
 
 input CreateWhiteboardInput {
-  content: WhiteboardContent
   """A readable identifier, unique within the containing scope."""
   nameID: NameID
   """The preview settings for the whiteboard."""
   previewSettings: CreateWhiteboardPreviewSettingsInput
   profile: CreateProfileInput
   """
-  Seed the new Whiteboard from the stored content of an existing Whiteboard (server-side copy). Mutually exclusive with `content` — supply exactly one.
+  Seed the new Whiteboard from the stored content of an existing Whiteboard through a server-side authorized copy. Omission creates an empty Whiteboard.
   """
   sourceWhiteboardID: UUID
 }
@@ -5341,7 +5359,7 @@ type Mutation {
   """
   migrateLegacyMemoContent: CollaborationMigrationResult!
   """
-  Migrates all pending legacy whiteboard content. Idempotent: repeated calls process only rows whose migrated marker is false.
+  Migrates pending legacy Whiteboard documents and independently normalizes every legacy Whiteboard contribution default, including defaults stored by Callout templates. Idempotent: repeated calls process only unmigrated documents and non-canonical defaults.
   """
   migrateLegacyWhiteboardContent: CollaborationMigrationResult!
   """
@@ -5422,6 +5440,10 @@ type Mutation {
   Replace the backing file of an existing CollaboraDocument in place, preserving its identity. Requires UPDATE on the document. The replacement must be an allowed OfficeDocs format, within the size cap, and the SAME document type as the current file. Refused while the document is being edited.
   """
   replaceCollaboraDocument(file: Upload!, replaceData: ReplaceCollaboraDocumentInput!): CollaboraDocument!
+  """
+  Replace a Whiteboard from another Whiteboard through the live collaboration room. Content and media are copied server-side; snapshot bytes never pass through GraphQL.
+  """
+  replaceWhiteboardContentFromSource(input: ReplaceWhiteboardContentFromSourceInput!): Whiteboard!
   """Resets the interaction with the VC by recreating the room."""
   resetConversationVc(input: ConversationVcResetInput!): Conversation!
   """Reset all license plans on Accounts"""
@@ -7086,6 +7108,13 @@ input ReplaceCollaboraDocumentInput {
   displayName: String
 }
 
+input ReplaceWhiteboardContentFromSourceInput {
+  """The Whiteboard whose content and media are copied into the target."""
+  sourceWhiteboardID: UUID!
+  """The Whiteboard whose content is replaced."""
+  targetWhiteboardID: UUID!
+}
+
 input RevokeAuthorizationCredentialInput {
   """The resource to which access is being removed."""
   resourceID: String!
@@ -8607,12 +8636,22 @@ input UpdateCalendarEventInput {
 }
 
 input UpdateCalloutContributionDefaultsInput {
+  """
+  Remove the stored Whiteboard contribution default. Mutually exclusive with sourceWhiteboardID and sourceCalloutID.
+  """
+  clearWhiteboardContent: Boolean
   """The default title to use for new contributions."""
   defaultDisplayName: String
   """The default description to use for new Post contributions."""
   postDescription: Markdown
-  """The default description to use for new Whiteboard contributions."""
-  whiteboardContent: WhiteboardContent
+  """
+  Copy the internal Whiteboard contribution default from this source Callout. Mutually exclusive with sourceWhiteboardID and clearWhiteboardContent.
+  """
+  sourceCalloutID: UUID
+  """
+  Replace the default from an existing Whiteboard. The server copies its content and media into the owning Callout bucket; the source id is not persisted.
+  """
+  sourceWhiteboardID: UUID
 }
 
 input UpdateCalloutContributorsSettingsInput {
@@ -8662,10 +8701,12 @@ input UpdateCalloutFramingInput {
   poll: UpdatePollInput
   """The Profile of the Template."""
   profile: UpdateProfileInput
+  """
+  Replace the framing Whiteboard from another Whiteboard through a server-side authorized copy.
+  """
+  sourceWhiteboardID: UUID
   """The type of additional content attached to the framing of the callout."""
   type: CalloutFramingType
-  """The new content to be used."""
-  whiteboardContent: WhiteboardContent
   """The new preview settings for the Whiteboard."""
   whiteboardPreviewSettings: UpdateWhiteboardPreviewSettingsInput
 }
@@ -9310,8 +9351,10 @@ input UpdateTemplateInput {
   postDefaultDescription: Markdown
   """The Profile of the Template."""
   profile: UpdateProfileInput
-  """The new content to be used."""
-  whiteboardContent: WhiteboardContent
+  """
+  Replace this Whiteboard Template from an existing Whiteboard through a server-side authorized copy.
+  """
+  sourceWhiteboardID: UUID
 }
 
 input UpdateUserGroupInput {
@@ -10474,11 +10517,6 @@ type Whiteboard {
   """The date at which the entity was last updated."""
   updatedDate: DateTime!
 }
-
-"""
-Content of a Whiteboard as a base64-encoded Yjs-V2 document snapshot (CRDT state, not an Excalidraw scene).
-"""
-scalar WhiteboardContent
 
 type WhiteboardPreviewCoordinates {
   """The height."""


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 341915 bytes
Snapshot md5: 52cd0243e485637ee0dc051efd893290

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to copy whiteboard content from a source whiteboard.
  * Added source whiteboard and callout references when creating or updating contribution defaults, framing, and templates.
  * Added an indicator showing whether whiteboard content is available.
  * Migration results now report unattached items.

* **Breaking Changes**
  * Direct whiteboard content submission is no longer supported in affected operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->