### PR TITLE
fix: claim whiteboard drafts when updating defaults

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -9514,6 +9514,10 @@ input UpdateCalloutContributionDefaultsInput {
   clearWhiteboardContent: Boolean
   """The default title to use for new contributions."""
   defaultDisplayName: String
+  """
+  Replace the default from a server-owned live Whiteboard contribution-default draft. Mutually exclusive with either source field and clearWhiteboardContent.
+  """
+  draftWhiteboardID: UUID
   """The default description to use for new Post contributions."""
   postDescription: Markdown
   """

--- a/src/domain/collaboration/callout-contribution-defaults/dto/callout.contribution.defaults.dto.update.ts
+++ b/src/domain/collaboration/callout-contribution-defaults/dto/callout.contribution.defaults.dto.update.ts
@@ -43,6 +43,14 @@ export class UpdateCalloutContributionDefaultsInput {
   @IsOptional()
   sourceCalloutID?: string;
 
+  @Field(() => UUID, {
+    nullable: true,
+    description:
+      'Replace the default from a server-owned live Whiteboard contribution-default draft. Mutually exclusive with either source field and clearWhiteboardContent.',
+  })
+  @IsOptional()
+  draftWhiteboardID?: string;
+
   @Field(() => Boolean, {
     nullable: true,
     description:

--- a/src/domain/collaboration/callout/callout.module.ts
+++ b/src/domain/collaboration/callout/callout.module.ts
@@ -6,6 +6,7 @@ import { AuthorizationPolicyModule } from '@domain/common/authorization-policy/a
 import { ClassificationModule } from '@domain/common/classification/classification.module';
 import { TagsetTemplateModule } from '@domain/common/tagset-template/tagset.template.module';
 import { WhiteboardModule } from '@domain/common/whiteboard/whiteboard.module';
+import { WhiteboardDraftModule } from '@domain/common/whiteboard-draft';
 import { RoomModule } from '@domain/communication/room/room.module';
 import { UserLookupModule } from '@domain/community/user-lookup/user.lookup.module';
 import { Module } from '@nestjs/common';
@@ -49,6 +50,7 @@ import { TaskBoardResolverMutations } from './task-board/task.board.resolver.mut
     UserLookupModule,
     NamingModule,
     WhiteboardModule,
+    WhiteboardDraftModule,
     CalloutFramingModule,
     CalloutContributionModule,
     CalloutContributionDefaultsModule,

--- a/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.spec.ts
@@ -20,6 +20,7 @@ import { CollaboraDocumentEventsService } from '@domain/collaboration/collabora-
 import { ReactionService } from '@domain/collaboration/reaction/reaction.service';
 import { AuthorizationPolicyService } from '@domain/common/authorization-policy/authorization.policy.service';
 import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
+import { WhiteboardDraftService } from '@domain/common/whiteboard-draft';
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotificationSpaceAdapter } from '@services/adapters/notification-adapter/notification.space.adapter';
 import { MockCacheManager } from '@test/mocks/cache-manager.mock';
@@ -53,6 +54,7 @@ describe('CalloutResolverMutations', () => {
   let _calloutContributionService: CalloutContributionService;
   let collaboraDocumentEventsService: CollaboraDocumentEventsService;
   let whiteboardService: WhiteboardService;
+  let whiteboardDraftService: WhiteboardDraftService;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -102,6 +104,15 @@ describe('CalloutResolverMutations', () => {
     _calloutContributionService = module.get(CalloutContributionService);
     collaboraDocumentEventsService = module.get(CollaboraDocumentEventsService);
     whiteboardService = module.get(WhiteboardService);
+    whiteboardDraftService = module.get(WhiteboardDraftService);
+    const releaseDraftLock = vi.fn();
+    vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue({
+      drafts: new Map(),
+      markConsumed: vi.fn(),
+      complete: vi.fn(),
+      release: releaseDraftLock,
+      [Symbol.asyncDispose]: releaseDraftLock,
+    });
   });
 
   it('should be defined', () => {
@@ -215,6 +226,147 @@ describe('CalloutResolverMutations', () => {
         whiteboardContent: 'canonical-internal',
         sourceStorageBucketID: 'source-bucket',
       });
+    });
+
+    it('atomically claims a Whiteboard draft before updating contribution defaults', async () => {
+      const target = {
+        id: 'target-callout',
+        authorization: { id: 'target-auth' },
+      } as any;
+      const updated = {
+        id: target.id,
+        authorization: target.authorization,
+      } as any;
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(target);
+      vi.mocked(calloutService.updateCallout).mockResolvedValue(updated);
+      const roomResolverService = (resolver as any).roomResolverService;
+      vi.mocked(
+        roomResolverService.getRoleSetAndPlatformRolesWithAccessForCallout
+      ).mockResolvedValue({
+        roleSet: { id: 'rs-1' },
+        platformRolesAccess: { roles: [] },
+      });
+      vi.mocked(
+        calloutAuthorizationService.applyAuthorizationPolicy
+      ).mockResolvedValue([{ id: 'updated-auth' }] as any);
+
+      const markConsumed = vi.fn();
+      const complete = vi.fn();
+      const release = vi.fn();
+      vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue(
+        {
+          drafts: new Map([
+            ['draft-whiteboard', { id: 'draft-whiteboard' } as any],
+          ]),
+          markConsumed,
+          complete,
+          release,
+          [Symbol.asyncDispose]: release,
+        }
+      );
+      const actorContext = { actorID: 'user-1' } as any;
+      const input = {
+        ID: target.id,
+        contributionDefaults: { draftWhiteboardID: 'draft-whiteboard' },
+      } as any;
+
+      await resolver.updateCallout(actorContext, input);
+
+      expect(whiteboardDraftService.acquireForConsumption).toHaveBeenCalledWith(
+        ['draft-whiteboard'],
+        actorContext
+      );
+      expect(contributionDefaultSourceService.prepare).toHaveBeenCalledWith(
+        {
+          draftWhiteboardID: undefined,
+          sourceWhiteboardID: 'draft-whiteboard',
+        },
+        actorContext
+      );
+      expect(calloutService.updateCallout).toHaveBeenCalledWith(
+        target,
+        input,
+        actorContext,
+        actorContext.actorID
+      );
+      expect(markConsumed).toHaveBeenCalledOnce();
+      expect(complete).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+    });
+
+    it('rejects a draft combined with another contribution-default source', async () => {
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue({
+        id: 'target-callout',
+        authorization: { id: 'target-auth' },
+      } as any);
+      const release = vi.fn();
+      vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue(
+        {
+          drafts: new Map([
+            ['draft-whiteboard', { id: 'draft-whiteboard' } as any],
+          ]),
+          markConsumed: vi.fn(),
+          complete: vi.fn(),
+          release,
+          [Symbol.asyncDispose]: release,
+        }
+      );
+
+      await expect(
+        resolver.updateCallout(
+          { actorID: 'user-1' } as any,
+          {
+            ID: 'target-callout',
+            contributionDefaults: {
+              draftWhiteboardID: 'draft-whiteboard',
+              clearWhiteboardContent: true,
+            },
+          } as any
+        )
+      ).rejects.toThrow(ValidationException);
+
+      expect(contributionDefaultSourceService.prepare).not.toHaveBeenCalled();
+      expect(calloutService.updateCallout).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledOnce();
+    });
+
+    it('does not consume the draft when the Callout update fails', async () => {
+      const target = {
+        id: 'target-callout',
+        authorization: { id: 'target-auth' },
+      } as any;
+      vi.mocked(calloutService.getCalloutOrFail).mockResolvedValue(target);
+      vi.mocked(calloutService.updateCallout).mockRejectedValue(
+        new Error('update failed')
+      );
+      const markConsumed = vi.fn();
+      const complete = vi.fn();
+      const release = vi.fn();
+      vi.mocked(whiteboardDraftService.acquireForConsumption).mockResolvedValue(
+        {
+          drafts: new Map([
+            ['draft-whiteboard', { id: 'draft-whiteboard' } as any],
+          ]),
+          markConsumed,
+          complete,
+          release,
+          [Symbol.asyncDispose]: release,
+        }
+      );
+
+      await expect(
+        resolver.updateCallout(
+          { actorID: 'user-1' } as any,
+          {
+            ID: target.id,
+            contributionDefaults: { draftWhiteboardID: 'draft-whiteboard' },
+          } as any
+        )
+      ).rejects.toThrow('update failed');
+
+      expect(markConsumed).not.toHaveBeenCalled();
+      expect(complete).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledOnce();
     });
 
     it('rejects clear plus any source selection before updating', async () => {

--- a/src/domain/collaboration/callout/callout.resolver.mutations.ts
+++ b/src/domain/collaboration/callout/callout.resolver.mutations.ts
@@ -29,6 +29,7 @@ import { AuthorizationPolicyService } from '@domain/common/authorization-policy/
 import { IMemo } from '@domain/common/memo/types';
 import { IWhiteboard } from '@domain/common/whiteboard/whiteboard.interface';
 import { WhiteboardService } from '@domain/common/whiteboard/whiteboard.service';
+import { WhiteboardDraftService } from '@domain/common/whiteboard-draft';
 import { Inject } from '@nestjs/common/decorators';
 import { ConfigService } from '@nestjs/config';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
@@ -99,6 +100,7 @@ export class CalloutResolverMutations {
     private readonly configService: ConfigService<AlkemioConfig, true>,
     private readonly collaborationLicenseService: CollaborationLicenseService,
     private readonly whiteboardService: WhiteboardService,
+    private readonly whiteboardDraftService: WhiteboardDraftService,
     private readonly reactionService: ReactionService,
     private readonly actorLookupService: ActorLookupService,
     private readonly taskBoardColumnService: TaskBoardColumnService,
@@ -168,10 +170,30 @@ export class CalloutResolverMutations {
       AuthorizationPrivilege.UPDATE,
       `update callout: ${callout.id}`
     );
-    await this.contributionDefaultSourceService.prepare(
-      calloutData.contributionDefaults,
-      actorContext
-    );
+
+    const defaults = calloutData.contributionDefaults;
+    const defaultsDraftID = defaults?.draftWhiteboardID;
+    await using draftConsumption =
+      await this.whiteboardDraftService.acquireForConsumption(
+        defaultsDraftID ? [defaultsDraftID] : [],
+        actorContext
+      );
+    if (defaultsDraftID) {
+      if (
+        defaults.sourceWhiteboardID ||
+        defaults.sourceCalloutID ||
+        defaults.clearWhiteboardContent
+      ) {
+        throw new ValidationException(
+          'draftWhiteboardID, contribution-default source fields, and clearWhiteboardContent are mutually exclusive',
+          LogContext.WHITEBOARDS
+        );
+      }
+      const draft = draftConsumption.drafts.get(defaultsDraftID)!;
+      defaults.sourceWhiteboardID = draft.id;
+      defaults.draftWhiteboardID = undefined;
+    }
+    await this.contributionDefaultSourceService.prepare(defaults, actorContext);
 
     // CONTRIBUTORS framing is admin-only and collaboration-only for LIVE callouts
     // (FR-004a/FR-004f, R5). Mirror the create guard on the update path so the
@@ -232,6 +254,11 @@ export class CalloutResolverMutations {
       actorContext.actorID
     );
 
+    // The updated Callout now durably owns the draft content. Make the draft
+    // non-consumable before later authorization work can fail, so a retry
+    // cannot apply the same draft to a second update.
+    await draftConsumption.markConsumed();
+
     // Reset authorization policy for the callout and its child entities
     // This is needed because updateCallout might create new entities (like comments room)
     // that need proper authorization policies
@@ -249,6 +276,7 @@ export class CalloutResolverMutations {
       );
 
     await this.authorizationPolicyService.saveAll(updatedAuthorizations);
+    await draftConsumption.complete();
     return updatedCallout;
   }
 

--- a/src/domain/common/whiteboard/whiteboard.graphql.contract.spec.ts
+++ b/src/domain/common/whiteboard/whiteboard.graphql.contract.spec.ts
@@ -52,6 +52,7 @@ describe('Whiteboard GraphQL content boundary', () => {
       expect.objectContaining({
         sourceWhiteboardID: expect.anything(),
         sourceCalloutID: expect.anything(),
+        draftWhiteboardID: expect.anything(),
         clearWhiteboardContent: expect.anything(),
       })
     );


### PR DESCRIPTION
## What this fixes

Adds create-symmetric whiteboard draft claiming to updateCalloutContributionDefaults. Editing an existing response default can now bind the edited draft atomically instead of losing the drawing or reverting to legacy snapshot transport.

The mutation acquires the draft, rejects conflicting whiteboard inputs, performs the durable update, marks the draft consumed, persists authorization, and only then completes canonical draft deletion. Failure paths release the claim without consuming the draft.

## Contract

- Adds optional draftWhiteboardID to UpdateCalloutContributionDefaultsInput.
- Implements the specs/058 whiteboard-draft update-flow delta.
- Thin client wiring follows in a separate client-web PR.
- Related parity audit: alkem-io/client-web#10217.

## Verification

- Full pre-commit suite: 760 files passed, 8,770 tests passed, 6 files / 7 tests skipped.
- Focused resolver and draft-lifecycle tests passed.
- Lint, typecheck, build, schema print/sort, and GraphQL boundary contract passed.
- Architecture review by the lifecycle co-seat: green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Callout contribution defaults can now be replaced using a server-owned live Whiteboard draft.
  * Draft Whiteboards are converted and applied atomically during callout updates.
  * Drafts are safely consumed after successful updates and preserved when updates fail.
* **Bug Fixes**
  * Added validation to prevent combining a draft Whiteboard with other source or clearing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->