### PR TITLE
fix(storage): authorize copied template media

### DIFF
--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -1,4 +1,5 @@
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
+import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import {
   DEFAULT_ALLOWED_MIME_TYPES,
   MimeFileType,
@@ -28,6 +29,7 @@ import { type Mock } from 'vitest';
 import { Document } from '../document/document.entity';
 import { IDocument } from '../document/document.interface';
 import { DocumentService } from '../document/document.service';
+import { DocumentAuthorizationService } from '../document/document.service.authorization';
 import { StorageBucket } from './storage.bucket.entity';
 import { IStorageBucket } from './storage.bucket.interface';
 import { StorageBucketService } from './storage.bucket.service';
@@ -83,6 +85,7 @@ describe('StorageBucketService', () => {
   let _documentRepository: Repository<Document>;
   let profileRepository: Repository<Profile>;
   let documentService: DocumentService;
+  let documentAuthorizationService: DocumentAuthorizationService;
   let authorizationPolicyService: AuthorizationPolicyService;
   let authorizationService: AuthorizationService;
   let avatarCreatorService: AvatarCreatorService;
@@ -114,6 +117,12 @@ describe('StorageBucketService', () => {
             deleteDocument: vi.fn(),
           },
         },
+        {
+          provide: DocumentAuthorizationService,
+          useValue: {
+            applyAuthorizationPolicy: vi.fn(),
+          },
+        },
       ],
     })
       .useMocker(defaultMockerFactory)
@@ -130,6 +139,9 @@ describe('StorageBucketService', () => {
       getRepositoryToken(Profile)
     );
     documentService = module.get<DocumentService>(DocumentService);
+    documentAuthorizationService = module.get<DocumentAuthorizationService>(
+      DocumentAuthorizationService
+    );
     authorizationPolicyService = module.get<AuthorizationPolicyService>(
       AuthorizationPolicyService
     );
@@ -664,6 +676,115 @@ describe('StorageBucketService', () => {
       // Auth + tagset stay attached (fresh row, not reused)
       expect(authorizationPolicyService.delete).not.toHaveBeenCalled();
       expect(tagsetService.removeTagset).not.toHaveBeenCalled();
+    });
+
+    it('applies the destination bucket authorization before returning a fresh copied document', async () => {
+      const inheritedReadRule = {
+        name: 'destination-read',
+        grantedPrivileges: [AuthorizationPrivilege.READ],
+        criterias: [],
+        cascade: true,
+      };
+      const destinationAuthorization = {
+        id: 'bucket-auth',
+        credentialRules: [inheritedReadRule],
+        privilegeRules: [],
+      };
+      const bucket = mockStorageBucket({
+        id: 'bucket-dst',
+        authorization: destinationAuthorization as any,
+      });
+      const source = makeSourceDoc();
+      const copiedDocument = mockDocument({
+        id: 'doc-new',
+        createdBy: 'user-caller',
+        authorization: {
+          id: 'doc-auth',
+          type: AuthorizationPolicyType.DOCUMENT,
+          credentialRules: [],
+          privilegeRules: [],
+        } as any,
+        tagset: {
+          id: 'tagset-saved',
+          name: 'default',
+          tags: [],
+          authorization: {
+            id: 'tagset-auth',
+            credentialRules: [],
+            privilegeRules: [],
+          },
+        } as any,
+      });
+
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationPolicyService.save as Mock).mockResolvedValue({
+        id: 'auth-saved',
+      });
+      (tagsetService.save as Mock).mockResolvedValue({ id: 'tagset-saved' });
+      (fileServiceAdapter.copyDocument as Mock).mockResolvedValue({
+        id: 'doc-new',
+        externalID: 'ext-shared',
+        mimeType: MimeTypeVisual.PNG,
+        size: 1234,
+        reused: false,
+      });
+      (documentService.getDocumentOrFail as Mock).mockResolvedValue(
+        copiedDocument
+      );
+      (
+        authorizationPolicyService.inheritParentAuthorization as Mock
+      ).mockImplementation((child: any, parent: any) => ({
+        ...child,
+        credentialRules: [...(parent?.credentialRules ?? [])],
+        privilegeRules: [...(parent?.privilegeRules ?? [])],
+      }));
+      (
+        authorizationPolicyService.createCredentialRule as Mock
+      ).mockImplementation((grantedPrivileges, criterias, name) => ({
+        name,
+        grantedPrivileges,
+        criterias,
+        cascade: true,
+      }));
+      (
+        authorizationPolicyService.appendCredentialAuthorizationRules as Mock
+      ).mockImplementation((authorization: any, rules: any[]) => ({
+        ...authorization,
+        credentialRules: [...authorization.credentialRules, ...rules],
+      }));
+      (authorizationPolicyService.saveAll as Mock).mockResolvedValue(undefined);
+      const realDocumentAuthorizationService = new DocumentAuthorizationService(
+        authorizationPolicyService
+      );
+      (
+        documentAuthorizationService.applyAuthorizationPolicy as Mock
+      ).mockImplementation(
+        realDocumentAuthorizationService.applyAuthorizationPolicy.bind(
+          realDocumentAuthorizationService
+        )
+      );
+
+      const result = await service.copyDocumentToBucket(
+        'bucket-dst',
+        source,
+        'user-caller'
+      );
+
+      expect(
+        documentAuthorizationService.applyAuthorizationPolicy
+      ).toHaveBeenCalledWith(copiedDocument, destinationAuthorization);
+      expect(result.authorization?.credentialRules).toEqual([
+        inheritedReadRule,
+        expect.objectContaining({
+          grantedPrivileges: [
+            AuthorizationPrivilege.CREATE,
+            AuthorizationPrivilege.READ,
+            AuthorizationPrivilege.UPDATE,
+            AuthorizationPrivilege.DELETE,
+          ],
+          criterias: [expect.objectContaining({ resourceID: 'user-caller' })],
+        }),
+      ]);
     });
 
     it('releases pre-created auth + tagset when Go responds reused:true', async () => {

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -13,6 +13,7 @@ import { AuthorizationService } from '@core/authorization/authorization.service'
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { Profile } from '@domain/common/profile/profile.entity';
 import { TagsetService } from '@domain/common/tagset/tagset.service';
+import { DocumentAuthorizationService } from '@domain/storage/document/document.service.authorization';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -29,7 +30,6 @@ import { type Mock } from 'vitest';
 import { Document } from '../document/document.entity';
 import { IDocument } from '../document/document.interface';
 import { DocumentService } from '../document/document.service';
-import { DocumentAuthorizationService } from '../document/document.service.authorization';
 import { StorageBucket } from './storage.bucket.entity';
 import { IStorageBucket } from './storage.bucket.interface';
 import { StorageBucketService } from './storage.bucket.service';

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -21,6 +21,7 @@ import { IAuthorizationPolicy } from '@domain/common/authorization-policy/author
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { Profile } from '@domain/common/profile/profile.entity';
 import { TagsetService } from '@domain/common/tagset/tagset.service';
+import { DocumentAuthorizationService } from '@domain/storage/document/document.service.authorization';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -34,7 +35,6 @@ import { EntityManager, FindOneOptions, Repository } from 'typeorm';
 import { Document } from '../document/document.entity';
 import { IDocument } from '../document/document.interface';
 import { DocumentService } from '../document/document.service';
-import { DocumentAuthorizationService } from '../document/document.service.authorization';
 import { StorageBucketArgsDocuments } from './dto/storage.bucket.args.documents';
 import { CreateStorageBucketInput } from './dto/storage.bucket.dto.create';
 import { IStorageBucketParent } from './dto/storage.bucket.dto.parent';

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -17,6 +17,7 @@ import { limitAndShuffle } from '@common/utils/limitAndShuffle';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { AuthorizationService } from '@core/authorization/authorization.service';
 import { AuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.entity';
+import { IAuthorizationPolicy } from '@domain/common/authorization-policy/authorization.policy.interface';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { Profile } from '@domain/common/profile/profile.entity';
 import { TagsetService } from '@domain/common/tagset/tagset.service';
@@ -33,6 +34,7 @@ import { EntityManager, FindOneOptions, Repository } from 'typeorm';
 import { Document } from '../document/document.entity';
 import { IDocument } from '../document/document.interface';
 import { DocumentService } from '../document/document.service';
+import { DocumentAuthorizationService } from '../document/document.service.authorization';
 import { StorageBucketArgsDocuments } from './dto/storage.bucket.args.documents';
 import { CreateStorageBucketInput } from './dto/storage.bucket.dto.create';
 import { IStorageBucketParent } from './dto/storage.bucket.dto.parent';
@@ -51,6 +53,7 @@ export class StorageBucketService {
 
   constructor(
     private documentService: DocumentService,
+    private documentAuthorizationService: DocumentAuthorizationService,
     private avatarCreatorService: AvatarCreatorService,
     private authorizationPolicyService: AuthorizationPolicyService,
     private authorizationService: AuthorizationService,
@@ -273,7 +276,7 @@ export class StorageBucketService {
     skipDedup = false
   ): Promise<IDocument> {
     const destination = await this.getStorageBucketOrFail(destinationBucketId, {
-      relations: {},
+      relations: { authorization: true },
     });
 
     this.validateMimeTypes(destination, sourceDocument.mimeType);
@@ -289,7 +292,8 @@ export class StorageBucketService {
           tagsetId,
           createdBy: userID || sourceDocument.createdBy || undefined,
           skipDedup: skipDedup || undefined,
-        })
+        }),
+      destination.authorization
     );
   }
 
@@ -311,7 +315,8 @@ export class StorageBucketService {
    */
   private async persistDocumentWithPreparedAuth(
     bucketId: string,
-    goCall: (authId: string, tagsetId: string) => Promise<CreateDocumentResult>
+    goCall: (authId: string, tagsetId: string) => Promise<CreateDocumentResult>,
+    parentAuthorization?: IAuthorizationPolicy
   ): Promise<IDocument> {
     let savedAuth;
     let savedTagset;
@@ -340,6 +345,17 @@ export class StorageBucketService {
           storageBucket: true,
         },
       });
+
+      // A copy creates a logical document in the destination bucket. Finish its
+      // inherited policy before its opaque file ID can escape to a whiteboard
+      // snapshot or another caller. Upload mutations apply authorization at
+      // their resolver boundary, so only copy supplies a parent here.
+      if (!result.reused && parentAuthorization) {
+        await this.documentAuthorizationService.applyAuthorizationPolicy(
+          document,
+          parentAuthorization
+        );
+      }
     } catch (error) {
       // Independent rollbacks so one cleanup failure doesn't skip the rest.
       // Bind narrowed values into const locals so the closures don't re-widen.


### PR DESCRIPTION
Fixes alkem-io/client-web#10210

## Root cause
StorageBucketService.copyDocumentToBucket created and reloaded a copied logical file document, but returned its opaque ID before applying the destination storage bucket's authorization policy. Whiteboard template asset rehoming therefore stored an ID whose document policy had no credential rules, and lookup.document rejected the visual.

## Fix
- apply the destination bucket authorization policy to every fresh copied document before returning its opaque ID
- run authorization application inside the existing compensation boundary so a failure rolls back the copied file, policy, and tagset
- preserve reused logical documents without mutating their existing authorization
- preserve the opaque file-ID contract; no client, chooser, Yjs binary, SHA, or blob-internal changes

## Regression coverage
- proves a fresh copied document immediately inherits the destination READ rule
- proves the copying actor receives CREATE, READ, UPDATE, and DELETE credentials before return
- exercises the same StorageBucketService copy path used by whiteboard template/media rehoming

## Validation
- Node 22.21.1
- focused Vitest: 46/46 passed
- full Vitest: 758 files passed, 6 skipped; 8,691 tests passed, 7 skipped
- pnpm build
- pnpm lint (native typecheck + Biome)
- normal signed pre-commit hook: full suite green

Comments use behavioral prose only and contain no issue or specification references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Document copies now inherit authorization settings from the destination storage bucket.
  * Newly copied documents receive the caller’s appropriate create, read, update, and delete privileges.
  * Existing reused documents retain their current authorization rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->