### PR TITLE
chore: update quickstart collaboration service to v0.0.3

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -529,7 +529,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_collaboration
     hostname: collaboration
-    image: alkemio/collaboration-service:v0.0.2
+    image: alkemio/collaboration-service:v0.0.3
     depends_on:
       rabbitmq:
         condition: service_healthy


### PR DESCRIPTION
Updates the authoritative local quickstart Compose stack from collaboration-service v0.0.2 to v0.0.3.

The effective Compose configuration resolves to `alkemio/collaboration-service:v0.0.3`.

Companion release PR: alkem-io/collaboration-service#19.
Tracking: alkem-io/alkemio#2082.

Do not merge until the v0.0.3 GitHub Release has published the DockerHub image.