### PR TITLE
fix: preserve callout bucket through framing update

### DIFF
--- a/src/domain/collaboration/callout/callout.service.spec.ts
+++ b/src/domain/collaboration/callout/callout.service.spec.ts
@@ -976,6 +976,24 @@ describe('CalloutService', () => {
   });
 
   describe('updateCallout', () => {
+    const createUpdatableCallout = (profile: Record<string, unknown>) =>
+      ({
+        id: 'callout-1',
+        framing: {
+          id: 'framing-1',
+          type: CalloutFramingType.NONE,
+          profile,
+        },
+        contributionDefaults: { id: 'defaults-1' },
+        settings: {
+          contribution: { allowedTypes: [] },
+          framing: { commentsEnabled: false },
+        },
+        classification: { id: 'class-1', tagsets: [] },
+        calloutsSet: { id: 'cs-1' },
+        isTemplate: true,
+      }) as any;
+
     it('should update callout framing, settings, classification, and save', async () => {
       const callout = {
         id: 'callout-1',
@@ -1030,6 +1048,101 @@ describe('CalloutService', () => {
       expect(framingService.updateCalloutFraming).toHaveBeenCalled();
       expect(classificationService.updateClassification).toHaveBeenCalled();
       expect(result.sortOrder).toBe(5);
+    });
+
+    it('materializes a Whiteboard default into the bucket loaded before the framing profile is updated', async () => {
+      const callout = createUpdatableCallout({
+        storageBucket: { id: 'target-bucket' },
+      });
+      callout.contributionDefaults.whiteboardContent = 'previous-content';
+
+      vi.mocked(repository.findOne).mockResolvedValue(callout);
+      vi.mocked(repository.save).mockResolvedValue(callout);
+      vi.mocked(
+        _storageAggregatorResolverService.getStorageAggregatorForCallout
+      ).mockResolvedValue({ id: 'agg-1' } as any);
+      vi.mocked(framingService.updateCalloutFraming).mockResolvedValue({
+        id: 'framing-1-updated',
+        type: CalloutFramingType.NONE,
+        profile: { id: 'profile-1' },
+      } as any);
+      vi.mocked(
+        framingService.validateAndNormalizeContributorsSettings
+      ).mockImplementation((_type, settings) => settings as any);
+      vi.mocked(
+        framingService.validateAndNormalizeSelectionSettings
+      ).mockImplementation((_type, settings) => settings as any);
+      vi.mocked(
+        contributionDefaultsService.updateCalloutContributionDefaults
+      ).mockImplementation(defaults => defaults);
+      vi.mocked(
+        contributionDefaultsService.materializeWhiteboardDefault
+      ).mockResolvedValue({
+        content: 'target-owned-content',
+        createdDocumentIDs: ['document-1'],
+      });
+
+      const result = await service.updateCallout(
+        callout,
+        {
+          framing: { profile: { displayName: 'Updated' } },
+          contributionDefaults: {
+            whiteboardContent: 'source-content',
+            sourceStorageBucketID: 'source-bucket',
+          },
+        } as any,
+        actorContextData.actorContext,
+        'user-1'
+      );
+
+      expect(
+        contributionDefaultsService.materializeWhiteboardDefault
+      ).toHaveBeenCalledWith(
+        {
+          whiteboardContent: 'source-content',
+          sourceStorageBucketID: 'source-bucket',
+        },
+        'target-bucket'
+      );
+      expect(result.contributionDefaults?.whiteboardContent).toBe(
+        'target-owned-content'
+      );
+    });
+
+    it('rejects a Whiteboard default when the callout genuinely has no storage bucket', async () => {
+      const callout = createUpdatableCallout({ id: 'profile-1' });
+
+      vi.mocked(repository.findOne).mockResolvedValue(callout);
+      vi.mocked(
+        _storageAggregatorResolverService.getStorageAggregatorForCallout
+      ).mockResolvedValue({ id: 'agg-1' } as any);
+      vi.mocked(
+        framingService.validateAndNormalizeContributorsSettings
+      ).mockImplementation((_type, settings) => settings as any);
+      vi.mocked(
+        framingService.validateAndNormalizeSelectionSettings
+      ).mockImplementation((_type, settings) => settings as any);
+      vi.mocked(
+        contributionDefaultsService.updateCalloutContributionDefaults
+      ).mockImplementation(defaults => defaults);
+
+      await expect(
+        service.updateCallout(
+          callout,
+          {
+            contributionDefaults: {
+              whiteboardContent: 'source-content',
+              sourceStorageBucketID: 'source-bucket',
+            },
+          } as any,
+          actorContextData.actorContext
+        )
+      ).rejects.toThrow(
+        'Callout has no storage bucket for its Whiteboard default'
+      );
+      expect(
+        contributionDefaultsService.materializeWhiteboardDefault
+      ).not.toHaveBeenCalled();
     });
 
     it('should throw EntityNotInitializedException when contributionDefaults is missing', async () => {

--- a/src/domain/collaboration/callout/callout.service.ts
+++ b/src/domain/collaboration/callout/callout.service.ts
@@ -548,6 +548,7 @@ export class CalloutService {
         LogContext.COLLABORATION
       );
     }
+    const targetStorageBucketID = callout.framing.profile?.storageBucket?.id;
 
     if (calloutUpdateData.framing) {
       callout.framing = await this.calloutFramingService.updateCalloutFraming(
@@ -651,7 +652,6 @@ export class CalloutService {
           calloutUpdateData.contributionDefaults
         );
 
-      const targetStorageBucketID = callout.framing.profile?.storageBucket?.id;
       if (
         calloutUpdateData.contributionDefaults.whiteboardContent !==
           undefined &&

--- a/src/domain/common/profile/profile.service.ts
+++ b/src/domain/common/profile/profile.service.ts
@@ -229,6 +229,10 @@ export class ProfileService {
     profileOrig: IProfile,
     profileData: UpdateProfileInput
   ): Promise<IProfile> {
+    // The returned profile intentionally omits storageBucket. That relation
+    // cascades, so loading it here would make every profile update traverse
+    // owned storage rows. Callers that need its id after this update must
+    // preserve the id before calling this method.
     const profile = await this.getProfileOrFail(profileOrig.id, {
       relations: {
         references: true,


### PR DESCRIPTION
## Source

Free-text bug report; no delivery-board story.

Cross-reference: client-web [#10244](https://github.com/alkem-io/client-web/pull/10244).

## Root cause

`CalloutService.updateCallout` initially loads `framing.profile.storageBucket`. Updating framing delegates to `ProfileService.updateProfile`, whose intentionally partial return omits the cascade-owned `storageBucket` relation. Replacing the in-memory framing profile therefore discarded the loaded relation before contribution-default Whiteboard materialization, causing error 12108 even though the bucket still existed.

## Minimal fix

- Preserve the target storage-bucket ID after the fully-related callout fetch and before framing update replaces the profile object.
- Materialize the contribution-default Whiteboard into that preserved bucket.
- Document the `ProfileService.updateProfile` return contract: it intentionally omits `storageBucket` because loading the cascade relation would amplify writes.
- Add regression coverage for relation loss and retain the genuine missing-bucket failure.

No GraphQL, lifecycle, storage ownership, or persistence contract changes.

## Regression evidence

RED before the production fix:

- relation-loss regression failed with `EntityNotInitializedException: Callout has no storage bucket for its Whiteboard default`.

GREEN on this head:

- complete `callout.service.spec.ts`: 67/67 passed.
- `pnpm lint`: passed (`tsc --noEmit` and Biome, 3288 files).
- `pnpm build`: passed.
- `pnpm test:ci:no:coverage`: 760 files passed, 6 skipped; 8772 tests passed, 7 skipped.
- `pnpm exec vitest run --coverage`: same 760/6 files and 8772/7 tests; exit 0.
- signed pre-commit gate reran typecheck and the full no-coverage suite successfully.
- `git diff --check`: passed.

## Deployment and live verification

Deploy this server PR before client-web #10244.

The developer stack remains frozen. The live parity case #6 re-walk waits for this PR to merge and deploy, plus explicit stack unfreeze from Anton. This PR does not merge, deploy, or mutate stack data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved callout updates so Whiteboard content is correctly materialized in the associated storage bucket.
  * Added validation when a storage bucket is unavailable, preventing invalid updates.

* **Documentation**
  * Clarified profile update behavior and storage bucket handling for more reliable integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Final live evidence (2026-08-30)

PASS after merge and stack unfreeze. The post-merge server at e59ab7024e58840c6bb4dd0d73a1f16eb3000027 loaded an existing callout-template default Whiteboard, saved an edit, and completed UpdateCalloutTemplate without code 12108. Reopen retained the edit; an unchanged save produced no new draft/update; cancelled edits did not persist; the draft was consumed exactly once. This live-proves the pre-captured storage-bucket fix required by client-web #10244.