### PR TITLE
chore: pin collaboration-service v0.0.2

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -529,7 +529,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_collaboration
     hostname: collaboration
-    image: alkemio/collaboration-service:v0.0.1
+    image: alkemio/collaboration-service:v0.0.2
     depends_on:
       rabbitmq:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- pin the local quickstart collaboration service to the released `v0.0.2` image
- carries the merged multi-user admission fixes from collaboration-service #16

## Verification
- `docker compose -f quickstart-services.yml config --quiet`
- DockerHub multi-arch manifest verified for linux/amd64 and linux/arm64
- release: https://github.com/alkem-io/collaboration-service/releases/tag/v0.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the collaboration service to the latest image version for improved reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->