### PR TITLE
fix: repair legacy whiteboard migration compatibility [patch] [Release 73]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-server",
-  "version": "0.163.4",
+  "version": "0.163.5",
   "description": "Alkemio server, responsible for managing the shared Alkemio platform",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/domain/common/whiteboard/conversion/whiteboard.scene.to.yjs.v2.state.spec.ts
+++ b/src/domain/common/whiteboard/conversion/whiteboard.scene.to.yjs.v2.state.spec.ts
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
 import type * as Yjs from 'yjs';
 import { EMPTY_WHITEBOARD_CONTENT } from '../empty.whiteboard.content';
+import { loadWhiteboardFork } from '../whiteboard.fork';
 import {
   parseLegacyWhiteboardScene,
   whiteboardSceneToYjsV2State,
@@ -160,6 +161,138 @@ describe('whiteboardSceneToYjsV2State (fork-based encoder)', () => {
     expect(typeof decoded.element('b')?.get('index')).toBe('string');
   });
 
+  it('moves legacy bound text after its container before seeding indices', async () => {
+    const scene = JSON.stringify({
+      type: 'excalidraw',
+      version: 2,
+      source: '',
+      elements: [
+        {
+          id: 'label',
+          type: 'text',
+          containerId: 'container',
+          text: 'Label',
+          originalText: 'Label',
+          x: 10,
+          y: 10,
+          index: 'a0',
+        },
+        {
+          id: 'container',
+          type: 'rectangle',
+          boundElements: [{ id: 'label', type: 'text' }],
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 50,
+          index: 'a1',
+        },
+      ],
+      appState: {},
+      files: {},
+    });
+
+    const fork = await loadWhiteboardFork();
+    const snapshot = fork.decodeSnapshot(
+      await whiteboardSceneToYjsV2State(scene)
+    );
+
+    expect(snapshot.elements.map(element => element.id)).toEqual([
+      'container',
+      'label',
+    ]);
+    expect(() =>
+      fork.validateFractionalIndices(snapshot.elements as never, {
+        shouldThrow: true,
+        includeBoundTextValidation: true,
+        ignoreLogs: true,
+      })
+    ).not.toThrow();
+  });
+
+  it('drops only stale text bindings that contradict the child container id', async () => {
+    const scene = JSON.stringify({
+      type: 'excalidraw',
+      version: 2,
+      source: '',
+      elements: [
+        {
+          id: 'owner',
+          type: 'rectangle',
+          boundElements: [{ id: 'label', type: 'text' }],
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 50,
+          index: 'a0',
+        },
+        {
+          id: 'label',
+          type: 'text',
+          containerId: 'owner',
+          text: 'Label',
+          originalText: 'Label',
+          x: 10,
+          y: 10,
+          index: 'a1',
+        },
+        {
+          id: 'stale-parent',
+          type: 'rectangle',
+          boundElements: [
+            { id: 'label', type: 'text' },
+            { id: 'arrow', type: 'arrow' },
+          ],
+          x: 200,
+          y: 0,
+          width: 100,
+          height: 50,
+          index: 'a2',
+        },
+        {
+          id: 'arrow',
+          type: 'arrow',
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+          points: [
+            [0, 0],
+            [10, 10],
+          ],
+          index: 'a3',
+        },
+      ],
+      appState: {},
+      files: {},
+    });
+
+    const fork = await loadWhiteboardFork();
+    const snapshot = fork.decodeSnapshot(
+      await whiteboardSceneToYjsV2State(scene)
+    );
+    const staleParent = snapshot.elements.find(
+      element => element.id === 'stale-parent'
+    );
+
+    expect(staleParent?.boundElements).toEqual([
+      { id: 'arrow', type: 'arrow' },
+    ]);
+    expect(snapshot.elements.map(element => element.id).sort()).toEqual([
+      'arrow',
+      'label',
+      'owner',
+      'stale-parent',
+    ]);
+    expect(() =>
+      fork.validateFractionalIndices(snapshot.elements as never, {
+        shouldThrow: true,
+        includeBoundTextValidation: true,
+        ignoreLogs: true,
+      })
+    ).not.toThrow();
+  });
+
   it('does NOT store the immutable input scene (no mutation of the caller records)', async () => {
     const elements = [{ id: 'a', type: 'rectangle', x: 0, y: 0 }] as const;
     const scene = JSON.stringify({
@@ -274,6 +407,10 @@ describe('parseLegacyWhiteboardScene', () => {
     expect(parsed?.elements).toHaveLength(1);
     expect(parsed?.files?.f1?.url).toBe('http://x/y.png');
     expect(parsed?.appState?.viewBackgroundColor).toBe('#fff');
+  });
+
+  it('recognizes the historical empty-object sentinel as an empty scene', () => {
+    expect(parseLegacyWhiteboardScene(' {} ')).toEqual({ elements: [] });
   });
 
   it('returns undefined for empty / non-JSON / structurally-invalid content', () => {

--- a/src/domain/common/whiteboard/conversion/whiteboard.scene.to.yjs.v2.state.ts
+++ b/src/domain/common/whiteboard/conversion/whiteboard.scene.to.yjs.v2.state.ts
@@ -6,7 +6,8 @@ import { loadWhiteboardFork } from '../whiteboard.fork';
  * z-index seeding, `files` asset map and V2 encoding are ALL owned by the
  * excalidraw-yjs headless fork (`@excalidraw-yjs/element/headless`): this adapter
  * does NOT reimplement any of them. It parses the legacy scene, seeds fractional
- * indices via the fork's canonical `syncInvalidIndices`, and hands
+ * legacy element order/bindings through the fork's canonical compatibility
+ * helpers, and hands
  * `{ elements, assets, appState }` to the fork's `encodeSnapshot`. The result is
  * therefore STRUCTURALLY identical to what an editor produces for the same scene
  * (FR-002 — one representation everywhere): same root types, per-property element
@@ -38,7 +39,8 @@ import { loadWhiteboardFork } from '../whiteboard.fork';
  * malformed NONEMPTY legacy scene BEFORE calling this (`parseLegacyWhiteboardScene`
  * returns `undefined` on a non-blank blob → the record FAILS and stays re-runnable, never
  * aborting the batch), rather than silently emptying it. Only a blank / whitespace legacy
- * value reaches here as canonical-empty.
+ * value, or the historical `{}` empty-scene sentinel, reaches here as
+ * canonical-empty.
  */
 export const whiteboardSceneToYjsV2State = async (
   sceneJSON: string,
@@ -47,9 +49,68 @@ export const whiteboardSceneToYjsV2State = async (
   const fork = await loadWhiteboardFork();
   const scene = parseLegacyWhiteboardScene(sceneJSON);
 
-  // Work on copies so `syncInvalidIndices` (which mutates elements in place to
-  // assign fractional indices) never touches the caller's records.
-  const elements = scene ? scene.elements.map(element => ({ ...element })) : [];
+  // Work on copies so the compatibility repair and `syncInvalidIndices` (which
+  // mutate element arrays/records) never touch the caller's scene.
+  const copiedElements: Record<string, unknown>[] = scene
+    ? scene.elements.map(
+        (element): Record<string, unknown> => ({
+          ...element,
+          // Old/minimal scenes can predate this required Excalidraw collection.
+          // The fork's order normalizer reads it unconditionally.
+          groupIds: Array.isArray(element.groupIds)
+            ? [...element.groupIds]
+            : [],
+          ...(Array.isArray(element.boundElements)
+            ? {
+                boundElements: element.boundElements.map(boundElement =>
+                  boundElement && typeof boundElement === 'object'
+                    ? { ...boundElement }
+                    : boundElement
+                ),
+              }
+            : {}),
+        })
+      )
+    : [];
+
+  // Some legacy scenes contain a stale text reference on one container while
+  // the text child points at another. The child's typed `containerId` is the
+  // canonical owner, so remove only the contradictory parent-side text ref.
+  // Non-text bindings (arrows, etc.) are deliberately preserved.
+  const elementsById = new Map(
+    copiedElements.flatMap(element =>
+      typeof element.id === 'string' ? [[element.id, element] as const] : []
+    )
+  );
+  const consistentElements = copiedElements.map(element => {
+    if (!Array.isArray(element.boundElements)) {
+      return element;
+    }
+    const boundElements = element.boundElements.filter(boundElement => {
+      if (
+        !boundElement ||
+        typeof boundElement !== 'object' ||
+        !('type' in boundElement) ||
+        boundElement.type !== 'text'
+      ) {
+        return true;
+      }
+      const boundId = 'id' in boundElement ? boundElement.id : undefined;
+      const child =
+        typeof boundId === 'string' ? elementsById.get(boundId) : undefined;
+      return (
+        child?.type === 'text' &&
+        typeof element.id === 'string' &&
+        child.containerId === element.id
+      );
+    });
+    return { ...element, boundElements };
+  });
+
+  // The fork owns the compatibility ordering rule. In particular, old scenes
+  // may place bound text before its container, which strict bound-text index
+  // validation rejects even though the scene is otherwise valid.
+  const elements = [...fork.normalizeElementOrder(consistentElements as never)];
   if (elements.length > 0) {
     // The fork's canonical fractional-index repair: seeds/repairs invalid indices
     // in the array's (z-)order, leaving already-valid indices untouched — the same
@@ -91,7 +152,9 @@ export type LegacyWhiteboardScene = {
 /**
  * Parses a stored legacy Excalidraw scene JSON into its structural parts. Returns
  * `undefined` for empty / non-JSON / structurally-absent (`elements` missing)
- * content so the caller seeds the canonical empty doc instead of throwing. Shared
+ * content so the caller seeds the canonical empty doc instead of throwing. The
+ * historical exact-empty-object sentinel (`{}`) is normalized to an empty scene.
+ * Shared
  * by the encoder (reads `elements` + `appState`) and the migration (reads `files`
  * to resolve asset locators), so both agree on what a valid scene is.
  */
@@ -107,11 +170,13 @@ export const parseLegacyWhiteboardScene = (
   } catch {
     return undefined;
   }
-  if (
-    !parsed ||
-    typeof parsed !== 'object' ||
-    !Array.isArray((parsed as { elements?: unknown }).elements)
-  ) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined;
+  }
+  if (Object.keys(parsed).length === 0) {
+    return { elements: [] };
+  }
+  if (!Array.isArray((parsed as { elements?: unknown }).elements)) {
     return undefined;
   }
   return parsed as LegacyWhiteboardScene;

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.spec.ts
@@ -970,6 +970,24 @@ describe('CollaborationMigrationService', () => {
       expect(memo.createQueryBuilder).toHaveBeenCalledTimes(1);
     });
 
+    it('reports a structured error code when an Error has an empty message', async () => {
+      memo.createQueryBuilder.mockReturnValueOnce(
+        queryBuilderMock([
+          [{ id: 'm1', content: null, storageBucketId: 'sb1' }],
+        ])
+      );
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      fileService.createSnapshotInBucket.mockRejectedValue(
+        Object.assign(new Error(), { code: 'SNAPSHOT_WRITE_FAILED' })
+      );
+
+      const summary = await svc.migrateAll();
+
+      expect(summary.failedDocuments).toEqual([
+        { id: 'm1', reason: 'SNAPSHOT_WRITE_FAILED' },
+      ]);
+    });
+
     it('publishes a reused snapshot id without treating it as an attempt-owned row', async () => {
       const update = updateQB(1);
       memo.createQueryBuilder
@@ -1200,6 +1218,38 @@ describe('CollaborationMigrationService', () => {
       const second = await svc.migrateWhiteboards();
       expect(second).toMatchObject({ total: 0, migrated: 0, failed: 0 });
       expect(contributionDefaults.createQueryBuilder).toHaveBeenCalledTimes(1);
+    });
+
+    it('migrates the historical empty-object contribution default as a canonical empty snapshot', async () => {
+      const storedContent = await compressText('{}');
+      const update = updateQB();
+      whiteboard.createQueryBuilder.mockReturnValue(queryBuilderMock([[]]));
+      contributionDefaults.query.mockResolvedValueOnce([
+        {
+          id: 'empty-default',
+          storedContent,
+          storageBucketId: 'callout-bucket-1',
+        },
+      ]);
+      contributionDefaults.createQueryBuilder.mockReturnValue(update.qb);
+
+      const summary = await svc.migrateWhiteboards();
+
+      expect(summary).toMatchObject({
+        total: 1,
+        migrated: 1,
+        flagged: 0,
+        failed: 0,
+      });
+      const canonicalStored = (
+        update.set.mock.calls as unknown as Array<
+          [{ whiteboardContent: string }]
+        >
+      )[0][0].whiteboardContent;
+      const canonical = await decompressText(canonicalStored);
+      expect(
+        await readStoredElementIds(Buffer.from(canonical, 'base64'))
+      ).toEqual([]);
     });
 
     it('counts and reports a legacy contribution default with no complete owning Callout path', async () => {
@@ -2889,6 +2939,18 @@ describe('CollaborationMigrationService', () => {
       expect(summary.migrated).toBe(0);
       expect(fileService.createSnapshotInBucket).not.toHaveBeenCalled();
       expect(update.set).not.toHaveBeenCalled();
+    });
+
+    it('migrate: the historical empty-object sentinel becomes a canonical empty snapshot', async () => {
+      const { summary, captured, update } = await migrateOneWhiteboard('{}');
+
+      expect(summary).toMatchObject({
+        migrated: 1,
+        flagged: 0,
+        failed: 0,
+      });
+      expect(await readStoredElementIds(captured.buffer!)).toEqual([]);
+      expect(update.set).toHaveBeenCalled();
     });
 
     it('migrate: a valid-JSON scene whose elements is NOT an array → failed, ZERO writes', async () => {

--- a/src/services/collaboration-integration/migration/collaboration-migration.service.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.service.ts
@@ -49,6 +49,25 @@ const Y = nodeRequire('yjs') as typeof import('yjs');
 
 const DEFAULT_BATCH_SIZE = 200;
 
+/** Stable operator-facing reason, including structured errors with empty prose. */
+const migrationErrorReason = (error: unknown): string => {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  if (error && typeof error === 'object') {
+    const code = Reflect.get(error, 'code');
+    if (typeof code === 'string' && code.trim()) {
+      return code;
+    }
+    const name = Reflect.get(error, 'name');
+    if (typeof name === 'string' && name.trim()) {
+      return name;
+    }
+  }
+  const fallback = String(error).trim();
+  return fallback || 'Unknown migration error';
+};
+
 /** The one canonical top-level Y root of a memo doc — a `Y.XmlFragment` named this. */
 const MEMO_ROOT = 'default';
 
@@ -407,7 +426,7 @@ export class CollaborationMigrationService {
         summary.failed++;
         summary.failedDocuments.push({
           id: record.id,
-          reason: error instanceof Error ? error.message : String(error),
+          reason: migrationErrorReason(error),
         });
         this.logger.error?.(
           {
@@ -472,7 +491,7 @@ export class CollaborationMigrationService {
         summary.failed++;
         summary.failedDocuments.push({
           id: record.id,
-          reason: error instanceof Error ? error.message : String(error),
+          reason: migrationErrorReason(error),
         });
         this.logger.error?.(
           {


### PR DESCRIPTION
## Source

Free-text production migration defect; there is no board story. This hotfix targets master, which now contains the merged release/73 line.

## Production symptom

A read-only production audit found legacy Whiteboards failing migration with blank reasons. The structural failures were invalid bound-text ordering or stale non-reciprocal text bindings. Two failed Whiteboards and seven flagged contribution-default snapshots were the historical exact-empty-object scene sentinel. Structured fork errors also exposed an empty message, producing blank report reasons. No production data was modified during investigation.

## Root cause

The scene converter repaired fractional indices but did not run the fork-owned legacy element-order normalization. It also retained parent-side text bindings that contradicted the text child canonical containerId. The legacy parser rejected the exact empty-object sentinel as malformed, and failure reporting used Error.message even when it was empty.

## Bounded fix

- Normalize legacy element order before fractional-index repair.
- Remove only contradictory parent-side text references; preserve every element and every non-text binding.
- Canonicalize only the exact empty-object sentinel into an empty editable Yjs document. Other malformed non-empty scenes still fail closed.
- Report a stable typed error code or name when error prose is empty.

Existing Whiteboard entities and contribution-default slots remain present. Empty sentinels become canonical empty Yjs snapshots; they are not deleted or converted into absent defaults.

## Regression coverage

- Bound text stored before its container.
- Stale non-reciprocal text binding with non-text binding preservation.
- Empty-object Whiteboard migration.
- Empty-object contribution-default migration.
- Structured error with an empty message.

## Gates

- pnpm test:ci: 8,778 passed; 7 skipped.
- pnpm build: passed.
- pnpm lint: passed (TypeScript plus Biome).
- Repository pre-commit suite: passed.

## Comment convention

The comments added by this diff contain no spec, issue, or PR references.