### PR TITLE
fix: expose multi-user collaboration entitlement

### DIFF
--- a/src/services/collaboration-integration/collaboration-integration.service.spec.ts
+++ b/src/services/collaboration-integration/collaboration-integration.service.spec.ts
@@ -32,11 +32,13 @@ describe('CollaborationIntegrationService', () => {
     getCollaborationMetadata: Mock;
     saveCollaborationMetadata: Mock;
     getProfile: Mock;
+    isMultiUser: Mock;
   };
   let whiteboardService: {
     getCollaborationMetadata: Mock;
     saveCollaborationMetadata: Mock;
     getProfile: Mock;
+    isMultiUser: Mock;
   };
   let contributionReporter: {
     memoContribution: Mock;
@@ -147,6 +149,7 @@ describe('CollaborationIntegrationService', () => {
   describe('fetch', () => {
     it('returns the memo index (pointer only, no seed bytes) incl. authorizationPolicyId + per-document storageBucketId (FR-005)', async () => {
       memoService.getCollaborationMetadata.mockResolvedValue(memoMeta);
+      memoService.isMultiUser.mockResolvedValue(false);
 
       const result = await service.fetch({ id: 'memo-1' });
 
@@ -164,7 +167,9 @@ describe('CollaborationIntegrationService', () => {
         // The memo's OWN bucket flows through the reply so the collab service
         // persists this doc's snapshot there, not into a flat platform bucket.
         storageBucketId: 'bucket-memo',
+        isMultiUser: false,
       });
+      expect(memoService.isMultiUser).toHaveBeenCalledWith('memo-1');
     });
 
     it('falls through to whiteboard when the id is not a memo (incl. its own storageBucketId)', async () => {
@@ -172,6 +177,7 @@ describe('CollaborationIntegrationService', () => {
       whiteboardService.getCollaborationMetadata.mockResolvedValue(
         whiteboardMeta
       );
+      whiteboardService.isMultiUser.mockResolvedValue(true);
 
       const result = await service.fetch({ id: 'wb-1' });
 
@@ -181,6 +187,8 @@ describe('CollaborationIntegrationService', () => {
       expect(result.authorizationPolicyId).toBe('policy-wb');
       // The whiteboard carries its OWN storage bucket, distinct from the memo's.
       expect(result.storageBucketId).toBe('bucket-wb');
+      expect(result.isMultiUser).toBe(true);
+      expect(whiteboardService.isMultiUser).toHaveBeenCalledWith('wb-1');
     });
 
     it('returns a structured not-found for an absent id (FR-004)', async () => {

--- a/src/services/collaboration-integration/collaboration-integration.service.ts
+++ b/src/services/collaboration-integration/collaboration-integration.service.ts
@@ -119,12 +119,14 @@ export class CollaborationIntegrationService {
     try {
       const memo = await this.tryGetMemoMetadata(data.id);
       if (memo) {
+        const isMultiUser = await this.memoService.isMultiUser(data.id);
         return {
           found: true,
           contentType: CollaborationContentType.MEMO,
           version: memo.version,
           contentPointer: memo.contentPointer,
           migrated: memo.migrated,
+          isMultiUser,
           authorizationPolicyId: memo.authorizationPolicyId,
           // The memo's OWN storage bucket — collab persists this doc's snapshot
           // there, not into a single flat platform bucket.
@@ -134,12 +136,14 @@ export class CollaborationIntegrationService {
 
       const whiteboard = await this.tryGetWhiteboardMetadata(data.id);
       if (whiteboard) {
+        const isMultiUser = await this.whiteboardService.isMultiUser(data.id);
         return {
           found: true,
           contentType: CollaborationContentType.WHITEBOARD,
           version: whiteboard.version,
           contentPointer: whiteboard.contentPointer,
           migrated: whiteboard.migrated,
+          isMultiUser,
           authorizationPolicyId: whiteboard.authorizationPolicyId,
           // The whiteboard's OWN storage bucket (see memo note above).
           storageBucketId: whiteboard.storageBucketId,

--- a/src/services/collaboration-integration/outputs/fetch.output.data.ts
+++ b/src/services/collaboration-integration/outputs/fetch.output.data.ts
@@ -14,6 +14,8 @@ export interface FetchOutputData {
   version?: number;
   contentPointer?: string;
   migrated?: boolean;
+  /** Whether this document's license allows more than one live editor. */
+  isMultiUser?: boolean;
   /** OPEN-1 / FR-005 — the entity's own AuthorizationPolicy.id. */
   authorizationPolicyId?: string;
   /**


### PR DESCRIPTION
## Source

Supports alkem-io/collaboration-service#15.

## Root cause

The unified collaboration metadata reply omitted the existing memo/whiteboard `isMultiUser` entitlement decision. The Go collaboration service therefore had no server-owned license result to enforce when a second writer joined.

## Fix

- include the existing `MemoService.isMultiUser` / `WhiteboardService.isMultiUser` result in `collaboration-fetch`
- keep the field additive/optional for rolling compatibility
- cover both memo and whiteboard reply paths

## Regression test

`collaboration-integration.service.spec.ts` proves an unlicensed memo returns `isMultiUser: false`, a licensed whiteboard returns `true`, and each existing entitlement service is called for the requested document.

## Verification

- normal signed commit hook, no bypass
- TypeScript + Biome green
- full Vitest: 760 files passed / 6 skipped; 8,724 tests passed / 7 skipped

## Rollout

Deploy this server change before the collaboration-service consumer so newly materialized rooms receive an explicit entitlement decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collaboration fetch responses now indicate whether a memo or whiteboard supports multiple live editors.
  * The multi-editor status is provided for both memo and whiteboard documents when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->