### PR TITLE
fix: hide collaboration snapshots from document APIs

### DIFF
--- a/src/domain/storage/document/document.resolver.mutations.ts
+++ b/src/domain/storage/document/document.resolver.mutations.ts
@@ -24,7 +24,7 @@ export class DocumentResolverMutations {
     @CurrentActor() actorContext: ActorContext,
     @Args('deleteData') deleteData: DeleteDocumentInput
   ): Promise<IDocument> {
-    const document = await this.documentService.getDocumentOrFail(
+    const document = await this.documentService.getUserFacingDocumentOrFail(
       deleteData.ID
     );
     await this.authorizationService.grantAccessOrFail(
@@ -44,7 +44,7 @@ export class DocumentResolverMutations {
     @CurrentActor() actorContext: ActorContext,
     @Args('documentData') documentData: UpdateDocumentInput
   ): Promise<IDocument> {
-    const document = await this.documentService.getDocumentOrFail(
+    const document = await this.documentService.getUserFacingDocumentOrFail(
       documentData.ID
     );
     await this.authorizationService.grantAccessOrFail(

--- a/src/domain/storage/document/document.resolver.spec.ts
+++ b/src/domain/storage/document/document.resolver.spec.ts
@@ -49,7 +49,9 @@ describe('DocumentResolverMutations', () => {
       const deleteData = { ID: 'doc-1' };
       const deletedDoc = { id: 'doc-1' };
 
-      (documentService.getDocumentOrFail as Mock).mockResolvedValue(document);
+      (documentService.getUserFacingDocumentOrFail as Mock).mockResolvedValue(
+        document
+      );
       (authorizationService.grantAccessOrFail as Mock).mockResolvedValue(
         undefined
       );
@@ -60,7 +62,9 @@ describe('DocumentResolverMutations', () => {
         deleteData as any
       );
 
-      expect(documentService.getDocumentOrFail).toHaveBeenCalledWith('doc-1');
+      expect(documentService.getUserFacingDocumentOrFail).toHaveBeenCalledWith(
+        'doc-1'
+      );
       expect(authorizationService.grantAccessOrFail).toHaveBeenCalledWith(
         actorContext,
         docAuth,
@@ -84,7 +88,9 @@ describe('DocumentResolverMutations', () => {
       const documentData = { ID: 'doc-2', displayName: 'updated.pdf' };
       const updatedDoc = { id: 'doc-2', displayName: 'updated.pdf' };
 
-      (documentService.getDocumentOrFail as Mock).mockResolvedValue(document);
+      (documentService.getUserFacingDocumentOrFail as Mock).mockResolvedValue(
+        document
+      );
       (authorizationService.grantAccessOrFail as Mock).mockResolvedValue(
         undefined
       );
@@ -95,7 +101,9 @@ describe('DocumentResolverMutations', () => {
         documentData as any
       );
 
-      expect(documentService.getDocumentOrFail).toHaveBeenCalledWith('doc-2');
+      expect(documentService.getUserFacingDocumentOrFail).toHaveBeenCalledWith(
+        'doc-2'
+      );
       expect(authorizationService.grantAccessOrFail).toHaveBeenCalledWith(
         actorContext,
         docAuth,

--- a/src/domain/storage/document/document.service.spec.ts
+++ b/src/domain/storage/document/document.service.spec.ts
@@ -198,6 +198,31 @@ describe('DocumentService', () => {
     });
   });
 
+  describe('getUserFacingDocumentOrFail', () => {
+    it('returns an authorized user-facing document', async () => {
+      const document = {
+        id: 'public-doc',
+        authorization: { id: 'auth-public' },
+      };
+      (documentRepository.findOne as Mock).mockResolvedValue(document);
+
+      const result = await service.getUserFacingDocumentOrFail('public-doc');
+
+      expect(result).toBe(document);
+    });
+
+    it('hides a policy-less internal file as not found', async () => {
+      (documentRepository.findOne as Mock).mockResolvedValue({
+        id: 'internal-snapshot',
+        authorization: undefined,
+      });
+
+      await expect(
+        service.getUserFacingDocumentOrFail('internal-snapshot')
+      ).rejects.toThrow(EntityNotFoundException);
+    });
+  });
+
   // ── updateDocument ──────────────────────────────────────────────
 
   describe('updateDocument', () => {

--- a/src/domain/storage/document/document.service.ts
+++ b/src/domain/storage/document/document.service.ts
@@ -86,6 +86,25 @@ export class DocumentService {
     return document;
   }
 
+  public isUserFacingDocument(document: IDocument): boolean {
+    return Boolean(document.authorization);
+  }
+
+  public async getUserFacingDocumentOrFail(
+    documentID: string,
+    options?: FindOneOptions<Document>
+  ): Promise<IDocument> {
+    const document = await this.getDocumentOrFail(documentID, options);
+    if (!this.isUserFacingDocument(document)) {
+      throw new EntityNotFoundException(
+        'Not able to locate document with the specified ID',
+        LogContext.STORAGE_BUCKET,
+        { documentID }
+      );
+    }
+    return document;
+  }
+
   public async getDocumentByExternalIdOrFail(
     externalID: string,
     { where, ...rest }: FindOneOptions<Document>

--- a/src/domain/storage/storage-bucket/storage.bucket.service.authorization.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.authorization.spec.ts
@@ -133,6 +133,38 @@ describe('StorageBucketAuthorizationService', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('skips policy-less internal files during the authorization cascade', async () => {
+      const bucketAuth = { id: 'bucket-auth-internal' };
+      const internalSnapshot = {
+        id: 'snapshot-internal',
+        authorization: undefined,
+        tagset: undefined,
+      };
+      const storageBucket = {
+        id: 'bucket-internal',
+        authorization: bucketAuth,
+        documents: [internalSnapshot],
+      } as unknown as IStorageBucket;
+
+      (authorizationPolicyService.reset as Mock).mockReturnValue(bucketAuth);
+      (
+        authorizationPolicyService.inheritParentAuthorization as Mock
+      ).mockReturnValue(bucketAuth);
+      (
+        authorizationPolicyService.appendPrivilegeAuthorizationRules as Mock
+      ).mockReturnValue(bucketAuth);
+      (authorizationPolicyService.saveAll as Mock).mockResolvedValue(undefined);
+
+      await service.applyAuthorizationPolicy(storageBucket, undefined);
+
+      expect(
+        documentAuthorizationService.applyAuthorizationPolicy
+      ).not.toHaveBeenCalled();
+      expect(authorizationPolicyService.saveAll).toHaveBeenCalledWith([
+        bucketAuth,
+      ]);
+    });
+
     it('should throw RelationshipNotFoundException when documents is undefined', async () => {
       const storageBucket = {
         id: 'bucket-3',

--- a/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.spec.ts
@@ -139,6 +139,9 @@ describe('StorageBucketService', () => {
       getRepositoryToken(Profile)
     );
     documentService = module.get<DocumentService>(DocumentService);
+    (documentService.isUserFacingDocument as Mock).mockImplementation(
+      document => Boolean(document.authorization)
+    );
     documentAuthorizationService = module.get<DocumentAuthorizationService>(
       DocumentAuthorizationService
     );
@@ -1007,6 +1010,86 @@ describe('StorageBucketService', () => {
       );
 
       expect(result).toEqual([doc1, doc2]);
+    });
+
+    it('omits policy-less internal files before authorizing user-facing documents', async () => {
+      const internalSnapshot = mockDocument({
+        id: 'snapshot-1',
+        authorization: undefined,
+        tagset: undefined,
+      });
+      const document = mockDocument({ id: 'document-1' });
+      const bucket = mockStorageBucket({
+        id: 'bucket-mixed',
+        documents: [internalSnapshot, document],
+      });
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+      (authorizationService.isAccessGranted as Mock).mockImplementation(
+        (_actorContext, authorization) => {
+          if (!authorization) {
+            throw new Error('authorization must not run for internal files');
+          }
+          return true;
+        }
+      );
+
+      const result = await service.getFilteredDocuments(
+        bucket,
+        {},
+        actorContext
+      );
+
+      expect(result).toEqual([document]);
+      expect(authorizationService.isAccessGranted).toHaveBeenCalledTimes(1);
+      expect(authorizationService.isAccessGranted).toHaveBeenCalledWith(
+        actorContext,
+        document.authorization,
+        AuthorizationPrivilege.READ
+      );
+    });
+
+    it('returns an empty collection when a bucket contains only policy-less internal files', async () => {
+      const internalSnapshot = mockDocument({
+        id: 'snapshot-only',
+        authorization: undefined,
+        tagset: undefined,
+      });
+      const bucket = mockStorageBucket({
+        id: 'bucket-internal-only',
+        documents: [internalSnapshot],
+      });
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+
+      const result = await service.getFilteredDocuments(
+        bucket,
+        {},
+        actorContext
+      );
+
+      expect(result).toEqual([]);
+      expect(authorizationService.isAccessGranted).not.toHaveBeenCalled();
+    });
+
+    it('fails an ID lookup for a policy-less internal file without authorizing it', async () => {
+      const internalSnapshot = mockDocument({
+        id: 'snapshot-by-id',
+        authorization: undefined,
+        tagset: undefined,
+      });
+      const bucket = mockStorageBucket({
+        id: 'bucket-internal-id',
+        documents: [internalSnapshot],
+      });
+      (storageBucketRepository.findOneOrFail as Mock).mockResolvedValue(bucket);
+
+      await expect(
+        service.getFilteredDocuments(
+          bucket,
+          { IDs: [internalSnapshot.id] },
+          actorContext
+        )
+      ).rejects.toThrow(EntityNotFoundException);
+      expect(authorizationService.isAccessGranted).not.toHaveBeenCalled();
     });
 
     it('should filter out documents the agent does not have READ access to', async () => {

--- a/src/domain/storage/storage-bucket/storage.bucket.service.ts
+++ b/src/domain/storage/storage-bucket/storage.bucket.service.ts
@@ -543,10 +543,14 @@ export class StorageBucketService {
         LogContext.STORAGE_BUCKET
       );
 
-    // First filter the documents the current user has READ privilege to
-    const readableDocuments = allDocuments.filter(document =>
-      this.hasAgentAccessToDocument(document, actorContext)
-    );
+    // Policy-less rows are internal collaboration snapshots. They are real
+    // file rows for quota and lifecycle purposes, but are not user-facing
+    // Documents and must never enter per-document authorization.
+    const readableDocuments = allDocuments
+      .filter(document => this.documentService.isUserFacingDocument(document))
+      .filter(document =>
+        this.hasAgentAccessToDocument(document, actorContext)
+      );
 
     // (a) by IDs, results in order specified by IDs
     if (args.IDs) {

--- a/src/services/adapters/file-service-adapter/file.service.adapter.ts
+++ b/src/services/adapters/file-service-adapter/file.service.adapter.ts
@@ -131,10 +131,12 @@ export class FileServiceAdapter extends HttpClientBase {
    * (its `UNIQUE(authorizationId)` permits any number of NULLs). The snapshot is
    * therefore pointer-compatible with the ones the collaboration-service writes
    * on every later save (latest-only: the room deletes the previous pointer's
-   * file on its first save), and it is NOT tracked as a server-side `Document`
-   * entity (no auth-policy / tagset rows). It still counts toward the space's
-   * storage quota because it lives in the document's own bucket under the space's
-   * storage aggregator.
+   * file on its first save). It is a real `file` row mapped by the server's
+   * `Document` entity, but it is not provisioned as a user-visible document: it
+   * has no authorization-policy or tagset rows and is filtered from public
+   * document collections and lookups. It still counts toward the space's storage
+   * quota because it lives in the document's own bucket under the space's storage
+   * aggregator.
    *
    */
   async createSnapshotInBucket(

--- a/src/services/api/lookup/lookup.resolver.fields.spec.ts
+++ b/src/services/api/lookup/lookup.resolver.fields.spec.ts
@@ -55,7 +55,7 @@ describe('LookupResolverFields', () => {
   let roomService: { getRoomOrFail: Mock };
   let calendarEventService: { getCalendarEventOrFail: Mock };
   let calendarService: { getCalendarOrFail: Mock };
-  let documentService: { getDocumentOrFail: Mock };
+  let documentService: { getUserFacingDocumentOrFail: Mock };
   let templateService: { getTemplateOrFail: Mock };
   let templatesSetService: { getTemplatesSetOrFail: Mock };
   let templatesManagerService: { getTemplatesManagerOrFail: Mock };
@@ -216,11 +216,14 @@ describe('LookupResolverFields', () => {
   describe('document', () => {
     it('should lookup document and check authorization', async () => {
       const doc = createEntityWithAuth('doc-1');
-      documentService.getDocumentOrFail.mockResolvedValue(doc);
+      documentService.getUserFacingDocumentOrFail.mockResolvedValue(doc);
       authorizationService.grantAccessOrFail.mockReturnValue(undefined);
 
       const result = await resolver.document(actorContext, 'doc-1');
       expect(result).toBe(doc);
+      expect(documentService.getUserFacingDocumentOrFail).toHaveBeenCalledWith(
+        'doc-1'
+      );
     });
   });
 

--- a/src/services/api/lookup/lookup.resolver.fields.ts
+++ b/src/services/api/lookup/lookup.resolver.fields.ts
@@ -229,7 +229,7 @@ export class LookupResolverFields {
     @CurrentActor() actorContext: ActorContext,
     @Args('ID', { type: () => UUID }) id: string
   ): Promise<IDocument> {
-    const document = await this.documentService.getDocumentOrFail(id);
+    const document = await this.documentService.getUserFacingDocumentOrFail(id);
     this.authorizationService.grantAccessOrFail(
       actorContext,
       document.authorization,

--- a/src/services/api/lookup/lookup.resolver.my.privileges.fields.spec.ts
+++ b/src/services/api/lookup/lookup.resolver.my.privileges.fields.spec.ts
@@ -41,7 +41,7 @@ describe('LookupMyPrivilegesResolverFields', () => {
   let spaceService: { getSpace: Mock };
   let accountService: { getAccountOrFail: Mock };
   let roleSetService: { getRoleSetOrFail: Mock };
-  let documentService: { getDocumentOrFail: Mock };
+  let documentService: { getUserFacingDocumentOrFail: Mock };
   let virtualContributorService: {
     getVirtualContributorByIdOrFail: Mock;
   };
@@ -172,11 +172,17 @@ describe('LookupMyPrivilegesResolverFields', () => {
   describe('document', () => {
     it('should return privileges for document', async () => {
       const doc = createEntityWithAuth('doc-1');
-      documentService.getDocumentOrFail.mockResolvedValue(doc);
+      documentService.getUserFacingDocumentOrFail.mockResolvedValue(doc);
       setupPrivilegesReturn();
 
       const result = await resolver.document(actorContext, 'doc-1');
       expect(result).toEqual(mockPrivileges);
+      expect(documentService.getUserFacingDocumentOrFail).toHaveBeenCalledWith(
+        'doc-1',
+        {
+          relations: { authorization: true },
+        }
+      );
     });
   });
 

--- a/src/services/api/lookup/lookup.resolver.my.privileges.fields.ts
+++ b/src/services/api/lookup/lookup.resolver.my.privileges.fields.ts
@@ -137,9 +137,12 @@ export class LookupMyPrivilegesResolverFields {
     @CurrentActor() actorContext: ActorContext,
     @Args('ID', { type: () => UUID }) id: string
   ): Promise<AuthorizationPrivilege[]> {
-    const document = await this.documentService.getDocumentOrFail(id, {
-      relations: { authorization: true },
-    });
+    const document = await this.documentService.getUserFacingDocumentOrFail(
+      id,
+      {
+        relations: { authorization: true },
+      }
+    );
 
     return this.getMyPrivilegesOnAuthorizable(actorContext, document);
   }


### PR DESCRIPTION
Fixes alkem-io/server#6406

## Root cause

Collaboration snapshots are real rows in the file table, but intentionally have no authorization policy or tagset. StorageBucket.documents sent every row through per-document authorization, so a snapshot triggered ENTITY_NOT_INITIALIZED and poisoned the entire collection.

## Fix

- Filter policy-less internal files before per-document authorization.
- Hide them from ID-filtered bucket access and direct user-facing document lookups, privilege lookup, update, and delete paths as not found.
- Keep internal lifecycle access and the authorization-reset skip behavior unchanged.
- Correct the snapshot documentation: the row is mapped by the server Document entity, but is not provisioned as a user-visible authorized document.

## Regression coverage

- Mixed buckets return authorized documents and never authorize the internal snapshot.
- Internal-only buckets return an empty collection.
- ID access to an internal snapshot fails closed without error 12108.
- Direct user-facing lookup rejects a policy-less row.
- Authorization reset continues to skip internal snapshots.

## Verification

- pnpm test:ci:no:coverage — 760 files passed, 8724 tests passed, 6 files / 7 tests skipped.
- pnpm build — passed.
- pnpm lint — passed.
- Normal signed commit hook — passed the full lint, typecheck, and test suite.

Changed comments contain no spec, issue, or PR number references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal snapshot files are now excluded from user-facing document listings and lookups.
  * Document updates, deletions, and privilege checks now consistently reject non-user-facing files.
  * Authorization filtering no longer evaluates internal files without access policies.
  * Internal snapshots continue to count toward storage quotas and lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->