### PR TITLE
fix: default standalone collaboration documents to single-user

### DIFF
--- a/src/domain/common/memo/memo.service.spec.ts
+++ b/src/domain/common/memo/memo.service.spec.ts
@@ -1,15 +1,19 @@
+import { LogContext } from '@common/enums';
 import { ContentUpdatePolicy } from '@common/enums/content.update.policy';
+import { LicenseEntitlementType } from '@common/enums/license.entitlement.type';
 import {
   EntityNotFoundException,
   EntityNotInitializedException,
   RelationshipNotFoundException,
 } from '@common/exceptions';
 import { CollaborationLifecycleService } from '@domain/common/collaboration-metadata';
+import { ILicense } from '@domain/common/license/license.interface';
 import { ProfileDocumentsService } from '@domain/profile-documents/profile.documents.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
 import { CollaborationDocumentService } from '@services/collaboration-client/collaboration-document.service';
+import { CommunityResolverService } from '@services/infrastructure/entity-resolver/community.resolver.service';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
@@ -18,6 +22,7 @@ import { repositoryProviderMockFactory } from '@test/utils/repository.provider.m
 import { Repository } from 'typeorm';
 import { type Mock } from 'vitest';
 import { AuthorizationPolicyService } from '../authorization-policy/authorization.policy.service';
+import { LicenseService } from '../license/license.service';
 import { ProfileService } from '../profile/profile.service';
 import { Memo } from './memo.entity';
 import { IMemo } from './memo.interface';
@@ -32,6 +37,8 @@ describe('MemoService', () => {
   let fileServiceAdapter: FileServiceAdapter;
   let collaborationLifecycleService: CollaborationLifecycleService;
   let collaborationDocumentService: CollaborationDocumentService;
+  let communityResolverService: CommunityResolverService;
+  let licenseService: LicenseService;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -62,6 +69,8 @@ describe('MemoService', () => {
     fileServiceAdapter = module.get(FileServiceAdapter);
     collaborationLifecycleService = module.get(CollaborationLifecycleService);
     collaborationDocumentService = module.get(CollaborationDocumentService);
+    communityResolverService = module.get(CommunityResolverService);
+    licenseService = module.get(LicenseService);
   });
 
   describe('getMemoOrFail', () => {
@@ -252,6 +261,54 @@ describe('MemoService', () => {
         expect.any(Function)
       );
       expect(fileServiceAdapter.createSnapshotInBucket).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isMultiUser', () => {
+    it('returns the attached collaboration entitlement', async () => {
+      const license = { id: 'license-1' } as ILicense;
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockResolvedValue(license);
+      vi.mocked(licenseService.isEntitlementEnabled).mockReturnValue(true);
+
+      await expect(service.isMultiUser('memo-1')).resolves.toBe(true);
+      expect(licenseService.isEntitlementEnabled).toHaveBeenCalledWith(
+        license,
+        LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
+      );
+    });
+
+    it('returns false when the attached entitlement is disabled', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockResolvedValue({ id: 'license-1' } as ILicense);
+      vi.mocked(licenseService.isEntitlementEnabled).mockReturnValue(false);
+
+      await expect(service.isMultiUser('memo-1')).resolves.toBe(false);
+    });
+
+    it('returns false when the memo has no parent collaboration', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockRejectedValue(
+        new EntityNotFoundException(
+          'Unable to find Collaboration with License for memo',
+          LogContext.COLLABORATION
+        )
+      );
+
+      await expect(service.isMultiUser('standalone-memo')).resolves.toBe(false);
+      expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
+    });
+
+    it('propagates unexpected entitlement lookup failures', async () => {
+      const failure = new Error('database unavailable');
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockRejectedValue(failure);
+
+      await expect(service.isMultiUser('memo-1')).rejects.toBe(failure);
     });
   });
 

--- a/src/domain/common/memo/memo.service.spec.ts
+++ b/src/domain/common/memo/memo.service.spec.ts
@@ -302,6 +302,21 @@ describe('MemoService', () => {
       expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
     });
 
+    it('propagates a missing entitlement from an attached license', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromMemoOrFail
+      ).mockResolvedValue({ id: 'license-1' } as ILicense);
+      const failure = new EntityNotFoundException(
+        'Entitlement not found',
+        LogContext.LICENSE
+      );
+      vi.mocked(licenseService.isEntitlementEnabled).mockImplementation(() => {
+        throw failure;
+      });
+
+      await expect(service.isMultiUser('memo-1')).rejects.toBe(failure);
+    });
+
     it('propagates unexpected entitlement lookup failures', async () => {
       const failure = new Error('database unavailable');
       vi.mocked(

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -14,6 +14,7 @@ import {
   CollaborationMetadata,
   CollaborationMetadataUpdate,
 } from '@domain/common/collaboration-metadata';
+import type { ILicense } from '@domain/common/license/license.interface';
 import { IProfile } from '@domain/common/profile';
 import { ProfileDocumentsService } from '@domain/profile-documents/profile.documents.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
@@ -476,22 +477,23 @@ export class MemoService {
   }
 
   public async isMultiUser(memoId: string): Promise<boolean> {
+    let license: ILicense;
     try {
-      const license =
+      license =
         await this.communityResolverService.getCollaborationLicenseFromMemoOrFail(
           memoId
         );
-
-      return this.licenseService.isEntitlementEnabled(
-        license,
-        LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
-      );
     } catch (error) {
       // Standalone memos (templates and pre-bind drafts) deliberately have no
       // parent Collaboration and therefore no inherited entitlement.
       if (error instanceof EntityNotFoundException) return false;
       throw error;
     }
+
+    return this.licenseService.isEntitlementEnabled(
+      license,
+      LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
+    );
   }
 
   public async getProfile(

--- a/src/domain/common/memo/memo.service.ts
+++ b/src/domain/common/memo/memo.service.ts
@@ -476,15 +476,22 @@ export class MemoService {
   }
 
   public async isMultiUser(memoId: string): Promise<boolean> {
-    const license =
-      await this.communityResolverService.getCollaborationLicenseFromMemoOrFail(
-        memoId
-      );
+    try {
+      const license =
+        await this.communityResolverService.getCollaborationLicenseFromMemoOrFail(
+          memoId
+        );
 
-    return this.licenseService.isEntitlementEnabled(
-      license,
-      LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
-    );
+      return this.licenseService.isEntitlementEnabled(
+        license,
+        LicenseEntitlementType.SPACE_FLAG_MEMO_MULTI_USER
+      );
+    } catch (error) {
+      // Standalone memos (templates and pre-bind drafts) deliberately have no
+      // parent Collaboration and therefore no inherited entitlement.
+      if (error instanceof EntityNotFoundException) return false;
+      throw error;
+    }
   }
 
   public async getProfile(

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -602,6 +602,21 @@ describe('WhiteboardService', () => {
       expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
     });
 
+    it('propagates a missing entitlement from an attached license', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromWhiteboardOrFail
+      ).mockResolvedValue({ id: 'license-1' } as ILicense);
+      const failure = new EntityNotFoundException(
+        'Entitlement not found',
+        LogContext.LICENSE
+      );
+      vi.mocked(licenseService.isEntitlementEnabled).mockImplementation(() => {
+        throw failure;
+      });
+
+      await expect(service.isMultiUser('wb-1')).rejects.toBe(failure);
+    });
+
     it('propagates unexpected entitlement lookup failures', async () => {
       const failure = new Error('database unavailable');
       vi.mocked(

--- a/src/domain/common/whiteboard/whiteboard.service.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.spec.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-import { ProfileType } from '@common/enums';
+import { LogContext, ProfileType } from '@common/enums';
 import { AuthorizationPolicyType } from '@common/enums/authorization.policy.type';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { ContentUpdatePolicy } from '@common/enums/content.update.policy';
@@ -586,6 +586,29 @@ describe('WhiteboardService', () => {
       const result = await service.isMultiUser('wb-1');
 
       expect(result).toBe(false);
+    });
+
+    it('returns false when the whiteboard has no parent collaboration', async () => {
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromWhiteboardOrFail
+      ).mockRejectedValue(
+        new EntityNotFoundException(
+          'Unable to find Collaboration with License for whiteboard',
+          LogContext.COLLABORATION
+        )
+      );
+
+      await expect(service.isMultiUser('standalone-wb')).resolves.toBe(false);
+      expect(licenseService.isEntitlementEnabled).not.toHaveBeenCalled();
+    });
+
+    it('propagates unexpected entitlement lookup failures', async () => {
+      const failure = new Error('database unavailable');
+      vi.mocked(
+        communityResolverService.getCollaborationLicenseFromWhiteboardOrFail
+      ).mockRejectedValue(failure);
+
+      await expect(service.isMultiUser('wb-1')).rejects.toBe(failure);
     });
   });
 

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -21,6 +21,7 @@ import {
   CollaborationMetadata,
   CollaborationMetadataUpdate,
 } from '@domain/common/collaboration-metadata';
+import type { ILicense } from '@domain/common/license/license.interface';
 import { IProfile } from '@domain/common/profile';
 import { DocumentService } from '@domain/storage/document/document.service';
 import { IStorageAggregator } from '@domain/storage/storage-aggregator/storage.aggregator.interface';
@@ -959,22 +960,23 @@ export class WhiteboardService {
   }
 
   public async isMultiUser(whiteboardId: string): Promise<boolean> {
+    let license: ILicense;
     try {
-      const license =
+      license =
         await this.communityResolverService.getCollaborationLicenseFromWhiteboardOrFail(
           whiteboardId
         );
-
-      return this.licenseService.isEntitlementEnabled(
-        license,
-        LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
-      );
     } catch (error) {
       // Standalone whiteboards (templates and pre-bind drafts) deliberately
       // have no parent Collaboration and therefore no inherited entitlement.
       if (error instanceof EntityNotFoundException) return false;
       throw error;
     }
+
+    return this.licenseService.isEntitlementEnabled(
+      license,
+      LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
+    );
   }
 
   public async getProfile(

--- a/src/domain/common/whiteboard/whiteboard.service.ts
+++ b/src/domain/common/whiteboard/whiteboard.service.ts
@@ -959,15 +959,22 @@ export class WhiteboardService {
   }
 
   public async isMultiUser(whiteboardId: string): Promise<boolean> {
-    const license =
-      await this.communityResolverService.getCollaborationLicenseFromWhiteboardOrFail(
-        whiteboardId
-      );
+    try {
+      const license =
+        await this.communityResolverService.getCollaborationLicenseFromWhiteboardOrFail(
+          whiteboardId
+        );
 
-    return this.licenseService.isEntitlementEnabled(
-      license,
-      LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
-    );
+      return this.licenseService.isEntitlementEnabled(
+        license,
+        LicenseEntitlementType.SPACE_FLAG_WHITEBOARD_MULTI_USER
+      );
+    } catch (error) {
+      // Standalone whiteboards (templates and pre-bind drafts) deliberately
+      // have no parent Collaboration and therefore no inherited entitlement.
+      if (error instanceof EntityNotFoundException) return false;
+      throw error;
+    }
   }
 
   public async getProfile(

--- a/src/services/collaboration-integration/collaboration-integration.service.spec.ts
+++ b/src/services/collaboration-integration/collaboration-integration.service.spec.ts
@@ -191,6 +191,37 @@ describe('CollaborationIntegrationService', () => {
       expect(whiteboardService.isMultiUser).toHaveBeenCalledWith('wb-1');
     });
 
+    it('fetches a standalone whiteboard with conservative single-user entitlement', async () => {
+      memoService.getCollaborationMetadata.mockRejectedValue(notFound());
+      whiteboardService.getCollaborationMetadata.mockResolvedValue(
+        whiteboardMeta
+      );
+      whiteboardService.isMultiUser.mockResolvedValue(false);
+
+      const result = await service.fetch({ id: 'standalone-wb' });
+
+      expect(result).toEqual({
+        found: true,
+        contentType: CollaborationContentType.WHITEBOARD,
+        version: 7,
+        contentPointer: 'wb-1',
+        migrated: true,
+        authorizationPolicyId: 'policy-wb',
+        storageBucketId: 'bucket-wb',
+        isMultiUser: false,
+      });
+    });
+
+    it('returns a structured error when entitlement resolution fails', async () => {
+      memoService.getCollaborationMetadata.mockResolvedValue(memoMeta);
+      memoService.isMultiUser.mockRejectedValue(new Error('database down'));
+
+      const result = await service.fetch({ id: 'memo-1' });
+
+      expect(result.found).toBe(false);
+      expect(result.error).toBe(CollaborationErrorCode.INTERNAL_ERROR);
+    });
+
     it('returns a structured not-found for an absent id (FR-004)', async () => {
       memoService.getCollaborationMetadata.mockRejectedValue(notFound());
       whiteboardService.getCollaborationMetadata.mockRejectedValue(notFound());


### PR DESCRIPTION
## Source

Free-text release-blocking bug found during the greenfield collaboration lifecycle live gate; no separate board story. Cross-references server #6422, client-web #10241, and collaboration-service #18.

## Root cause

Collaboration fetch always resolves the document multi-user entitlement through a parent Collaboration. Reusable templates and pre-bind drafts are valid standalone documents, so they have no callout contribution/framing parent yet and the resolver throws EntityNotFoundException. The collaboration service receives internal_error and the client correctly remains in its patient loading loop.

Live differential proof: the same disposable whiteboard failed repeatedly while unattached, then reached Saved immediately after the supported post mutation attached it. A reusable template reproduced the unattached failure.

## Fix

- Treat only the deterministic missing parent Collaboration/license as conservative single-user entitlement.
- Preserve attached-document entitlement evaluation unchanged.
- Propagate every other resolver/database failure.
- Apply the same rule to whiteboards and memos.

This grants no capability: the document authorization policy remains the access gate, and single-user is the restrictive entitlement default.

## Verification

- Node 22 pnpm lint: PASS
- Node 22 pnpm build: PASS
- Focused domain/integration tests: 107/107 PASS
- Full Node 22 suite: 760 files passed, 6 skipped; 8755 tests passed, 7 skipped
- Architecture gate: GREEN

Post-PR live gate: rebuild the exact server head, then retest standalone template source loading, template application including assets, and unattached draft edit -> Saved -> bind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standalone memos and whiteboards without collaboration licenses are now correctly treated as single-user items.
  - Collaboration-enabled content continues to respect entitlement settings.
  - Unexpected license or entitlement lookup failures are now surfaced consistently.
  - Standalone whiteboards can be retrieved correctly when single-user access applies.

- **Tests**
  - Expanded coverage for standalone content, collaboration entitlements, retrieval, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->