### PR TITLE
fix(auth): preserve named guests at forward auth (workspace#057)

### DIFF
--- a/docs/Guest-Users.md
+++ b/docs/Guest-Users.md
@@ -24,6 +24,13 @@ curl -X POST \
   http://localhost:4000/graphql
 ```
 
+Raw ASCII names remain supported for API compatibility. Browser clients encode
+Unicode names as UTF-8 base64 in the same header; the server decodes that form
+first and falls back to the raw value for legacy callers. Because the historical
+header has no encoding marker, a raw value that is itself canonical base64 of
+whitespace is treated as encoded and therefore empty; callers should encode
+browser-supplied names or use an ordinary non-base64 raw display name.
+
 ### Implementation Details
 
 #### Core Architecture:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@alkemio/notifications-lib": "0.20.0",
     "@apollo/server": "^4.13.0",
     "@elastic/elasticsearch": "^8.12.2",
-    "@excalidraw-yjs/element": "0.5.1",
+    "@excalidraw-yjs/element": "0.5.2",
     "@golevelup/nestjs-rabbitmq": "^6.1.0",
     "@hedger/nestjs-encryption": "^0.1.5",
     "@modelcontextprotocol/sdk": "^1.25.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^8.12.2
         version: 8.19.1
       '@excalidraw-yjs/element':
-        specifier: 0.5.1
-        version: 0.5.1(yjs@13.6.27)
+        specifier: 0.5.2
+        version: 0.5.2(yjs@13.6.27)
       '@golevelup/nestjs-rabbitmq':
         specifier: ^6.1.0
         version: 6.1.0(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -1178,20 +1178,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@excalidraw-yjs/common@0.5.1':
-    resolution: {integrity: sha512-jc2SihgLz9hP1yA22os3buCp88tuMLkHggmBSfJwa5bufaT00dpxJGdq4NPictWMNLqv7x9e0G1MFFLc+RFMJA==}
+  '@excalidraw-yjs/common@0.5.2':
+    resolution: {integrity: sha512-zGydAF2Rhewxb6b++S2dVm16M4l8HRlH6DG1/Ox3hD0s317TRFjMtZJfCjGCsC6HORA4IlUI5wlkwYFDTnwjRg==}
 
-  '@excalidraw-yjs/element@0.5.1':
-    resolution: {integrity: sha512-FFoWGV9rJFxW4fbuuh4ziUYo+kEo6WRV/r+RToHqZdjM6oYgpaVMFtZ4YGslp8psmnmkCzCIUXw1OO2Qgh7KPQ==}
+  '@excalidraw-yjs/element@0.5.2':
+    resolution: {integrity: sha512-3SlXumkQ5dVqKz2WFUxD+kEJoqtNdy35kVeFL0CEnBkaVwvD17EJnWQw/bKKnJvlWmJHtFBIIYEC1QNvs9ViBg==}
     peerDependencies:
       yjs: ^13.6.27
 
-  '@excalidraw-yjs/fractional-indexing@0.5.1':
-    resolution: {integrity: sha512-NpBqf5SEkD/N+GImWtLPkAoY8SVM2bTkNxIq1MPrsCIJG4ltvVBmYMg8tuP/PveXg+iGRI+X6bN8fFXVkqy/4Q==}
+  '@excalidraw-yjs/fractional-indexing@0.5.2':
+    resolution: {integrity: sha512-+kHb4JYOiljxflKXk+BEEc0oEneh7VVCxiR0uO9zh6dlqHmP4XWKNrKiv0zyGgM/vv+Lw2nbElcfOMT9J1yv2Q==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
-  '@excalidraw-yjs/math@0.5.1':
-    resolution: {integrity: sha512-3nWjt012FTWvLMMdQ2b+McAqmudeAOMCQ089OuLMUz65Av4QZFjbMsWUsdOSoFM9WRYDJ7KnBDoKM6fIAKxFyQ==}
+  '@excalidraw-yjs/math@0.5.2':
+    resolution: {integrity: sha512-+g5VcBUFSGJOFkV5FOmXFJMn6IQAZewXoR6QBfKaNGAA88stF4o56/UuyF+6d8I4UPzUx/seg0z8zgRmScx8AA==}
 
   '@exodus/bytes@1.9.0':
     resolution: {integrity: sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww==}
@@ -7401,21 +7401,21 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@excalidraw-yjs/common@0.5.1':
+  '@excalidraw-yjs/common@0.5.2':
     dependencies:
-      '@excalidraw-yjs/math': 0.5.1
+      '@excalidraw-yjs/math': 0.5.2
       tinycolor2: 1.6.0
 
-  '@excalidraw-yjs/element@0.5.1(yjs@13.6.27)':
+  '@excalidraw-yjs/element@0.5.2(yjs@13.6.27)':
     dependencies:
-      '@excalidraw-yjs/common': 0.5.1
-      '@excalidraw-yjs/fractional-indexing': 0.5.1
-      '@excalidraw-yjs/math': 0.5.1
+      '@excalidraw-yjs/common': 0.5.2
+      '@excalidraw-yjs/fractional-indexing': 0.5.2
+      '@excalidraw-yjs/math': 0.5.2
       yjs: 13.6.27
 
-  '@excalidraw-yjs/fractional-indexing@0.5.1': {}
+  '@excalidraw-yjs/fractional-indexing@0.5.2': {}
 
-  '@excalidraw-yjs/math@0.5.1': {}
+  '@excalidraw-yjs/math@0.5.2': {}
 
   '@exodus/bytes@1.9.0(@noble/hashes@1.8.0)':
     optionalDependencies:

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -725,7 +725,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_authorization_evaluation
     hostname: authorization-evaluation
-    image: alkemio/authorization-evaluation-service:v0.0.4
+    image: alkemio/authorization-evaluation-service:v0.0.5
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/core/auth/oidc/constants.ts
+++ b/src/core/auth/oidc/constants.ts
@@ -11,3 +11,9 @@ value for un-credentialed traffic keeps the contract uniform while letting
 auth-eval still resolve GLOBAL_ANONYMOUS for public-read privileges.
  */
 export const ANONYMOUS_ACTOR_ID = NIL_UUID;
+
+/**
+ * Non-persisted transport identity for a named guest. Only ForwardAuth emits
+ * this value; authorization-evaluation-service maps it to global-guest.
+ */
+export const GUEST_ACTOR_ID = '00000000-0000-0000-0000-000000000001';

--- a/src/core/auth/oidc/forward-auth.controller.spec.ts
+++ b/src/core/auth/oidc/forward-auth.controller.spec.ts
@@ -1,0 +1,150 @@
+import { ActorContext } from '@core/actor-context/actor.context';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { Request, Response } from 'express';
+import { type Mocked, vi } from 'vitest';
+import {
+  ANONYMOUS_ACTOR_ID,
+  GUEST_ACTOR_ID,
+  HEADER_ACTOR_ID,
+} from './constants';
+import { ForwardAuthController } from './forward-auth.controller';
+import {
+  ForwardAuthResolverService,
+  SessionStoreUnavailableError,
+} from './forward-auth.resolver.service';
+
+describe('ForwardAuthController', () => {
+  let controller: ForwardAuthController;
+  let resolver: Mocked<ForwardAuthResolverService>;
+
+  const buildRes = () =>
+    ({
+      setHeader: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      end: vi.fn(),
+    }) as unknown as Response & {
+      setHeader: ReturnType<typeof vi.fn>;
+      status: ReturnType<typeof vi.fn>;
+      end: ReturnType<typeof vi.fn>;
+    };
+
+  const actor = (values: Partial<ActorContext>) =>
+    Object.assign(new ActorContext(), values);
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ForwardAuthController,
+        {
+          provide: ForwardAuthResolverService,
+          useValue: { resolveActorContext: vi.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(ForwardAuthController);
+    resolver = module.get(ForwardAuthResolverService);
+  });
+
+  it('pins the named-guest wire identity', () => {
+    expect(GUEST_ACTOR_ID).toBe('00000000-0000-0000-0000-000000000001');
+  });
+
+  it.each([
+    {
+      source: 'forwarded URI',
+      direct: undefined,
+      headers: {
+        'x-forwarded-uri':
+          '/collab/whiteboard-1?type=whiteboard&guestName=Jos%C3%A9%20M%C3%BCller',
+      },
+    },
+    {
+      source: 'encoded header',
+      direct: undefined,
+      headers: {
+        'x-guest-name': Buffer.from('José Müller', 'utf8').toString('base64'),
+      },
+    },
+    { source: 'direct query', direct: 'José Müller', headers: {} },
+  ])('emits the guest identity from $source', async ({ direct, headers }) => {
+    resolver.resolveActorContext.mockResolvedValue(
+      actor({ isGuest: true, guestName: 'José Müller' })
+    );
+    const res = buildRes();
+
+    await controller.resolve(direct, { headers } as unknown as Request, res);
+
+    expect(resolver.resolveActorContext).toHaveBeenCalledWith(
+      expect.anything(),
+      'José Müller'
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(HEADER_ACTOR_ID, GUEST_ACTOR_ID);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it.each([
+    { source: 'blank direct query', direct: '   ', headers: {} },
+    {
+      source: 'malformed encoded header',
+      direct: undefined,
+      headers: { 'x-guest-name': 'not-base64!!!' },
+    },
+    {
+      source: 'malformed forwarded URI',
+      direct: undefined,
+      headers: { 'x-forwarded-uri': '/collab/id?guestName=%E0%A4%A' },
+    },
+    {
+      source: 'repeated direct query',
+      direct: ['Alice', 'Mallory'],
+      headers: {},
+    },
+  ])('keeps $source anonymous', async ({ direct, headers }) => {
+    resolver.resolveActorContext.mockResolvedValue(
+      actor({ isAnonymous: true })
+    );
+    const res = buildRes();
+
+    await controller.resolve(direct, { headers } as unknown as Request, res);
+
+    expect(resolver.resolveActorContext).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      HEADER_ACTOR_ID,
+      ANONYMOUS_ACTOR_ID
+    );
+  });
+
+  it('keeps an authenticated actor authoritative when guest metadata exists', async () => {
+    resolver.resolveActorContext.mockResolvedValue(
+      actor({ actorID: 'user-1' })
+    );
+    const res = buildRes();
+
+    await controller.resolve(
+      'Mallory',
+      { headers: {} } as unknown as Request,
+      res
+    );
+
+    expect(res.setHeader).toHaveBeenCalledWith(HEADER_ACTOR_ID, 'user-1');
+  });
+
+  it('returns 503 without an actor header when the session store is unavailable', async () => {
+    resolver.resolveActorContext.mockRejectedValue(
+      new SessionStoreUnavailableError()
+    );
+    const res = buildRes();
+
+    await controller.resolve(undefined, { headers: {} } as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.setHeader).not.toHaveBeenCalledWith(
+      HEADER_ACTOR_ID,
+      expect.anything()
+    );
+  });
+});

--- a/src/core/auth/oidc/forward-auth.controller.ts
+++ b/src/core/auth/oidc/forward-auth.controller.ts
@@ -1,6 +1,11 @@
+import { resolveForwardAuthGuestName } from '@core/authentication/guest-name.resolver';
 import { Controller, Get, Query, Req, Res } from '@nestjs/common';
 import type { Request, Response } from 'express';
-import { ANONYMOUS_ACTOR_ID, HEADER_ACTOR_ID } from './constants';
+import {
+  ANONYMOUS_ACTOR_ID,
+  GUEST_ACTOR_ID,
+  HEADER_ACTOR_ID,
+} from './constants';
 import {
   ForwardAuthResolverService,
   SessionStoreUnavailableError,
@@ -19,13 +24,13 @@ import {
   Identity sources tried in order:
     1. session cookie               — browsers/SPA (BFF Redis-backed session).
     2. `Authorization: Bearer <jwt>` — API/M2M (Hydra-issued, JWKS-validated)
-    3. `?guestName=` query param    — anonymous guest with display name
+    3. existing guest metadata      — named guest compatibility identity
   …all resolved by the shared `ForwardAuthResolverService`.
 
   Semantics: ALWAYS returns 200 AND ALWAYS stamps `X-Alkemio-Actor-Id`.
-  Authenticated users get their canonical actor id; guests get the synthetic
-  `guest-<uuid>` minted by ActorContextService.createGuest; un-credentialed
-  callers get the nil-UUID sentinel (`ANONYMOUS_ACTOR_ID`), which
+  Authenticated users get their canonical actor id; named guests get the
+  reserved transport UUID (`GUEST_ACTOR_ID`); un-credentialed callers get the
+  nil-UUID sentinel (`ANONYMOUS_ACTOR_ID`), which
   auth-evaluation-service resolves to GLOBAL_ANONYMOUS. Downstream services
   (file-service-go, etc.) require the header to ALWAYS be present so they
   can distinguish "gateway stamped: anonymous" from "gateway didn't run".
@@ -46,14 +51,13 @@ export class ForwardAuthController {
 
   @Get('forward-auth')
   async resolve(
-    @Query('guestName') guestNameRaw: string | undefined,
+    @Query('guestName') guestNameRaw: unknown,
     @Req() req: Request,
     @Res() res: Response
   ): Promise<void> {
     res.setHeader('Cache-Control', 'no-store');
 
-    const guestName =
-      typeof guestNameRaw === 'string' ? guestNameRaw : undefined;
+    const guestName = resolveForwardAuthGuestName(req, guestNameRaw);
 
     let ctx;
     try {
@@ -70,14 +74,20 @@ export class ForwardAuthController {
       throw err;
     }
 
-    // Always stamp the actor header. Authenticated/guest contexts carry their
-    // own actorID; anonymous contexts get the nil-UUID sentinel that
+    // Always stamp the actor header. The named guest sentinel exists only on
+    // this transport boundary; general ActorContext guest semantics retain an
+    // empty actorID so no persisted-actor consumer can mistake it for a user.
+    // Anonymous contexts get the nil-UUID sentinel that
     // auth-evaluation-service recognises as GLOBAL_ANONYMOUS. Downstream
     // services 401 on a missing header (by design), so omitting it here would
     // make public reads unreachable for unauthenticated callers.
     res.setHeader(
       HEADER_ACTOR_ID,
-      ctx.actorID && ctx.actorID.length > 0 ? ctx.actorID : ANONYMOUS_ACTOR_ID
+      ctx.actorID && ctx.actorID.length > 0
+        ? ctx.actorID
+        : ctx.isGuest
+          ? GUEST_ACTOR_ID
+          : ANONYMOUS_ACTOR_ID
     );
     res.status(200).end();
   }

--- a/src/core/authentication/authentication.service.spec.ts
+++ b/src/core/authentication/authentication.service.spec.ts
@@ -1,6 +1,7 @@
 import { ActorContext } from '@core/actor-context/actor.context';
 import { ActorContextCacheService } from '@core/actor-context/actor.context.cache.service';
 import { ActorContextService } from '@core/actor-context/actor.context.service';
+import type { AlkemioSessionPayload } from '@core/auth/oidc/session-store.redis';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
@@ -64,6 +65,57 @@ describe('AuthenticationService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getActorContextFromBffPayload', () => {
+    it('creates a guest only when a signed-out request carries a name', async () => {
+      const guestContext = {
+        ...mockActorContext,
+        actorID: '',
+        isGuest: true,
+        guestName: 'José',
+      };
+      actorContextService.createGuest.mockReturnValue(guestContext);
+
+      const result = await service.getActorContextFromBffPayload(
+        null,
+        ' José '
+      );
+
+      expect(actorContextService.createGuest).toHaveBeenCalledWith('José');
+      expect(result).toBe(guestContext);
+    });
+
+    it('keeps an authenticated session authoritative over guest metadata', async () => {
+      const session = {
+        alkemio_actor_id: 'actor-1',
+        absolute_expires_at: Math.floor(Date.now() / 1000) + 3600,
+      } as AlkemioSessionPayload;
+      const authenticatedContext = { ...mockActorContext, actorID: 'actor-1' };
+      vi.spyOn(service, 'createActorContext').mockResolvedValue(
+        authenticatedContext
+      );
+
+      const result = await service.getActorContextFromBffPayload(
+        session,
+        'Mallory'
+      );
+
+      expect(service.createActorContext).toHaveBeenCalledWith('actor-1');
+      expect(actorContextService.createGuest).not.toHaveBeenCalled();
+      expect(result).toBe(authenticatedContext);
+    });
+
+    it('keeps a signed-out request without a name anonymous', async () => {
+      const anonymousContext = { ...mockActorContext, isAnonymous: true };
+      actorContextService.createAnonymous.mockReturnValue(anonymousContext);
+
+      const result = await service.getActorContextFromBffPayload(null);
+
+      expect(actorContextService.createAnonymous).toHaveBeenCalled();
+      expect(actorContextService.createGuest).not.toHaveBeenCalled();
+      expect(result).toBe(anonymousContext);
+    });
   });
 
   describe('createActorContext', () => {

--- a/src/core/authentication/guest-name.resolver.spec.ts
+++ b/src/core/authentication/guest-name.resolver.spec.ts
@@ -1,0 +1,80 @@
+import type { IncomingMessage } from 'http';
+import { describe, expect, it } from 'vitest';
+import {
+  decodeForwardedGuestName,
+  decodeGuestNameHeader,
+  resolveForwardAuthGuestName,
+} from './guest-name.resolver';
+
+const request = (headers: IncomingMessage['headers'] = {}) =>
+  ({ headers }) as IncomingMessage;
+
+describe('guest-name resolver', () => {
+  it('decodes Unicode from the trusted forwarded URI', () => {
+    expect(
+      decodeForwardedGuestName(
+        request({
+          'x-forwarded-uri':
+            '/collab/wb-1?type=whiteboard&guestName=Jos%C3%A9%20M%C3%BCller',
+        })
+      )
+    ).toBe('José Müller');
+  });
+
+  it('decodes the existing Unicode-safe guest header', () => {
+    expect(
+      decodeGuestNameHeader(
+        request({
+          'x-guest-name': Buffer.from('李 明', 'utf8').toString('base64'),
+        })
+      )
+    ).toBe('李 明');
+  });
+
+  it('preserves the original raw ASCII guest-header contract', () => {
+    expect(
+      decodeGuestNameHeader(request({ 'x-guest-name': 'John Visitor' }))
+    ).toBe('John Visitor');
+    expect(decodeGuestNameHeader(request({ 'x-guest-name': 'John' }))).toBe(
+      'John'
+    );
+    expect(decodeGuestNameHeader(request({ 'x-guest-name': 'Mike' }))).toBe(
+      'Mike'
+    );
+  });
+
+  it.each([
+    ['malformed encoded header', request({ 'x-guest-name': 'not-base64!!!' })],
+    [
+      'invalid UTF-8',
+      request({ 'x-guest-name': Buffer.from([0xff]).toString('base64') }),
+    ],
+    [
+      'malformed percent encoding',
+      request({ 'x-forwarded-uri': '/collab/wb-1?guestName=%E0%A4%A' }),
+    ],
+  ])('rejects %s', (_name, req) => {
+    expect(resolveForwardAuthGuestName(req)).toBeUndefined();
+  });
+
+  it('rejects non-string direct query values without throwing', () => {
+    expect(
+      resolveForwardAuthGuestName(request(), ['Alice', 'Mallory'])
+    ).toBeUndefined();
+  });
+
+  it('uses the compatibility sources in direct, forwarded, header order', () => {
+    const req = request({
+      'x-forwarded-uri': '/collab/wb-1?guestName=Forwarded',
+      'x-guest-name': Buffer.from('Header', 'utf8').toString('base64'),
+    });
+
+    expect(resolveForwardAuthGuestName(req, 'Direct')).toBe('Direct');
+    expect(resolveForwardAuthGuestName(req)).toBe('Forwarded');
+    expect(
+      resolveForwardAuthGuestName(
+        request({ 'x-guest-name': req.headers['x-guest-name'] })
+      )
+    ).toBe('Header');
+  });
+});

--- a/src/core/authentication/guest-name.resolver.spec.ts
+++ b/src/core/authentication/guest-name.resolver.spec.ts
@@ -63,6 +63,29 @@ describe('guest-name resolver', () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    {
+      source: 'direct query',
+      req: request(),
+      direct: 'Alice\u0000Mallory',
+    },
+    {
+      source: 'forwarded URI',
+      req: request({
+        'x-forwarded-uri': '/collab/wb-1?guestName=Alice%00Mallory',
+      }),
+      direct: undefined,
+    },
+    {
+      source: 'raw compatibility header',
+      req: request({ 'x-guest-name': 'Alice\u0000Mallory' }),
+      direct: undefined,
+    },
+  ])('rejects control characters from the $source', ({ req, direct }) => {
+    expect(resolveForwardAuthGuestName(req, direct)).toBeUndefined();
+    expect(decodeGuestNameHeader(req)).toBeUndefined();
+  });
+
   it('uses the compatibility sources in direct, forwarded, header order', () => {
     const req = request({
       'x-forwarded-uri': '/collab/wb-1?guestName=Forwarded',

--- a/src/core/authentication/guest-name.resolver.ts
+++ b/src/core/authentication/guest-name.resolver.ts
@@ -1,0 +1,110 @@
+import { X_GUEST_NAME_HEADER } from '@core/authentication/constants';
+import type { IncomingMessage } from 'http';
+import { TextDecoder } from 'util';
+
+const X_FORWARDED_URI_HEADER = 'x-forwarded-uri';
+const BASE64_PATTERN =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const CONTROL_CHARACTER_PATTERN = /\p{Cc}/u;
+
+const firstHeaderValue = (
+  request: IncomingMessage,
+  header: string
+): string | undefined => {
+  const raw = request.headers?.[header];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};
+
+const normalizeGuestName = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  if (!normalized || normalized.includes('\uFFFD')) {
+    return undefined;
+  }
+  return normalized;
+};
+
+type EncodedGuestName = {
+  matched: boolean;
+  guestName?: string;
+};
+
+const decodeEncodedGuestName = (encoded: string): EncodedGuestName => {
+  if (!BASE64_PATTERN.test(encoded)) {
+    return { matched: false };
+  }
+
+  try {
+    const bytes = Buffer.from(encoded, 'base64');
+    if (bytes.toString('base64') !== encoded) {
+      return { matched: false };
+    }
+    const decoded = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    const guestName = normalizeGuestName(decoded);
+    if (guestName && CONTROL_CHARACTER_PATTERN.test(guestName)) {
+      return { matched: false };
+    }
+    return { matched: true, guestName };
+  } catch {
+    return { matched: false };
+  }
+};
+
+const decodeEncodedGuestNameHeader = (
+  request: IncomingMessage
+): string | undefined => {
+  const encoded = firstHeaderValue(request, X_GUEST_NAME_HEADER);
+  return encoded ? decodeEncodedGuestName(encoded).guestName : undefined;
+};
+
+/**
+ * Resolves the platform guest header for the global authentication interceptor.
+ * New browser callers use Unicode-safe base64; the original public contract
+ * also permits a raw ASCII display name, which remains supported here.
+ */
+export const decodeGuestNameHeader = (
+  request: IncomingMessage
+): string | undefined => {
+  const raw = firstHeaderValue(request, X_GUEST_NAME_HEADER);
+  if (!raw) {
+    return undefined;
+  }
+  const encoded = decodeEncodedGuestName(raw);
+  return encoded.matched ? encoded.guestName : normalizeGuestName(raw);
+};
+
+/** Reads guestName from the original target URI supplied by trusted ForwardAuth. */
+export const decodeForwardedGuestName = (
+  request: IncomingMessage
+): string | undefined => {
+  const forwardedUri = firstHeaderValue(request, X_FORWARDED_URI_HEADER);
+  if (!forwardedUri) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(forwardedUri, 'http://forward-auth.internal');
+    return normalizeGuestName(
+      parsed.searchParams.get('guestName') ?? undefined
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Resolves the current guest metadata sources at the ForwardAuth boundary.
+ * Direct query is retained for compatibility; production WS and asset requests
+ * arrive through the trusted forwarded URI and encoded header respectively.
+ */
+export const resolveForwardAuthGuestName = (
+  request: IncomingMessage,
+  directGuestName?: unknown
+): string | undefined =>
+  normalizeGuestName(directGuestName) ??
+  decodeForwardedGuestName(request) ??
+  decodeEncodedGuestNameHeader(request);

--- a/src/core/authentication/guest-name.resolver.ts
+++ b/src/core/authentication/guest-name.resolver.ts
@@ -22,7 +22,11 @@ const normalizeGuestName = (value: unknown): string | undefined => {
   }
 
   const normalized = value.trim();
-  if (!normalized || normalized.includes('\uFFFD')) {
+  if (
+    !normalized ||
+    normalized.includes('\uFFFD') ||
+    CONTROL_CHARACTER_PATTERN.test(normalized)
+  ) {
     return undefined;
   }
   return normalized;
@@ -45,7 +49,7 @@ const decodeEncodedGuestName = (encoded: string): EncodedGuestName => {
     }
     const decoded = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
     const guestName = normalizeGuestName(decoded);
-    if (guestName && CONTROL_CHARACTER_PATTERN.test(guestName)) {
+    if (CONTROL_CHARACTER_PATTERN.test(decoded)) {
       return { matched: false };
     }
     return { matched: true, guestName };

--- a/src/core/interceptors/auth.interceptor.spec.ts
+++ b/src/core/interceptors/auth.interceptor.spec.ts
@@ -350,6 +350,22 @@ describe('AuthInterceptor', () => {
       expect(actorContextService.createGuest).not.toHaveBeenCalled();
       expect(mockReq.user).toEqual({ isAnonymous: true, credentials: [] });
     });
+
+    it('preserves the original raw ASCII guest-header contract', async () => {
+      const mockReq = guestHeaderRequest('John Visitor');
+      noAuthenticatedUser();
+
+      await interceptor.intercept(httpContext(mockReq), mockNext);
+
+      expect(actorContextService.createGuest).toHaveBeenCalledWith(
+        'John Visitor'
+      );
+      expect(mockReq.user).toEqual({
+        isAnonymous: false,
+        guestName: 'John Visitor',
+        credentials: [{ type: 'global-guest', resourceID: '' }],
+      });
+    });
   });
 
   // server#6315. This interceptor is global, so a rejected cookie session 401s

--- a/src/core/interceptors/auth.interceptor.ts
+++ b/src/core/interceptors/auth.interceptor.ts
@@ -21,7 +21,7 @@ import {
   AUTH_STRATEGY_OIDC_COOKIE_SESSION,
   AUTH_STRATEGY_OIDC_HYDRA_BEARER,
 } from '@core/auth/oidc/strategies/strategy.names';
-import { X_GUEST_NAME_HEADER } from '@core/authentication/constants';
+import { decodeGuestNameHeader } from '@core/authentication/guest-name.resolver';
 import {
   CallHandler,
   ContextType,
@@ -279,10 +279,11 @@ export class AuthInterceptor implements NestInterceptor {
   }
 
   /**
-   * No session/bearer resolved. a public client
+   * No session/bearer resolved. A public client
    * (e.g. the guest-share whiteboard SPA) self-identifies with a display name
-   * in the `x-guest-name` header so per-resource guest-access policies can
-   * grant it `GLOBAL_GUEST`. Otherwise fall back to anonymous.
+   * in the Unicode-safe base64 or legacy raw `x-guest-name` header so
+   * per-resource guest-access policies can grant it `GLOBAL_GUEST`. Otherwise
+   * fall back to anonymous.
    */
   private resolveUnauthenticated(req: IncomingMessage): ActorContext {
     const guestName = decodeGuestNameHeader(req);
@@ -292,26 +293,6 @@ export class AuthInterceptor implements NestInterceptor {
     return this.actorContextService.createAnonymous();
   }
 }
-
-/**
- * Reads the `x-guest-name` header and base64-decodes it. The client encodes
- * the name (Unicode-safe) because HTTP headers are ISO-8859-1 only, so names
- * like `李明` cannot ride the wire raw. Returns the trimmed name, or undefined
- * when the header is absent, malformed, or empty after decode.
- */
-const decodeGuestNameHeader = (req: IncomingMessage): string | undefined => {
-  const raw = req.headers?.[X_GUEST_NAME_HEADER];
-  const value = Array.isArray(raw) ? raw[0] : raw;
-  if (typeof value !== 'string' || value.length === 0) {
-    return undefined;
-  }
-  try {
-    const decoded = Buffer.from(value, 'base64').toString('utf-8').trim();
-    return decoded.length > 0 ? decoded : undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 const getRequest = (context: ExecutionContext) => {
   const contextType = context.getType<ContextType | 'graphql' | 'rmq'>();


### PR DESCRIPTION
## Summary

- classify a resolved named guest as the reserved guest transport actor
- preserve authenticated actor precedence and keep anonymous requests on the nil UUID
- share guest-name resolution across ForwardAuth and the application interceptor
- preserve compatible raw ASCII and canonical UTF-8 base64 guest-name headers
- reject control characters consistently across direct query, forwarded URI, and encoded header sources
- pin authorization-evaluation-service v0.0.5 in the local quickstart stack
- pin @excalidraw-yjs/element v0.5.2 from npmjs
- add focused regression coverage for query, forwarded URI, header, session, and outage paths

## Contract

Reserved transport actor ID: 00000000-0000-0000-0000-000000000001

The sentinel exists only at the trusted service boundary. It is never persisted as an Actor. Normal application guest context continues to have an empty actor ID.

## Rollout dependency

authorization-evaluation-service PR https://github.com/alkem-io/authorization-evaluation-service/pull/22 is merged and released as v0.0.5: https://github.com/alkem-io/authorization-evaluation-service/releases/tag/v0.0.5

Deploy v0.0.5 before this server version starts emitting the sentinel.

Excalidraw-Yjs PR https://github.com/alkem-io/excalidraw-yjs/pull/6 is merged and released as v0.5.2: https://github.com/alkem-io/excalidraw-yjs/releases/tag/v0.5.2

## Verification

- focused authentication suite: 59 tests
- CodeRabbit triage: one valid finding fixed and resolved; one incompatible raw-header fallback declined with contract and producer evidence; no remaining untriaged findings
- merged current server develop into the feature branch
- pnpm lint (TypeScript + Biome)
- full Node 22 Vitest on the merged tree: 758 files passed, 6 skipped; 8690 tests passed, 7 skipped
- all feature, dependency, review-fix, and merge commits signed
- independent correctness, security/regression, and cross-contract reviews: clean

Tracks https://github.com/alkem-io/alkemio/issues/1909
Workspace spec: alkem-io/agents-hq workspace#057-guest-collab-auth