### PR TITLE
fix: consume typed collaboration session lifecycle

### DIFF
--- a/src/domain/common/memo/memo.service.spec.ts
+++ b/src/domain/common/memo/memo.service.spec.ts
@@ -1,15 +1,19 @@
+import { LogContext } from '@common/enums';
 import { ContentUpdatePolicy } from '@common/enums/content.update.policy';
+import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
 import {
   EntityNotFoundException,
   EntityNotInitializedException,
   RelationshipNotFoundException,
 } from '@common/exceptions';
 import { CollaborationLifecycleService } from '@domain/common/collaboration-metadata';
+import { ILicense } from '@domain/common/license/license.interface';
 import { ProfileDocumentsService } from '@domain/profile-documents/profile.documents.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
 import { CollaborationDocumentService } from '@services/collaboration-client/collaboration-document.service';
+import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
@@ -18,6 +22,7 @@ import { repositoryProviderMockFactory } from '@test/utils/repository.provider.m
 import { Repository } from 'typeorm';
 import { type Mock } from 'vitest';
 import { AuthorizationPolicyService } from '../authorization-policy/authorization.policy.service';
+import { LicenseService } from '../license/license.service';
 import { ProfileService } from '../profile/profile.service';
 import { Memo } from './memo.entity';
 import { IMemo } from './memo.interface';
@@ -32,6 +37,8 @@ describe('MemoService', () => {
   let fileServiceAdapter: FileServiceAdapter;
   let collaborationLifecycleService: CollaborationLifecycleService;
   let collaborationDocumentService: CollaborationDocumentService;
+  let communityResolverService: CommunityResolverService;
+  let licenseService: LicenseService;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -62,6 +69,8 @@ describe('MemoService', () => {
     fileServiceAdapter = module.get(FileServiceAdapter);
     collaborationLifecycleService = module.get(CollaborationLifecycleService);
     collaborationDocumentService = module.get(CollaborationDocumentService);
+    communityResolverService = module.get(CommunityResolverService);
+    licenseService = module.get(LicenseService);
   });
 
   describe('getMemoOrFail', () => {
@@ -252,6 +261,54 @@ describe('MemoService', () => {
         expect.any(Function)
       );
       expect(fileServiceAdapter.createSnapshotInBucket).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isMultiUser', () => {
+    it('returns the attached collaboration entitlement', async () => {
+      const license = { id: 'license-1' } as ILicense;
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockResolvedValue(license);
+      vi.mocked(licenseService.isEntitlementEnabled).mockReturnValue(true);
+
+      await expect(service.isMultiUser('memo-1')).resolves.toBe(true);
+      expect(licenseService.isEntitlementEnabled).toHaveBeenCalledWith(
+        license,
+        LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
+      );
+    });
+
+    it('returns false when the attached entitlement is disabled', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockResolvedValue({ id: 'license-1' } as ILicense);
+      vi.mocked(licenseService.isEntitlementEnabled).mockReturnValue(false);
+
+      await expect(service.isMultiUser('memo-1')).resolves.toBe(false);
+    });
+
+    it('returns false when the memo has no parent collaboration', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockRejectedValue(
+        new EntityNotFoundException(
+          'Unable to find Collaboration with License for memo',
+          LogContext.COLLABORATION
+        )
+      );
+
+      await expect(service.isMultiUser('standalone-memo')).resolves.toBe(false);
+      expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
+    });
+
+    it('propagates unexpected entitlement lookup failures', async () => {
+      const failure = new Error('database unavailable');
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockRejectedValue(failure);
+
+      await expect(service.isMultiUser('memo-1')).rejects.toBe(failure);
     });
   });
 

--- a/src/domain/common/memo/memo.service.spec.ts
+++ b/src/domain/common/memo/memo.service.spec.ts
@@ -265,6 +265,10 @@ describe('MemoService', () => {
   });
 
   describe('isMultiUser', () => {
+    beforeEach(() => {
+      memoRepository.findOne!.mockResolvedValue({ id: 'memo-1' } as Memo);
+    });
+
     it('returns the attached collaboration entitlement', async () => {
       const license = { id: 'license-1' } as ILicense;
       vi.mocked(
@@ -300,6 +304,17 @@ describe('MemoService', () => {
 
       await expect(service.isMultiUser('standalone-memo')).resolves.toBe(false);
       expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
+    });
+
+    it('propagates not found for an unknown memo', async () => {
+      memoRepository.findOne!.mockResolvedValue(null);
+
+      await expect(service.isMultiUser('missing-memo')).rejects.toThrow(
+        EntityNotFoundException
+      );
+      expect(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).not.toHaveBeenCalled();
     });
 
     it('propagates a missing entitlement from an attached license', async () => {

--- a/src/domain/common/memo/memo.service.spec.ts
+++ b/src/domain/common/memo/memo.service.spec.ts
@@ -302,6 +302,21 @@ describe('MemoService', () => {
       expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
     });
 
+    it('propagates a missing entitlement from an attached license', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockResolvedValue({ id: 'license-1' } as ILicense);
+      const failure = new EntityNotFoundException(
+        'Entitlement not found',
+        LogContext.LICENSE
+      );
+      vi.mocked(licenseService.isEntitlementEnabled).mockImplementation(() => {
+        throw failure;
+      });
+
+      await expect(service.isMultiUser('memo-1')).rejects.toBe(failure);
+    });
+
     it('propagates unexpected entitlement lookup failures', async () => {
       const failure = new Error('database unavailable');
       vi.mocked(

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -14,6 +14,7 @@ import {
   CollaborationMetadata,
   CollaborationMetadataUpdate,
 } from '@domain/common/collaboration-metadata';
+import type { ILicense } from '@domain/common/license/license.interface';
 import { IProfile } from '@domain/common/profile';
 import { ProfileDocumentsService } from '@domain/profile-documents/profile.documents.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
@@ -476,22 +477,23 @@ export class MemoService {
   }
 
   public async isMultiUser(memoId: string): Promise<boolean> {
+    let license: ILicense;
     try {
-      const license =
+      license =
         await this.communityResolverService.getCollaborationLicenseFromMemoOrFail(
           memoId
         );
-
-      return this.licenseService.isEntitlementEnabled(
-        license,
-        LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
-      );
     } catch (error) {
       // Standalone memos (templates and pre-bind drafts) deliberately have no
       // parent Collaboration and therefore no inherited entitlement.
       if (error instanceof EntityNotFoundException) return false;
       throw error;
     }
+
+    return this.licenseService.isEntitlementEnabled(
+      license,
+      LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
+    );
   }
 
   public async getProfile(

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -477,6 +477,8 @@ export class MemoService {
   }
 
   public async isMultiUser(memoId: string): Promise<boolean> {
+    await this.getMemoOrFail(memoId);
+
     let license: ILicense;
     try {
       license =

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -476,15 +476,22 @@ export class MemoService {
   }
 
   public async isMultiUser(memoId: string): Promise<boolean> {
-    const license =
-      await this.communityResolverService.getCollaborationLicenseFromMemoOrFail(
-        memoId
-      );
+    try {
+      const license =
+        await this.communityResolverService.getCollaborationLicenseFromMemoOrFail(
+          memoId
+        );
 
-    return this.licenseService.isEntitlementEnabled(
-      license,
-      LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
-    );
+      return this.licenseService.isEntitlementEnabled(
+        license,
+        LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
+      );
+    } catch (error) {
+      // Standalone memos (templates and pre-bind drafts) deliberately have no
+      // parent Collaboration and therefore no inherited entitlement.
+      if (error instanceof EntityNotFoundException) return false;
+      throw error;
+    }
   }
 
   public async getProfile(

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -602,6 +602,21 @@ describe('WhiteboardService', () => {
       expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
     });
 
+    it('propagates a missing entitlement from an attached license', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromWhiteboardOrFail
+      ).mockResolvedValue({ id: 'license-1' } as ILicense);
+      const failure = new EntityNotFoundException(
+        'Entitlement not found',
+        LogContext.LICENSE
+      );
+      vi.mocked(licenseService.isEntitlementEnabled).mockImplementation(() => {
+        throw failure;
+      });
+
+      await expect(service.isMultiUser('wb-1')).rejects.toBe(failure);
+    });
+
     it('propagates unexpected entitlement lookup failures', async () => {
       const failure = new Error('database unavailable');
       vi.mocked(

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -553,6 +553,12 @@ describe('WhiteboardService', () => {
   });
 
   describe('isMultiUser', () => {
+    beforeEach(() => {
+      whiteboardRepository.findOne!.mockResolvedValue({
+        id: 'wb-1',
+      } as Whiteboard);
+    });
+
     it('should return true when multi-user entitlement is enabled', async () => {
       const mockLicense = { id: 'license-1' } as ILicense;
       vi.mocked(
@@ -600,6 +606,17 @@ describe('WhiteboardService', () => {
 
       await expect(service.isMultiUser('standalone-wb')).resolves.toBe(false);
       expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
+    });
+
+    it('propagates not found for an unknown whiteboard', async () => {
+      whiteboardRepository.findOne!.mockResolvedValue(null);
+
+      await expect(service.isMultiUser('missing-wb')).rejects.toThrow(
+        EntityNotFoundException
+      );
+      expect(
+        communityResolverService.getCollaborationLicenseFromWhiteboardOrFail
+      ).not.toHaveBeenCalled();
     });
 
     it('propagates a missing entitlement from an attached license', async () => {

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-import { ProfileType } from '@common/enums';
+import { LogContext, ProfileType } from '@common/enums';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { ContentUpdatePolicy } from '@common/enums/content.update.policy';
@@ -586,6 +586,29 @@ describe('WhiteboardService', () => {
       const result = await service.isMultiUser('wb-1');
 
       expect(result).toBe(false);
+    });
+
+    it('returns false when the whiteboard has no parent collaboration', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromWhiteboardOrFail
+      ).mockRejectedValue(
+        new EntityNotFoundException(
+          'Unable to find Collaboration with License for whiteboard',
+          LogContext.COLLABORATION
+        )
+      );
+
+      await expect(service.isMultiUser('standalone-wb')).resolves.toBe(false);
+      expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
+    });
+
+    it('propagates unexpected entitlement lookup failures', async () => {
+      const failure = new Error('database unavailable');
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromWhiteboardOrFail
+      ).mockRejectedValue(failure);
+
+      await expect(service.isMultiUser('wb-1')).rejects.toBe(failure);
     });
   });
 

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -960,6 +960,8 @@ export class WhiteboardService {
   }
 
   public async isMultiUser(whiteboardId: string): Promise<boolean> {
+    await this.getWhiteboardOrFail(whiteboardId);
+
     let license: ILicense;
     try {
       license =

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -21,6 +21,7 @@ import {
   CollaborationMetadata,
   CollaborationMetadataUpdate,
 } from '@domain/common/collaboration-metadata';
+import type { ILicense } from '@domain/common/license/license.interface';
 import { IProfile } from '@domain/common/profile';
 import { DocumentService } from '@domain/storage/document/document.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
@@ -959,22 +960,23 @@ export class WhiteboardService {
   }
 
   public async isMultiUser(whiteboardId: string): Promise<boolean> {
+    let license: ILicense;
     try {
-      const license =
+      license =
         await this.communityResolverService.getCollaborationLicenseFromWhiteboardOrFail(
           whiteboardId
         );
-
-      return this.licenseService.isEntitlementEnabled(
-        license,
-        LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
-      );
     } catch (error) {
       // Standalone whiteboards (templates and pre-bind drafts) deliberately
       // have no parent Collaboration and therefore no inherited entitlement.
       if (error instanceof EntityNotFoundException) return false;
       throw error;
     }
+
+    return this.licenseService.isEntitlementEnabled(
+      license,
+      LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
+    );
   }
 
   public async getProfile(

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -959,15 +959,22 @@ export class WhiteboardService {
   }
 
   public async isMultiUser(whiteboardId: string): Promise<boolean> {
-    const license =
-      await this.communityResolverService.getCollaborationLicenseFromWhiteboardOrFail(
-        whiteboardId
-      );
+    try {
+      const license =
+        await this.communityResolverService.getCollaborationLicenseFromWhiteboardOrFail(
+          whiteboardId
+        );
 
-    return this.licenseService.isEntitlementEnabled(
-      license,
-      LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
-    );
+      return this.licenseService.isEntitlementEnabled(
+        license,
+        LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
+      );
+    } catch (error) {
+      // Standalone whiteboards (templates and pre-bind drafts) deliberately
+      // have no parent Collaboration and therefore no inherited entitlement.
+      if (error instanceof EntityNotFoundException) return false;
+      throw error;
+    }
   }
 
   public async getProfile(

--- a/src/services/collaboration-client/collaboration-document.service.spec.ts
+++ b/src/services/collaboration-client/collaboration-document.service.spec.ts
@@ -1,7 +1,10 @@
 import { vi } from 'vitest';
 import * as Y from 'yjs';
 import { CollaborationDocumentService } from './collaboration-document.service';
-import { UpdateRejectedError } from './collaboration-document.session';
+import {
+  CollaborationSessionEndError,
+  UpdateRejectedError,
+} from './collaboration-document.session';
 
 /**
  * The service `mutate()` retry loop, at the smallest possible seam: `newSession` is
@@ -101,5 +104,57 @@ describe('CollaborationDocumentService.mutate — correlated-barrier retry seman
     expect(newSession).toHaveBeenCalledTimes(1);
     expect(s0.resend).not.toHaveBeenCalled();
     expect(s0.close).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'manual',
+    'terminal',
+  ] as const)('a %s session end is thrown without resending the same update', async disposition => {
+    const service = buildService();
+    const ended = new CollaborationSessionEndError(
+      'wb-1',
+      disposition,
+      'document-size-limit-exceeded'
+    );
+    const s0 = fakeSession({
+      mutationBytes: new Uint8Array([1]),
+      durability: () => Promise.reject(ended),
+    });
+    const newSession = vi
+      .spyOn(service as never as { newSession: () => unknown }, 'newSession')
+      .mockReturnValueOnce(s0 as never);
+
+    await expect(
+      service.mutate('wb-1', 'whiteboard', 'actor-1', () => undefined)
+    ).rejects.toBe(ended);
+    expect(newSession).toHaveBeenCalledOnce();
+    expect(s0.resend).not.toHaveBeenCalled();
+  });
+
+  it('a transient typed end follows the existing bounded resend path', async () => {
+    const service = buildService();
+    const bytes = new Uint8Array([5, 6]);
+    const s0 = fakeSession({
+      mutationBytes: bytes,
+      durability: () =>
+        Promise.reject(
+          new CollaborationSessionEndError(
+            'wb-1',
+            'transient',
+            'server-shutdown'
+          )
+        ),
+    });
+    const s1 = fakeSession({ durability: () => Promise.resolve() });
+    const newSession = vi
+      .spyOn(service as never as { newSession: () => unknown }, 'newSession')
+      .mockReturnValueOnce(s0 as never)
+      .mockReturnValueOnce(s1 as never);
+
+    await expect(
+      service.mutate('wb-1', 'whiteboard', 'actor-1', () => undefined)
+    ).resolves.toBeUndefined();
+    expect(newSession).toHaveBeenCalledTimes(2);
+    expect(s1.resend).toHaveBeenCalledWith(bytes);
   });
 });

--- a/src/services/collaboration-client/collaboration-document.service.ts
+++ b/src/services/collaboration-client/collaboration-document.service.ts
@@ -6,6 +6,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import * as Y from 'yjs';
 import {
   CollaborationDocumentSession,
+  CollaborationSessionEndError,
   DocumentPurgingError,
   ReadOnlyRoomError,
   UpdateRejectedError,
@@ -120,6 +121,8 @@ export class CollaborationDocumentService {
           err instanceof DocumentPurgingError ||
           err instanceof ReadOnlyRoomError ||
           err instanceof UpdateRejectedError ||
+          (err instanceof CollaborationSessionEndError &&
+            err.disposition !== 'transient') ||
           update === null ||
           attempt === this.maxResendRetries
         ) {

--- a/src/services/collaboration-client/collaboration-document.session.spec.ts
+++ b/src/services/collaboration-client/collaboration-document.session.spec.ts
@@ -147,11 +147,9 @@ describe('CollaborationDocumentSession — admission and typed session end', () 
 
     feedControl(session, { kind: 'admission', mode: 'viewer' });
 
-    await synced.catch(error => {
-      expect(error).toMatchObject({
-        message: 'Invalid collaboration admission',
-        details: { documentId: 'wb-1', mode: 'viewer' },
-      });
+    await expect(synced).rejects.toMatchObject({
+      message: 'Invalid collaboration admission',
+      details: { documentId: 'wb-1', mode: 'viewer' },
     });
     expect(wsSend).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalledOnce();

--- a/src/services/collaboration-client/collaboration-document.session.spec.ts
+++ b/src/services/collaboration-client/collaboration-document.session.spec.ts
@@ -368,6 +368,12 @@ describe('CollaborationDocumentSession.requestDurability — correlated persist 
       disposition: 'manual',
     });
     await expect(p).rejects.toBeInstanceOf(UpdateRejectedError);
+    await p.catch(error => {
+      expect(error).toMatchObject({
+        message: 'Collaboration update rejected',
+        details: { documentId: 'wb-1', reason: undefined },
+      });
+    });
     // A later persisted with the ORIGINAL reqId finds no barrier — inert, cannot resolve.
     feedControl(session, { kind: 'persisted', requestId: reqId });
     // The sticky poison makes a fresh request reject IMMEDIATELY, without sending.

--- a/src/services/collaboration-client/collaboration-document.session.spec.ts
+++ b/src/services/collaboration-client/collaboration-document.session.spec.ts
@@ -147,7 +147,12 @@ describe('CollaborationDocumentSession — admission and typed session end', () 
 
     feedControl(session, { kind: 'admission', mode: 'viewer' });
 
-    await expect(synced).rejects.toThrow('Invalid collaboration admission');
+    await synced.catch(error => {
+      expect(error).toMatchObject({
+        message: 'Invalid collaboration admission',
+        details: { documentId: 'wb-1', mode: 'viewer' },
+      });
+    });
     expect(wsSend).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalledOnce();
   });
@@ -205,6 +210,14 @@ describe('CollaborationDocumentSession — admission and typed session end', () 
         expect((error as CollaborationSessionEndError).disposition).toBe(
           'terminal'
         );
+        expect(error).toMatchObject({
+          message: 'Collaboration session ended',
+          details: {
+            documentId: 'wb-1',
+            code: 'future-ending',
+            disposition: 'terminal',
+          },
+        });
       });
     }
   });

--- a/src/services/collaboration-client/collaboration-document.session.spec.ts
+++ b/src/services/collaboration-client/collaboration-document.session.spec.ts
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 import * as Y from 'yjs';
 import {
   CollaborationDocumentSession,
+  CollaborationSessionEndError,
   UpdateRejectedError,
 } from './collaboration-document.session';
 
@@ -73,6 +74,139 @@ describe('CollaborationDocumentSession.sendMutation — no frame on mutator thro
 
     expect(bytes).toBeNull();
     expect(wsSend).not.toHaveBeenCalled();
+  });
+});
+
+describe('CollaborationDocumentSession — admission and typed session end', () => {
+  const WIRE_SYNC = 0;
+  const WIRE_CONTROL = 3;
+
+  const buildSession = () => {
+    const session = new CollaborationDocumentSession(
+      'ws://collab/room',
+      {},
+      'wb-1'
+    );
+    const wsSend = vi.fn();
+    (session as unknown as { ws: { send: (b: Uint8Array) => void } }).ws = {
+      send: wsSend,
+    };
+    return { session, wsSend };
+  };
+
+  const feedControl = (
+    session: CollaborationDocumentSession,
+    msg: Record<string, unknown>
+  ): void => {
+    const enc = encoding.createEncoder();
+    encoding.writeVarUint(enc, WIRE_CONTROL);
+    encoding.writeUint8Array(
+      enc,
+      new TextEncoder().encode(JSON.stringify(msg))
+    );
+    const bytes = encoding.toUint8Array(enc);
+    (session as unknown as { onMessage: (d: ArrayBuffer) => void }).onMessage(
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+    );
+  };
+
+  it('waits for admission, records read access, then starts SyncStep1', () => {
+    const { session, wsSend } = buildSession();
+
+    feedControl(session, {
+      kind: 'admission',
+      mode: 'read',
+      reason: 'no-update-access',
+    });
+
+    expect(session.isReadOnly()).toBe(true);
+    expect(session.readOnlyError().reason).toBe('no-update-access');
+    expect(wsSend).toHaveBeenCalledTimes(1);
+    const dec = decoding.createDecoder(wsSend.mock.calls[0][0] as Uint8Array);
+    expect(decoding.readVarUint(dec)).toBe(WIRE_SYNC);
+  });
+
+  it('write admission starts sync without carrying a read-only reason', () => {
+    const { session, wsSend } = buildSession();
+    feedControl(session, { kind: 'admission', mode: 'write' });
+    expect(session.isReadOnly()).toBe(false);
+    expect(wsSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed without publishing Yjs state for an invalid admission mode', async () => {
+    const { session, wsSend } = buildSession();
+    const close = vi.fn();
+    const synced = (session as unknown as { syncedPromise: Promise<void> })
+      .syncedPromise;
+    (
+      session as unknown as { ws: { send: typeof wsSend; close: typeof close } }
+    ).ws = {
+      send: wsSend,
+      close,
+    };
+
+    feedControl(session, { kind: 'admission', mode: 'viewer' });
+
+    await expect(synced).rejects.toThrow('Invalid collaboration admission');
+    expect(wsSend).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('ignores unknown control kinds, including the temporary legacy rejection', async () => {
+    const { session, wsSend } = buildSession();
+    // A durability request is reachable only after connect() resolved. This
+    // focused control test bypasses connect(), so model that precondition.
+    (session as unknown as { synced: boolean }).synced = true;
+    const barrier = session.requestDurability(1000);
+    feedControl(session, {
+      kind: 'update-rejected',
+      error: 'legacy compatibility frame',
+    });
+    feedControl(session, { kind: 'future-control', value: 1 });
+
+    let settled = false;
+    barrier.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      }
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    feedControl(session, {
+      kind: 'session-end',
+      code: 'content-refused',
+      scope: 'member',
+      disposition: 'manual',
+    });
+    await expect(barrier).rejects.toBeInstanceOf(UpdateRejectedError);
+    wsSend.mockClear();
+    await expect(session.requestDurability(1000)).rejects.toBeInstanceOf(
+      UpdateRejectedError
+    );
+    expect(wsSend).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a typed session end has a missing or unknown disposition', async () => {
+    for (const disposition of [undefined, 'future-disposition']) {
+      const { session } = buildSession();
+      (session as unknown as { synced: boolean }).synced = true;
+      const barrier = session.requestDurability(1000);
+      feedControl(session, {
+        kind: 'session-end',
+        code: 'future-ending',
+        disposition,
+      });
+      await barrier.catch(error => {
+        expect(error).toBeInstanceOf(CollaborationSessionEndError);
+        expect((error as CollaborationSessionEndError).disposition).toBe(
+          'terminal'
+        );
+      });
+    }
   });
 });
 
@@ -209,14 +343,16 @@ describe('CollaborationDocumentSession.requestDurability — correlated persist 
     await expect(p).rejects.toThrow('store unavailable');
   });
 
-  it('update-rejected (uncorrelated, NO requestId) rejects the barrier, sticky-poisons the session, and a later matching persisted cannot flip it to success', async () => {
+  it('content-refused session-end rejects the barrier, sticky-poisons the session, and a later matching persisted cannot flip it to success', async () => {
     const { session, wsSend } = buildSession();
+    (session as unknown as { synced: boolean }).synced = true;
     const p = session.requestDurability(1000);
     const reqId = sentRequestId(wsSend.mock.calls[0][0] as Uint8Array);
-    // The real Go frame carries NO requestId (it answers the preceding update).
     feedControl(session, {
-      kind: 'update-rejected',
-      error: 'file locators must be references, not inline data',
+      kind: 'session-end',
+      code: 'content-refused',
+      scope: 'member',
+      disposition: 'manual',
     });
     await expect(p).rejects.toBeInstanceOf(UpdateRejectedError);
     // A later persisted with the ORIGINAL reqId finds no barrier — inert, cannot resolve.

--- a/src/services/collaboration-client/collaboration-document.session.ts
+++ b/src/services/collaboration-client/collaboration-document.session.ts
@@ -80,15 +80,15 @@ export class ReadOnlyRoomError extends Error {
  * ephemeral MCP caller — resending identical rejected bytes is futile; a genuine fresh
  * generation (new session / resync) is the only recovery.
  */
-export class UpdateRejectedError extends Error {
+export class UpdateRejectedError extends BaseExceptionInternal {
   constructor(
     documentId: string,
     public readonly reason?: string
   ) {
-    super(
-      `Document ${documentId} update rejected by the server${reason ? ` (${reason})` : ''}`
-    );
-    this.name = 'UpdateRejectedError';
+    super('Collaboration update rejected', LogContext.COLLABORATION, {
+      documentId,
+      reason,
+    });
   }
 }
 

--- a/src/services/collaboration-client/collaboration-document.session.ts
+++ b/src/services/collaboration-client/collaboration-document.session.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+import { LogContext } from '@common/enums';
+import { BaseExceptionInternal } from '@common/exceptions/internal/base.exception.internal';
 import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import { WebSocket } from 'ws';
@@ -96,18 +98,17 @@ export type CollaborationSessionEndDisposition =
   | 'terminal';
 
 /** A typed room ending whose disposition controls the caller's retry decision. */
-export class CollaborationSessionEndError extends Error {
+export class CollaborationSessionEndError extends BaseExceptionInternal {
   constructor(
     documentId: string,
     public readonly disposition: CollaborationSessionEndDisposition,
     code?: string
   ) {
-    super(
-      `Collaboration session ended for ${documentId}` +
-        `${code ? ` (${code})` : ''}` +
-        ` [${disposition}]`
-    );
-    this.name = 'CollaborationSessionEndError';
+    super('Collaboration session ended', LogContext.COLLABORATION, {
+      documentId,
+      code,
+      disposition,
+    });
   }
 }
 
@@ -409,8 +410,10 @@ export class CollaborationDocumentSession {
         // authoritative capability for this one-shot session; the legacy
         // read-only-state below remains a rolling-deployment compatibility input.
         if (msg.mode !== 'read' && msg.mode !== 'write') {
-          const err = new Error(
-            `Invalid collaboration admission for ${this.documentId}`
+          const err = new BaseExceptionInternal(
+            'Invalid collaboration admission',
+            LogContext.COLLABORATION,
+            { documentId: this.documentId, mode: msg.mode }
           );
           this.closeError = err;
           this.failPending(err);

--- a/src/services/collaboration-client/collaboration-document.session.ts
+++ b/src/services/collaboration-client/collaboration-document.session.ts
@@ -27,22 +27,25 @@ const WIRE_DURABILITY_REQUEST = 4;
  */
 interface ControlMessage {
   kind:
+    | 'admission'
     | 'saved'
     | 'save-error'
     | 'read-only-state'
     | 'persisted'
     | 'persist-failed'
-    | 'update-rejected'
+    | 'session-end'
     | string;
   version?: number;
   error?: string;
   readOnly?: boolean;
   reason?: string;
+  mode?: 'read' | 'write';
+  code?: string;
+  scope?: 'member' | 'document';
+  disposition?: 'transient' | 'manual' | 'terminal';
   /**
    * Correlates a `persisted` / `persist-failed` reply to the durability request
-   * that asked. ABSENT on every other kind — in particular on `update-rejected`,
-   * which answers the preceding update (sent before the barrier request exists),
-   * so it is matched by nothing and settles the sole outstanding barrier uncorrelated.
+   * that asked. ABSENT on every other kind.
    */
   requestId?: string;
 }
@@ -69,8 +72,8 @@ export class ReadOnlyRoomError extends Error {
 }
 
 /**
- * Raised when the server REJECTED a local update on this session (an `update-rejected`
- * control): the connection's generation holds a struct the server refused, so nothing
+ * Raised when the server rejects local content on this session (a typed
+ * `content-refused` session end): the connection holds a struct the server refused, so nothing
  * it wrote is durable and no barrier may ever answer `persisted`. TERMINAL for the
  * ephemeral MCP caller — resending identical rejected bytes is futile; a genuine fresh
  * generation (new session / resync) is the only recovery.
@@ -84,6 +87,27 @@ export class UpdateRejectedError extends Error {
       `Document ${documentId} update rejected by the server${reason ? ` (${reason})` : ''}`
     );
     this.name = 'UpdateRejectedError';
+  }
+}
+
+export type CollaborationSessionEndDisposition =
+  | 'transient'
+  | 'manual'
+  | 'terminal';
+
+/** A typed room ending whose disposition controls the caller's retry decision. */
+export class CollaborationSessionEndError extends Error {
+  constructor(
+    documentId: string,
+    public readonly disposition: CollaborationSessionEndDisposition,
+    code?: string
+  ) {
+    super(
+      `Collaboration session ended for ${documentId}` +
+        `${code ? ` (${code})` : ''}` +
+        ` [${disposition}]`
+    );
+    this.name = 'CollaborationSessionEndError';
   }
 }
 
@@ -107,7 +131,7 @@ export class CollaborationDocumentSession {
   private syncedReject?: (err: Error) => void;
   private readonly syncedPromise: Promise<void>;
 
-  /** Set once a read-only-state frame with `readOnly: true` arrives. */
+  /** Set by admission before sync; the legacy read-only frame is compatibility only. */
   private readOnly = false;
   private readOnlyReason?: string;
   /** Terminal close cause distinguished by the 1008 close reason string. */
@@ -115,7 +139,7 @@ export class CollaborationDocumentSession {
   /**
    * The single OUTSTANDING durability barrier (at most one per connection). It owns
    * its own timer and is settled EXACTLY ONCE via {@link settleBarrier} — on the
-   * matching `persisted` (resolve) / `persist-failed` (reject), an `update-rejected`
+   * matching `persisted` (resolve) / `persist-failed` (reject), a content-refused end
    * or terminal close/ws error (reject), timeout, or session close — clearing both
    * the waiter and the timer so a later frame can never act on stale state.
    */
@@ -126,7 +150,7 @@ export class CollaborationDocumentSession {
     timer: ReturnType<typeof setTimeout>;
   };
   /**
-   * STICKY once the server rejects a local update on this connection (`update-rejected`):
+   * STICKY once the server rejects local content on this connection (`content-refused`):
    * that generation holds a struct the server refused, so no barrier may ever answer
    * `persisted`. Mirrors the server's per-member `durabilityPoisoned`; cleared only by a
    * fresh session.
@@ -150,14 +174,9 @@ export class CollaborationDocumentSession {
     ws.binaryType = 'arraybuffer';
     this.ws = ws;
 
-    ws.on('open', () => {
-      // SyncStep1: advertise our (empty) state vector so the room replies with its
-      // full state as SyncStep2.
-      const encoder = encoding.createEncoder();
-      encoding.writeVarUint(encoder, WIRE_SYNC);
-      syncProtocol.writeSyncStep1(encoder, this.doc);
-      this.send(encoding.toUint8Array(encoder));
-    });
+    // Admission is the first server frame. Sync starts only after the session's
+    // immutable read/write capability is known, so a read-admitted consumer can
+    // never publish local state before learning it is a viewer.
 
     ws.on('message', (data: ArrayBuffer | Buffer) => this.onMessage(data));
 
@@ -185,7 +204,7 @@ export class CollaborationDocumentSession {
     await this.withTimeout(this.syncedPromise, timeoutMs, 'sync');
   }
 
-  /** True once a read-only-state frame marked this actor a viewer. */
+  /** True when admission (or the temporary legacy frame) marks this actor read-only. */
   isReadOnly(): boolean {
     return this.readOnly;
   }
@@ -248,7 +267,7 @@ export class CollaborationDocumentSession {
    * is by the `requestId` this call mints. At most ONE barrier may be outstanding per
    * connection; a second concurrent call rejects WITHOUT sending anything. The waiter is
    * installed BEFORE the request frame is sent, so an immediate reply cannot race ahead
-   * of it. Rejects on `persist-failed`, an `update-rejected` (which sticky-poisons this
+   * of it. Rejects on `persist-failed`, a content-refused end (which sticky-poisons this
    * session), a terminal close/ws error, or timeout — every path clears the waiter+timer.
    */
   requestDurability(timeoutMs: number): Promise<void> {
@@ -385,18 +404,34 @@ export class CollaborationDocumentSession {
           )
         );
         break;
-      case 'update-rejected':
-        // The server refused a local update on THIS connection (it answers the
-        // preceding update and carries NO requestId). Poison the session permanently
-        // and reject the sole outstanding barrier UNCORRELATED — nothing this
-        // generation wrote is durable, and a later persisted/persist-failed after this
-        // finds no barrier, so it can never flip the outcome back to success.
-        this.durabilityPoisoned = true;
-        this.settleBarrier(
-          undefined,
-          new UpdateRejectedError(this.documentId, msg.error)
-        );
+      case 'admission':
+        // The service guarantees this is the first frame. Its mode is the
+        // authoritative capability for this one-shot session; the legacy
+        // read-only-state below remains a rolling-deployment compatibility input.
+        if (msg.mode !== 'read' && msg.mode !== 'write') {
+          const err = new Error(
+            `Invalid collaboration admission for ${this.documentId}`
+          );
+          this.closeError = err;
+          this.failPending(err);
+          this.ws?.close();
+          break;
+        }
+        this.readOnly = msg.mode === 'read';
+        this.readOnlyReason = this.readOnly ? msg.reason : undefined;
+        this.sendSyncStep1();
         break;
+      case 'session-end': {
+        const err = this.sessionEndError(msg);
+        if (msg.code === 'content-refused') {
+          // Sticky exactly like the service's per-member poison: no later
+          // persisted frame may convert refused content into success.
+          this.durabilityPoisoned = true;
+        }
+        this.closeError = err;
+        this.failPending(err);
+        break;
+      }
       case 'saved':
       case 'save-error':
         // Room-wide broadcasts — NOT correlated to any per-request barrier. The durable
@@ -422,7 +457,7 @@ export class CollaborationDocumentSession {
    * Settle the single outstanding barrier EXACTLY ONCE, clearing both the waiter and
    * its timer. When `requestId` is provided (a `persisted`/`persist-failed` reply) the
    * barrier is settled ONLY if it matches — a mismatched/stale reply is ignored. When
-   * `requestId` is undefined (close / ws error / `update-rejected`, and the barrier's own
+   * `requestId` is undefined (close / ws error / typed content refusal, and the barrier's own
    * timeout which passes its own id) it settles whatever barrier is outstanding. A
    * non-null `err` rejects; its absence resolves.
    */
@@ -451,6 +486,27 @@ export class CollaborationDocumentSession {
     this.settleBarrier(undefined, err);
   }
 
+  private sendSyncStep1(): void {
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, WIRE_SYNC);
+    syncProtocol.writeSyncStep1(encoder, this.doc);
+    this.send(encoding.toUint8Array(encoder));
+  }
+
+  private sessionEndError(msg: ControlMessage): Error {
+    if (msg.code === 'document-deleted') {
+      return new DocumentPurgingError(this.documentId);
+    }
+    if (msg.code === 'content-refused') {
+      return new UpdateRejectedError(this.documentId, msg.reason ?? msg.error);
+    }
+    return new CollaborationSessionEndError(
+      this.documentId,
+      isSessionEndDisposition(msg.disposition) ? msg.disposition : 'terminal',
+      msg.code
+    );
+  }
+
   private send(bytes: Uint8Array): void {
     this.ws?.send(bytes);
   }
@@ -476,4 +532,10 @@ export class CollaborationDocumentSession {
       clearTimeout(timer)
     ) as Promise<T>;
   }
+}
+
+function isSessionEndDisposition(
+  value: string | undefined
+): value is CollaborationSessionEndDisposition {
+  return value === 'transient' || value === 'manual' || value === 'terminal';
 }

--- a/src/services/collaboration-integration/collaboration-integration.service.spec.ts
+++ b/src/services/collaboration-integration/collaboration-integration.service.spec.ts
@@ -191,6 +191,37 @@ describe('CollaborationIntegrationService', () => {
       expect(whiteboardService.isMultiUser).toHaveBeenCalledWith('wb-1');
     });
 
+    it('fetches a standalone whiteboard with conservative single-user entitlement', async () => {
+      memoService.getCollaborationMetadata.mockRejectedValue(notFound());
+      whiteboardService.getCollaborationMetadata.mockResolvedValue(
+        whiteboardMeta
+      );
+      whiteboardService.isMultiUser.mockResolvedValue(false);
+
+      const result = await service.fetch({ id: 'standalone-wb' });
+
+      expect(result).toEqual({
+        found: true,
+        contentType: CollaborationContentType.WHITEBOARD,
+        version: 7,
+        contentPointer: 'wb-1',
+        migrated: true,
+        authorizationPolicyId: 'policy-wb',
+        storageBucketId: 'bucket-wb',
+        isMultiUser: false,
+      });
+    });
+
+    it('returns a structured error when entitlement resolution fails', async () => {
+      memoService.getCollaborationMetadata.mockResolvedValue(memoMeta);
+      memoService.isMultiUser.mockRejectedValue(new Error('database down'));
+
+      const result = await service.fetch({ id: 'memo-1' });
+
+      expect(result.found).toBe(false);
+      expect(result.error).toBe(CollaborationErrorCode.INTERNAL_ERROR);
+    });
+
     it('returns a structured not-found for an absent id (FR-004)', async () => {
       memoService.getCollaborationMetadata.mockRejectedValue(notFound());
       whiteboardService.getCollaborationMetadata.mockRejectedValue(notFound());


### PR DESCRIPTION
## Root cause

The server's headless collaboration client inferred retry policy from a small set of error subclasses. Manual and terminal session ends outside that set could therefore trigger futile identical mutation retries, and the client had no typed admission fact for read-only rooms.

## Change

- consume typed admission and session-end controls
- map `content-refused` to the existing sticky invalid-content failure
- preserve `document-deleted` as `DocumentPurgingError`
- carry disposition on session-end errors and retry mutations only when it is `transient`
- fail closed on malformed or unknown dispositions
- tolerate the service's 1013 capacity close and ignore unknown future control kinds

## Companion PRs and rollout

- alkem-io/collaboration-service#18
- alkem-io/client-web#10241, now targeting develop after client-web#10240 merged

Deploy the service first; it retains legacy frames during the rolling-compatibility window. This server PR may deploy afterward.

## Verification

- production lint + TypeScript build
- full Vitest: 760 files, 8,755 passed, 7 skipped
- two adversarial whole-head architecture reviews: round 2 returned zero findings and zero new lifecycle concepts

## Post-review convention amendment

CodeRabbit correctly found dynamic identifiers in two newly changed exception messages. Commit `3b83489eb` moves those values into the repository's structured `ExceptionDetails` while preserving the typed disposition field; lint and the full 8,755-test suite remain green. This changes error presentation only, not lifecycle or retry semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collaboration session handling for read and write access.
  * Added clear handling for deleted documents, refused content, and ended sessions.
  * Prevented retries for permanent failures while preserving recovery from temporary interruptions.
  * Invalid access responses now fail safely and close the affected session.
  * Standalone memos and whiteboards are correctly treated as single-user.
  * Collaboration metadata and entitlement errors are handled more reliably without exposing internal details.
* **Tests**
  * Expanded coverage for synchronization, access control, session termination, entitlement handling, and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Standalone document entitlement fallback

This PR also contains the independently reviewed standalone-document fix formerly tracked as #6423. Collaboration fetch treats only the deterministic absence of a parent Collaboration/license as single-user for standalone whiteboard and memo documents (reusable templates and pre-bind drafts). Attached-document entitlement evaluation is unchanged and missing/misconfigured entitlements still propagate as errors.

Live differential evidence on the exact delivery stack:

- an unattached draft that previously returned collaboration-fetch `internal_error` opened, edited, reached **Saved** before binding, bound through the supported Post flow, and reopened with its marker intact;
- a standalone reusable template opened to **Saved**, previewed non-empty content, applied additively, and imported a real 64×64 PNG; the target reopened **Saved** with image and text intact;
- post-fix collaboration logs contained no collaboration-fetch `internal_error`, room-join-refused, or authorization-policy errors; supported cleanup left zero fixture profiles/templates/whiteboards.

Combined final-byte verification: lint/typecheck/Biome and build pass; full Vitest passes 760 files and 8,765 tests (7 skipped). The clean folded head `c33cad3eb` has the same tree hash as the independently gated combined tree.