### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -8682,6 +8682,10 @@ input UpdateCalloutContributionDefaultsInput {
   clearWhiteboardContent: Boolean
   """The default title to use for new contributions."""
   defaultDisplayName: String
+  """
+  Replace the default from a server-owned live Whiteboard contribution-default draft. Mutually exclusive with either source field and clearWhiteboardContent.
+  """
+  draftWhiteboardID: UUID
   """The default description to use for new Post contributions."""
   postDescription: Markdown
   """


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 343661 bytes
Snapshot md5: 023ce27ff5e6861ecdf6ee2b40251ce4

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a callout’s default Whiteboard content from a draft Whiteboard.
  * The new option is mutually exclusive with other Whiteboard source and clearing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->