### PR TITLE
fix: recover legacy whiteboard media locators

### DIFF
--- a/src/main.collaboration-migration.ts
+++ b/src/main.collaboration-migration.ts
@@ -11,7 +11,8 @@ import { CollaborationMigrationService } from '@services/collaboration-integrati
  *   node dist/main.collaboration-migration --verify
  *
  * Prints one machine-readable JSON line and a human-readable summary (no
- * secrets), and exits non-zero on any failure (migrate: flagged/failed rows;
+ * secrets), and exits non-zero on any non-clean outcome (migrate: source-flagged,
+ * migrated-with-explicit-visual-loss, or failed rows;
  * verify: any NULL pointer, any pointer that does not resolve in file-service, or
  * any snapshot that fails decode / content-root-schema validation).
  * Boots a minimal side-effect-free Nest application context (no scheduler / RMQ /

--- a/src/services/collaboration-integration/migration/collaboration-migration.result.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.result.ts
@@ -24,12 +24,17 @@ export class CollaborationMigrationResult {
   })
   unattached!: number;
 
+  /**
+   * Rows requiring operator review. This can overlap with `migrated` when an
+   * otherwise-usable Whiteboard was salvaged after irrecoverable visuals were removed.
+   */
   @Field(() => Int)
   flagged!: number;
 
   @Field(() => Int)
   failed!: number;
 
+  /** Source-decode failures and explicit migrated-with-visual-loss warnings. */
   @Field(() => [CollaborationMigrationIssue])
   flaggedDocuments!: CollaborationMigrationIssue[];
 

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
@@ -1,5 +1,7 @@
 import { createRequire } from 'node:module';
 import { CollaborationContentType } from '@common/enums/collaboration.content.type';
+import { LogContext } from '@common/enums/logging.context';
+import { EntityNotFoundException } from '@common/exceptions';
 import { compressText, decompressText } from '@common/utils/compression.util';
 import { CalloutContributionDefaults } from '@domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.entity';
 import { markdownToYjsV2State } from '@domain/common/memo/conversion';
@@ -29,10 +31,9 @@ import { LegacyContentRecord } from './legacy.content.record';
 const Y = createRequire(__filename)('yjs') as typeof import('yjs');
 
 /**
- * A minimal `DocumentService` stub. `getDocumentFromURL` resolves a legacy
- * `BinaryFileData.url` to its file-service document (whose `.id` is the locator);
- * the URL helpers mirror the real base-path id extraction the dangling-ref
- * fallback uses.
+ * A minimal `DocumentService` stub. Migration extracts only an exact-route UUID
+ * from a legacy `BinaryFileData.url`, resolves it locally through
+ * `getDocumentOrFail`, and separately proves its file-service bytes exist.
  */
 const documentServiceMock = () => ({
   getDocumentFromURL: vi.fn(),
@@ -102,6 +103,13 @@ const documentAuthorizationServiceMock = () => ({
 const VALID_PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
 const VALID_PNG_DATA_URL = `data:image/png;base64,${VALID_PNG_B64}`;
+
+const missingDocument = (documentID: string) =>
+  new EntityNotFoundException(
+    'Not able to locate document with the specified ID',
+    LogContext.STORAGE_BUCKET,
+    { documentID }
+  );
 
 /**
  * Full cold-load chain resolver: decode the STORED fork snapshot → find the LIVE
@@ -557,7 +565,9 @@ describe('CollaborationMigrationService', () => {
       fileService = {
         createSnapshotInBucket: vi.fn(),
         deleteDocument: vi.fn().mockResolvedValue(undefined),
-        getContentBatch: vi.fn(),
+        getContentBatch: vi.fn(async (ids: string[]) =>
+          ids.map(id => ({ id, found: true, contentBase64: 'AQ==' }))
+        ),
       };
       documentService = documentServiceMock();
       storageBucketService = storageBucketServiceMock();
@@ -1049,11 +1059,77 @@ describe('CollaborationMigrationService', () => {
         files: { [opts.fileId]: opts.file },
       });
 
+    // Minimized from another_row.txt. The failed row has two live image
+    // elements sharing one fileId/URL and a third image using another fileId.
+    // Add one ordinary element so lossy salvage proves usable board content is
+    // retained, not merely that an empty snapshot can be published.
+    const sharedMissingMediaScene = (): string =>
+      JSON.stringify({
+        type: 'excalidraw',
+        version: 2,
+        elements: [
+          {
+            id: 'rect-survives',
+            type: 'rectangle',
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            index: 'a0',
+          },
+          {
+            id: 'Ll_d9HPJ561cHPIcoS_ml',
+            type: 'image',
+            fileId: 'fd57ee7c7f9fc5d9f5e52616d5b761a5ba893828',
+            x: 20,
+            y: 20,
+            width: 10,
+            height: 10,
+            index: 'a1',
+          },
+          {
+            id: 'NNXO5EEpo0XfbW-Nzgpa5',
+            type: 'image',
+            fileId: 'fd57ee7c7f9fc5d9f5e52616d5b761a5ba893828',
+            x: 40,
+            y: 20,
+            width: 10,
+            height: 10,
+            index: 'a2',
+          },
+          {
+            id: 'kkawEszJx29MZHsNZsZJc',
+            type: 'image',
+            fileId: 'f69966b9685a5624f7d9d0e7dfc2236a741302d1',
+            x: 60,
+            y: 20,
+            width: 10,
+            height: 10,
+            index: 'a3',
+          },
+        ],
+        appState: {},
+        files: {
+          fd57ee7c7f9fc5d9f5e52616d5b761a5ba893828: {
+            id: 'fd57ee7c7f9fc5d9f5e52616d5b761a5ba893828',
+            url: 'https://acc.alkem.io/api/private/rest/storage/document/23a19cd1-f2d5-4d4c-b4a1-87c4fc4fd5d7',
+            dataURL: '',
+            mimeType: 'image/jpeg',
+          },
+          f69966b9685a5624f7d9d0e7dfc2236a741302d1: {
+            id: 'f69966b9685a5624f7d9d0e7dfc2236a741302d1',
+            url: 'https://acc.alkem.io/api/private/rest/storage/document/7d18aec9-c330-49c4-8818-50ff8d5f76e8',
+            dataURL: '',
+            mimeType: 'image/png',
+          },
+        },
+      });
+
     // Wire a single legacy whiteboard through migrateAll and capture the snapshot
     // buffer handed to file-service. Returns the captured buffer.
     const migrateOneWhiteboard = async (
       sceneJSON: string,
-      options: { snapshotError?: Error } = {}
+      options: { snapshotError?: Error; dryRun?: boolean } = {}
     ) => {
       const compressed = await compressText(sceneJSON);
       const update = updateQB();
@@ -1078,7 +1154,7 @@ describe('CollaborationMigrationService', () => {
           }
         );
       }
-      const summary = await svc.migrateAll();
+      const summary = await svc.migrateAll({ dryRun: options.dryRun });
       return { summary, captured, update };
     };
 
@@ -1218,6 +1294,55 @@ describe('CollaborationMigrationService', () => {
       });
     });
 
+    it('salvages a legacy Whiteboard contribution default with genuinely missing visual bytes and flags the migrated default', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      const storedContent = await compressText(
+        legacyMediaScene({
+          fileId: 'file-default',
+          file: {
+            id: 'file-default',
+            url: `https://acc.alkem.io/api/private/rest/storage/document/${locator}`,
+          },
+        })
+      );
+      const update = updateQB();
+      documentService.getDocumentOrFail.mockRejectedValue(
+        missingDocument(locator)
+      );
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      contributionDefaults.query.mockResolvedValueOnce([
+        {
+          id: 'default-missing-media',
+          storedContent,
+          storageBucketId: 'callout-bucket-media',
+        },
+      ]);
+      contributionDefaults.createQueryBuilder.mockReturnValue(update.qb);
+
+      const summary = await svc.migrateWhiteboards();
+
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
+      expect(summary.flaggedDocuments).toEqual([
+        {
+          id: 'default-missing-media',
+          reason: expect.stringMatching(/img-1.*file-default/),
+        },
+      ]);
+      const canonical = await decompressText(
+        (
+          update.set.mock.calls as unknown as Array<
+            [{ whiteboardContent: string }]
+          >
+        )[0][0].whiteboardContent
+      );
+      expect(
+        await readStoredElementIds(Buffer.from(canonical, 'base64'))
+      ).toEqual(['rect-1']);
+      expect(
+        await readStoredAssetLocators(Buffer.from(canonical, 'base64'))
+      ).toEqual({});
+    });
+
     it('does not partially publish a default when media authorization fails and compensates the up-homed file', async () => {
       const storedContent = await compressText(
         legacyMediaScene({
@@ -1290,11 +1415,66 @@ describe('CollaborationMigrationService', () => {
       ]);
     });
 
-    it('CRITICAL: migrates a legacy media whiteboard — FILES holds locator STRINGS (resolved via getDocumentFromURL), never BinaryFileData objects', async () => {
-      const url = 'https://alkem.io/api/private/rest/storage/document/DOC-XYZ';
-      documentService.getDocumentFromURL.mockResolvedValue({
-        id: 'DOC-XYZ',
-      } as any);
+    it("does not report this attempt's visual-loss warning when a different canonical default wins the CAS", async () => {
+      const missingLocator = '11111111-2222-4333-8444-555555555555';
+      const storedContent = await compressText(
+        legacyMediaScene({
+          fileId: 'file-default',
+          file: {
+            id: 'file-default',
+            url: `https://acc.alkem.io/api/private/rest/storage/document/${missingLocator}`,
+          },
+        })
+      );
+      const winnerBytes = await whiteboardSceneToYjsV2State(
+        JSON.stringify({
+          type: 'excalidraw',
+          version: 2,
+          elements: [
+            {
+              id: 'winner-rect',
+              type: 'rectangle',
+              x: 0,
+              y: 0,
+              width: 10,
+              height: 10,
+              index: 'a0',
+            },
+          ],
+          appState: {},
+          files: {},
+        }),
+        {}
+      );
+      const winnerStored = await compressText(
+        Buffer.from(winnerBytes).toString('base64')
+      );
+      const update = updateQB(0);
+      documentService.getDocumentOrFail.mockRejectedValue(
+        missingDocument(missingLocator)
+      );
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      contributionDefaults.query
+        .mockResolvedValueOnce([
+          {
+            id: 'default-cas-lossy-loser',
+            storedContent,
+            storageBucketId: 'callout-bucket-cas',
+          },
+        ])
+        .mockResolvedValueOnce([{ whiteboardContent: winnerStored }]);
+      contributionDefaults.createQueryBuilder.mockReturnValue(update.qb);
+
+      const summary = await svc.migrateWhiteboards();
+
+      expect(summary).toMatchObject({ migrated: 1, flagged: 0, failed: 0 });
+      expect(summary.flaggedDocuments).toEqual([]);
+    });
+
+    it('CRITICAL: migrates a legacy media whiteboard — FILES holds byte-proven locator STRINGS, never BinaryFileData objects', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      const url = `https://alkem.io/api/private/rest/storage/document/${locator}`;
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
 
       const { summary, captured, update } = await migrateOneWhiteboard(
         legacyMediaScene({
@@ -1307,16 +1487,15 @@ describe('CollaborationMigrationService', () => {
       expect(summary.failed).toBe(0);
       expect(summary.flagged).toBe(0);
       // Resolved the legacy media url to its file-service document id (the locator).
-      expect(documentService.getDocumentFromURL).toHaveBeenCalledWith(
-        url,
-        expect.anything()
-      );
+      expect(documentService.getDocumentOrFail).toHaveBeenCalledWith(locator, {
+        loadEagerRelations: false,
+      });
       // The stored FILES map holds a locator STRING, read losslessly through the
       // REAL fork — NO loud throw, the exact shape the unified read path expects.
       // (readAssetLocators would THROW here if the map held a BinaryFileData object,
       // which is precisely the pre-fix bug.)
       expect(await readStoredAssetLocators(captured.buffer!)).toEqual({
-        'file-abc': 'DOC-XYZ',
+        'file-abc': locator,
       });
       // Discriminating: the raw FILES value is a primitive string, not an object.
       const doc = new Y.Doc();
@@ -1373,7 +1552,7 @@ describe('CollaborationMigrationService', () => {
       });
     });
 
-    it('fails closed for a cross-host URL on the document route whose suffix is not a UUID', async () => {
+    it('never trusts a cross-host document-route suffix that is not a UUID; it salvages the board and flags the removed image', async () => {
       const { summary, captured } = await migrateOneWhiteboard(
         legacyMediaScene({
           fileId: 'file-1',
@@ -1384,8 +1563,8 @@ describe('CollaborationMigrationService', () => {
         })
       );
 
-      expect(summary).toMatchObject({ migrated: 0, failed: 1 });
-      expect(captured.buffer).toBeUndefined();
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
+      expect(await readStoredElementIds(captured.buffer!)).toEqual(['rect-1']);
       expect(documentService.getDocumentOrFail).not.toHaveBeenCalled();
       expect(documentService.getDocumentFromURL).not.toHaveBeenCalled();
     });
@@ -1393,7 +1572,7 @@ describe('CollaborationMigrationService', () => {
     it('up-homes retained inline bytes when an historical URL locator no longer exists', async () => {
       const deadLocator = '11111111-2222-4333-8444-555555555555';
       documentService.getDocumentOrFail.mockRejectedValue(
-        new Error('missing current row')
+        missingDocument(deadLocator)
       );
 
       const { summary, captured } = await migrateOneWhiteboard(
@@ -1416,30 +1595,328 @@ describe('CollaborationMigrationService', () => {
       expect(uphomedId).not.toBe(deadLocator);
     });
 
-    it('preserves the embedded document id for a dangling media ref — valid Alkemio URL, no live row, and NO inline bytes (case 3)', async () => {
-      // Explicitly NO dataURL, so this exercises the dangling-id fallback (case 3),
-      // not a masked dataURL up-home (case 2).
-      documentService.getDocumentFromURL.mockResolvedValue(undefined);
+    it('salvages the exact shared-reference shape: removes every image using the missing fileId, keeps unrelated content and a recoverable image, and flags the row', async () => {
+      const missingLocator = '23a19cd1-f2d5-4d4c-b4a1-87c4fc4fd5d7';
+      const recoverableLocator = '7d18aec9-c330-49c4-8818-50ff8d5f76e8';
+      documentService.getDocumentOrFail.mockImplementation(
+        async (documentId: string) => {
+          if (documentId === recoverableLocator) {
+            return { id: recoverableLocator } as any;
+          }
+          throw missingDocument(documentId);
+        }
+      );
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        sharedMissingMediaScene()
+      );
+
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
+      expect(summary.flaggedDocuments).toHaveLength(1);
+      expect(summary.flaggedDocuments[0]).toMatchObject({ id: 'w1' });
+      expect(summary.flaggedDocuments[0].reason).toContain(
+        'Ll_d9HPJ561cHPIcoS_ml'
+      );
+      expect(summary.flaggedDocuments[0].reason).toContain(
+        'NNXO5EEpo0XfbW-Nzgpa5'
+      );
+      expect(summary.flaggedDocuments[0].reason).toContain(
+        'fd57ee7c7f9fc5d9f5e52616d5b761a5ba893828'
+      );
+      expect((await readStoredElementIds(captured.buffer!)).sort()).toEqual([
+        'kkawEszJx29MZHsNZsZJc',
+        'rect-survives',
+      ]);
+      expect(await readStoredAssetLocators(captured.buffer!)).toEqual({
+        f69966b9685a5624f7d9d0e7dfc2236a741302d1: recoverableLocator,
+      });
+      // One descriptor lookup per phase, not one lookup per image element.
+      expect(
+        documentService.getDocumentOrFail.mock.calls.filter(
+          ([id]) => id === missingLocator
+        )
+      ).toHaveLength(2);
+      expect(
+        documentService.getDocumentOrFail.mock.calls.filter(
+          ([id]) => id === recoverableLocator
+        )
+      ).toHaveLength(2);
+      expect(fileService.getContentBatch).toHaveBeenCalledTimes(2);
+    });
+
+    it('dry-run predicts the same shared-reference visual loss without uploads, authorization, snapshot writes, or pointer mutation', async () => {
+      const recoverableLocator = '7d18aec9-c330-49c4-8818-50ff8d5f76e8';
+      documentService.getDocumentOrFail.mockImplementation(
+        async (documentId: string) => {
+          if (documentId === recoverableLocator) {
+            return { id: recoverableLocator } as any;
+          }
+          throw missingDocument(documentId);
+        }
+      );
+
+      const { summary, captured, update } = await migrateOneWhiteboard(
+        sharedMissingMediaScene(),
+        { dryRun: true }
+      );
+
+      expect(summary).toMatchObject({
+        migrated: 1,
+        flagged: 1,
+        failed: 0,
+        dryRun: true,
+      });
+      expect(summary.flaggedDocuments[0].reason).toMatch(
+        /Ll_d9HPJ561cHPIcoS_ml, NNXO5EEpo0XfbW-Nzgpa5.*fd57ee7c7f9fc5d9f5e52616d5b761a5ba893828/
+      );
+      expect(captured.buffer).toBeUndefined();
+      expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
+      expect(
+        storageBucketService.uploadFileAsDocumentFromBuffer
+      ).not.toHaveBeenCalled();
+      expect(
+        documentAuthorizationService.applyAuthorizationPolicy
+      ).not.toHaveBeenCalled();
+      expect(update.set).not.toHaveBeenCalled();
+      expect(fileService.getContentBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not report this attempt's visual-loss warning when a different canonical snapshot wins the row CAS", async () => {
+      const recoverableLocator = '7d18aec9-c330-49c4-8818-50ff8d5f76e8';
+      documentService.getDocumentOrFail.mockImplementation(
+        async (documentId: string) => {
+          if (documentId === recoverableLocator) {
+            return { id: recoverableLocator } as any;
+          }
+          throw missingDocument(documentId);
+        }
+      );
+      const compressed = await compressText(sharedMissingMediaScene());
+      const update = updateQB(0);
+      whiteboard.createQueryBuilder
+        .mockReturnValueOnce(
+          queryBuilderMock([
+            [{ id: 'w1', content: compressed, storageBucketId: 'sb-w1' }],
+          ])
+        )
+        .mockReturnValueOnce(update.qb)
+        .mockReturnValueOnce(
+          convergenceQB({
+            migrated: true,
+            contentPointer: 'winner-snapshot',
+          })
+        );
+      memo.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      fileService.createSnapshotInBucket.mockResolvedValue({
+        id: 'loser-snapshot',
+        reused: false,
+      });
+
+      const summary = await svc.migrateAll();
+
+      expect(summary).toMatchObject({ migrated: 1, flagged: 0, failed: 0 });
+      expect(summary.flaggedDocuments).toEqual([]);
+      expect(fileService.deleteDocument).toHaveBeenCalledWith('loser-snapshot');
+    });
+
+    it('falls back to retained dataURL bytes when metadata exists but file-service reports the locator content missing', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      fileService.getContentBatch.mockResolvedValue([
+        { id: locator, found: false },
+      ]);
 
       const { summary, captured } = await migrateOneWhiteboard(
         legacyMediaScene({
           fileId: 'file-1',
           file: {
             id: 'file-1',
-            url: 'https://alkem.io/api/private/rest/storage/document/DEAD-DOC',
-            // no dataURL
+            mimeType: 'image/png',
+            url: `https://acc.alkem.io/api/private/rest/storage/document/${locator}`,
+            dataURL: VALID_PNG_DATA_URL,
           },
         })
       );
 
-      expect(summary.migrated).toBe(1);
-      expect(summary.failed).toBe(0);
-      // The reference is preserved by extracting the id embedded in the url, so the
-      // asset points exactly where it did pre-006 — never a new crash.
+      expect(summary).toMatchObject({ migrated: 1, flagged: 0, failed: 0 });
+      const [uphomedId] = [...storageBucketService.store.keys()];
       expect(await readStoredAssetLocators(captured.buffer!)).toEqual({
-        'file-1': 'DEAD-DOC',
+        'file-1': uphomedId,
       });
-      // No inline bytes → no up-home occurred (this is genuinely case 3, not a masked case 2).
+      expect(uphomedId).not.toBe(locator);
+    });
+
+    it('treats an existing metadata row with empty file-service content as proven visual loss, never as a usable locator', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      fileService.getContentBatch.mockResolvedValue([
+        { id: locator, found: true, contentBase64: '' },
+      ]);
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            url: `https://alkem.io/api/private/rest/storage/document/${locator}`,
+          },
+        })
+      );
+
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
+      expect(await readStoredElementIds(captured.buffer!)).toEqual(['rect-1']);
+      expect(await readStoredAssetLocators(captured.buffer!)).toEqual({});
+    });
+
+    it('fails re-runnably instead of deleting a visual when locator byte validation is malformed or throws', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      fileService.getContentBatch.mockResolvedValue([
+        { id: locator, found: true, contentBase64: 'not-base64!!!' },
+      ]);
+
+      const malformed = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            url: `https://alkem.io/api/private/rest/storage/document/${locator}`,
+          },
+        })
+      );
+
+      expect(malformed.summary).toMatchObject({
+        migrated: 0,
+        flagged: 0,
+        failed: 1,
+      });
+      expect(malformed.captured.buffer).toBeUndefined();
+    });
+
+    it('fails re-runnably when locator byte validation returns a different file id', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      fileService.getContentBatch.mockResolvedValue([
+        {
+          id: '66666666-7777-4888-8999-000000000000',
+          found: true,
+          contentBase64: VALID_PNG_B64,
+        },
+      ]);
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            url: `https://alkem.io/api/private/rest/storage/document/${locator}`,
+          },
+        })
+      );
+
+      expect(summary).toMatchObject({ migrated: 0, flagged: 0, failed: 1 });
+      expect(summary.failedDocuments[0].reason).toMatch(/different id/);
+      expect(captured.buffer).toBeUndefined();
+      expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
+    });
+
+    it('fails re-runnably on a transient locator-content lookup error instead of deleting the visual', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      fileService.getContentBatch.mockRejectedValue(
+        new Error('file-service temporarily unavailable')
+      );
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            url: `https://alkem.io/api/private/rest/storage/document/${locator}`,
+          },
+        })
+      );
+
+      expect(summary).toMatchObject({ migrated: 0, flagged: 0, failed: 1 });
+      expect(captured.buffer).toBeUndefined();
+      expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates byte checks when different legacy fileIds carry the same locator', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      const scene = JSON.stringify({
+        type: 'excalidraw',
+        version: 2,
+        elements: [
+          {
+            id: 'img-a',
+            type: 'image',
+            fileId: 'file-a',
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            index: 'a0',
+          },
+          {
+            id: 'img-b',
+            type: 'image',
+            fileId: 'file-b',
+            x: 20,
+            y: 0,
+            width: 10,
+            height: 10,
+            index: 'a1',
+          },
+        ],
+        files: {
+          'file-a': {
+            url: `https://alkem.io/api/private/rest/storage/document/${locator}`,
+          },
+          'file-b': {
+            url: `https://acc.alkem.io/api/private/rest/storage/document/${locator}`,
+          },
+        },
+      });
+
+      const { summary, captured } = await migrateOneWhiteboard(scene);
+
+      expect(summary.failedDocuments).toEqual([]);
+      expect(summary).toMatchObject({ migrated: 1, flagged: 0, failed: 0 });
+      expect(await readStoredAssetLocators(captured.buffer!)).toEqual({
+        'file-a': locator,
+        'file-b': locator,
+      });
+      // Once in planning and once in the real pass, never once per fileId.
+      expect(fileService.getContentBatch).toHaveBeenCalledTimes(2);
+    });
+
+    it('migrates a current-host missing-row board with explicit visual-loss warning instead of a dangling locator', async () => {
+      const deadLocator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockRejectedValue(
+        missingDocument(deadLocator)
+      );
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            url: `https://alkem.io/api/private/rest/storage/document/${deadLocator}`,
+          },
+        })
+      );
+
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
+      expect(summary.flaggedDocuments).toEqual([
+        {
+          id: 'w1',
+          reason: expect.stringMatching(/img-1.*file-1/),
+        },
+      ]);
+      expect(await readStoredElementIds(captured.buffer!)).toEqual(['rect-1']);
+      expect(await readStoredAssetLocators(captured.buffer!)).toEqual({});
       expect(
         storageBucketService.uploadFileAsDocumentFromBuffer
       ).not.toHaveBeenCalled();
@@ -1450,7 +1927,10 @@ describe('CollaborationMigrationService', () => {
       // dataURL on the uploaded descriptor). If the Alkemio row is gone at migration time but
       // the inline bytes are valid, pre-006 rendered from the bytes — a RECOVERABLE image.
       // Returning the dead-doc id would turn it into an unresolvable locator = data loss.
-      documentService.getDocumentFromURL.mockResolvedValue(undefined);
+      const deadLocator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockRejectedValue(
+        missingDocument(deadLocator)
+      );
       const expectedBytes = Buffer.from(VALID_PNG_B64, 'base64');
 
       const { summary, captured } = await migrateOneWhiteboard(
@@ -1459,7 +1939,7 @@ describe('CollaborationMigrationService', () => {
           file: {
             id: 'file-1',
             mimeType: 'image/png',
-            url: 'https://alkem.io/api/private/rest/storage/document/DEAD-DOC',
+            url: `https://alkem.io/api/private/rest/storage/document/${deadLocator}`,
             dataURL: VALID_PNG_DATA_URL,
           },
         })
@@ -1482,7 +1962,7 @@ describe('CollaborationMigrationService', () => {
       const [uphomedId] = [...storageBucketService.store.keys()];
       const locators = await readStoredAssetLocators(captured.buffer!);
       expect(locators).toEqual({ 'file-1': uphomedId });
-      expect(locators['file-1']).not.toBe('DEAD-DOC');
+      expect(locators['file-1']).not.toBe(deadLocator);
 
       // Full cold-load chain: image element → FILES locator → bucket resolves to the exact bytes.
       const resolved = await resolveImageFromStore(
@@ -1494,7 +1974,7 @@ describe('CollaborationMigrationService', () => {
       expect(resolved.bytes.equals(expectedBytes)).toBe(true);
     });
 
-    it('FAILS the record when a LIVE image references a non-Alkemio external url that cannot become a locator (no broken migration; pointer stays NULL/rerunnable; no snapshot/CAS)', async () => {
+    it('migrates remaining content and flags visual loss when a live external-only image has no recoverable bytes', async () => {
       const { summary, captured, update } = await migrateOneWhiteboard(
         legacyMediaScene({
           fileId: 'file-1',
@@ -1502,14 +1982,13 @@ describe('CollaborationMigrationService', () => {
         })
       );
 
-      // An external-only url can never become a locator, and a LIVE image references it —
-      // migrating would ship a permanently-broken image. Fail instead: pointer stays NULL
-      // (the pending-only worker retries after the operator remediates), no snapshot, no CAS.
-      expect(summary.migrated).toBe(0);
-      expect(summary.failed).toBe(1);
-      expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
-      expect(captured.buffer).toBeUndefined();
-      expect(update.set).not.toHaveBeenCalled();
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
+      expect(summary.flaggedDocuments[0]).toMatchObject({
+        id: 'w1',
+        reason: expect.stringMatching(/img-1.*file-1/),
+      });
+      expect(await readStoredElementIds(captured.buffer!)).toEqual(['rect-1']);
+      expect(update.set).toHaveBeenCalled();
       // Never fetched or stored the external url (SSRF / no-external-locator).
       expect(documentService.getDocumentFromURL).not.toHaveBeenCalled();
     });
@@ -1527,6 +2006,55 @@ describe('CollaborationMigrationService', () => {
       expect(summary.migrated).toBe(1);
       expect(summary.failed).toBe(0);
       expect(await readStoredAssetLocators(captured.buffer!)).toEqual({});
+    });
+
+    it('issues zero legacy-media lookups for deleted images and unreferenced descriptors', async () => {
+      const deletedLocator = '11111111-2222-4333-8444-555555555555';
+      const unreferencedLocator = '66666666-7777-4888-8999-000000000000';
+      const scene = JSON.stringify({
+        type: 'excalidraw',
+        version: 2,
+        elements: [
+          {
+            id: 'rect-1',
+            type: 'rectangle',
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            index: 'a0',
+          },
+          {
+            id: 'deleted-image',
+            type: 'image',
+            fileId: 'deleted-file',
+            isDeleted: true,
+            updated: 1,
+            x: 20,
+            y: 0,
+            width: 10,
+            height: 10,
+            index: 'a1',
+          },
+        ],
+        appState: {},
+        files: {
+          'deleted-file': {
+            url: `https://alkem.io/api/private/rest/storage/document/${deletedLocator}`,
+          },
+          'unreferenced-file': {
+            url: `https://alkem.io/api/private/rest/storage/document/${unreferencedLocator}`,
+          },
+        },
+      });
+
+      const { summary, captured } = await migrateOneWhiteboard(scene);
+
+      expect(summary.failedDocuments).toEqual([]);
+      expect(summary).toMatchObject({ migrated: 1, flagged: 0, failed: 0 });
+      expect(await readStoredAssetLocators(captured.buffer!)).toEqual({});
+      expect(documentService.getDocumentOrFail).not.toHaveBeenCalled();
+      expect(fileService.getContentBatch).not.toHaveBeenCalled();
     });
 
     it('CRITICAL (dataURL up-home): the image survives cold-load — element→FILES→bucket resolves to the exact decoded bytes', async () => {
@@ -1917,7 +2445,7 @@ describe('CollaborationMigrationService', () => {
       });
     });
 
-    it('FAILS the record when a LIVE image references a descriptor with no usable url and no inline bytes (unrepresentable live media blocks the row, not a broken migration)', async () => {
+    it('salvages and flags a board when a LIVE image descriptor has neither a usable url nor inline bytes', async () => {
       const { summary, captured, update } = await migrateOneWhiteboard(
         legacyMediaScene({
           fileId: 'file-1',
@@ -1925,17 +2453,13 @@ describe('CollaborationMigrationService', () => {
         })
       );
 
-      // The image bytes are unrecoverable (no url, no dataURL) and a LIVE image references
-      // it → fail the row (blocks cleanup until remediated) rather than migrate a broken
-      // image. No up-home, no snapshot, no CAS; pointer stays NULL/rerunnable.
-      expect(summary.migrated).toBe(0);
-      expect(summary.failed).toBe(1);
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
       expect(
         storageBucketService.uploadFileAsDocumentFromBuffer
       ).not.toHaveBeenCalled();
-      expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
-      expect(captured.buffer).toBeUndefined();
-      expect(update.set).not.toHaveBeenCalled();
+      expect(fileService.createSnapshotInBucket).toHaveBeenCalled();
+      expect(await readStoredElementIds(captured.buffer!)).toEqual(['rect-1']);
+      expect(update.set).toHaveBeenCalled();
     });
 
     it('an UNREFERENCED descriptor with no usable url and no bytes (no live image) is skipped, still migrating', async () => {
@@ -1977,10 +2501,10 @@ describe('CollaborationMigrationService', () => {
       expect(summary.migrated).toBe(0);
     });
 
-    // --- Release-A migration WRITE-PATH guards: planning builds a REPRESENTABLE snapshot with
-    // ZERO writes, then verifyContent rejects a malformed scene, an unrepresentable live image,
-    // a malformed-base64 dataURL, an unknown element type, or a corrupt memo BEFORE any upload
-    // or pointer CAS (pointer stays NULL / re-runnable). ---
+    // --- Release-A migration WRITE-PATH guards: planning performs read-only resolution and
+    // builds the exact structurally-salvaged snapshot with ZERO writes. Malformed scene/schema,
+    // transient locator lookup failures, or a corrupt memo still fail before any upload/CAS;
+    // proven unusable visual bytes are removed + explicitly flagged instead. ---
 
     // Wire one legacy whiteboard row for a DRY-RUN (no second update QB — dry-run never writes
     // a pointer), then run migrateAll in preview mode.
@@ -1996,8 +2520,8 @@ describe('CollaborationMigrationService', () => {
     };
 
     // Assert the migration touched NO side-effect surface: no snapshot upload, no dataURL
-    // up-home, no up-home authorization, and no Alkemio-document DB lookup. (The pointer CAS is
-    // asserted per-test via its own update QB where one is wired.)
+    // up-home, and no up-home authorization. Read-only document/content lookup is permitted so
+    // dry-run predicts the same salvage as the real migration.
     const expectNoMigrationWrites = () => {
       expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
       expect(
@@ -2009,7 +2533,7 @@ describe('CollaborationMigrationService', () => {
       expect(documentService.getDocumentFromURL).not.toHaveBeenCalled();
     };
 
-    it('dry-run: a LIVE image referencing an external-only url (no inline bytes) is UNREPRESENTABLE → failed in planning, ZERO writes', async () => {
+    it('dry-run: an external-only image with no bytes predicts migrated + flagged salvage, with ZERO writes', async () => {
       const summary = await dryRunOneWhiteboard(
         legacyMediaScene({
           fileId: 'file-x',
@@ -2021,8 +2545,7 @@ describe('CollaborationMigrationService', () => {
         })
       );
       expect(summary.dryRun).toBe(true);
-      expect(summary.failed).toBe(1);
-      expect(summary.migrated).toBe(0);
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
       expectNoMigrationWrites();
     });
 
@@ -2043,7 +2566,7 @@ describe('CollaborationMigrationService', () => {
       expectNoMigrationWrites();
     });
 
-    it('dry-run: a LIVE image dataURL with MALFORMED base64 padding (TQ=) → unrepresentable → failed, ZERO writes (strict base64)', async () => {
+    it('dry-run: malformed inline base64 is proven unusable and predicts flagged visual removal with ZERO writes', async () => {
       const summary = await dryRunOneWhiteboard(
         legacyMediaScene({
           fileId: 'file-x',
@@ -2054,8 +2577,7 @@ describe('CollaborationMigrationService', () => {
           },
         })
       );
-      expect(summary.failed).toBe(1);
-      expect(summary.migrated).toBe(0);
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
       expectNoMigrationWrites();
     });
 
@@ -2075,7 +2597,7 @@ describe('CollaborationMigrationService', () => {
       expectNoMigrationWrites();
     });
 
-    it('dry-run: a LIVE image dataURL whose base64 marker is a MALFORMED token (;base64junk) → unrepresentable → failed, ZERO writes', async () => {
+    it('dry-run: a malformed base64 marker predicts flagged visual removal with ZERO writes', async () => {
       const summary = await dryRunOneWhiteboard(
         legacyMediaScene({
           fileId: 'file-x',
@@ -2088,8 +2610,7 @@ describe('CollaborationMigrationService', () => {
           },
         })
       );
-      expect(summary.failed).toBe(1);
-      expect(summary.migrated).toBe(0);
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
       expectNoMigrationWrites();
     });
 
@@ -2109,7 +2630,7 @@ describe('CollaborationMigrationService', () => {
       expectNoMigrationWrites();
     });
 
-    it('migrate (real): a LIVE image dataURL with MALFORMED base64 → failed, pointer stays NULL, ZERO upload/authz/snapshot/CAS', async () => {
+    it('migrate (real): malformed inline base64 removes only the image, flags the row, and publishes the usable remainder', async () => {
       const compressed = await compressText(
         legacyMediaScene({
           fileId: 'file-x',
@@ -2129,15 +2650,22 @@ describe('CollaborationMigrationService', () => {
         )
         .mockReturnValueOnce(update.qb);
       memo.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      fileService.createSnapshotInBucket.mockResolvedValue({
+        id: 'snap-w1',
+        reused: false,
+      });
 
       const summary = await svc.migrateAll();
 
-      expect(summary.failed).toBe(1);
-      expect(summary.migrated).toBe(0);
-      // Rejected in PLANNING → no up-home upload, no up-home authz, no snapshot, and the
-      // pointer CAS never runs (stays NULL / re-runnable).
-      expectNoMigrationWrites();
-      expect(update.set).not.toHaveBeenCalled();
+      expect(summary).toMatchObject({ migrated: 1, flagged: 1, failed: 0 });
+      expect(
+        storageBucketService.uploadFileAsDocumentFromBuffer
+      ).not.toHaveBeenCalled();
+      expect(
+        documentAuthorizationService.applyAuthorizationPolicy
+      ).not.toHaveBeenCalled();
+      expect(fileService.createSnapshotInBucket).toHaveBeenCalled();
+      expect(update.set).toHaveBeenCalled();
     });
 
     it('migrate: a MALFORMED nonempty scene (unparseable JSON) → failed, ZERO writes (never silently emptied)', async () => {

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
@@ -1471,6 +1471,127 @@ describe('CollaborationMigrationService', () => {
       expect(summary.flaggedDocuments).toEqual([]);
     });
 
+    it("reconciles an ambiguous default CAS to a different canonical winner without attributing this attempt's warning", async () => {
+      const missingLocator = '11111111-2222-4333-8444-555555555555';
+      const storedContent = await compressText(
+        legacyMediaScene({
+          fileId: 'file-default',
+          file: {
+            id: 'file-default',
+            url: `https://acc.alkem.io/api/private/rest/storage/document/${missingLocator}`,
+          },
+        })
+      );
+      const winnerBytes = await whiteboardSceneToYjsV2State(
+        JSON.stringify({
+          type: 'excalidraw',
+          version: 2,
+          elements: [
+            {
+              id: 'winner-rect',
+              type: 'rectangle',
+              x: 0,
+              y: 0,
+              width: 10,
+              height: 10,
+              index: 'a0',
+            },
+          ],
+          appState: {},
+          files: {},
+        }),
+        {}
+      );
+      const winnerStored = await compressText(
+        Buffer.from(winnerBytes).toString('base64')
+      );
+      const update = updateQB();
+      update.execute.mockRejectedValue(new Error('commit outcome unknown'));
+      documentService.getDocumentOrFail.mockRejectedValue(
+        missingDocument(missingLocator)
+      );
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      contributionDefaults.query
+        .mockResolvedValueOnce([
+          {
+            id: 'default-ambiguous-winner',
+            storedContent,
+            storageBucketId: 'callout-bucket-cas',
+          },
+        ])
+        .mockResolvedValueOnce([{ whiteboardContent: winnerStored }]);
+      contributionDefaults.createQueryBuilder.mockReturnValue(update.qb);
+
+      const summary = await svc.migrateWhiteboards();
+
+      expect(summary).toMatchObject({ migrated: 1, flagged: 0, failed: 0 });
+      expect(summary.flaggedDocuments).toEqual([]);
+    });
+
+    it('compensates up-homed media when an ambiguous default CAS is reconciled to no published content', async () => {
+      const storedContent = await compressText(
+        legacyMediaScene({
+          fileId: 'file-default',
+          file: {
+            id: 'file-default',
+            mimeType: 'image/png',
+            dataURL: VALID_PNG_DATA_URL,
+          },
+        })
+      );
+      const update = updateQB();
+      update.execute.mockRejectedValue(new Error('commit outcome unknown'));
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      contributionDefaults.query
+        .mockResolvedValueOnce([
+          {
+            id: 'default-ambiguous-unpublished',
+            storedContent,
+            storageBucketId: 'callout-bucket-cas',
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      contributionDefaults.createQueryBuilder.mockReturnValue(update.qb);
+
+      const summary = await svc.migrateWhiteboards();
+
+      expect(summary).toMatchObject({ migrated: 0, flagged: 0, failed: 1 });
+      expect(documentService.deleteDocument).toHaveBeenCalledWith({
+        ID: 'uphomed-doc-1',
+      });
+    });
+
+    it('preserves up-homed media when both the default CAS outcome and reconciliation read are unavailable', async () => {
+      const storedContent = await compressText(
+        legacyMediaScene({
+          fileId: 'file-default',
+          file: {
+            id: 'file-default',
+            mimeType: 'image/png',
+            dataURL: VALID_PNG_DATA_URL,
+          },
+        })
+      );
+      const update = updateQB();
+      update.execute.mockRejectedValue(new Error('commit outcome unknown'));
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      contributionDefaults.query
+        .mockResolvedValueOnce([
+          {
+            id: 'default-ambiguous-unreadable',
+            storedContent,
+            storageBucketId: 'callout-bucket-cas',
+          },
+        ])
+        .mockRejectedValueOnce(new Error('database unavailable'));
+      contributionDefaults.createQueryBuilder.mockReturnValue(update.qb);
+
+      const summary = await svc.migrateWhiteboards();
+
+      expect(summary).toMatchObject({ migrated: 0, flagged: 0, failed: 1 });
+      expect(documentService.deleteDocument).not.toHaveBeenCalled();
+    });
+
     it('CRITICAL: migrates a legacy media whiteboard — FILES holds byte-proven locator STRINGS, never BinaryFileData objects', async () => {
       const locator = '11111111-2222-4333-8444-555555555555';
       const url = `https://alkem.io/api/private/rest/storage/document/${locator}`;

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
@@ -36,6 +36,7 @@ const Y = createRequire(__filename)('yjs') as typeof import('yjs');
  */
 const documentServiceMock = () => ({
   getDocumentFromURL: vi.fn(),
+  getDocumentOrFail: vi.fn(),
   deleteDocument: vi.fn().mockResolvedValue(undefined),
   isAlkemioDocumentURL: vi.fn((url: string) =>
     url.startsWith('https://alkem.io/api/private/rest/storage/document')
@@ -1337,6 +1338,82 @@ describe('CollaborationMigrationService', () => {
         contentVersion: 0,
         migrated: true,
       });
+    });
+
+    it('recovers a legacy file locator from an historical Alkemio document URL on another deployment host', async () => {
+      // Minimized from a failed production-shaped row: the Excalidraw fileId is
+      // content-derived, while the opaque file-service locator is the UUID in
+      // the legacy document URL. Historical scenes can retain another Alkemio
+      // deployment host even after the owning rows move to the current stack.
+      const fileId = '0123456789abcdef0123456789abcdef01234567';
+      const locator = '11111111-2222-4333-8444-555555555555';
+      const historicalUrl = `https://acc.alkem.io/api/private/rest/storage/document/${locator}`;
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId,
+          file: {
+            id: fileId,
+            mimeType: 'image/jpeg',
+            url: historicalUrl,
+          },
+        })
+      );
+
+      expect(summary).toMatchObject({ migrated: 1, failed: 0 });
+      expect(await readStoredAssetLocators(captured.buffer!)).toEqual({
+        [fileId]: locator,
+      });
+      // Cross-host recovery extracts an opaque id only. It never fetches the
+      // historical host and therefore does not create an SSRF surface.
+      expect(documentService.getDocumentFromURL).not.toHaveBeenCalled();
+      expect(documentService.getDocumentOrFail).toHaveBeenCalledWith(locator, {
+        loadEagerRelations: false,
+      });
+    });
+
+    it('fails closed for a cross-host URL on the document route whose suffix is not a UUID', async () => {
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            url: 'https://external.example/api/private/rest/storage/document/not-a-uuid',
+          },
+        })
+      );
+
+      expect(summary).toMatchObject({ migrated: 0, failed: 1 });
+      expect(captured.buffer).toBeUndefined();
+      expect(documentService.getDocumentOrFail).not.toHaveBeenCalled();
+      expect(documentService.getDocumentFromURL).not.toHaveBeenCalled();
+    });
+
+    it('up-homes retained inline bytes when an historical URL locator no longer exists', async () => {
+      const deadLocator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockRejectedValue(
+        new Error('missing current row')
+      );
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            mimeType: 'image/png',
+            url: `https://acc.alkem.io/api/private/rest/storage/document/${deadLocator}`,
+            dataURL: VALID_PNG_DATA_URL,
+          },
+        })
+      );
+
+      expect(summary).toMatchObject({ migrated: 1, failed: 0 });
+      const [uphomedId] = [...storageBucketService.store.keys()];
+      expect(await readStoredAssetLocators(captured.buffer!)).toEqual({
+        'file-1': uphomedId,
+      });
+      expect(uphomedId).not.toBe(deadLocator);
     });
 
     it('preserves the embedded document id for a dangling media ref — valid Alkemio URL, no live row, and NO inline bytes (case 3)', async () => {

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
@@ -1844,7 +1844,7 @@ describe('CollaborationMigrationService', () => {
       const locator = '11111111-2222-4333-8444-555555555555';
       documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
       fileService.getContentBatch.mockResolvedValue([
-        { id: locator, found: false },
+        { id: locator, found: false, error: 'document not found' },
       ]);
 
       const { summary, captured } = await migrateOneWhiteboard(
@@ -1865,6 +1865,88 @@ describe('CollaborationMigrationService', () => {
         'file-1': uphomedId,
       });
       expect(uphomedId).not.toBe(locator);
+    });
+
+    it.each([
+      ['content unavailable', false],
+      ['backend unavailable', false],
+      ['batch content limit exceeded', true],
+      [undefined, true],
+    ])('fails re-runnably when file-service returns an inconclusive miss (%s, dryRun=%s)', async (error, dryRun) => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      fileService.getContentBatch.mockResolvedValue([
+        { id: locator, found: false, error },
+      ]);
+
+      const { summary, captured } = await migrateOneWhiteboard(
+        legacyMediaScene({
+          fileId: 'file-1',
+          file: {
+            id: 'file-1',
+            mimeType: 'image/png',
+            url: `https://alkem.io/api/private/rest/storage/document/${locator}`,
+            dataURL: VALID_PNG_DATA_URL,
+          },
+        }),
+        { dryRun }
+      );
+
+      expect(summary).toMatchObject({
+        migrated: 0,
+        flagged: 0,
+        failed: 1,
+        dryRun,
+      });
+      expect(summary.failedDocuments[0].reason).toContain('inconclusive');
+      expect(captured.buffer).toBeUndefined();
+      expect(
+        storageBucketService.uploadFileAsDocumentFromBuffer
+      ).not.toHaveBeenCalled();
+      expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
+    });
+
+    it('applies the same inconclusive-miss retry boundary to contribution defaults', async () => {
+      const locator = '11111111-2222-4333-8444-555555555555';
+      const storedContent = await compressText(
+        legacyMediaScene({
+          fileId: 'file-default',
+          file: {
+            id: 'file-default',
+            mimeType: 'image/png',
+            url: `https://alkem.io/api/private/rest/storage/document/${locator}`,
+            dataURL: VALID_PNG_DATA_URL,
+          },
+        })
+      );
+      documentService.getDocumentOrFail.mockResolvedValue({ id: locator });
+      fileService.getContentBatch.mockResolvedValue([
+        { id: locator, found: false, error: 'content unavailable' },
+      ]);
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      contributionDefaults.query.mockResolvedValueOnce([
+        {
+          id: 'default-inconclusive-content',
+          storedContent,
+          storageBucketId: 'callout-bucket-1',
+        },
+      ]);
+
+      const summary = await svc.migrateWhiteboards();
+
+      expect(summary).toMatchObject({
+        migrated: 0,
+        flagged: 0,
+        failed: 1,
+      });
+      expect(summary.failedDocuments[0]).toMatchObject({
+        id: 'default-inconclusive-content',
+        reason: expect.stringContaining('inconclusive'),
+      });
+      expect(contributionDefaults.createQueryBuilder).not.toHaveBeenCalled();
+      expect(
+        storageBucketService.uploadFileAsDocumentFromBuffer
+      ).not.toHaveBeenCalled();
     });
 
     it('treats an existing metadata row with empty file-service content as proven visual loss, never as a usable locator', async () => {

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.ts
@@ -26,6 +26,7 @@ import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { CreateDocumentResult } from '@services/adapters/file-service-adapter/dto/create.document.result';
 import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
+import { isUUID } from 'class-validator';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { IsNull, Repository } from 'typeorm';
 import { LegacyContentRecord } from './legacy.content.record';
@@ -1451,6 +1452,8 @@ export class CollaborationMigrationService {
     const url = typeof file?.url === 'string' ? file.url.trim() : '';
     const isAlkemioUrl =
       url !== '' && this.documentService.isAlkemioDocumentURL(url);
+    const embeddedDocumentId =
+      url !== '' ? this.extractLegacyDocumentId(url) : undefined;
 
     if (planning) {
       // PLANNING (dry-run): prove the descriptor is REPRESENTABLE with ZERO writes, no auth,
@@ -1466,6 +1469,9 @@ export class CollaborationMigrationService {
         if (id) {
           return id;
         }
+      }
+      if (embeddedDocumentId) {
+        return embeddedDocumentId;
       }
       return this.planDataUrlLocator(fileId, file);
     }
@@ -1503,6 +1509,37 @@ export class CollaborationMigrationService {
       return id || undefined;
     }
 
+    // Historical scenes can retain a document URL from another Alkemio
+    // deployment host. The host-specific live URL check above intentionally
+    // rejects it, but the exact document route still carries the opaque UUID
+    // understood by the current file-service. Resolve that UUID against the
+    // current database only; never request the historical host.
+    if (embeddedDocumentId) {
+      try {
+        const document = await this.documentService.getDocumentOrFail(
+          embeddedDocumentId,
+          { loadEagerRelations: false }
+        );
+        return document.id;
+      } catch {
+        // Match the current-host recovery order: retained inline bytes are
+        // stronger evidence than a dangling URL, so up-home them first.
+        const uphomed = await this.uphomeDataUrlAsset(
+          fileId,
+          file,
+          record,
+          createdArtifacts
+        );
+        if (uphomed) {
+          return uphomed;
+        }
+      }
+      // Preserve the original opaque id when neither the current row nor
+      // inline bytes exist. This is no worse than the legacy reference, and
+      // the post-migration verifier will report it if it still has no bytes.
+      return embeddedDocumentId;
+    }
+
     // 4. No usable Alkemio url → up-home inline bytes if present, else skip + surface.
     const uphomed = await this.uphomeDataUrlAsset(
       fileId,
@@ -1523,6 +1560,35 @@ export class CollaborationMigrationService {
       LogContext.COLLABORATION_INTEGRATION
     );
     return undefined;
+  }
+
+  /**
+   * Extracts the opaque document UUID from the configured Alkemio document
+   * route while deliberately ignoring the URL host. Legacy database copies
+   * and environment renames leave otherwise-valid document URLs pointing at
+   * an historical host. Matching the exact route plus a UUID is safe because
+   * this method performs no network request; arbitrary external paths and
+   * non-UUID suffixes remain unrecoverable and fail closed when referenced.
+   */
+  private extractLegacyDocumentId(url: string): string | undefined {
+    try {
+      const candidate = new URL(url);
+      if (candidate.protocol !== 'https:' && candidate.protocol !== 'http:') {
+        return undefined;
+      }
+      const configured = new URL(
+        this.documentService.getDocumentsBaseUrlPath()
+      );
+      const route = configured.pathname.replace(/\/+$/, '');
+      const prefix = `${route}/`;
+      if (!candidate.pathname.startsWith(prefix)) {
+        return undefined;
+      }
+      const id = candidate.pathname.slice(prefix.length);
+      return !id.includes('/') && isUUID(id) ? id : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /**

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.ts
@@ -53,6 +53,17 @@ const DEFAULT_BATCH_SIZE = 200;
 const MEMO_ROOT = 'default';
 
 /**
+ * `content-batch` reports both definitive misses and per-item read failures as
+ * `found: false`. Only these stable endpoint reasons prove that no usable
+ * document/content exists; every other reason is inconclusive and must leave
+ * the source row pending for a retry.
+ */
+const PROVEN_MISSING_CONTENT_REASONS = new Set([
+  'document not found',
+  'content not found',
+]);
+
+/**
  * Strictly decode a valid STANDARD base64 string to bytes, or `undefined` if it is NOT valid
  * standard base64 OR decodes to zero bytes. Node's `Buffer.from(x, 'base64')` is LENIENT — it
  * silently drops any non-alphabet byte and decodes whatever remains ('not-base64!!!' → 7 junk
@@ -1678,7 +1689,15 @@ export class CollaborationMigrationService {
       );
     }
     if (!result.found) {
-      return false;
+      if (
+        typeof result.error === 'string' &&
+        PROVEN_MISSING_CONTENT_REASONS.has(result.error)
+      ) {
+        return false;
+      }
+      throw new Error(
+        `legacy media content lookup was inconclusive: ${result.error ?? 'file-service returned no miss reason'}`
+      );
     }
     if (
       typeof result.contentBase64 !== 'string' ||

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.ts
@@ -1221,23 +1221,27 @@ export class CollaborationMigrationService {
         .execute();
       affected = result.affected;
     } catch (error) {
-      const current = await this.readStoredDefaultContent(record.id).catch(
-        () => undefined
-      );
-      if (current === canonical) {
-        return warnings;
-      }
-      if (current === undefined) {
+      let current: string | undefined;
+      try {
+        current = await this.readStoredDefaultContent(record.id);
+      } catch (reconciliationError) {
+        // As with document rows, an unavailable reconciliation read leaves the
+        // publication outcome unknown. Preserve possible canonical media rather
+        // than deleting assets that the ambiguous UPDATE may have published.
         this.logger.warn?.(
           {
             message:
               'Migration: contribution-default publication outcome is unknown; preserving up-homed media',
             id: record.id,
             error: String(error),
+            reconciliationError: String(reconciliationError),
           },
           LogContext.COLLABORATION_INTEGRATION
         );
         throw error;
+      }
+      if (current === canonical) {
+        return warnings;
       }
       const cleanupFailures = await this.cleanupCreatedArtifacts(
         record.id,
@@ -1247,6 +1251,16 @@ export class CollaborationMigrationService {
         throw new Error(
           `Contribution-default publication failed and media compensation was incomplete: ${String(error)}`
         );
+      }
+      // A different canonical writer owns both the published content and any
+      // visual-loss warning. Once this attempt's artifacts are compensated,
+      // converge successfully without attributing its discarded warnings.
+      if (
+        current &&
+        current !== record.storedContent &&
+        (await this.isCanonicalStoredWhiteboardDefault(current))
+      ) {
+        return [];
       }
       throw error;
     }

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { CollaborationContentType, LogContext } from '@common/enums';
+import { EntityNotFoundException } from '@common/exceptions';
 import { compressText, decompressText } from '@common/utils/compression.util';
 import { CalloutContributionDefaults } from '@domain/collaboration/callout-contribution-defaults/callout.contribution.defaults.entity';
 import {
@@ -10,6 +11,7 @@ import { Memo } from '@domain/common/memo/memo.entity';
 import {
   enumerateLiveImageRefs,
   type LegacyBinaryFileData,
+  type LegacyWhiteboardScene,
   type LiveImageRef,
   parseLegacyWhiteboardScene,
   whiteboardSceneToYjsV2State,
@@ -121,7 +123,8 @@ const parseDataUrl = (
     if (isBase64) {
       // STRICT base64 via the shared decoder — rejects any non-alphabet byte or malformed
       // padding ('not-base64!!!' would otherwise decode to 7 junk bytes and up-home garbage).
-      // `undefined` here FAILS the record.
+      // `undefined` marks these inline bytes unusable; migration can still salvage the
+      // remaining board while explicitly flagging removal of affected live images.
       buffer = decodeStrictBase64(data);
     } else {
       // URI-encoded (non-base64) data URL — historically supported; keep the lenient decode.
@@ -146,23 +149,28 @@ const extensionForMimeType = (mimeType: string): string => {
 /**
  * Outcome of one `migrateAll` run (US6/FR-007). Counters let an operator confirm
  * a clean migration: every reached legacy document either got a snapshot pointer,
- * was flagged (un-decodable, surfaced for review — NEVER silently dropped), or
- * failed (re-runnable). Pending-only at source means every reached record migrates.
+ * was source-flagged and left pending, or failed re-runnably. A board whose usable
+ * content migrated after irrecoverable live visuals were removed increments BOTH
+ * `migrated` and `flagged`, so loss is visible and the operator result is non-clean.
  */
 export interface MigrationSummary {
   total: number;
   migrated: number;
   /** Legacy contribution defaults with no complete owning Callout path. */
   unattached: number;
-  /** Un-decodable legacy content surfaced for manual review (not migrated). */
+  /**
+   * Rows requiring manual review. Source-decode failures are not migrated; lossy
+   * visual salvage is migrated and therefore overlaps with `migrated`.
+   */
   flagged: number;
   /**
    * A record could not be migrated (re-runnable): planning/encode rejected it (malformed
-   * scene, unrepresentable live media, invalid schema/element), a snapshot write / up-home /
-   * authorization failed, or the pointer CAS lost to a concurrent writer.
+   * scene, invalid schema/element, or an inconclusive metadata/content lookup), a snapshot
+   * write / up-home / authorization failed, or publication did not converge to a canonical
+   * pointer/default.
    */
   failed: number;
-  /** The flagged document ids + reasons, for operator follow-up. */
+  /** Flagged document ids + reasons, including explicit migrated-with-loss warnings. */
   flaggedDocuments: { id: string; reason: string }[];
   /** Runtime failures with ids + reasons, for retry/remediation. */
   failedDocuments: { id: string; reason: string }[];
@@ -180,6 +188,11 @@ export interface MigrationOptions {
 interface CreatedMigrationArtifacts {
   assetDocumentIds: string[];
   snapshotDocumentId?: string;
+}
+
+interface EncodedSnapshot {
+  bytes: Buffer;
+  warnings: string[];
 }
 
 interface LegacyWhiteboardDefaultRecord extends LegacyContentRecord {
@@ -376,8 +389,9 @@ export class CollaborationMigrationService {
         continue;
       }
       try {
-        await this.migrateWhiteboardDefault(record, dryRun);
+        const warnings = await this.migrateWhiteboardDefault(record, dryRun);
         summary.migrated++;
+        this.recordMigrationWarnings(summary, record.id, warnings);
       } catch (error) {
         summary.failed++;
         summary.failedDocuments.push({
@@ -440,8 +454,9 @@ export class CollaborationMigrationService {
       }
 
       try {
-        await this.migrateRecord(record, dryRun);
+        const warnings = await this.migrateRecord(record, dryRun);
         summary.migrated++;
+        this.recordMigrationWarnings(summary, record.id, warnings);
       } catch (error) {
         summary.failed++;
         summary.failedDocuments.push({
@@ -473,6 +488,28 @@ export class CollaborationMigrationService {
       LogContext.COLLABORATION_INTEGRATION
     );
     return summary;
+  }
+
+  private recordMigrationWarnings(
+    summary: MigrationSummary,
+    id: string,
+    warnings: string[]
+  ): void {
+    if (warnings.length === 0) {
+      return;
+    }
+    const reason = warnings.join('; ');
+    summary.flagged++;
+    summary.flaggedDocuments.push({ id, reason });
+    this.logger.warn?.(
+      {
+        message:
+          'Collaboration migration: document migrated with explicit visual loss',
+        id,
+        reason,
+      },
+      LogContext.COLLABORATION_INTEGRATION
+    );
   }
 
   /**
@@ -924,7 +961,7 @@ export class CollaborationMigrationService {
   private async migrateRecord(
     record: LegacyContentRecord,
     dryRun: boolean
-  ): Promise<void> {
+  ): Promise<string[]> {
     if (!record.storageBucketId) {
       throw new Error(
         `Document ${record.id} has no storage bucket; cannot write snapshot`
@@ -952,17 +989,16 @@ export class CollaborationMigrationService {
       assetDocumentIds: [],
     };
 
-    // 1. PLANNING (zero writes): build a REPRESENTABILITY-only snapshot — media resolved to
-    //    synthetic/structural locators, no uploads, no auth, no Alkemio-doc lookups — then
-    //    verifyContent it. This catches a malformed scene and every schema/structural defect
-    //    (an external-only live image, a non-array `elements`, a corrupt memo) BEFORE any side
-    //    effect. A throw propagates to migrateAll's per-record catch as `failed`, leaving the
-    //    pointer NULL and re-runnable. (Dry-run does NOT prove file-service resolution of the
-    //    CURRENT locators — post-migrate `--verify` is the definitive resolution gate.)
+    // 1. PLANNING (zero writes): resolve existing media metadata + bytes READ-ONLY and use
+    //    synthetic locators for valid inline bytes, then remove only proven-unrecoverable live
+    //    images and verify the exact planned structure. Malformed scenes/schema, transient
+    //    lookup failures, and corrupt memos fail BEFORE any side effect; proven visual loss is
+    //    returned as an explicit warning. Dry-run therefore predicts real salvage without
+    //    uploading media/snapshots, applying authorization, or mutating the pointer.
     const planned = await this.encodeSnapshot(record, true);
-    this.verifyContent(planned, record.contentType, fork);
+    this.verifyContent(planned.bytes, record.contentType, fork);
     if (dryRun) {
-      return; // dry-run stops after planning — provably zero writes
+      return planned.warnings; // dry-run stops after planning — provably zero writes
     }
 
     // 2. REAL: resolve media for real (Alkemio-doc lookups + dataURL up-home writes), build the
@@ -970,15 +1006,17 @@ export class CollaborationMigrationService {
     //    verifier would reject. EVERY reached (null-pointer) record is seeded, including empty
     //    content (encodeSnapshot returns the canonical empty Y.Doc), so no row is left null.
     let result: CreateDocumentResult;
+    let warnings: string[];
     try {
-      const snapshot = await this.encodeSnapshot(
+      const encoded = await this.encodeSnapshot(
         record,
         false,
         createdArtifacts
       );
-      this.verifyContent(snapshot, record.contentType, fork);
+      this.verifyContent(encoded.bytes, record.contentType, fork);
+      warnings = encoded.warnings;
       result = await this.fileServiceAdapter.createSnapshotInBucket(
-        snapshot,
+        encoded.bytes,
         record.storageBucketId
       );
       // Only a row inserted by this request belongs to this attempt. A reused
@@ -1045,7 +1083,7 @@ export class CollaborationMigrationService {
         throw error;
       }
       if (convergedPointer === result.id) {
-        return;
+        return warnings;
       }
       const cleanupFailures = await this.cleanupCreatedArtifacts(
         record.id,
@@ -1057,12 +1095,12 @@ export class CollaborationMigrationService {
         );
       }
       if (convergedPointer) {
-        return;
+        return [];
       }
       throw error;
     }
     if (updateResult.affected === 1) {
-      return;
+      return warnings;
     }
 
     // A concurrent migration may already have completed both fields. If the
@@ -1098,8 +1136,9 @@ export class CollaborationMigrationService {
             'Concurrent migration converged but artifact compensation was incomplete'
           );
         }
+        return [];
       }
-      return;
+      return warnings;
     }
 
     // Known negative outcome: our CAS changed nothing and no atomic winner is
@@ -1121,7 +1160,7 @@ export class CollaborationMigrationService {
   private async migrateWhiteboardDefault(
     record: LegacyWhiteboardDefaultRecord,
     dryRun: boolean
-  ): Promise<void> {
+  ): Promise<string[]> {
     if (!record.storageBucketId) {
       throw new Error(
         'Contribution default has no owning Callout storage bucket'
@@ -1129,23 +1168,33 @@ export class CollaborationMigrationService {
     }
     const fork = await loadWhiteboardFork();
     const planned = await this.encodeSnapshot(record, true);
-    this.verifyContent(planned, CollaborationContentType.WHITEBOARD, fork);
+    this.verifyContent(
+      planned.bytes,
+      CollaborationContentType.WHITEBOARD,
+      fork
+    );
     if (dryRun) {
-      return;
+      return planned.warnings;
     }
 
     const createdArtifacts: CreatedMigrationArtifacts = {
       assetDocumentIds: [],
     };
     let canonical: string;
+    let warnings: string[];
     try {
-      const snapshot = await this.encodeSnapshot(
+      const encoded = await this.encodeSnapshot(
         record,
         false,
         createdArtifacts
       );
-      this.verifyContent(snapshot, CollaborationContentType.WHITEBOARD, fork);
-      canonical = await compressText(snapshot.toString('base64'));
+      this.verifyContent(
+        encoded.bytes,
+        CollaborationContentType.WHITEBOARD,
+        fork
+      );
+      warnings = encoded.warnings;
+      canonical = await compressText(encoded.bytes.toString('base64'));
     } catch (error) {
       const cleanupFailures = await this.cleanupCreatedArtifacts(
         record.id,
@@ -1176,7 +1225,7 @@ export class CollaborationMigrationService {
         () => undefined
       );
       if (current === canonical) {
-        return;
+        return warnings;
       }
       if (current === undefined) {
         this.logger.warn?.(
@@ -1203,11 +1252,11 @@ export class CollaborationMigrationService {
     }
 
     if (affected === 1) {
-      return;
+      return warnings;
     }
     const current = await this.readStoredDefaultContent(record.id);
     if (current === canonical) {
-      return;
+      return warnings;
     }
     const cleanupFailures = await this.cleanupCreatedArtifacts(
       record.id,
@@ -1223,7 +1272,7 @@ export class CollaborationMigrationService {
       current !== record.storedContent &&
       (await this.isCanonicalStoredWhiteboardDefault(current))
     ) {
-      return;
+      return [];
     }
     throw new Error(
       'Contribution default did not converge after migration CAS'
@@ -1343,11 +1392,14 @@ export class CollaborationMigrationService {
     record: LegacyContentRecord,
     planning: boolean,
     createdArtifacts?: CreatedMigrationArtifacts
-  ): Promise<Buffer> {
+  ): Promise<EncodedSnapshot> {
     if (record.contentType === CollaborationContentType.MEMO) {
-      return record.content
-        ? Buffer.from(record.content, 'base64')
-        : Buffer.from(markdownToYjsV2State(''));
+      return {
+        bytes: record.content
+          ? Buffer.from(record.content, 'base64')
+          : Buffer.from(markdownToYjsV2State('')),
+        warnings: [],
+      };
     }
     // Whiteboard: resolve the legacy embedded-media references to opaque locator
     // strings (url-backed → its document id; dataURL-only → bytes up-homed into this
@@ -1359,63 +1411,134 @@ export class CollaborationMigrationService {
     // the SAME `undefined` the encoder maps to the canonical EMPTY doc, which would SILENTLY
     // discard real content. Fail the record instead. A genuinely empty / whitespace legacy
     // value is canonical-empty and passes (it is never parsed as a scene).
-    if (
-      sceneJSON.trim() !== '' &&
-      parseLegacyWhiteboardScene(sceneJSON) === undefined
-    ) {
+    const scene = parseLegacyWhiteboardScene(sceneJSON);
+    if (sceneJSON.trim() !== '' && scene === undefined) {
       throw new Error(
         'whiteboard legacy content is nonempty but not a parseable Excalidraw scene (malformed JSON or missing/non-array elements); refusing to migrate it as empty'
       );
     }
-    // `planning` (dry-run) resolves media to REPRESENTABLE synthetic/structural locators with
-    // ZERO writes; the real path performs the Alkemio-doc lookups + dataURL up-home. The
-    // shared cold-load image→locator invariant is enforced by the CALLER's `verifyContent` on
-    // the resulting snapshot (one owner) BEFORE any upload/CAS — a live image that resolved to
-    // no locator fails the record there.
+    // `planning` (dry-run) performs the same read-only document + byte checks as the real path
+    // and uses synthetic locators only for valid inline bytes. Both paths remove the same
+    // proven-unrecoverable live images before the shared cold-load verifier runs; the real path
+    // alone up-homes inline bytes and persists the snapshot.
     const assetLocators = await this.resolveWhiteboardAssetLocators(
-      sceneJSON,
+      scene,
       record,
       planning,
       createdArtifacts
     );
-    return Buffer.from(
-      await whiteboardSceneToYjsV2State(sceneJSON, assetLocators)
+    const salvage = scene
+      ? this.removeUnrecoverableLiveImages(scene, assetLocators)
+      : { sceneJSON, warnings: [] };
+    return {
+      bytes: Buffer.from(
+        await whiteboardSceneToYjsV2State(salvage.sceneJSON, assetLocators)
+      ),
+      warnings: salvage.warnings,
+    };
+  }
+
+  private removeUnrecoverableLiveImages(
+    scene: LegacyWhiteboardScene,
+    assetLocators: Record<string, string>
+  ): { sceneJSON: string; warnings: string[] } {
+    const missing = new Map<string, string[]>();
+    for (const element of scene.elements) {
+      if (element.type !== 'image' || element.isDeleted) {
+        continue;
+      }
+      const fileId = element.fileId;
+      if (
+        typeof fileId !== 'string' ||
+        fileId.length === 0 ||
+        assetLocators[fileId]
+      ) {
+        continue;
+      }
+      const ids = missing.get(fileId) ?? [];
+      ids.push(typeof element.id === 'string' ? element.id : '<unknown>');
+      missing.set(fileId, ids);
+    }
+    if (missing.size === 0) {
+      return { sceneJSON: JSON.stringify(scene), warnings: [] };
+    }
+
+    const elements = scene.elements.filter(element => {
+      const fileId = element.fileId;
+      return !(
+        element.type === 'image' &&
+        !element.isDeleted &&
+        typeof fileId === 'string' &&
+        missing.has(fileId)
+      );
+    });
+    const files = scene.files
+      ? Object.fromEntries(
+          Object.entries(scene.files).filter(([fileId]) =>
+            Boolean(assetLocators[fileId])
+          )
+        )
+      : undefined;
+    const warnings = [...missing.entries()].map(
+      ([fileId, elementIds]) =>
+        `migrated with visual loss: removed live image elements [${elementIds.join(', ')}] because fileId '${fileId}' has no recoverable file-service content or inline bytes`
     );
+    return {
+      sceneJSON: JSON.stringify({ ...scene, elements, files }),
+      warnings,
+    };
   }
 
   /**
    * Resolves a legacy whiteboard scene's embedded-media map
    * (`fileId -> BinaryFileData`) to the unified `fileId -> file-service locator
-   * string` map the fork writes into the snapshot's `FILES` `Y.Map`. Iterates the
-   * scene's own `files`; each entry that resolves to a locator is kept. A genuinely
+   * string` map the fork writes into the snapshot's `FILES` `Y.Map`. Resolves only
+   * descriptors referenced by live image elements; deleted/unreferenced descriptors
+   * issue no metadata/content requests and are pruned. Each live entry that resolves
+   * to a locator is kept. A genuinely
    * unrecoverable entry (malformed/undecodable, no usable url or bytes) is dropped here
-   * (never a crash) — but if a LIVE image element references it, `migrateRecord`'s
-   * `verifyContent` then FAILS the record at the shared image→locator boundary
-   * (`enumerateLiveImageRefs`), so a broken live image never migrates; only an UNREFERENCED
-   * (or deleted-only) dropped entry passes. `planning` selects representability-only
-   * resolution (zero writes) vs the real Alkemio-doc lookups + dataURL up-home.
+   * (never a crash). Before encoding, every LIVE image sharing that missing fileId is removed
+   * while unrelated content remains, and the migrated row is explicitly flagged with the
+   * affected element ids + fileId. Deleted/unreferenced entries need no loss warning.
+   * `planning` performs the same read-only locator lookup and predicts the same removal, while
+   * replacing valid inline bytes with a synthetic locator so it still writes nothing.
    * A transient upload/read failure THROWS and fails the record (re-runnable) rather than
    * silently dropping media. Returns an empty map for an empty/undecodable scene or one
    * with no media.
    */
   private async resolveWhiteboardAssetLocators(
-    sceneJSON: string,
+    scene: LegacyWhiteboardScene | undefined,
     record: LegacyContentRecord,
     planning: boolean,
     createdArtifacts?: CreatedMigrationArtifacts
   ): Promise<Record<string, string>> {
-    const files = parseLegacyWhiteboardScene(sceneJSON)?.files;
+    const files = scene?.files;
     if (!files) {
       return {};
     }
+    const liveFileIds = new Set(
+      scene.elements.flatMap(element =>
+        element.type === 'image' &&
+        !element.isDeleted &&
+        typeof element.fileId === 'string' &&
+        element.fileId.length > 0
+          ? [element.fileId]
+          : []
+      )
+    );
     const locators: Record<string, string> = {};
+    const locatorContentCache = new Map<string, Promise<boolean>>();
     for (const [fileId, file] of Object.entries(files)) {
+      if (!liveFileIds.has(fileId)) {
+        continue;
+      }
       const locator = await this.resolveLegacyFileLocator(
         fileId,
         file,
         record,
         planning,
-        createdArtifacts
+        createdArtifacts,
+        locatorContentCache
       );
       if (locator) {
         locators[fileId] = locator;
@@ -1436,9 +1559,8 @@ export class CollaborationMigrationService {
    *  2. `url` is a valid Alkemio doc URL whose row is gone, BUT decodable `dataURL`
    *     bytes are present → up-home the bytes (pre-006 rendered them) — a recoverable
    *     image must not degrade into an unresolvable dead-doc locator.
-   *  3. valid Alkemio doc URL, missing row, NO usable bytes → preserve the embedded
-   *     (dangling) id, so the asset points where it did pre-006 (a later restore
-   *     resolves it; no regression).
+   *  3. valid Alkemio doc URL, missing row, NO usable bytes → no locator; the caller
+   *     removes only live images sharing that fileId and records explicit visual loss.
    *  4. no usable Alkemio url (external url, or none): up-home the `dataURL` bytes if
    *     present; otherwise (external-only, no bytes) skip + surface.
    */
@@ -1447,100 +1569,32 @@ export class CollaborationMigrationService {
     file: LegacyBinaryFileData,
     record: LegacyContentRecord,
     planning: boolean,
-    createdArtifacts?: CreatedMigrationArtifacts
+    createdArtifacts: CreatedMigrationArtifacts | undefined,
+    locatorContentCache: Map<string, Promise<boolean>>
   ): Promise<string | undefined> {
     const url = typeof file?.url === 'string' ? file.url.trim() : '';
-    const isAlkemioUrl =
-      url !== '' && this.documentService.isAlkemioDocumentURL(url);
     const embeddedDocumentId =
       url !== '' ? this.extractLegacyDocumentId(url) : undefined;
 
-    if (planning) {
-      // PLANNING (dry-run): prove the descriptor is REPRESENTABLE with ZERO writes, no auth,
-      // and no DB — never the real locator. An Alkemio doc URL is representable by its embedded
-      // structural id; a decodable inline dataURL is representable by a deterministic synthetic
-      // locator; everything else (external-only url with no bytes, undecodable dataURL) is
-      // UNREPRESENTABLE → undefined, so a LIVE image referencing it FAILS the planning
-      // snapshot's verifyContent before any real work. Post-migrate `--verify` remains the
-      // definitive file-service-resolution gate for the CURRENT locators.
-      if (isAlkemioUrl) {
-        const base = this.documentService.getDocumentsBaseUrlPath();
-        const id = url.substring(base.length + 1);
-        if (id) {
-          return id;
-        }
-      }
-      if (embeddedDocumentId) {
+    // Current-host and historical-host document URLs share the same local-only
+    // lookup. Only the exact configured route with one UUID suffix reaches this
+    // branch; no network request is ever made to a URL host.
+    if (embeddedDocumentId) {
+      const hasContent = await this.legacyDocumentHasContent(
+        embeddedDocumentId,
+        locatorContentCache
+      );
+      if (hasContent) {
         return embeddedDocumentId;
       }
+    }
+
+    if (planning) {
       return this.planDataUrlLocator(fileId, file);
     }
 
-    // 1–3. Alkemio file-service document URL.
-    if (isAlkemioUrl) {
-      const document = await this.documentService.getDocumentFromURL(url, {
-        loadEagerRelations: false,
-      });
-      if (document) {
-        return document.id; // 1. live row → its document id.
-      }
-      // 2. Row gone, but inline bytes are still there (recoverable) → up-home them.
-      const uphomed = await this.uphomeDataUrlAsset(
-        fileId,
-        file,
-        record,
-        createdArtifacts
-      );
-      if (uphomed) {
-        return uphomed;
-      }
-      // 3. No usable bytes → preserve the dangling id (no regression).
-      const base = this.documentService.getDocumentsBaseUrlPath();
-      const id = url.substring(base.length + 1);
-      this.logger.warn?.(
-        {
-          message:
-            'Migration: whiteboard asset url did not resolve to a live document and has no inline bytes; preserving the reference id',
-          id: record.id,
-          fileId,
-        },
-        LogContext.COLLABORATION_INTEGRATION
-      );
-      return id || undefined;
-    }
-
-    // Historical scenes can retain a document URL from another Alkemio
-    // deployment host. The host-specific live URL check above intentionally
-    // rejects it, but the exact document route still carries the opaque UUID
-    // understood by the current file-service. Resolve that UUID against the
-    // current database only; never request the historical host.
-    if (embeddedDocumentId) {
-      try {
-        const document = await this.documentService.getDocumentOrFail(
-          embeddedDocumentId,
-          { loadEagerRelations: false }
-        );
-        return document.id;
-      } catch {
-        // Match the current-host recovery order: retained inline bytes are
-        // stronger evidence than a dangling URL, so up-home them first.
-        const uphomed = await this.uphomeDataUrlAsset(
-          fileId,
-          file,
-          record,
-          createdArtifacts
-        );
-        if (uphomed) {
-          return uphomed;
-        }
-      }
-      // Preserve the original opaque id when neither the current row nor
-      // inline bytes exist. This is no worse than the legacy reference, and
-      // the post-migration verifier will report it if it still has no bytes.
-      return embeddedDocumentId;
-    }
-
-    // 4. No usable Alkemio url → up-home inline bytes if present, else skip + surface.
+    // Missing/invalid URL → up-home inline bytes if present, else let the
+    // caller remove only affected live image elements and flag the migration.
     const uphomed = await this.uphomeDataUrlAsset(
       fileId,
       file,
@@ -1553,7 +1607,7 @@ export class CollaborationMigrationService {
     this.logger.warn?.(
       {
         message:
-          'Migration: whiteboard asset has no Alkemio url and no inline bytes; skipping asset',
+          'Migration: whiteboard asset has no live file row and no inline bytes; skipping asset',
         id: record.id,
         fileId,
       },
@@ -1562,13 +1616,78 @@ export class CollaborationMigrationService {
     return undefined;
   }
 
+  private async legacyDocumentHasContent(
+    documentId: string,
+    cache: Map<string, Promise<boolean>>
+  ): Promise<boolean> {
+    const existing = cache.get(documentId);
+    if (existing) {
+      return existing;
+    }
+    const pending = this.loadLegacyDocumentContentState(documentId);
+    cache.set(documentId, pending);
+    return pending;
+  }
+
+  private async loadLegacyDocumentContentState(
+    documentId: string
+  ): Promise<boolean> {
+    let document;
+    try {
+      document = await this.documentService.getDocumentOrFail(documentId, {
+        loadEagerRelations: false,
+      });
+    } catch (error) {
+      if (error instanceof EntityNotFoundException) {
+        return false;
+      }
+      throw error;
+    }
+    if (document.id !== documentId) {
+      throw new Error(
+        `legacy media metadata lookup returned a different id (requested '${documentId}', got '${document.id}')`
+      );
+    }
+
+    const response = await this.fileServiceAdapter.getContentBatch([
+      documentId,
+    ]);
+    if (response.length !== 1 || !response[0]) {
+      throw new Error(
+        `legacy media locator '${documentId}' returned a malformed content response`
+      );
+    }
+    const result = response[0];
+    if (result.id !== documentId) {
+      throw new Error(
+        `legacy media locator '${documentId}' returned content for a different id '${result.id}'`
+      );
+    }
+    if (!result.found) {
+      return false;
+    }
+    if (
+      typeof result.contentBase64 !== 'string' ||
+      result.contentBase64.trim() === ''
+    ) {
+      return false;
+    }
+    if (!decodeStrictBase64(result.contentBase64)) {
+      throw new Error(
+        `legacy media locator '${documentId}' returned malformed base64 content`
+      );
+    }
+    return true;
+  }
+
   /**
    * Extracts the opaque document UUID from the configured Alkemio document
    * route while deliberately ignoring the URL host. Legacy database copies
    * and environment renames leave otherwise-valid document URLs pointing at
    * an historical host. Matching the exact route plus a UUID is safe because
    * this method performs no network request; arbitrary external paths and
-   * non-UUID suffixes remain unrecoverable and fail closed when referenced.
+   * non-UUID suffixes are never trusted as locators; affected live visuals are
+   * removed with an explicit migration warning when no inline bytes exist.
    */
   private extractLegacyDocumentId(url: string): string | undefined {
     try {
@@ -1624,7 +1743,7 @@ export class CollaborationMigrationService {
    * policy internally (its own `saveAll`; it returns no rules for the caller to save), and
    * it is awaited BEFORE the locator is returned — hence before the snapshot write and the
    * `contentPointer` CAS in `migrateRecord`. Returns `undefined` (letting the caller
-   * decide the fallback — preserve a dangling id, or skip) when there is nothing to
+   * remove only affected live images and flag the row) when there is nothing to
    * up-home: NO `dataURL` (silently), an undecodable `data:` URI (surfaced), or a missing
    * bucket (surfaced; a bucketless record already fails in `migrateRecord`). A real
    * upload OR authorization failure THROWS → the record fails (unmigrated + re-runnable),
@@ -1638,7 +1757,7 @@ export class CollaborationMigrationService {
   ): Promise<string | undefined> {
     const dataURL = typeof file?.dataURL === 'string' ? file.dataURL : '';
     if (!dataURL) {
-      return undefined; // no inline bytes — caller falls back (dangling id / skip).
+      return undefined; // no inline bytes — caller performs explicit lossy salvage.
     }
     const decoded = parseDataUrl(dataURL);
     if (!decoded) {

--- a/src/services/collaboration-integration/migration/legacy.content.record.ts
+++ b/src/services/collaboration-integration/migration/legacy.content.record.ts
@@ -15,8 +15,9 @@ import { CollaborationContentType } from '@common/enums/collaboration.content.ty
  *   (`Memo.content.toString('base64')`); `undefined` for a never-edited memo
  *   (the job seeds an empty Y.Doc — not a failure).
  * - whiteboard: `content` is the decompressed Excalidraw JSON string;
- *   `flagged = true` marks a decompression failure surfaced for manual review
- *   (not silently dropped).
+ *   record-level `flagged = true` marks a source decompression failure and is
+ *   not migrated. This is distinct from a MigrationSummary flag emitted after
+ *   an otherwise-usable board migrates with explicit visual loss.
  */
 export interface LegacyContentRecord {
   id: string;


### PR DESCRIPTION
## Source

Free-text bug report; no board story.

## Root cause

The supplied production-shaped rows decode to valid legacy Excalidraw scenes, but their live image elements use SHA-like Excalidraw `fileId` values while the associated descriptors contain either:

- an empty `dataURL` plus an Alkemio document URL whose UUID is the real file locator, sometimes on a historical host; or
- neither a usable current file-service object nor valid embedded bytes.

The original migration recognized only URLs on the currently configured host and treated a matching server `Document` row as sufficient proof. That either rejected recoverable historical URLs or could preserve a dangling locator whose file-service bytes were missing. The strict canonical verifier correctly rejected those results.

## Fix and failure taxonomy

- Apply one shared media-resolution policy to legacy Whiteboard rows and legacy contribution defaults/templates.
- Parse only the exact Alkemio document route with one UUID suffix; current and historical HTTP(S) hosts are treated symmetrically, and no historical host is fetched.
- Accept a recovered UUID only after the current server metadata row exists **and** a one-at-a-time file-service content lookup returns the same ID with strict, non-empty base64 bytes. Lookups are deduplicated per locator.
- If the row or bytes are proven missing/empty, use valid inline `dataURL` bytes through the existing up-home path.
- If neither source exists, remove only the affected live image elements (all elements sharing that `fileId`), prune the unusable descriptor, preserve unrelated elements and recoverable images, and return an explicit migrated-with-loss warning.
- Treat malformed/wrong-ID content responses and transport failures as transient/corrupt failures: do not delete visuals, do not commit a pointer, and leave the record rerunnable.
- Dry-run performs the same read-only resolution and predicts the same loss warnings, but performs no upload, snapshot, authorization, or CAS writes.
- On CAS convergence, warnings are returned only when this attempt's canonical snapshot/default wins (or is byte-identical to the canonical winner); warnings from a discarded candidate are suppressed.
- The post-migration verifier remains strict and unchanged.

`migrated` and `flagged` intentionally overlap for lossy salvage: the board becomes usable, while the explicit flag and non-zero migration command status keep the visual loss auditable. A source scene that cannot be decoded remains failed/flagged and is not migrated.

## Regression coverage

- Historical- and current-host UUID routes with verified file-service bytes.
- Missing metadata or missing/empty file-service bytes with valid inline-byte fallback.
- Genuinely missing bytes: one or multiple live elements sharing a `fileId` are removed and reported while unrelated/recoverable content survives and canonical validation passes.
- Identical behavior for document rows and contribution defaults/templates.
- Malformed base64, wrong echoed IDs, malformed responses, and transport failures remain fail-closed and rerunnable.
- Per-locator lookup deduplication; deleted/unreferenced descriptors issue no content lookup.
- Dry-run warning parity with zero writes.
- Row/default CAS concurrency suppresses warnings from a different canonical winner and compensates only newly-created discarded artifacts.
- Sanitized regression derived from the supplied `another_row.txt` fixture (two live elements sharing one genuinely missing `fileId`).

## Gates

- Normal signed pre-commit hook: biome/lint-staged, typecheck, and full Vitest green (760 files passed, 6 skipped; 8,739 tests passed, 7 skipped; 0 failed).
- `pnpm lint`: green.
- `pnpm build`: green.
- Migration service spec: 113/113 green.
- `git diff --check`: clean.

## Comments

New and changed comments contain no specification, issue, or pull-request numeric references.

