### PR TITLE
fix: serialize whiteboard draft consumption

### DIFF
--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
@@ -366,6 +366,34 @@ describe('CalloutsSetResolverMutations', () => {
       expect(release).toHaveBeenCalledOnce();
     });
 
+    it('does not consume a nullable GraphQL draft ID', async () => {
+      const calloutsSet = framingCloneCalloutsSet();
+      vi.mocked(calloutsSetService.getCalloutsSetOrFail).mockResolvedValue(
+        calloutsSet
+      );
+      vi.mocked(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).mockRejectedValue(new Error('stop after draft acquisition'));
+
+      await expect(
+        resolver.createCalloutOnCalloutsSet(
+          { actorID: 'user-1' } as any,
+          {
+            calloutsSetID: calloutsSet.id,
+            framing: {
+              type: CalloutFramingType.WHITEBOARD,
+              whiteboard: { draftWhiteboardID: null },
+            },
+          } as any
+        )
+      ).rejects.toThrow('stop after draft acquisition');
+
+      expect(whiteboardDraftService.acquireForConsumption).toHaveBeenCalledWith(
+        [],
+        { actorID: 'user-1' }
+      );
+    });
+
     it('deletes a consumed draft before releasing the final-callout lock', async () => {
       const calloutsSet = framingCloneCalloutsSet();
       const callout = {

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
@@ -61,6 +61,7 @@ describe('CalloutsSetResolverMutations', () => {
     const releaseDraftLock = vi.fn();
     vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue({
       drafts: new Map(),
+      markConsumed: vi.fn(),
       complete: vi.fn(),
       release: releaseDraftLock,
       [Symbol.asyncDispose]: releaseDraftLock,
@@ -332,6 +333,7 @@ describe('CalloutsSetResolverMutations', () => {
       vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue(
         {
           drafts: new Map([[draft.id, draft]]),
+          markConsumed: vi.fn(),
           complete,
           release,
           [Symbol.asyncDispose]: release,
@@ -427,6 +429,9 @@ describe('CalloutsSetResolverMutations', () => {
           drafts: new Map([
             ['draft-whiteboard-1', { id: 'draft-whiteboard-1' } as any],
           ]),
+          markConsumed: vi.fn(async () => {
+            order.push('markConsumed');
+          }),
           complete,
           release,
           [Symbol.asyncDispose]: release,
@@ -445,7 +450,70 @@ describe('CalloutsSetResolverMutations', () => {
         input
       );
 
-      expect(order).toEqual(['complete', 'release']);
+      expect(order).toEqual(['markConsumed', 'complete', 'release']);
+    });
+
+    it('does not create a duplicate after a post-persistence failure', async () => {
+      const calloutsSet = framingCloneCalloutsSet();
+      const callout = {
+        id: 'callout-1',
+        nameID: 'test-callout',
+        settings: { visibility: CalloutVisibility.DRAFT },
+      } as any;
+      vi.mocked(calloutsSetService.getCalloutsSetOrFail).mockResolvedValue(
+        calloutsSet
+      );
+      vi.mocked(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).mockResolvedValue(callout);
+      vi.mocked(calloutService.save).mockResolvedValue(callout);
+      const temporaryStorageService = (resolver as any).temporaryStorageService;
+      vi.mocked(
+        temporaryStorageService.moveTemporaryDocuments
+      ).mockRejectedValue(new Error('post-persistence integration failed'));
+      let consumed = false;
+      vi.mocked(
+        whiteboardDraftService.acquireForConsumption
+      ).mockImplementation(async () => {
+        if (consumed) {
+          throw new ValidationException(
+            'Whiteboard draft has expired',
+            LogContext.WHITEBOARDS
+          );
+        }
+        const release = vi.fn();
+        return {
+          drafts: new Map([
+            ['draft-whiteboard-1', { id: 'draft-whiteboard-1' } as any],
+          ]),
+          markConsumed: vi.fn(async () => {
+            consumed = true;
+          }),
+          complete: vi.fn(),
+          release,
+          [Symbol.asyncDispose]: release,
+        };
+      });
+      const input = () =>
+        ({
+          calloutsSetID: calloutsSet.id,
+          framing: {
+            type: CalloutFramingType.WHITEBOARD,
+            whiteboard: { draftWhiteboardID: 'draft-whiteboard-1' },
+          },
+        }) as any;
+      const actor = { actorID: 'user-1' } as any;
+
+      await expect(
+        resolver.createCalloutOnCalloutsSet(actor, input())
+      ).rejects.toThrow('post-persistence integration failed');
+      await expect(
+        resolver.createCalloutOnCalloutsSet(actor, input())
+      ).rejects.toThrow('Whiteboard draft has expired');
+
+      expect(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).toHaveBeenCalledOnce();
     });
 
     it('should trigger notifications and activity when published on COLLABORATION type', async () => {

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.spec.ts
@@ -58,6 +58,13 @@ describe('CalloutsSetResolverMutations', () => {
     configService = module.get(ConfigService);
     whiteboardService = module.get(WhiteboardService);
     whiteboardDraftService = module.get(WhiteboardDraftService);
+    const releaseDraftLock = vi.fn();
+    vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue({
+      drafts: new Map(),
+      complete: vi.fn(),
+      release: releaseDraftLock,
+      [Symbol.asyncDispose]: releaseDraftLock,
+    });
     vi.mocked(configService.get).mockReturnValue(5000 as any);
   });
 
@@ -320,8 +327,15 @@ describe('CalloutsSetResolverMutations', () => {
         calloutsSet
       );
       const draft = { id: 'draft-whiteboard-1' } as any;
-      vi.mocked(whiteboardDraftService.getForConsumption).mockResolvedValue(
-        draft
+      const complete = vi.fn();
+      const release = vi.fn();
+      vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue(
+        {
+          drafts: new Map([[draft.id, draft]]),
+          complete,
+          release,
+          [Symbol.asyncDispose]: release,
+        }
       );
       const failed = new Error('final create failed');
       vi.mocked(
@@ -340,15 +354,70 @@ describe('CalloutsSetResolverMutations', () => {
         resolver.createCalloutOnCalloutsSet(actor, input)
       ).rejects.toBe(failed);
 
-      expect(whiteboardDraftService.getForConsumption).toHaveBeenCalledWith(
-        'draft-whiteboard-1',
+      expect(whiteboardDraftService.acquireForConsumption).toHaveBeenCalledWith(
+        ['draft-whiteboard-1'],
         actor
       );
       expect(input.framing.whiteboard).toEqual({
         draftWhiteboardID: undefined,
         sourceWhiteboardID: draft.id,
       });
-      expect(whiteboardDraftService.cleanupConsumed).not.toHaveBeenCalled();
+      expect(complete).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledOnce();
+    });
+
+    it('deletes a consumed draft before releasing the final-callout lock', async () => {
+      const calloutsSet = framingCloneCalloutsSet();
+      const callout = {
+        id: 'callout-1',
+        nameID: 'test-callout',
+        settings: { visibility: CalloutVisibility.DRAFT },
+      } as any;
+      vi.mocked(calloutsSetService.getCalloutsSetOrFail).mockResolvedValue(
+        calloutsSet
+      );
+      vi.mocked(
+        calloutsSetService.createCalloutOnCalloutsSet
+      ).mockResolvedValue(callout);
+      vi.mocked(calloutService.save).mockResolvedValue(callout);
+      vi.mocked(calloutService.getStorageBucket).mockResolvedValue({
+        id: 'sb-1',
+      } as any);
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(callout);
+      vi.mocked(
+        calloutAuthorizationService.applyAuthorizationPolicy
+      ).mockResolvedValue([]);
+      const order: string[] = [];
+      const complete = vi.fn(async () => {
+        order.push('complete');
+      });
+      const release = vi.fn(async () => {
+        order.push('release');
+      });
+      vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue(
+        {
+          drafts: new Map([
+            ['draft-whiteboard-1', { id: 'draft-whiteboard-1' } as any],
+          ]),
+          complete,
+          release,
+          [Symbol.asyncDispose]: release,
+        }
+      );
+      const input = {
+        calloutsSetID: calloutsSet.id,
+        framing: {
+          type: CalloutFramingType.WHITEBOARD,
+          whiteboard: { draftWhiteboardID: 'draft-whiteboard-1' },
+        },
+      } as any;
+
+      await resolver.createCalloutOnCalloutsSet(
+        { actorID: 'user-1' } as any,
+        input
+      );
+
+      expect(order).toEqual(['complete', 'release']);
     });
 
     it('should trigger notifications and activity when published on COLLABORATION type', async () => {

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
@@ -164,8 +164,15 @@ export class CalloutsSetResolverMutations {
       `create callout on callouts Set: ${calloutsSet.id}`
     );
 
-    const consumedDraftIDs: string[] = [];
     const framingDraftID = calloutData.framing?.whiteboard?.draftWhiteboardID;
+    const defaultsDraftID = calloutData.contributionDefaults?.draftWhiteboardID;
+    await using draftConsumption =
+      await this.whiteboardDraftService.acquireForConsumption(
+        [framingDraftID, defaultsDraftID].filter(
+          (id): id is string => id !== undefined
+        ),
+        actorContext
+      );
     if (framingDraftID) {
       const whiteboardInput = calloutData.framing.whiteboard!;
       if (whiteboardInput.sourceWhiteboardID) {
@@ -174,15 +181,10 @@ export class CalloutsSetResolverMutations {
           LogContext.WHITEBOARDS
         );
       }
-      const draft = await this.whiteboardDraftService.getForConsumption(
-        framingDraftID,
-        actorContext
-      );
-      consumedDraftIDs.push(draft.id);
+      const draft = draftConsumption.drafts.get(framingDraftID)!;
       whiteboardInput.sourceWhiteboardID = draft.id;
       whiteboardInput.draftWhiteboardID = undefined;
     }
-    const defaultsDraftID = calloutData.contributionDefaults?.draftWhiteboardID;
     if (defaultsDraftID) {
       const defaults = calloutData.contributionDefaults!;
       if (defaults.sourceWhiteboardID || defaults.sourceCalloutID) {
@@ -191,11 +193,7 @@ export class CalloutsSetResolverMutations {
           LogContext.WHITEBOARDS
         );
       }
-      const draft = await this.whiteboardDraftService.getForConsumption(
-        defaultsDraftID,
-        actorContext
-      );
-      consumedDraftIDs.push(draft.id);
+      const draft = draftConsumption.drafts.get(defaultsDraftID)!;
       defaults.sourceWhiteboardID = draft.id;
       defaults.draftWhiteboardID = undefined;
     }
@@ -392,23 +390,7 @@ export class CalloutsSetResolverMutations {
     }
 
     const result = await this.calloutService.getCalloutOrFail(callout.id);
-    for (const draftID of consumedDraftIDs) {
-      try {
-        await this.whiteboardDraftService.cleanupConsumed(draftID);
-      } catch (error) {
-        this.logger.error?.(
-          {
-            message:
-              'Final Callout was created but Whiteboard draft cleanup remains retryable',
-            calloutID: result.id,
-            draftID,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          error instanceof Error ? (error.stack ?? '') : '',
-          LogContext.WHITEBOARDS
-        );
-      }
-    }
+    await draftConsumption.complete();
     return result;
   }
 

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
@@ -169,7 +169,7 @@ export class CalloutsSetResolverMutations {
     await using draftConsumption =
       await this.whiteboardDraftService.acquireForConsumption(
         [framingDraftID, defaultsDraftID].filter(
-          (id): id is string => id !== undefined
+          (id): id is string => typeof id === 'string'
         ),
         actorContext
       );

--- a/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
+++ b/src/domain/collaboration/callouts-set/callouts.set.resolver.mutations.ts
@@ -300,6 +300,11 @@ export class CalloutsSetResolverMutations {
       () => this.calloutService.deleteCallout(savedCallout.id)
     );
 
+    // The final callout is now durable and fully materialized. Persist the
+    // draft-consumption marker before any later integration/notification step
+    // can fail, so a client retry cannot create a duplicate final object.
+    await draftConsumption.markConsumed();
+
     // Now the contribution is saved, we can look to move any temporary documents
     // to be stored in the storage bucket of the profile.
     // Note: important to do before auth reset is done

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
@@ -5,36 +5,125 @@ import { Whiteboard } from '@domain/common/whiteboard/whiteboard.entity';
 import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
 import { WhiteboardAuthorizationService } from '@domain/common/whiteboard/whiteboard.service.authorization';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
-import { Repository } from 'typeorm';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WhiteboardDraftService } from './whiteboard.draft.service';
+
+class AdvisoryLockHarness {
+  private readonly held = new Set<string>();
+  private readonly waiters = new Map<string, Array<() => void>>();
+
+  async acquire(key: string): Promise<void> {
+    if (!this.held.has(key)) {
+      this.held.add(key);
+      return;
+    }
+    await new Promise<void>(resolve => {
+      const waiters = this.waiters.get(key) ?? [];
+      waiters.push(resolve);
+      this.waiters.set(key, waiters);
+    });
+  }
+
+  release(key: string): void {
+    const next = this.waiters.get(key)?.shift();
+    if (next) {
+      next();
+      return;
+    }
+    this.held.delete(key);
+  }
+
+  waiting(key: string): number {
+    return this.waiters.get(key)?.length ?? 0;
+  }
+}
 
 describe('WhiteboardDraftService', () => {
   const actorContext = {
     actorID: '6c0552d4-a1e6-4e52-b008-28c3fbd29e67',
   } as ActorContext;
   const parentAuthorization = { id: 'parent-auth' } as IAuthorizationPolicy;
-  let repository: Pick<Repository<Whiteboard>, 'find' | 'findOne'>;
+  const draftID = 'draft-wb';
+  let drafts: Map<string, Whiteboard>;
+  let repository: Pick<Repository<Whiteboard>, 'find'>;
+  let lockedRepository: Pick<Repository<Whiteboard>, 'findOne'>;
   let whiteboardService: Pick<
     WhiteboardService,
     'createWhiteboard' | 'deleteWhiteboard'
   >;
   const whiteboardAuthorizationService = { applyAuthorizationPolicy: vi.fn() };
   const authorizationPolicyService = { saveAll: vi.fn() };
+  let lockHarness: AdvisoryLockHarness;
+  let dataSource: Pick<DataSource, 'createQueryRunner'>;
   let service: WhiteboardDraftService;
+
+  const futureDraft = (id = draftID): Whiteboard =>
+    ({
+      id,
+      createdBy: actorContext.actorID,
+      draftExpiresAt: new Date(Date.now() + 60_000),
+    }) as Whiteboard;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    repository = { find: vi.fn(), findOne: vi.fn() };
+    drafts = new Map();
+    repository = { find: vi.fn() };
+    lockedRepository = {
+      findOne: vi.fn(async options => {
+        const where = options.where as {
+          id: string;
+          draftExpiresAt?: unknown;
+        };
+        const draft = drafts.get(where.id);
+        if (!draft) return null;
+        if (
+          where.draftExpiresAt !== undefined &&
+          (!draft.draftExpiresAt || draft.draftExpiresAt.getTime() > Date.now())
+        ) {
+          return null;
+        }
+        return draft;
+      }),
+    };
     whiteboardService = {
       createWhiteboard: vi.fn(),
-      deleteWhiteboard: vi.fn(),
+      deleteWhiteboard: vi.fn(async id => {
+        drafts.delete(id);
+        return {} as Whiteboard;
+      }),
+    };
+    lockHarness = new AdvisoryLockHarness();
+    dataSource = {
+      createQueryRunner: vi.fn(() => {
+        const runner = {
+          connect: vi.fn(),
+          release: vi.fn(),
+          manager: {
+            getRepository: vi.fn(() => lockedRepository),
+          },
+          query: vi.fn(async (sql: string, parameters: string[]) => {
+            const key = parameters[0];
+            if (sql.includes('pg_advisory_unlock')) {
+              lockHarness.release(key);
+              return [{ pg_advisory_unlock: true }];
+            }
+            if (!sql.includes('pg_advisory_lock')) {
+              throw new Error('expected PostgreSQL advisory lock query');
+            }
+            await lockHarness.acquire(key);
+            return [{ pg_advisory_lock: null }];
+          }),
+        } as unknown as QueryRunner;
+        return runner;
+      }),
     };
     service = new WhiteboardDraftService(
       repository as Repository<Whiteboard>,
       whiteboardService as WhiteboardService,
       whiteboardAuthorizationService as unknown as WhiteboardAuthorizationService,
-      authorizationPolicyService as unknown as AuthorizationPolicyService
+      authorizationPolicyService as unknown as AuthorizationPolicyService,
+      dataSource as DataSource
     );
     whiteboardAuthorizationService.applyAuthorizationPolicy.mockResolvedValue(
       []
@@ -88,53 +177,163 @@ describe('WhiteboardDraftService', () => {
     expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith('wb-1');
   });
 
+  it('serializes concurrent final submissions so only one materializes', async () => {
+    drafts.set(draftID, futureDraft());
+    let materializations = 0;
+    let allowFirstToFinish!: () => void;
+    let firstStarted!: () => void;
+    const firstStartedPromise = new Promise<void>(resolve => {
+      firstStarted = resolve;
+    });
+    const finishFirstPromise = new Promise<void>(resolve => {
+      allowFirstToFinish = resolve;
+    });
+
+    const finalize = async (): Promise<void> => {
+      const consumption = await service.acquireForConsumption(
+        [draftID],
+        actorContext
+      );
+      try {
+        materializations++;
+        firstStarted();
+        await finishFirstPromise;
+        await consumption.complete();
+      } finally {
+        await consumption.release();
+      }
+    };
+
+    const first = finalize();
+    await firstStartedPromise;
+    const second = finalize();
+    await vi.waitFor(() => {
+      expect(lockHarness.waiting(`whiteboard-draft:${draftID}`)).toBe(1);
+    });
+    expect(materializations).toBe(1);
+
+    allowFirstToFinish();
+    const results = await Promise.allSettled([first, second]);
+
+    expect(results.map(result => result.status).sort()).toEqual([
+      'fulfilled',
+      'rejected',
+    ]);
+    expect(materializations).toBe(1);
+    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes discard wait until an in-flight source copy releases the draft', async () => {
+    drafts.set(draftID, futureDraft());
+    const consumption = await service.acquireForConsumption(
+      [draftID],
+      actorContext
+    );
+
+    const discard = service.discard(draftID, actorContext);
+    await vi.waitFor(() => {
+      expect(lockHarness.waiting(`whiteboard-draft:${draftID}`)).toBe(1);
+    });
+    expect(whiteboardService.deleteWhiteboard).not.toHaveBeenCalled();
+
+    await consumption.release();
+    await expect(discard).resolves.toBe(draftID);
+    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith(draftID);
+  });
+
+  it("refuses to discard another actor's draft", async () => {
+    drafts.set(draftID, {
+      ...futureDraft(),
+      createdBy: 'other-actor',
+    } as Whiteboard);
+
+    await expect(service.discard(draftID, actorContext)).rejects.toThrow(
+      'Only the actor that created a Whiteboard draft may discard it'
+    );
+    expect(whiteboardService.deleteWhiteboard).not.toHaveBeenCalled();
+  });
+
+  it('deletes an unchanged expired draft through the canonical path', async () => {
+    drafts.set(draftID, {
+      ...futureDraft(),
+      draftExpiresAt: new Date(Date.now() - 60_000),
+    } as Whiteboard);
+
+    await service.cleanupExpired(draftID);
+
+    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith(draftID);
+  });
+
+  it.each([
+    ['cleared', null],
+    ['extended', 'future'],
+  ])('does not delete a selected expiry candidate after its marker is %s', async (_label, marker) => {
+    drafts.set(draftID, {
+      ...futureDraft(),
+      draftExpiresAt: new Date(Date.now() - 60_000),
+    } as Whiteboard);
+    vi.mocked(repository.find).mockResolvedValue([
+      { id: draftID } as Whiteboard,
+    ]);
+
+    await expect(service.findExpired(25)).resolves.toEqual([draftID]);
+    drafts.get(draftID)!.draftExpiresAt =
+      marker === null ? null : new Date(Date.now() + 60_000);
+
+    await service.cleanupExpired(draftID);
+
+    expect(whiteboardService.deleteWhiteboard).not.toHaveBeenCalled();
+  });
+
+  it('never deletes an ordinary Whiteboard through discard or expiry cleanup', async () => {
+    drafts.set('ordinary-wb', {
+      id: 'ordinary-wb',
+      createdBy: actorContext.actorID,
+      draftExpiresAt: null,
+    } as Whiteboard);
+
+    await expect(service.discard('ordinary-wb', actorContext)).resolves.toBe(
+      'ordinary-wb'
+    );
+    await service.cleanupExpired('ordinary-wb');
+
+    expect(whiteboardService.deleteWhiteboard).not.toHaveBeenCalled();
+  });
+
   it('refuses an ordinary Whiteboard as a draft source', async () => {
-    vi.mocked(repository.findOne).mockResolvedValue({
+    drafts.set('ordinary-wb', {
       id: 'ordinary-wb',
       createdBy: actorContext.actorID,
       draftExpiresAt: null,
     } as Whiteboard);
 
     await expect(
-      service.getForConsumption('ordinary-wb', actorContext)
+      service.acquireForConsumption(['ordinary-wb'], actorContext)
     ).rejects.toThrow('Whiteboard draft not found');
   });
 
   it('refuses a draft owned by another actor', async () => {
-    vi.mocked(repository.findOne).mockResolvedValue({
-      id: 'draft-wb',
+    drafts.set(draftID, {
+      ...futureDraft(),
       createdBy: 'other-actor',
-      draftExpiresAt: new Date(Date.now() + 60_000),
     } as Whiteboard);
 
     await expect(
-      service.getForConsumption('draft-wb', actorContext)
+      service.acquireForConsumption([draftID], actorContext)
     ).rejects.toThrow(
       'Only the actor that created a Whiteboard draft may consume it'
     );
   });
 
   it('refuses an expired draft as a final-create source', async () => {
-    vi.mocked(repository.findOne).mockResolvedValue({
-      id: 'draft-wb',
-      createdBy: actorContext.actorID,
+    drafts.set(draftID, {
+      ...futureDraft(),
       draftExpiresAt: new Date(Date.now() - 1),
     } as Whiteboard);
 
     await expect(
-      service.getForConsumption('draft-wb', actorContext)
+      service.acquireForConsumption([draftID], actorContext)
     ).rejects.toThrow('Whiteboard draft has expired');
-  });
-
-  it('does not delete an ordinary Whiteboard even when cleanup receives its id', async () => {
-    vi.mocked(repository.findOne).mockResolvedValue(null);
-
-    await service.cleanupConsumed('ordinary-wb');
-
-    expect(repository.findOne).toHaveBeenCalledWith({
-      where: { id: 'ordinary-wb', draftExpiresAt: expect.anything() },
-    });
-    expect(whiteboardService.deleteWhiteboard).not.toHaveBeenCalled();
   });
 
   it('periodic cleanup discovers only expired non-NULL draft expiries', async () => {
@@ -150,33 +349,5 @@ describe('WhiteboardDraftService', () => {
       order: { draftExpiresAt: 'ASC' },
       take: 25,
     });
-  });
-
-  it('rechecks exact id and expired draftness before periodic deletion', async () => {
-    vi.mocked(repository.findOne).mockResolvedValue({
-      id: 'expired-draft',
-    } as Whiteboard);
-
-    await service.cleanupExpired('expired-draft');
-
-    expect(repository.findOne).toHaveBeenCalledWith({
-      where: { id: 'expired-draft', draftExpiresAt: expect.anything() },
-    });
-    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith(
-      'expired-draft'
-    );
-  });
-
-  it('explicit discard requires creator ownership and a non-NULL expiry', async () => {
-    vi.mocked(repository.findOne).mockResolvedValue({
-      id: 'draft-wb',
-      createdBy: actorContext.actorID,
-      draftExpiresAt: new Date(Date.now() + 60_000),
-    } as Whiteboard);
-
-    await expect(service.discard('draft-wb', actorContext)).resolves.toBe(
-      'draft-wb'
-    );
-    expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledWith('draft-wb');
   });
 });

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
@@ -1,3 +1,4 @@
+import { LogContext } from '@common/enums';
 import { ActorContext } from '@core/actor-context/actor.context';
 import { IAuthorizationPolicy } from '@domain/common/authorization-policy';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
@@ -54,6 +55,7 @@ describe('WhiteboardDraftService', () => {
   >;
   const whiteboardAuthorizationService = { applyAuthorizationPolicy: vi.fn() };
   const authorizationPolicyService = { saveAll: vi.fn() };
+  const logger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
   let lockHarness: AdvisoryLockHarness;
   let dataSource: Pick<DataSource, 'createQueryRunner'>;
   let service: WhiteboardDraftService;
@@ -112,6 +114,9 @@ describe('WhiteboardDraftService', () => {
             getRepository: vi.fn(() => lockedRepository),
           },
           query: vi.fn(async (sql: string, parameters: string[]) => {
+            if (sql.startsWith('SET lock_timeout')) {
+              return [];
+            }
             const key = parameters[0];
             if (sql.includes('pg_advisory_unlock')) {
               lockHarness.release(key);
@@ -132,7 +137,8 @@ describe('WhiteboardDraftService', () => {
       whiteboardService as WhiteboardService,
       whiteboardAuthorizationService as unknown as WhiteboardAuthorizationService,
       authorizationPolicyService as unknown as AuthorizationPolicyService,
-      dataSource as DataSource
+      dataSource as DataSource,
+      logger
     );
     whiteboardAuthorizationService.applyAuthorizationPolicy.mockResolvedValue(
       []
@@ -246,9 +252,58 @@ describe('WhiteboardDraftService', () => {
     await consumption.release();
 
     expect(drafts.get(draftID)?.draftExpiresAt?.getTime()).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'Consumed Whiteboard draft deletion failed; expiry sweep will retry',
+        whiteboardID: draftID,
+        error: 'file service unavailable',
+      }),
+      LogContext.WHITEBOARDS
+    );
     await expect(
       service.acquireForConsumption([draftID], actorContext)
     ).rejects.toThrow('Whiteboard draft has expired');
+  });
+
+  it('marks a persisted final source consumed without deleting it yet', async () => {
+    drafts.set(draftID, futureDraft());
+    const consumption = await service.acquireForConsumption(
+      [draftID],
+      actorContext
+    );
+
+    await consumption.markConsumed();
+
+    expect(drafts.get(draftID)?.draftExpiresAt?.getTime()).toBe(0);
+    expect(whiteboardService.deleteWhiteboard).not.toHaveBeenCalled();
+    await consumption.release();
+    await expect(
+      service.acquireForConsumption([draftID], actorContext)
+    ).rejects.toThrow('Whiteboard draft has expired');
+  });
+
+  it('bounds a blocked advisory-lock acquisition and releases the runner', async () => {
+    drafts.set(draftID, futureDraft());
+    const runner = dataSource.createQueryRunner() as QueryRunner;
+    vi.mocked(runner.query).mockImplementation(
+      async (sql: string, _parameters?: string[]) => {
+        if (sql.startsWith('SET lock_timeout')) return [];
+        if (sql.includes('pg_advisory_lock')) {
+          throw new Error('canceling statement due to lock timeout');
+        }
+        return [];
+      }
+    );
+    vi.mocked(dataSource.createQueryRunner).mockReturnValueOnce(runner);
+
+    await expect(
+      service.acquireForConsumption([draftID], actorContext)
+    ).rejects.toThrow('canceling statement due to lock timeout');
+
+    expect(runner.query).toHaveBeenCalledWith("SET lock_timeout = '5000ms'");
+    expect(runner.query).toHaveBeenCalledWith('SET lock_timeout = DEFAULT');
+    expect(runner.release).toHaveBeenCalledOnce();
   });
 
   it('unlocks every acquired draft and clears the session after a keyed unlock fails', async () => {
@@ -265,6 +320,9 @@ describe('WhiteboardDraftService', () => {
     let keyedUnlocks = 0;
     vi.mocked(runner.query).mockImplementation(
       async (sql: string, parameters?: string[]) => {
+        if (sql.startsWith('SET lock_timeout')) {
+          return [];
+        }
         if (sql.includes('pg_advisory_unlock_all')) {
           lockHarness.release(`whiteboard-draft:${firstID}`);
           lockHarness.release(`whiteboard-draft:${secondID}`);

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.spec.ts
@@ -47,7 +47,7 @@ describe('WhiteboardDraftService', () => {
   const draftID = 'draft-wb';
   let drafts: Map<string, Whiteboard>;
   let repository: Pick<Repository<Whiteboard>, 'find'>;
-  let lockedRepository: Pick<Repository<Whiteboard>, 'findOne'>;
+  let lockedRepository: Pick<Repository<Whiteboard>, 'findOne' | 'update'>;
   let whiteboardService: Pick<
     WhiteboardService,
     'createWhiteboard' | 'deleteWhiteboard'
@@ -84,6 +84,15 @@ describe('WhiteboardDraftService', () => {
           return null;
         }
         return draft;
+      }),
+      update: vi.fn(async (ids: string | string[], update) => {
+        for (const id of Array.isArray(ids) ? ids : [ids]) {
+          const draft = drafts.get(id);
+          if (draft && update.draftExpiresAt !== undefined) {
+            draft.draftExpiresAt = update.draftExpiresAt as Date;
+          }
+        }
+        return { affected: 1, raw: [], generatedMaps: [] };
       }),
     };
     whiteboardService = {
@@ -221,6 +230,66 @@ describe('WhiteboardDraftService', () => {
     ]);
     expect(materializations).toBe(1);
     expect(whiteboardService.deleteWhiteboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires a consumed draft before best-effort canonical deletion', async () => {
+    drafts.set(draftID, futureDraft());
+    vi.mocked(whiteboardService.deleteWhiteboard).mockRejectedValueOnce(
+      new Error('file service unavailable')
+    );
+
+    const consumption = await service.acquireForConsumption(
+      [draftID],
+      actorContext
+    );
+    await expect(consumption.complete()).resolves.toBeUndefined();
+    await consumption.release();
+
+    expect(drafts.get(draftID)?.draftExpiresAt?.getTime()).toBe(0);
+    await expect(
+      service.acquireForConsumption([draftID], actorContext)
+    ).rejects.toThrow('Whiteboard draft has expired');
+  });
+
+  it('unlocks every acquired draft and clears the session after a keyed unlock fails', async () => {
+    const firstID = 'draft-a';
+    const secondID = 'draft-b';
+    drafts.set(firstID, futureDraft(firstID));
+    drafts.set(secondID, futureDraft(secondID));
+    const consumption = await service.acquireForConsumption(
+      [firstID, secondID],
+      actorContext
+    );
+    const runner = vi.mocked(dataSource.createQueryRunner).mock.results[0]
+      .value as QueryRunner;
+    let keyedUnlocks = 0;
+    vi.mocked(runner.query).mockImplementation(
+      async (sql: string, parameters?: string[]) => {
+        if (sql.includes('pg_advisory_unlock_all')) {
+          lockHarness.release(`whiteboard-draft:${firstID}`);
+          lockHarness.release(`whiteboard-draft:${secondID}`);
+          return [{ pg_advisory_unlock_all: null }];
+        }
+        if (sql.includes('pg_advisory_unlock')) {
+          keyedUnlocks++;
+          if (keyedUnlocks === 1) {
+            throw new Error('keyed unlock failed');
+          }
+          lockHarness.release(parameters![0]);
+          return [{ pg_advisory_unlock: true }];
+        }
+        await lockHarness.acquire(parameters![0]);
+        return [{ pg_advisory_lock: null }];
+      }
+    );
+
+    await expect(consumption.release()).resolves.toBeUndefined();
+
+    expect(keyedUnlocks).toBe(2);
+    expect(runner.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_unlock_all()'
+    );
+    expect(runner.release).toHaveBeenCalledOnce();
   });
 
   it('makes discard wait until an in-flight source copy releases the draft', async () => {

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
@@ -12,12 +12,14 @@ import { Whiteboard } from '@domain/common/whiteboard/whiteboard.entity';
 import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
 import { WhiteboardAuthorizationService } from '@domain/common/whiteboard/whiteboard.service.authorization';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { DataSource, LessThanOrEqual, QueryRunner, Repository } from 'typeorm';
 import { CreateWhiteboardDraftInput } from './dto';
 
 const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const DRAFT_LOCK_TIMEOUT_MS = 5_000;
 
 export interface WhiteboardDraftMaterializationInput
   extends CreateWhiteboardDraftInput {
@@ -27,6 +29,7 @@ export interface WhiteboardDraftMaterializationInput
 
 export interface WhiteboardDraftConsumption {
   drafts: ReadonlyMap<string, Whiteboard>;
+  markConsumed(): Promise<void>;
   complete(): Promise<void>;
   release(): Promise<void>;
   [Symbol.asyncDispose](): Promise<void>;
@@ -41,8 +44,9 @@ export class WhiteboardDraftService {
     private readonly whiteboardService: WhiteboardService,
     private readonly whiteboardAuthorizationService: WhiteboardAuthorizationService,
     private readonly authorizationPolicyService: AuthorizationPolicyService,
-    @InjectDataSource()
-    private readonly dataSource: DataSource
+    @InjectDataSource() private readonly dataSource: DataSource,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService
   ) {}
 
   async materialize(
@@ -89,6 +93,7 @@ export class WhiteboardDraftService {
     if (draftIDs.length === 0) {
       return {
         drafts: new Map(),
+        markConsumed: async () => undefined,
         complete: async () => undefined,
         release: async () => undefined,
         [Symbol.asyncDispose]: async () => undefined,
@@ -112,21 +117,39 @@ export class WhiteboardDraftService {
         this.assertConsumable(draft, whiteboardID, actorContext);
         drafts.set(whiteboardID, draft);
       }
+      let consumed = false;
+      const markConsumed = async (): Promise<void> => {
+        if (consumed) return;
+        await lockedRepository.update(draftIDs, {
+          draftExpiresAt: new Date(0),
+        });
+        consumed = true;
+      };
       return {
         drafts,
+        markConsumed,
         complete: async () => {
           // Make every consumed draft immediately non-consumable while its
           // advisory lock is held. Canonical deletion also removes its files,
           // but a transient delete failure must not allow a retry to create a
           // second final Whiteboard from the same draft. The expiry sweep will
           // retry canonical deletion for any row left behind.
-          await lockedRepository.update(draftIDs, {
-            draftExpiresAt: new Date(0),
-          });
+          await markConsumed();
           for (const draftID of draftIDs) {
             await this.whiteboardService
               .deleteWhiteboard(draftID)
-              .catch(() => undefined);
+              .catch(error => {
+                this.logger.warn?.(
+                  {
+                    message:
+                      'Consumed Whiteboard draft deletion failed; expiry sweep will retry',
+                    whiteboardID: draftID,
+                    error:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                  LogContext.WHITEBOARDS
+                );
+              });
           }
         },
         release,
@@ -235,6 +258,9 @@ export class WhiteboardDraftService {
     await queryRunner.connect();
     const acquiredIDs: string[] = [];
     try {
+      await queryRunner.query(
+        `SET lock_timeout = '${DRAFT_LOCK_TIMEOUT_MS}ms'`
+      );
       for (const whiteboardID of whiteboardIDs) {
         await queryRunner.query(
           'SELECT pg_advisory_lock(hashtextextended($1, 0))',
@@ -272,7 +298,11 @@ export class WhiteboardDraftService {
         await queryRunner.query('SELECT pg_advisory_unlock_all()');
       }
     } finally {
-      await queryRunner.release();
+      try {
+        await queryRunner.query('SET lock_timeout = DEFAULT');
+      } finally {
+        await queryRunner.release();
+      }
     }
   }
 

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
@@ -13,8 +13,8 @@ import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service'
 import { WhiteboardAuthorizationService } from '@domain/common/whiteboard/whiteboard.service.authorization';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, LessThanOrEqual, Not, Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, LessThanOrEqual, QueryRunner, Repository } from 'typeorm';
 import { CreateWhiteboardDraftInput } from './dto';
 
 const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -25,6 +25,13 @@ export interface WhiteboardDraftMaterializationInput
   sourceStorageBucketID?: string;
 }
 
+export interface WhiteboardDraftConsumption {
+  drafts: ReadonlyMap<string, Whiteboard>;
+  complete(): Promise<void>;
+  release(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
 /** A live draft is an ordinary Whiteboard with a non-NULL expiry marker. */
 @Injectable()
 export class WhiteboardDraftService {
@@ -33,7 +40,9 @@ export class WhiteboardDraftService {
     private readonly repository: Repository<Whiteboard>,
     private readonly whiteboardService: WhiteboardService,
     private readonly whiteboardAuthorizationService: WhiteboardAuthorizationService,
-    private readonly authorizationPolicyService: AuthorizationPolicyService
+    private readonly authorizationPolicyService: AuthorizationPolicyService,
+    @InjectDataSource()
+    private readonly dataSource: DataSource
   ) {}
 
   async materialize(
@@ -71,14 +80,110 @@ export class WhiteboardDraftService {
     return whiteboard.id;
   }
 
-  async getForConsumption(
+  async acquireForConsumption(
+    whiteboardIDs: string[],
+    actorContext: ActorContext
+  ): Promise<WhiteboardDraftConsumption> {
+    this.assertActor(actorContext);
+    const draftIDs = [...new Set(whiteboardIDs)].sort();
+    if (draftIDs.length === 0) {
+      return {
+        drafts: new Map(),
+        complete: async () => undefined,
+        release: async () => undefined,
+        [Symbol.asyncDispose]: async () => undefined,
+      };
+    }
+    const queryRunner = await this.acquireLocks(draftIDs);
+    let released = false;
+    const release = async (): Promise<void> => {
+      if (released) return;
+      released = true;
+      await this.releaseLocks(queryRunner, draftIDs);
+    };
+
+    try {
+      const lockedRepository = queryRunner.manager.getRepository(Whiteboard);
+      const drafts = new Map<string, Whiteboard>();
+      for (const whiteboardID of draftIDs) {
+        const draft = await lockedRepository.findOne({
+          where: { id: whiteboardID },
+        });
+        this.assertConsumable(draft, whiteboardID, actorContext);
+        drafts.set(whiteboardID, draft);
+      }
+      return {
+        drafts,
+        complete: async () => {
+          for (const draftID of draftIDs) {
+            await this.whiteboardService.deleteWhiteboard(draftID);
+          }
+        },
+        release,
+        [Symbol.asyncDispose]: release,
+      };
+    } catch (error) {
+      await release();
+      throw error;
+    }
+  }
+
+  async discard(
     whiteboardID: string,
     actorContext: ActorContext
-  ): Promise<Whiteboard> {
+  ): Promise<string> {
     this.assertActor(actorContext);
-    const draft = await this.repository.findOne({
-      where: { id: whiteboardID },
+    return this.withLocks([whiteboardID], async queryRunner => {
+      const draft = await queryRunner.manager
+        .getRepository(Whiteboard)
+        .findOne({ where: { id: whiteboardID } });
+      if (!draft?.draftExpiresAt) return whiteboardID;
+      if (draft.createdBy !== actorContext.actorID) {
+        throw new ForbiddenException(
+          'Only the actor that created a Whiteboard draft may discard it',
+          LogContext.WHITEBOARDS,
+          { whiteboardID }
+        );
+      }
+      await this.whiteboardService.deleteWhiteboard(whiteboardID);
+      return whiteboardID;
     });
+  }
+
+  async findExpired(limit: number): Promise<string[]> {
+    // This is the complete cleanup corpus. Ordinary Whiteboards have NULL and
+    // cannot be selected by this query.
+    const drafts = await this.repository.find({
+      select: { id: true },
+      where: { draftExpiresAt: LessThanOrEqual(new Date()) },
+      order: { draftExpiresAt: 'ASC' },
+      take: limit,
+    });
+    return drafts.map(draft => draft.id);
+  }
+
+  async cleanupExpired(whiteboardID: string): Promise<void> {
+    await this.withLocks([whiteboardID], async queryRunner => {
+      // The sweep selection is only a candidate list. Re-read the marker while
+      // holding the same cross-replica lock used by consumption and discard.
+      const draft = await queryRunner.manager
+        .getRepository(Whiteboard)
+        .findOne({
+          where: {
+            id: whiteboardID,
+            draftExpiresAt: LessThanOrEqual(new Date()),
+          },
+        });
+      if (!draft) return;
+      await this.whiteboardService.deleteWhiteboard(draft.id);
+    });
+  }
+
+  private assertConsumable(
+    draft: Whiteboard | null,
+    whiteboardID: string,
+    actorContext: ActorContext
+  ): asserts draft is Whiteboard {
     if (!draft?.draftExpiresAt) {
       throw new EntityNotFoundException(
         'Whiteboard draft not found',
@@ -100,59 +205,54 @@ export class WhiteboardDraftService {
         { whiteboardID }
       );
     }
-    return draft;
   }
 
-  async discard(
-    whiteboardID: string,
-    actorContext: ActorContext
-  ): Promise<string> {
-    this.assertActor(actorContext);
-    const draft = await this.repository.findOne({
-      where: { id: whiteboardID },
-    });
-    if (!draft?.draftExpiresAt) return whiteboardID;
-    if (draft.createdBy !== actorContext.actorID) {
-      throw new ForbiddenException(
-        'Only the actor that created a Whiteboard draft may discard it',
-        LogContext.WHITEBOARDS,
-        { whiteboardID }
-      );
+  private async withLocks<T>(
+    whiteboardIDs: string[],
+    operation: (queryRunner: QueryRunner) => Promise<T>
+  ): Promise<T> {
+    const draftIDs = [...new Set(whiteboardIDs)].sort();
+    const queryRunner = await this.acquireLocks(draftIDs);
+    try {
+      return await operation(queryRunner);
+    } finally {
+      await this.releaseLocks(queryRunner, draftIDs);
     }
-    await this.whiteboardService.deleteWhiteboard(whiteboardID);
-    return whiteboardID;
   }
 
-  async cleanupConsumed(whiteboardID: string): Promise<void> {
-    const draft = await this.repository.findOne({
-      where: { id: whiteboardID, draftExpiresAt: Not(IsNull()) },
-    });
-    if (!draft) return;
-    await this.whiteboardService.deleteWhiteboard(draft.id);
+  private async acquireLocks(whiteboardIDs: string[]): Promise<QueryRunner> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    const acquiredIDs: string[] = [];
+    try {
+      for (const whiteboardID of whiteboardIDs) {
+        await queryRunner.query(
+          'SELECT pg_advisory_lock(hashtextextended($1, 0))',
+          [`whiteboard-draft:${whiteboardID}`]
+        );
+        acquiredIDs.push(whiteboardID);
+      }
+      return queryRunner;
+    } catch (error) {
+      await this.releaseLocks(queryRunner, acquiredIDs);
+      throw error;
+    }
   }
 
-  async findExpired(limit: number): Promise<string[]> {
-    // This is the complete cleanup corpus. Ordinary Whiteboards have NULL and
-    // cannot be selected by this query.
-    const drafts = await this.repository.find({
-      select: { id: true },
-      where: { draftExpiresAt: LessThanOrEqual(new Date()) },
-      order: { draftExpiresAt: 'ASC' },
-      take: limit,
-    });
-    return drafts.map(draft => draft.id);
-  }
-
-  async cleanupExpired(whiteboardID: string): Promise<void> {
-    // Recheck the exact id and expiry immediately before canonical deletion.
-    const draft = await this.repository.findOne({
-      where: {
-        id: whiteboardID,
-        draftExpiresAt: LessThanOrEqual(new Date()),
-      },
-    });
-    if (!draft) return;
-    await this.whiteboardService.deleteWhiteboard(draft.id);
+  private async releaseLocks(
+    queryRunner: QueryRunner,
+    whiteboardIDs: string[]
+  ): Promise<void> {
+    try {
+      for (const whiteboardID of [...whiteboardIDs].reverse()) {
+        await queryRunner.query(
+          'SELECT pg_advisory_unlock(hashtextextended($1, 0))',
+          [`whiteboard-draft:${whiteboardID}`]
+        );
+      }
+    } finally {
+      await queryRunner.release();
+    }
   }
 
   private assertActor(actorContext: ActorContext): void {

--- a/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
+++ b/src/domain/common/whiteboard-draft/whiteboard.draft.service.ts
@@ -115,8 +115,18 @@ export class WhiteboardDraftService {
       return {
         drafts,
         complete: async () => {
+          // Make every consumed draft immediately non-consumable while its
+          // advisory lock is held. Canonical deletion also removes its files,
+          // but a transient delete failure must not allow a retry to create a
+          // second final Whiteboard from the same draft. The expiry sweep will
+          // retry canonical deletion for any row left behind.
+          await lockedRepository.update(draftIDs, {
+            draftExpiresAt: new Date(0),
+          });
           for (const draftID of draftIDs) {
-            await this.whiteboardService.deleteWhiteboard(draftID);
+            await this.whiteboardService
+              .deleteWhiteboard(draftID)
+              .catch(() => undefined);
           }
         },
         release,
@@ -243,12 +253,23 @@ export class WhiteboardDraftService {
     queryRunner: QueryRunner,
     whiteboardIDs: string[]
   ): Promise<void> {
+    let exactUnlockFailed = false;
     try {
       for (const whiteboardID of [...whiteboardIDs].reverse()) {
-        await queryRunner.query(
-          'SELECT pg_advisory_unlock(hashtextextended($1, 0))',
-          [`whiteboard-draft:${whiteboardID}`]
-        );
+        try {
+          await queryRunner.query(
+            'SELECT pg_advisory_unlock(hashtextextended($1, 0))',
+            [`whiteboard-draft:${whiteboardID}`]
+          );
+        } catch {
+          exactUnlockFailed = true;
+        }
+      }
+      if (exactUnlockFailed) {
+        // A QueryRunner owns one PostgreSQL session exclusively. Clear any
+        // lock left by a failed keyed unlock before returning that session to
+        // the pool; otherwise an unrelated request could inherit the lock.
+        await queryRunner.query('SELECT pg_advisory_unlock_all()');
       }
     } finally {
       await queryRunner.release();

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
@@ -64,6 +64,7 @@ describe('TemplatesSetResolverMutations', () => {
     whiteboardDraftService = {
       acquireForConsumption: vi.fn().mockResolvedValue({
         drafts: new Map(),
+        markConsumed: vi.fn(),
         complete: vi.fn(),
         release: releaseDraftLock,
         [Symbol.asyncDispose]: releaseDraftLock,
@@ -140,6 +141,9 @@ describe('TemplatesSetResolverMutations', () => {
       });
       whiteboardDraftService.acquireForConsumption.mockResolvedValue({
         drafts: new Map([['draft-wb', { id: 'draft-wb' }]]),
+        markConsumed: vi.fn(async () => {
+          order.push('markConsumed');
+        }),
         complete,
         release,
         [Symbol.asyncDispose]: release,
@@ -160,7 +164,53 @@ describe('TemplatesSetResolverMutations', () => {
         draftWhiteboardID: undefined,
         sourceWhiteboardID: 'draft-wb',
       });
-      expect(order).toEqual(['complete', 'release']);
+      expect(order).toEqual(['markConsumed', 'complete', 'release']);
+    });
+
+    it('does not create a duplicate after a post-persistence failure', async () => {
+      const templatesSet = { id: 'ts-1', authorization: { id: 'ts-auth' } };
+      templatesSetService.getTemplatesSetOrFail.mockResolvedValue(templatesSet);
+      templatesSetService.createTemplate.mockResolvedValue({ id: 'tpl-1' });
+      whiteboardService.getWhiteboardOrFail.mockResolvedValue({
+        id: 'draft-wb',
+        authorization: { id: 'draft-auth' },
+      });
+      templateAuthorizationService.applyAuthorizationPolicy.mockRejectedValue(
+        new Error('post-persistence authorization failed')
+      );
+      let consumed = false;
+      whiteboardDraftService.acquireForConsumption.mockImplementation(
+        async () => {
+          if (consumed) {
+            throw new Error('Whiteboard draft has expired');
+          }
+          const release = vi.fn();
+          return {
+            drafts: new Map([['draft-wb', { id: 'draft-wb' }]]),
+            markConsumed: vi.fn(async () => {
+              consumed = true;
+            }),
+            complete: vi.fn(),
+            release,
+            [Symbol.asyncDispose]: release,
+          };
+        }
+      );
+      const input = () =>
+        ({
+          templatesSetID: 'ts-1',
+          whiteboard: { draftWhiteboardID: 'draft-wb' },
+        }) as any;
+      const actorContext = { actorID: 'user-1' } as any;
+
+      await expect(
+        resolver.createTemplate(actorContext, input())
+      ).rejects.toThrow('post-persistence authorization failed');
+      await expect(
+        resolver.createTemplate(actorContext, input())
+      ).rejects.toThrow('Whiteboard draft has expired');
+
+      expect(templatesSetService.createTemplate).toHaveBeenCalledOnce();
     });
 
     it('does not consume a nullable GraphQL draft ID', async () => {

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
@@ -163,6 +163,27 @@ describe('TemplatesSetResolverMutations', () => {
       expect(order).toEqual(['complete', 'release']);
     });
 
+    it('does not consume a nullable GraphQL draft ID', async () => {
+      const templatesSet = { id: 'ts-1', authorization: { id: 'ts-auth' } };
+      templatesSetService.getTemplatesSetOrFail.mockResolvedValue(templatesSet);
+      templatesSetService.createTemplate.mockRejectedValue(
+        new Error('stop after draft acquisition')
+      );
+      const actorContext = { actorID: 'user-1' } as any;
+
+      await expect(
+        resolver.createTemplate(actorContext, {
+          templatesSetID: 'ts-1',
+          whiteboard: { draftWhiteboardID: null },
+        } as any)
+      ).rejects.toThrow('stop after draft acquisition');
+
+      expect(whiteboardDraftService.acquireForConsumption).toHaveBeenCalledWith(
+        [],
+        actorContext
+      );
+    });
+
     it('does NOT load a source whiteboard when the template has no sourceWhiteboardID', async () => {
       const templatesSet = { id: 'ts-1', authorization: { id: 'ts-auth' } };
       templatesSetService.getTemplatesSetOrFail.mockResolvedValue(templatesSet);

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.spec.ts
@@ -5,9 +5,7 @@ import { WhiteboardService } from '@domain/common/whiteboard';
 import { WhiteboardDraftService } from '@domain/common/whiteboard-draft';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { TemplateContentSpaceService } from '@domain/template/template-content-space/template.content.space.service';
-import { LoggerService } from '@nestjs/common';
 import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
-import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { vi } from 'vitest';
 import { TemplateService } from '../template/template.service';
 import { TemplateAuthorizationService } from '../template/template.service.authorization';
@@ -38,6 +36,10 @@ describe('TemplatesSetResolverMutations', () => {
   let whiteboardService: {
     getWhiteboardOrFail: ReturnType<typeof vi.fn>;
   };
+  let whiteboardDraftService: {
+    acquireForConsumption: ReturnType<typeof vi.fn>;
+    materialize: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     authorizationService = { grantAccessOrFail: vi.fn() };
@@ -58,6 +60,16 @@ describe('TemplatesSetResolverMutations', () => {
     whiteboardService = {
       getWhiteboardOrFail: vi.fn(),
     };
+    const releaseDraftLock = vi.fn();
+    whiteboardDraftService = {
+      acquireForConsumption: vi.fn().mockResolvedValue({
+        drafts: new Map(),
+        complete: vi.fn(),
+        release: releaseDraftLock,
+        [Symbol.asyncDispose]: releaseDraftLock,
+      }),
+      materialize: vi.fn(),
+    };
 
     resolver = new TemplatesSetResolverMutations(
       authorizationService as unknown as AuthorizationService,
@@ -68,15 +80,10 @@ describe('TemplatesSetResolverMutations', () => {
       spaceLookupService as unknown as SpaceLookupService,
       templateContentSpaceService as unknown as TemplateContentSpaceService,
       whiteboardService as unknown as WhiteboardService,
-      {
-        getForConsumption: vi.fn(),
-        cleanupConsumed: vi.fn(),
-        materialize: vi.fn(),
-      } as unknown as WhiteboardDraftService,
+      whiteboardDraftService as unknown as WhiteboardDraftService,
       {
         getStorageAggregatorForTemplatesSet: vi.fn(),
-      } as unknown as StorageAggregatorResolverService,
-      MockWinstonProvider.useValue as unknown as LoggerService
+      } as unknown as StorageAggregatorResolverService
     );
   });
 
@@ -109,6 +116,51 @@ describe('TemplatesSetResolverMutations', () => {
       );
       expect(authorizationPolicyService.saveAll).toHaveBeenCalled();
       expect(result).toBe(template);
+    });
+
+    it('holds an owned framing draft through final creation and deletes it before releasing', async () => {
+      const templatesSet = { id: 'ts-1', authorization: { id: 'ts-auth' } };
+      templatesSetService.getTemplatesSetOrFail.mockResolvedValue(templatesSet);
+      const template = { id: 'tpl-1' };
+      templatesSetService.createTemplate.mockResolvedValue(template);
+      templateAuthorizationService.applyAuthorizationPolicy.mockResolvedValue(
+        []
+      );
+      templateService.getTemplateOrFail.mockResolvedValue(template);
+      whiteboardService.getWhiteboardOrFail.mockResolvedValue({
+        id: 'draft-wb',
+        authorization: { id: 'draft-auth' },
+      });
+      const order: string[] = [];
+      const complete = vi.fn(async () => {
+        order.push('complete');
+      });
+      const release = vi.fn(async () => {
+        order.push('release');
+      });
+      whiteboardDraftService.acquireForConsumption.mockResolvedValue({
+        drafts: new Map([['draft-wb', { id: 'draft-wb' }]]),
+        complete,
+        release,
+        [Symbol.asyncDispose]: release,
+      });
+      const input = {
+        templatesSetID: 'ts-1',
+        whiteboard: { draftWhiteboardID: 'draft-wb' },
+      } as any;
+      const actorContext = { actorID: 'user-1' } as any;
+
+      await resolver.createTemplate(actorContext, input);
+
+      expect(whiteboardDraftService.acquireForConsumption).toHaveBeenCalledWith(
+        ['draft-wb'],
+        actorContext
+      );
+      expect(input.whiteboard).toEqual({
+        draftWhiteboardID: undefined,
+        sourceWhiteboardID: 'draft-wb',
+      });
+      expect(order).toEqual(['complete', 'release']);
     });
 
     it('does NOT load a source whiteboard when the template has no sourceWhiteboardID', async () => {

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.ts
@@ -14,11 +14,9 @@ import {
 } from '@domain/common/whiteboard-draft';
 import { SpaceLookupService } from '@domain/space/space.lookup/space.lookup.service';
 import { TemplateContentSpaceService } from '@domain/template/template-content-space/template.content.space.service';
-import { Inject, LoggerService } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { StorageAggregatorResolverService } from '@services/infrastructure/storage-aggregator-resolver/storage.aggregator.resolver.service';
 import { InstrumentResolver } from '@src/apm/decorators';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ITemplate } from '../template/template.interface';
 import { TemplateService } from '../template/template.service';
 import { TemplateAuthorizationService } from '../template/template.service.authorization';
@@ -40,8 +38,7 @@ export class TemplatesSetResolverMutations {
     private templateContentSpaceService: TemplateContentSpaceService,
     private whiteboardService: WhiteboardService,
     private whiteboardDraftService: WhiteboardDraftService,
-    private storageAggregatorResolverService: StorageAggregatorResolverService,
-    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
+    private storageAggregatorResolverService: StorageAggregatorResolverService
   ) {}
 
   @Mutation(() => UUID, {
@@ -120,7 +117,6 @@ export class TemplatesSetResolverMutations {
       AuthorizationPrivilege.CREATE,
       `templates set create template: ${templatesSet.id}`
     );
-    const consumedDraftIDs: string[] = [];
     const whiteboardInputs = [
       templateData.whiteboard,
       templateData.calloutData?.framing?.whiteboard,
@@ -132,6 +128,14 @@ export class TemplatesSetResolverMutations {
       );
     }
     const framingInput = whiteboardInputs[0];
+    const defaults = templateData.calloutData?.contributionDefaults;
+    await using draftConsumption =
+      await this.whiteboardDraftService.acquireForConsumption(
+        [framingInput?.draftWhiteboardID, defaults?.draftWhiteboardID].filter(
+          (id): id is string => id !== undefined
+        ),
+        actorContext
+      );
     if (framingInput?.draftWhiteboardID) {
       if (framingInput.sourceWhiteboardID) {
         throw new ValidationException(
@@ -139,15 +143,12 @@ export class TemplatesSetResolverMutations {
           LogContext.WHITEBOARDS
         );
       }
-      const draft = await this.whiteboardDraftService.getForConsumption(
-        framingInput.draftWhiteboardID,
-        actorContext
-      );
-      consumedDraftIDs.push(draft.id);
+      const draft = draftConsumption.drafts.get(
+        framingInput.draftWhiteboardID
+      )!;
       framingInput.sourceWhiteboardID = draft.id;
       framingInput.draftWhiteboardID = undefined;
     }
-    const defaults = templateData.calloutData?.contributionDefaults;
     if (defaults?.draftWhiteboardID) {
       if (defaults.sourceWhiteboardID || defaults.sourceCalloutID) {
         throw new ValidationException(
@@ -155,11 +156,7 @@ export class TemplatesSetResolverMutations {
           LogContext.WHITEBOARDS
         );
       }
-      const draft = await this.whiteboardDraftService.getForConsumption(
-        defaults.draftWhiteboardID,
-        actorContext
-      );
-      consumedDraftIDs.push(draft.id);
+      const draft = draftConsumption.drafts.get(defaults.draftWhiteboardID)!;
       defaults.sourceWhiteboardID = draft.id;
       defaults.draftWhiteboardID = undefined;
     }
@@ -196,22 +193,7 @@ export class TemplatesSetResolverMutations {
 
     await this.authorizationPolicyService.saveAll(authorizations);
     const result = await this.templateService.getTemplateOrFail(template.id);
-    for (const draftID of consumedDraftIDs) {
-      try {
-        await this.whiteboardDraftService.cleanupConsumed(draftID);
-      } catch (error) {
-        this.logger.error?.(
-          {
-            message:
-              'Final Template was created but Whiteboard draft cleanup remains retryable',
-            templateID: result.id,
-            draftID,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          error instanceof Error ? (error.stack ?? '') : ''
-        );
-      }
-    }
+    await draftConsumption.complete();
     return result;
   }
 

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.ts
@@ -132,7 +132,7 @@ export class TemplatesSetResolverMutations {
     await using draftConsumption =
       await this.whiteboardDraftService.acquireForConsumption(
         [framingInput?.draftWhiteboardID, defaults?.draftWhiteboardID].filter(
-          (id): id is string => id !== undefined
+          (id): id is string => typeof id === 'string'
         ),
         actorContext
       );

--- a/src/domain/template/templates-set/templates.set.resolver.mutations.ts
+++ b/src/domain/template/templates-set/templates.set.resolver.mutations.ts
@@ -185,6 +185,10 @@ export class TemplatesSetResolverMutations {
       templateData,
       actorContext
     );
+    // createTemplate returns only after the final template is persisted and
+    // materialized. Mark its draft consumed before later authorization/read
+    // work can fail and make a retry create a duplicate template.
+    await draftConsumption.markConsumed();
     const authorizations =
       await this.templateAuthorizationService.applyAuthorizationPolicy(
         template,


### PR DESCRIPTION
## Summary

Serializes every destructive use of a whiteboard draft with a shared PostgreSQL advisory lock, preventing concurrent final submissions from materializing duplicate final objects and preventing discard/expiry cleanup from deleting a draft while it is being copied.

This is a free-text follow-up defect discovered during review; there is no Projects/50 board story.

## Root cause

`WhiteboardDraftService.getForConsumption()` performed an unlocked read, while final creation copied the draft before a later cleanup. Explicit discard and expiry cleanup also selected a draft before deleting it without revalidating its marker under shared cross-replica serialization.

## Fix

- Use a session-level PostgreSQL advisory lock keyed by draft ID in all three competing paths: final consumption, explicit discard, and expiry cleanup.
- Acquire multiple draft locks in deterministic lexical order and release them in reverse order.
- Re-read and revalidate draft ownership and `draftExpiresAt` inside the lock.
- Hold the lock across final source copying and canonical consumed-draft deletion.
- Preserve failure semantics: failed final creation releases the lock without deleting the usable draft; successful final creation deletes it before unlock.
- Keep the existing nullable `whiteboard.draftExpiresAt` contract; no schema, table, status, lease, or state-machine change.

A session advisory lock is used instead of a row lock or enclosing transaction so the existing `WhiteboardService` copy/delete operations may safely use their own pooled connections without transaction self-deadlock.

## Regression coverage

- concurrent final submissions: exactly one materializes and the second rejects after locked re-read
- discard waits and cannot delete while final copying is in flight
- expiry cleanup does not delete after the marker is cleared or extended
- ordinary whiteboards with a null draft marker are never deleted
- exact callout and template finalization entry points retain drafts on failure and delete on success

## Verification

- Node 22.21.1
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm lint`
- focused Vitest: 3 files / 43 tests passed
- full Vitest: 760 files passed, 6 skipped; 8,708 tests passed, 7 skipped
- normal signed commit hook passed on the final staged state (Biome, TypeScript, full Vitest; no bypass)

## Traceability

- Follow-up to merged server PR #6405
- Review source: [agents-hq PR #127](https://github.com/alkem-io/agents-hq/pull/127), including triage commit [`f96809ba`](https://github.com/alkem-io/agents-hq/commit/f96809ba)

New implementation comments do not cite issue or specification numbers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of whiteboard drafts during callout and template creation.
  * Multiple referenced drafts can now be acquired and processed together.

* **Bug Fixes**
  * Prevented drafts from being reused after consumption, including when deletion encounters a temporary failure.
  * Improved protection against concurrent consumption and cleanup conflicts.
  * Added safer recovery when draft locks are interrupted or released unexpectedly.
  * Strengthened validation for expired, discarded, or unauthorized drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->