### PR TITLE
feat(058): add server-owned whiteboard drafts

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2622,6 +2622,10 @@ type CreateCalloutContributionData {
 type CreateCalloutContributionDefaultsData {
   """The default title to use for new contributions."""
   defaultDisplayName: String
+  """
+  Use a server-owned live Whiteboard contribution-default draft. Mutually exclusive with either source field.
+  """
+  draftWhiteboardID: UUID
   """The default description to use for new Post contributions."""
   postDescription: Markdown
   """
@@ -2893,6 +2897,10 @@ type CreateVisualOnProfileData {
 }
 
 type CreateWhiteboardData {
+  """
+  Use a server-owned live Whiteboard draft as the trusted source for final materialization. Mutually exclusive with sourceWhiteboardID.
+  """
+  draftWhiteboardID: UUID
   """A readable identifier, unique within the containing scope."""
   nameID: NameID
   """The preview settings for the whiteboard."""
@@ -4397,6 +4405,14 @@ type Mutation {
   createUser(userData: CreateUserInput!): User!
   """Creates a new VirtualContributor on an Account."""
   createVirtualContributor(virtualContributorData: CreateVirtualContributorOnAccountInput!): VirtualContributor!
+  """
+  Materializes a server-owned live Whiteboard draft for a Callout form. Content remains on the collaboration transport; GraphQL returns identifiers only.
+  """
+  createWhiteboardDraftOnCalloutsSet(draftData: CreateWhiteboardDraftOnCalloutsSetInput!): UUID!
+  """
+  Materializes a server-owned live Whiteboard draft for a Template form. GraphQL returns identifiers only.
+  """
+  createWhiteboardDraftOnTemplatesSet(draftData: CreateWhiteboardDraftOnTemplatesSetInput!): UUID!
   """Creates an account in Wingback"""
   createWingbackAccount(accountID: UUID!): String!
   """Removes the specified Application."""
@@ -4461,6 +4477,10 @@ type Mutation {
   deleteVisualFromMediaGallery(deleteData: DeleteVisualFromMediaGalleryInput!): Visual!
   """Deletes the specified Whiteboard."""
   deleteWhiteboard(whiteboardData: DeleteWhiteboardInput!): Whiteboard!
+  """
+  Idempotently discards a server-owned live Whiteboard draft through the canonical Whiteboard deletion path.
+  """
+  deleteWhiteboardDraft(whiteboardID: UUID!): UUID!
   """
   Re-enable a previously disabled push notification subscription for the current user.
   """
@@ -7935,6 +7955,10 @@ input CreateCalendarEventOnCalendarInput {
 input CreateCalloutContributionDefaultsInput {
   """The default title to use for new contributions."""
   defaultDisplayName: String
+  """
+  Use a server-owned live Whiteboard contribution-default draft. Mutually exclusive with either source field.
+  """
+  draftWhiteboardID: UUID
   """The default description to use for new Post contributions."""
   postDescription: Markdown
   """
@@ -8621,7 +8645,23 @@ input CreateVisualOnProfileInput {
   uri: String!
 }
 
+input CreateWhiteboardDraftOnCalloutsSetInput {
+  calloutsSetID: UUID!
+  sourceCalloutID: UUID
+  sourceWhiteboardID: UUID
+}
+
+input CreateWhiteboardDraftOnTemplatesSetInput {
+  sourceCalloutID: UUID
+  sourceWhiteboardID: UUID
+  templatesSetID: UUID!
+}
+
 input CreateWhiteboardInput {
+  """
+  Use a server-owned live Whiteboard draft as the trusted source for final materialization. Mutually exclusive with sourceWhiteboardID.
+  """
+  draftWhiteboardID: UUID
   """A readable identifier, unique within the containing scope."""
   nameID: NameID
   """The preview settings for the whiteboard."""

--- a/src/domain/collaboration/callout-contribution-defaults/dto/callout.contribution.defaults.dto.create.ts
+++ b/src/domain/collaboration/callout-contribution-defaults/dto/callout.contribution.defaults.dto.create.ts
@@ -43,4 +43,12 @@ export class CreateCalloutContributionDefaultsInput {
   })
   @IsOptional()
   sourceCalloutID?: string;
+
+  @Field(() => UUID, {
+    nullable: true,
+    description:
+      'Use a server-owned live Whiteboard contribution-default draft. Mutually exclusive with either source field.',
+  })
+  @IsOptional()
+  draftWhiteboardID?: string;
 }

--- a/src/domain/collaboration/callout/callout.contribution.default.source.service.ts
+++ b/src/domain/collaboration/callout/callout.contribution.default.source.service.ts
@@ -12,6 +12,7 @@ export interface ContributionDefaultSourceInput {
   clearWhiteboardContent?: boolean;
   whiteboardContent?: string;
   sourceStorageBucketID?: string;
+  draftWhiteboardID?: string;
 }
 
 /**
@@ -37,11 +38,12 @@ export class CalloutContributionDefaultSourceService {
     const selectedSources = [
       defaults.sourceWhiteboardID,
       defaults.sourceCalloutID,
+      defaults.draftWhiteboardID,
       defaults.clearWhiteboardContent ? 'clear' : undefined,
     ].filter(Boolean);
     if (selectedSources.length > 1) {
       throw new ValidationException(
-        'sourceWhiteboardID, sourceCalloutID, and clearWhiteboardContent are mutually exclusive',
+        'sourceWhiteboardID, sourceCalloutID, draftWhiteboardID, and clearWhiteboardContent are mutually exclusive',
         LogContext.WHITEBOARDS
       );
     }
@@ -74,6 +76,15 @@ export class CalloutContributionDefaultSourceService {
         );
       }
       return;
+    }
+    // A draft is claimed and normalized to sourceWhiteboardID by the owning
+    // Callout/TemplatesSet mutation before this service runs. Seeing the raw id
+    // here would bypass actor/scope/purpose validation.
+    if (defaults.draftWhiteboardID) {
+      throw new ValidationException(
+        'draftWhiteboardID must be claimed before preparing contribution defaults',
+        LogContext.WHITEBOARDS
+      );
     }
     if (!defaults.sourceWhiteboardID) {
       return;

--- a/src/domain/collaboration/callouts-set/callouts.set.module.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.module.ts
@@ -2,6 +2,7 @@ import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { TagsetTemplateSetModule } from '@domain/common/tagset-template-set/tagset.template.set.module';
 import { WhiteboardModule } from '@domain/common/whiteboard/whiteboard.module';
+import { WhiteboardDraftModule } from '@domain/common/whiteboard-draft';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ActivityAdapterModule } from '@services/adapters/activity-adapter/activity.adapter.module';
@@ -35,6 +36,7 @@ import { CalloutsSetAuthorizationService } from './callouts.set.service.authoriz
     NamingModule,
     EntityResolverModule,
     WhiteboardModule,
+    WhiteboardDraftModule,
     PostModule,
     TypeOrmModule.forFeature([CalloutsSet]),
   ],

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
@@ -8,6 +8,7 @@ import { ForbiddenException, ValidationException } from '@common/exceptions';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
+import { WhiteboardDraftService } from '@domain/common/whiteboard-draft';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
@@ -30,6 +31,7 @@ describe('CalloutsSetResolverMutations', () => {
   let calloutAuthorizationService: CalloutAuthorizationService;
   let configService: ConfigService;
   let whiteboardService: WhiteboardService;
+  let whiteboardDraftService: WhiteboardDraftService;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -55,11 +57,45 @@ describe('CalloutsSetResolverMutations', () => {
     calloutAuthorizationService = module.get(CalloutAuthorizationService);
     configService = module.get(ConfigService);
     whiteboardService = module.get(WhiteboardService);
+    whiteboardDraftService = module.get(WhiteboardDraftService);
     vi.mocked(configService.get).mockReturnValue(5000 as any);
   });
 
   it('should be defined', () => {
     expect(resolver).toBeDefined();
+  });
+
+  describe('createWhiteboardDraftOnCalloutsSet', () => {
+    it('requires READ on a source Whiteboard before materializing a draft', async () => {
+      vi.mocked(calloutsSetService.getCalloutsSetOrFail).mockResolvedValue({
+        id: 'cs-1',
+        authorization: { id: 'auth-cs' },
+      } as any);
+      vi.mocked(whiteboardService.getWhiteboardOrFail).mockResolvedValue({
+        id: 'source-wb-1',
+        authorization: { id: 'auth-source' },
+      } as any);
+      vi.mocked(authorizationService.grantAccessOrFail).mockImplementation(
+        (_actor, _authorization, privilege) => {
+          if (privilege === AuthorizationPrivilege.READ) {
+            throw new ForbiddenException('denied', LogContext.AUTH);
+          }
+          return true as never;
+        }
+      );
+
+      await expect(
+        resolver.createWhiteboardDraftOnCalloutsSet(
+          { actorID: 'user-1' } as any,
+          {
+            calloutsSetID: 'cs-1',
+            sourceWhiteboardID: 'source-wb-1',
+          } as any
+        )
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(whiteboardDraftService.materialize).not.toHaveBeenCalled();
+    });
   });
 
   describe('createCalloutOnCalloutsSet', () => {
@@ -276,6 +312,43 @@ describe('CalloutsSetResolverMutations', () => {
       expect(
         calloutsSetService.createCalloutOnCalloutsSet
       ).not.toHaveBeenCalled();
+    });
+
+    it('uses an owned draft as a server-side source and leaves it intact when final creation fails', async () => {
+      const calloutsSet = framingCloneCalloutsSet();
+      vi.mocked(calloutsSetService.getCalloutsSetOrFail).mockResolvedValue(
+        calloutsSet
+      );
+      const draft = { id: 'draft-whiteboard-1' } as any;
+      vi.mocked(whiteboardDraftService.getForConsumption).mockResolvedValue(
+        draft
+      );
+      const failed = new Error('final create failed');
+      vi.mocked(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).mockRejectedValue(failed);
+      const input = {
+        calloutsSetID: calloutsSet.id,
+        framing: {
+          type: CalloutFramingType.WHITEBOARD,
+          whiteboard: { draftWhiteboardID: 'draft-whiteboard-1' },
+        },
+      } as any;
+      const actor = { actorID: 'user-1' } as any;
+
+      await expect(
+        resolver.createCalloutOnCalloutsSet(actor, input)
+      ).rejects.toBe(failed);
+
+      expect(whiteboardDraftService.getForConsumption).toHaveBeenCalledWith(
+        'draft-whiteboard-1',
+        actor
+      );
+      expect(input.framing.whiteboard).toEqual({
+        draftWhiteboardID: undefined,
+        sourceWhiteboardID: draft.id,
+      });
+      expect(whiteboardDraftService.cleanupConsumed).not.toHaveBeenCalled();
     });
 
     it('should trigger notifications and activity when published on COLLABORATION type', async () => {

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
@@ -12,7 +12,12 @@ import { IPlatformRolesAccess } from '@domain/access/platform-roles-access/platf
 import { IRoleSet } from '@domain/access/role-set/role.set.interface';
 import { introducesCollaboraDocument } from '@domain/collaboration/callout/callout.collabora.gate.util';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { UUID } from '@domain/common/scalars';
 import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
+import {
+  CreateWhiteboardDraftOnCalloutsSetInput,
+  WhiteboardDraftService,
+} from '@domain/common/whiteboard-draft';
 import { Inject, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
@@ -23,12 +28,16 @@ import { NotificationSpaceAdapter } from '@services/adapters/notification-adapte
 import { ContributionReporterService } from '@services/external/elasticsearch/contribution-reporter/contribution.reporter.service';
 import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { RoomResolverService } from '@services/infrastructure/entity-resolver/room.resolver.service';
+import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
 import { TemporaryStorageService } from '@services/infrastructure/temporary-storage/temporary.storage.service';
 import { InstrumentResolver } from '@src/apm/decorators';
 import { AlkemioConfig } from '@src/types/alkemio.config';
 import { FileUpload, GraphQLUpload } from 'graphql-upload';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { CalloutContributionDefaultSourceService } from '../callout/callout.contribution.default.source.service';
+import {
+  CalloutContributionDefaultSourceService,
+  ContributionDefaultSourceInput,
+} from '../callout/callout.contribution.default.source.service';
 import { ICallout } from '../callout/callout.interface';
 import { CalloutService } from '../callout/callout.service';
 import { CalloutAuthorizationService } from '../callout/callout.service.authorization';
@@ -57,8 +66,58 @@ export class CalloutsSetResolverMutations {
     private configService: ConfigService<AlkemioConfig, true>,
     private collaborationLicenseService: CollaborationLicenseService,
     private whiteboardService: WhiteboardService,
+    private whiteboardDraftService: WhiteboardDraftService,
+    private storageAggregatorResolverService: StorageAggregatorResolverService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
+
+  @Mutation(() => UUID, {
+    description:
+      'Materializes a server-owned live Whiteboard draft for a Callout form. Content remains on the collaboration transport; GraphQL returns identifiers only.',
+  })
+  async createWhiteboardDraftOnCalloutsSet(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('draftData') draftData: CreateWhiteboardDraftOnCalloutsSetInput
+  ): Promise<string> {
+    const calloutsSet = await this.calloutsSetService.getCalloutsSetOrFail(
+      draftData.calloutsSetID
+    );
+    this.authorizationService.grantAccessOrFail(
+      actorContext,
+      calloutsSet.authorization,
+      AuthorizationPrivilege.CREATE_CALLOUT,
+      `create whiteboard draft on callouts Set: ${calloutsSet.id}`
+    );
+
+    let sourceContent: string | undefined;
+    let sourceStorageBucketID: string | undefined;
+    await this.assertActorCanReadSourceWhiteboard(
+      actorContext,
+      draftData.sourceWhiteboardID
+    );
+    if (draftData.sourceCalloutID) {
+      const source: ContributionDefaultSourceInput = {
+        sourceCalloutID: draftData.sourceCalloutID,
+      };
+      await this.contributionDefaultSourceService.prepare(source, actorContext);
+      sourceContent = source.whiteboardContent;
+      sourceStorageBucketID = source.sourceStorageBucketID;
+    }
+    const storageAggregator =
+      await this.storageAggregatorResolverService.getStorageAggregatorForCalloutsSet(
+        calloutsSet.id
+      );
+    return this.whiteboardDraftService.materialize(
+      {
+        ...draftData,
+        sourceContent,
+        sourceStorageBucketID,
+      },
+      storageAggregator,
+      calloutsSet.authorization,
+      actorContext
+    );
+  }
 
   /**
    * A clone may read its source only after the actor is granted READ: when a
@@ -104,6 +163,42 @@ export class CalloutsSetResolverMutations {
       AuthorizationPrivilege.CREATE_CALLOUT,
       `create callout on callouts Set: ${calloutsSet.id}`
     );
+
+    const consumedDraftIDs: string[] = [];
+    const framingDraftID = calloutData.framing?.whiteboard?.draftWhiteboardID;
+    if (framingDraftID) {
+      const whiteboardInput = calloutData.framing.whiteboard!;
+      if (whiteboardInput.sourceWhiteboardID) {
+        throw new ValidationException(
+          'draftWhiteboardID and sourceWhiteboardID are mutually exclusive',
+          LogContext.WHITEBOARDS
+        );
+      }
+      const draft = await this.whiteboardDraftService.getForConsumption(
+        framingDraftID,
+        actorContext
+      );
+      consumedDraftIDs.push(draft.id);
+      whiteboardInput.sourceWhiteboardID = draft.id;
+      whiteboardInput.draftWhiteboardID = undefined;
+    }
+    const defaultsDraftID = calloutData.contributionDefaults?.draftWhiteboardID;
+    if (defaultsDraftID) {
+      const defaults = calloutData.contributionDefaults!;
+      if (defaults.sourceWhiteboardID || defaults.sourceCalloutID) {
+        throw new ValidationException(
+          'draftWhiteboardID and contribution-default source fields are mutually exclusive',
+          LogContext.WHITEBOARDS
+        );
+      }
+      const draft = await this.whiteboardDraftService.getForConsumption(
+        defaultsDraftID,
+        actorContext
+      );
+      consumedDraftIDs.push(draft.id);
+      defaults.sourceWhiteboardID = draft.id;
+      defaults.draftWhiteboardID = undefined;
+    }
 
     // CONTRIBUTORS and SPACES framings are admin-only and collaboration-only
     // (FR-004a/FR-004d/FR-004f, R5): reject on non-COLLABORATION callouts sets and
@@ -296,7 +391,25 @@ export class CalloutsSetResolverMutations {
       }
     }
 
-    return await this.calloutService.getCalloutOrFail(callout.id);
+    const result = await this.calloutService.getCalloutOrFail(callout.id);
+    for (const draftID of consumedDraftIDs) {
+      try {
+        await this.whiteboardDraftService.cleanupConsumed(draftID);
+      } catch (error) {
+        this.logger.error?.(
+          {
+            message:
+              'Final Callout was created but Whiteboard draft cleanup remains retryable',
+            calloutID: result.id,
+            draftID,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          error instanceof Error ? (error.stack ?? '') : '',
+          LogContext.WHITEBOARDS
+        );
+      }
+    }
+    return result;
   }
 
   @Mutation(() => [ICallout], {

--- a/src/domain/common/whiteboard-draft/dto/index.ts
+++ b/src/domain/common/whiteboard-draft/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './whiteboard.draft.dto.create';

--- a/src/domain/common/whiteboard-draft/dto/whiteboard.draft.dto.create.ts
+++ b/src/domain/common/whiteboard-draft/dto/whiteboard.draft.dto.create.ts
@@ -1,0 +1,32 @@
+import { UUID } from '@domain/common/scalars';
+import { Field, InputType } from '@nestjs/graphql';
+import { IsOptional, IsUUID } from 'class-validator';
+
+@InputType({ isAbstract: true })
+abstract class CreateWhiteboardDraftInputBase {
+  @Field(() => UUID, { nullable: true })
+  @IsOptional()
+  @IsUUID()
+  sourceWhiteboardID?: string;
+
+  @Field(() => UUID, { nullable: true })
+  @IsOptional()
+  @IsUUID()
+  sourceCalloutID?: string;
+}
+
+@InputType()
+export class CreateWhiteboardDraftOnCalloutsSetInput extends CreateWhiteboardDraftInputBase {
+  @Field(() => UUID)
+  @IsUUID()
+  calloutsSetID!: string;
+}
+
+@InputType()
+export class CreateWhiteboardDraftOnTemplatesSetInput extends CreateWhiteboardDraftInputBase {
+  @Field(() => UUID)
+  @IsUUID()
+  templatesSetID!: string;
+}
+
+export type CreateWhiteboardDraftInput = CreateWhiteboardDraftInputBase;

--- a/src/domain/common/whiteboard-draft/index.ts
+++ b/src/domain/common/whiteboard-draft/index.ts
@@ -1,0 +1,3 @@
+export * from './dto';
+export * from './whiteboard.draft.module';
+export * from './whiteboard.draft.service';

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.module.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.module.ts
@@ -1,0 +1,23 @@
+import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
+import { Whiteboard } from '@domain/common/whiteboard/whiteboard.entity';
+import { WhiteboardModule } from '@domain/common/whiteboard/whiteboard.module';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WhiteboardDraftResolver } from './whiteboard.draft.resolver';
+import { WhiteboardDraftService } from './whiteboard.draft.service';
+import { WhiteboardDraftSweepService } from './whiteboard.draft.sweep.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Whiteboard]),
+    WhiteboardModule,
+    AuthorizationPolicyModule,
+  ],
+  providers: [
+    WhiteboardDraftService,
+    WhiteboardDraftResolver,
+    WhiteboardDraftSweepService,
+  ],
+  exports: [WhiteboardDraftService],
+})
+export class WhiteboardDraftModule {}

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.resolver.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.resolver.ts
@@ -1,0 +1,23 @@
+import { CurrentActor } from '@common/decorators/current-actor.decorator';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { UUID } from '@domain/common/scalars';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { InstrumentResolver } from '@src/apm/decorators';
+import { WhiteboardDraftService } from './whiteboard.draft.service';
+
+@InstrumentResolver()
+@Resolver()
+export class WhiteboardDraftResolver {
+  constructor(private readonly service: WhiteboardDraftService) {}
+
+  @Mutation(() => UUID, {
+    description:
+      'Idempotently discards a server-owned live Whiteboard draft through the canonical Whiteboard deletion path.',
+  })
+  async deleteWhiteboardDraft(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('whiteboardID', { type: () => UUID }) whiteboardID: string
+  ): Promise<string> {
+    return this.service.discard(whiteboardID, actorContext);
+  }
+}

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
@@ -1,0 +1,182 @@
+import { ActorContext } from '@core/actor-context/actor.context';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { Whiteboard } from '@domain/common/whiteboard/whiteboard.entity';
+import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
+import { WhiteboardAuthorizationService } from '@domain/common/whiteboard/whiteboard.service.authorization';
+import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
+import { Repository } from 'typeorm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WhiteboardDraftService } from './whiteboard.draft.service';
+
+describe('WhiteboardDraftService', () => {
+  const actorContext = {
+    actorID: '6c0552d4-a1e6-4e52-b008-28c3fbd29e67',
+  } as ActorContext;
+  const parentAuthorization = { id: 'parent-auth' } as IAuthorizationPolicy;
+  let repository: Pick<Repository<Whiteboard>, 'find' | 'findOne'>;
+  let whiteboardService: Pick<
+    WhiteboardService,
+    'createWhiteboard' | 'deleteWhiteboard'
+  >;
+  const whiteboardAuthorizationService = { applyAuthorizationPolicy: vi.fn() };
+  const authorizationPolicyService = { saveAll: vi.fn() };
+  let service: WhiteboardDraftService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository = { find: vi.fn(), findOne: vi.fn() };
+    whiteboardService = {
+      createWhiteboard: vi.fn(),
+      deleteWhiteboard: vi.fn(),
+    };
+    service = new WhiteboardDraftService(
+      repository as Repository<Whiteboard>,
+      whiteboardService as WhiteboardService,
+      whiteboardAuthorizationService as unknown as WhiteboardAuthorizationService,
+      authorizationPolicyService as unknown as AuthorizationPolicyService
+    );
+    whiteboardAuthorizationService.applyAuthorizationPolicy.mockResolvedValue(
+      []
+    );
+  });
+
+  it('creates an ordinary Whiteboard with only a draft expiry marker', async () => {
+    vi.mocked(whiteboardService.createWhiteboard).mockResolvedValue({
+      id: 'wb-1',
+    } as Whiteboard);
+
+    const result = await service.materialize(
+      {},
+      {} as IStorageAggregator,
+      parentAuthorization,
+      actorContext
+    );
+
+    expect(whiteboardService.createWhiteboard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftExpiresAt: expect.any(Date),
+        profile: { displayName: 'Whiteboard draft' },
+      }),
+      expect.anything(),
+      actorContext
+    );
+    expect(result).toBe('wb-1');
+    expect(
+      whiteboardAuthorizationService.applyAuthorizationPolicy
+    ).toHaveBeenCalledWith('wb-1', parentAuthorization);
+    expect(authorizationPolicyService.saveAll).toHaveBeenCalledWith([]);
+  });
+
+  it('deletes the draft when its authorization cannot be initialized', async () => {
+    vi.mocked(whiteboardService.createWhiteboard).mockResolvedValue({
+      id: 'wb-1',
+    } as Whiteboard);
+    whiteboardAuthorizationService.applyAuthorizationPolicy.mockRejectedValue(
+      new Error('authorization failed')
+    );
+
+    await expect(
+      service.materialize(
+        {},
+        {} as IStorageAggregator,
+        parentAuthorization,
+        actorContext
+      )
+    ).rejects.toThrow('authorization failed');
+
+    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith('wb-1');
+  });
+
+  it('refuses an ordinary Whiteboard as a draft source', async () => {
+    vi.mocked(repository.findOne).mockResolvedValue({
+      id: 'ordinary-wb',
+      createdBy: actorContext.actorID,
+      draftExpiresAt: null,
+    } as Whiteboard);
+
+    await expect(
+      service.getForConsumption('ordinary-wb', actorContext)
+    ).rejects.toThrow('Whiteboard draft not found');
+  });
+
+  it('refuses a draft owned by another actor', async () => {
+    vi.mocked(repository.findOne).mockResolvedValue({
+      id: 'draft-wb',
+      createdBy: 'other-actor',
+      draftExpiresAt: new Date(Date.now() + 60_000),
+    } as Whiteboard);
+
+    await expect(
+      service.getForConsumption('draft-wb', actorContext)
+    ).rejects.toThrow(
+      'Only the actor that created a Whiteboard draft may consume it'
+    );
+  });
+
+  it('refuses an expired draft as a final-create source', async () => {
+    vi.mocked(repository.findOne).mockResolvedValue({
+      id: 'draft-wb',
+      createdBy: actorContext.actorID,
+      draftExpiresAt: new Date(Date.now() - 1),
+    } as Whiteboard);
+
+    await expect(
+      service.getForConsumption('draft-wb', actorContext)
+    ).rejects.toThrow('Whiteboard draft has expired');
+  });
+
+  it('does not delete an ordinary Whiteboard even when cleanup receives its id', async () => {
+    vi.mocked(repository.findOne).mockResolvedValue(null);
+
+    await service.cleanupConsumed('ordinary-wb');
+
+    expect(repository.findOne).toHaveBeenCalledWith({
+      where: { id: 'ordinary-wb', draftExpiresAt: expect.anything() },
+    });
+    expect(whiteboardService.deleteWhiteboard).not.toHaveBeenCalled();
+  });
+
+  it('periodic cleanup discovers only expired non-NULL draft expiries', async () => {
+    vi.mocked(repository.find).mockResolvedValue([
+      { id: 'expired-draft' } as Whiteboard,
+    ]);
+
+    await expect(service.findExpired(25)).resolves.toEqual(['expired-draft']);
+
+    expect(repository.find).toHaveBeenCalledWith({
+      select: { id: true },
+      where: { draftExpiresAt: expect.anything() },
+      order: { draftExpiresAt: 'ASC' },
+      take: 25,
+    });
+  });
+
+  it('rechecks exact id and expired draftness before periodic deletion', async () => {
+    vi.mocked(repository.findOne).mockResolvedValue({
+      id: 'expired-draft',
+    } as Whiteboard);
+
+    await service.cleanupExpired('expired-draft');
+
+    expect(repository.findOne).toHaveBeenCalledWith({
+      where: { id: 'expired-draft', draftExpiresAt: expect.anything() },
+    });
+    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith(
+      'expired-draft'
+    );
+  });
+
+  it('explicit discard requires creator ownership and a non-NULL expiry', async () => {
+    vi.mocked(repository.findOne).mockResolvedValue({
+      id: 'draft-wb',
+      createdBy: actorContext.actorID,
+      draftExpiresAt: new Date(Date.now() + 60_000),
+    } as Whiteboard);
+
+    await expect(service.discard('draft-wb', actorContext)).resolves.toBe(
+      'draft-wb'
+    );
+    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith('draft-wb');
+  });
+});

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from 'node:crypto';
+import { LogContext } from '@common/enums';
+import {
+  EntityNotFoundException,
+  ForbiddenException,
+  ValidationException,
+} from '@common/exceptions';
+import { ActorContext } from '@core/actor-context/actor.context';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
+import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { Whiteboard } from '@domain/common/whiteboard/whiteboard.entity';
+import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
+import { WhiteboardAuthorizationService } from '@domain/common/whiteboard/whiteboard.service.authorization';
+import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, LessThanOrEqual, Not, Repository } from 'typeorm';
+import { CreateWhiteboardDraftInput } from './dto';
+
+const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface WhiteboardDraftMaterializationInput
+  extends CreateWhiteboardDraftInput {
+  sourceContent?: string;
+  sourceStorageBucketID?: string;
+}
+
+/** A live draft is an ordinary Whiteboard with a non-NULL expiry marker. */
+@Injectable()
+export class WhiteboardDraftService {
+  constructor(
+    @InjectRepository(Whiteboard)
+    private readonly repository: Repository<Whiteboard>,
+    private readonly whiteboardService: WhiteboardService,
+    private readonly whiteboardAuthorizationService: WhiteboardAuthorizationService,
+    private readonly authorizationPolicyService: AuthorizationPolicyService
+  ) {}
+
+  async materialize(
+    input: WhiteboardDraftMaterializationInput,
+    storageAggregator: IStorageAggregator,
+    parentAuthorization: IAuthorizationPolicy | undefined,
+    actorContext: ActorContext
+  ): Promise<string> {
+    this.assertActor(actorContext);
+    this.assertSources(input);
+    const expiresAt = new Date(Date.now() + DRAFT_TTL_MS);
+    const whiteboard = await this.whiteboardService.createWhiteboard(
+      {
+        profile: { displayName: 'Whiteboard draft' },
+        nameID: randomUUID().slice(0, 8),
+        sourceWhiteboardID: input.sourceWhiteboardID,
+        content: input.sourceContent,
+        sourceStorageBucketID: input.sourceStorageBucketID,
+        draftExpiresAt: expiresAt,
+      },
+      storageAggregator,
+      actorContext
+    );
+    try {
+      const authorizations =
+        await this.whiteboardAuthorizationService.applyAuthorizationPolicy(
+          whiteboard.id,
+          parentAuthorization
+        );
+      await this.authorizationPolicyService.saveAll(authorizations);
+    } catch (error) {
+      await this.whiteboardService.deleteWhiteboard(whiteboard.id);
+      throw error;
+    }
+    return whiteboard.id;
+  }
+
+  async getForConsumption(
+    whiteboardID: string,
+    actorContext: ActorContext
+  ): Promise<Whiteboard> {
+    this.assertActor(actorContext);
+    const draft = await this.repository.findOne({
+      where: { id: whiteboardID },
+    });
+    if (!draft?.draftExpiresAt) {
+      throw new EntityNotFoundException(
+        'Whiteboard draft not found',
+        LogContext.WHITEBOARDS,
+        { whiteboardID }
+      );
+    }
+    if (draft.createdBy !== actorContext.actorID) {
+      throw new ForbiddenException(
+        'Only the actor that created a Whiteboard draft may consume it',
+        LogContext.WHITEBOARDS,
+        { whiteboardID }
+      );
+    }
+    if (draft.draftExpiresAt.getTime() <= Date.now()) {
+      throw new ValidationException(
+        'Whiteboard draft has expired',
+        LogContext.WHITEBOARDS,
+        { whiteboardID }
+      );
+    }
+    return draft;
+  }
+
+  async discard(
+    whiteboardID: string,
+    actorContext: ActorContext
+  ): Promise<string> {
+    this.assertActor(actorContext);
+    const draft = await this.repository.findOne({
+      where: { id: whiteboardID },
+    });
+    if (!draft?.draftExpiresAt) return whiteboardID;
+    if (draft.createdBy !== actorContext.actorID) {
+      throw new ForbiddenException(
+        'Only the actor that created a Whiteboard draft may discard it',
+        LogContext.WHITEBOARDS,
+        { whiteboardID }
+      );
+    }
+    await this.whiteboardService.deleteWhiteboard(whiteboardID);
+    return whiteboardID;
+  }
+
+  async cleanupConsumed(whiteboardID: string): Promise<void> {
+    const draft = await this.repository.findOne({
+      where: { id: whiteboardID, draftExpiresAt: Not(IsNull()) },
+    });
+    if (!draft) return;
+    await this.whiteboardService.deleteWhiteboard(draft.id);
+  }
+
+  async findExpired(limit: number): Promise<string[]> {
+    // This is the complete cleanup corpus. Ordinary Whiteboards have NULL and
+    // cannot be selected by this query.
+    const drafts = await this.repository.find({
+      select: { id: true },
+      where: { draftExpiresAt: LessThanOrEqual(new Date()) },
+      order: { draftExpiresAt: 'ASC' },
+      take: limit,
+    });
+    return drafts.map(draft => draft.id);
+  }
+
+  async cleanupExpired(whiteboardID: string): Promise<void> {
+    // Recheck the exact id and expiry immediately before canonical deletion.
+    const draft = await this.repository.findOne({
+      where: {
+        id: whiteboardID,
+        draftExpiresAt: LessThanOrEqual(new Date()),
+      },
+    });
+    if (!draft) return;
+    await this.whiteboardService.deleteWhiteboard(draft.id);
+  }
+
+  private assertActor(actorContext: ActorContext): void {
+    if (!actorContext.actorID) {
+      throw new ForbiddenException(
+        'Whiteboard drafts require an authenticated actor',
+        LogContext.WHITEBOARDS
+      );
+    }
+  }
+
+  private assertSources(input: CreateWhiteboardDraftInput): void {
+    if (input.sourceWhiteboardID && input.sourceCalloutID) {
+      throw new ValidationException(
+        'sourceWhiteboardID and sourceCalloutID are mutually exclusive',
+        LogContext.WHITEBOARDS
+      );
+    }
+  }
+}

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.sweep.service.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.sweep.service.ts
@@ -1,0 +1,36 @@
+import { LogContext } from '@common/enums';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { WhiteboardDraftService } from './whiteboard.draft.service';
+
+const SWEEP_BATCH_SIZE = 25;
+
+@Injectable()
+export class WhiteboardDraftSweepService {
+  constructor(
+    private readonly draftService: WhiteboardDraftService,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async sweep(): Promise<void> {
+    const whiteboardIDs = await this.draftService.findExpired(SWEEP_BATCH_SIZE);
+    for (const whiteboardID of whiteboardIDs) {
+      try {
+        await this.draftService.cleanupExpired(whiteboardID);
+      } catch (error) {
+        this.logger.error?.(
+          {
+            message: 'Whiteboard draft cleanup failed; it remains retryable',
+            whiteboardID,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          error instanceof Error ? (error.stack ?? '') : '',
+          LogContext.WHITEBOARDS
+        );
+      }
+    }
+  }
+}

--- a/src/domain/common/whiteboard/dto/whiteboard.dto.create.ts
+++ b/src/domain/common/whiteboard/dto/whiteboard.dto.create.ts
@@ -41,11 +41,22 @@ export class CreateWhiteboardInput {
   @IsOptional()
   sourceWhiteboardID?: string;
 
+  @Field(() => UUID, {
+    nullable: true,
+    description:
+      'Use a server-owned live Whiteboard draft as the trusted source for final materialization. Mutually exclusive with sourceWhiteboardID.',
+  })
+  @IsOptional()
+  draftWhiteboardID?: string;
+
   /**
    * Server-internal ownership boundary for canonical content copied from a
    * persisted Callout default. It is deliberately not a GraphQL field.
    */
   sourceStorageBucketID?: string;
+
+  /** Server-internal expiry marker for a live form draft. */
+  draftExpiresAt?: Date;
 
   @Field(() => CreateWhiteboardPreviewSettingsInput, {
     nullable: true,

--- a/src/domain/common/whiteboard/whiteboard.entity.ts
+++ b/src/domain/common/whiteboard/whiteboard.entity.ts
@@ -48,6 +48,14 @@ export class Whiteboard extends NameableEntity implements IWhiteboard {
   @Column('uuid', { nullable: true })
   createdBy?: string;
 
+  /**
+   * Non-NULL only while this Whiteboard is a temporary live form draft.
+   * Ordinary and finalized Whiteboards always keep this NULL, which makes the
+   * cleanup boundary explicit without a parallel draft model.
+   */
+  @Column('timestamptz', { nullable: true })
+  draftExpiresAt?: Date | null;
+
   @Column('varchar', {
     length: ENUM_LENGTH,
     nullable: false,

--- a/src/domain/common/whiteboard/whiteboard.interface.ts
+++ b/src/domain/common/whiteboard/whiteboard.interface.ts
@@ -43,5 +43,9 @@ export abstract class IWhiteboard extends INameable {
 
   createdBy?: string;
 
+  // Internal lifecycle marker. NULL means this is an ordinary Whiteboard and
+  // therefore outside the draft cleanup corpus.
+  draftExpiresAt?: Date | null;
+
   callout?: ICallout;
 }

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -103,6 +103,8 @@ export class WhiteboardService {
       content,
       sourceWhiteboardID,
       sourceStorageBucketID,
+      draftWhiteboardID: _draftWhiteboardID,
+      draftExpiresAt,
       ...entityData
     } = whiteboardData;
 
@@ -114,6 +116,12 @@ export class WhiteboardService {
     if (content != null && sourceWhiteboardID != null) {
       throw new ValidationException(
         'A whiteboard create must supply EITHER content OR sourceWhiteboardID, not both',
+        LogContext.WHITEBOARDS
+      );
+    }
+    if (_draftWhiteboardID != null) {
+      throw new ValidationException(
+        'draftWhiteboardID must be claimed by the owning create mutation before Whiteboard materialization',
         LogContext.WHITEBOARDS
       );
     }
@@ -152,6 +160,7 @@ export class WhiteboardService {
     // `ActorContext.actorID` is typed `string` and defaults to '' for an empty/anonymous
     // context; `|| undefined` keeps a malformed empty-string out of the UUID column (NULL).
     whiteboard.createdBy = actorContext.actorID || undefined;
+    whiteboard.draftExpiresAt = draftExpiresAt;
     whiteboard.contentUpdatePolicy = ContentUpdatePolicy.CONTRIBUTORS;
 
     const profileData = {

--- a/src/domain/template/templates-set/templates.set.module.ts
+++ b/src/domain/template/templates-set/templates.set.module.ts
@@ -1,6 +1,7 @@
 import { AuthorizationModule } from '@core/authorization/authorization.module';
 import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/authorization.policy.module';
 import { WhiteboardModule } from '@domain/common/whiteboard/whiteboard.module';
+import { WhiteboardDraftModule } from '@domain/common/whiteboard-draft';
 import { SpaceLookupModule } from '@domain/space/space.lookup/space.lookup.module';
 import { TemplateContentSpaceModule } from '@domain/template/template-content-space/template.content.space.module';
 import { Module } from '@nestjs/common';
@@ -26,6 +27,7 @@ import { TemplatesSetAuthorizationService } from './templates.set.service.author
     InputCreatorModule,
     TemplateContentSpaceModule,
     WhiteboardModule,
+    WhiteboardDraftModule,
     TypeOrmModule.forFeature([TemplatesSet]),
   ],
   providers: [

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
@@ -2,9 +2,11 @@ import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { WhiteboardService } from '@domain/common/whiteboard';
+import { WhiteboardDraftService } from '@domain/common/whiteboard-draft';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { TemplateContentSpaceService } from '@domain/template/template-content-space/template.content.space.service';
 import { LoggerService } from '@nestjs/common';
+import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { vi } from 'vitest';
 import { TemplateService } from '../template/template.service';
@@ -66,6 +68,14 @@ describe('TemplatesSetResolverMutations', () => {
       spaceLookupService as unknown as SpaceLookupService,
       templateContentSpaceService as unknown as TemplateContentSpaceService,
       whiteboardService as unknown as WhiteboardService,
+      {
+        getForConsumption: vi.fn(),
+        cleanupConsumed: vi.fn(),
+        materialize: vi.fn(),
+      } as unknown as WhiteboardDraftService,
+      {
+        getStorageAggregatorForTemplatesSet: vi.fn(),
+      } as unknown as StorageAggregatorResolverService,
       MockWinstonProvider.useValue as unknown as LoggerService
     );
   });

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.ts
@@ -1,13 +1,22 @@
 import { CurrentActor } from '@common/decorators/current-actor.decorator';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
+import { LogContext } from '@common/enums/logging.context';
+import { ValidationException } from '@common/exceptions';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
+import { ContributionDefaultSourceInput } from '@domain/collaboration/callout/callout.contribution.default.source.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
+import { UUID } from '@domain/common/scalars';
 import { WhiteboardService } from '@domain/common/whiteboard';
+import {
+  CreateWhiteboardDraftOnTemplatesSetInput,
+  WhiteboardDraftService,
+} from '@domain/common/whiteboard-draft';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { TemplateContentSpaceService } from '@domain/template/template-content-space/template.content.space.service';
 import { Inject, LoggerService } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
 import { InstrumentResolver } from '@src/apm/decorators';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ITemplate } from '../template/template.interface';
@@ -30,8 +39,69 @@ export class TemplatesSetResolverMutations {
     private spaceLookupService: SpaceLookupService,
     private templateContentSpaceService: TemplateContentSpaceService,
     private whiteboardService: WhiteboardService,
+    private whiteboardDraftService: WhiteboardDraftService,
+    private storageAggregatorResolverService: StorageAggregatorResolverService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
+
+  @Mutation(() => UUID, {
+    description:
+      'Materializes a server-owned live Whiteboard draft for a Template form. GraphQL returns identifiers only.',
+  })
+  async createWhiteboardDraftOnTemplatesSet(
+    @CurrentActor() actorContext: ActorContext,
+    @Args('draftData') draftData: CreateWhiteboardDraftOnTemplatesSetInput
+  ): Promise<string> {
+    const templatesSet = await this.templatesSetService.getTemplatesSetOrFail(
+      draftData.templatesSetID
+    );
+    this.authorizationService.grantAccessOrFail(
+      actorContext,
+      templatesSet.authorization,
+      AuthorizationPrivilege.CREATE,
+      `templates set create whiteboard draft: ${templatesSet.id}`
+    );
+
+    let sourceContent: string | undefined;
+    let sourceStorageBucketID: string | undefined;
+    if (draftData.sourceWhiteboardID) {
+      const source = await this.whiteboardService.getWhiteboardOrFail(
+        draftData.sourceWhiteboardID,
+        { relations: { authorization: true } }
+      );
+      this.authorizationService.grantAccessOrFail(
+        actorContext,
+        source.authorization,
+        AuthorizationPrivilege.READ,
+        `template draft clone whiteboard content from source: ${source.id}`
+      );
+    }
+    if (draftData.sourceCalloutID) {
+      const source: ContributionDefaultSourceInput = {
+        sourceCalloutID: draftData.sourceCalloutID,
+      };
+      await this.templateService.prepareContributionDefaultSource(
+        source,
+        actorContext
+      );
+      sourceContent = source.whiteboardContent;
+      sourceStorageBucketID = source.sourceStorageBucketID;
+    }
+    const storageAggregator =
+      await this.storageAggregatorResolverService.getStorageAggregatorForTemplatesSet(
+        templatesSet.id
+      );
+    return this.whiteboardDraftService.materialize(
+      {
+        ...draftData,
+        sourceContent,
+        sourceStorageBucketID,
+      },
+      storageAggregator,
+      templatesSet.authorization,
+      actorContext
+    );
+  }
 
   @Mutation(() => ITemplate, {
     description: 'Creates a new Template on the specified TemplatesSet.',
@@ -50,6 +120,49 @@ export class TemplatesSetResolverMutations {
       AuthorizationPrivilege.CREATE,
       `templates set create template: ${templatesSet.id}`
     );
+    const consumedDraftIDs: string[] = [];
+    const whiteboardInputs = [
+      templateData.whiteboard,
+      templateData.calloutData?.framing?.whiteboard,
+    ].filter(input => input?.draftWhiteboardID);
+    if (whiteboardInputs.length > 1) {
+      throw new ValidationException(
+        'A Template create may consume only one framing draft',
+        LogContext.TEMPLATES
+      );
+    }
+    const framingInput = whiteboardInputs[0];
+    if (framingInput?.draftWhiteboardID) {
+      if (framingInput.sourceWhiteboardID) {
+        throw new ValidationException(
+          'draftWhiteboardID and sourceWhiteboardID are mutually exclusive',
+          LogContext.WHITEBOARDS
+        );
+      }
+      const draft = await this.whiteboardDraftService.getForConsumption(
+        framingInput.draftWhiteboardID,
+        actorContext
+      );
+      consumedDraftIDs.push(draft.id);
+      framingInput.sourceWhiteboardID = draft.id;
+      framingInput.draftWhiteboardID = undefined;
+    }
+    const defaults = templateData.calloutData?.contributionDefaults;
+    if (defaults?.draftWhiteboardID) {
+      if (defaults.sourceWhiteboardID || defaults.sourceCalloutID) {
+        throw new ValidationException(
+          'draftWhiteboardID and contribution-default source fields are mutually exclusive',
+          LogContext.WHITEBOARDS
+        );
+      }
+      const draft = await this.whiteboardDraftService.getForConsumption(
+        defaults.draftWhiteboardID,
+        actorContext
+      );
+      consumedDraftIDs.push(draft.id);
+      defaults.sourceWhiteboardID = draft.id;
+      defaults.draftWhiteboardID = undefined;
+    }
     // A whiteboard template that seeds from a source whiteboard (duplicate / import) must
     // first prove the actor can READ that source before the server copies its stored
     // snapshot — mirrors the callout create path. No-op for any other template.
@@ -82,7 +195,24 @@ export class TemplatesSetResolverMutations {
       );
 
     await this.authorizationPolicyService.saveAll(authorizations);
-    return this.templateService.getTemplateOrFail(template.id);
+    const result = await this.templateService.getTemplateOrFail(template.id);
+    for (const draftID of consumedDraftIDs) {
+      try {
+        await this.whiteboardDraftService.cleanupConsumed(draftID);
+      } catch (error) {
+        this.logger.error?.(
+          {
+            message:
+              'Final Template was created but Whiteboard draft cleanup remains retryable',
+            templateID: result.id,
+            draftID,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          error instanceof Error ? (error.stack ?? '') : ''
+        );
+      }
+    }
+    return result;
   }
 
   @Mutation(() => ITemplate, {

--- a/src/migrations/1787500000000-WhiteboardDraft.ts
+++ b/src/migrations/1787500000000-WhiteboardDraft.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** Adds the single nullable marker that distinguishes live form drafts. */
+export class WhiteboardDraft1787500000000 implements MigrationInterface {
+  name = 'WhiteboardDraft1787500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "whiteboard" ADD "draftExpiresAt" TIMESTAMP WITH TIME ZONE'
+    );
+    await queryRunner.query(`
+      CREATE INDEX "IDX_whiteboard_draft_expiry"
+        ON "whiteboard" ("draftExpiresAt")
+        WHERE "draftExpiresAt" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM "whiteboard" WHERE "draftExpiresAt" IS NOT NULL LIMIT 1
+        ) THEN
+          RAISE EXCEPTION 'Refusing to remove draftExpiresAt while live Whiteboard drafts exist';
+        END IF;
+      END $$
+    `);
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_whiteboard_draft_expiry"');
+    await queryRunner.query('ALTER TABLE "whiteboard" DROP COLUMN "draftExpiresAt"');
+  }
+}

--- a/src/migrations/__tests__/1787500000000-WhiteboardDraft.spec.ts
+++ b/src/migrations/__tests__/1787500000000-WhiteboardDraft.spec.ts
@@ -1,0 +1,27 @@
+import { QueryRunner } from 'typeorm';
+import { describe, expect, it, vi } from 'vitest';
+import { WhiteboardDraft1787500000000 } from '../1787500000000-WhiteboardDraft';
+
+describe('WhiteboardDraft1787500000000', () => {
+  it('adds only a nullable expiry marker and a partial index', async () => {
+    const queryRunner = { query: vi.fn() } as unknown as QueryRunner;
+
+    await new WhiteboardDraft1787500000000().up(queryRunner);
+
+    const sql = vi.mocked(queryRunner.query).mock.calls.flat().join('\n');
+    expect(sql).toContain('ALTER TABLE "whiteboard" ADD "draftExpiresAt"');
+    expect(sql).toContain('WHERE "draftExpiresAt" IS NOT NULL');
+    expect(sql).not.toContain('CREATE TABLE');
+  });
+
+  it('refuses rollback while any live draft marker remains', async () => {
+    const queryRunner = { query: vi.fn() } as unknown as QueryRunner;
+
+    await new WhiteboardDraft1787500000000().down(queryRunner);
+
+    const sql = vi.mocked(queryRunner.query).mock.calls.flat().join('\n');
+    expect(sql).toContain('WHERE "draftExpiresAt" IS NOT NULL');
+    expect(sql).toContain('Refusing to remove draftExpiresAt');
+    expect(sql).toContain('DROP COLUMN "draftExpiresAt"');
+  });
+});


### PR DESCRIPTION
## Outcome\n\nAdds a minimal server-owned lifecycle for live whiteboard drafts used while authoring callouts and templates.\n\n- Creates an unattached live whiteboard only when the client asks to edit.\n- Stores expiry in one nullable whiteboard.draftExpiresAt column; NULL remains the invariant for ordinary/final whiteboards.\n- Final creation consumes the draft through the existing source-copy and media-rehome path.\n- Cancel and expiry cleanup use canonical whiteboard deletion.\n- Keeps Yjs snapshots and Excalidraw scenes out of GraphQL payloads.\n- Covers framing defaults, response defaults, templates, cancellation, failure retention, expiry cleanup, and migration safety.\n\nDelivery links:\n- Client: https://github.com/alkem-io/client-web/pull/10213\n- Workspace specification: https://github.com/alkem-io/agents-hq/pull/127\n- Bug: https://github.com/alkem-io/client-web/issues/10206\n\n## Verification\n\n- Normal signed commit hook passed under Node 22: Biome, TypeScript, and full Vitest.\n- Full Vitest: 760 files; 8,703 passed; 7 skipped.\n- The first hook run encountered an unrelated OIDC logout timeout after 8,702 passes; the focused OIDC suite passed 9/9 and the unchanged normal-hook retry passed completely.\n- Local browser acceptance remains unclaimed because the available local authentication session expired.