### PR TITLE
fix(collabora): add CHOWN + FOWNER to match the deployed manifests

### DIFF
--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -810,12 +810,22 @@ services:
     cap_drop:
       - ALL
     cap_add:
-      # Collabora needs both of these to build its per-document chroot jails,
-      # and it needs them together — verified against 26.04.2.4.1 with a
-      # drop-ALL baseline:
-      #   drop ALL + SYS_ADMIN              -> chroot() fails EPERM, kit crash-loop
-      #   drop ALL + SYS_ADMIN + SYS_CHROOT -> jails build, export works
-      #   ... + MKNOD                       -> no change, so MKNOD is NOT needed
+      # Collabora picks its forkit at RUNTIME depending on whether it can create
+      # a user namespace, and the two modes need different capabilities. This
+      # set is the union, so the same list works on every runtime:
+      #
+      #   userns available -> coolforkit-ns   (bind-mounted jails)
+      #   userns blocked   -> coolforkit-caps (additionally needs CHOWN, FOWNER)
+      #
+      # Both export the same document to a byte-identical 57,375-byte PDF.
+      #
+      # SYS_ADMIN + SYS_CHROOT alone is enough HERE (Docker Desktop always has
+      # user namespaces) but NOT on a host that blocks them: coolwsd falls back
+      # to coolforkit-caps and dies with "Failed to spawn coolforkit" /
+      # "waitpid failed (ECHILD)" / exit 70. That is what broke the k3s dev
+      # cluster (alkem-io/dev-orchestration#82). Keeping the full union here
+      # means local dev matches the deployed manifests instead of quietly
+      # depending on Docker Desktop's more permissive runtime.
       #
       # These grants and the removal of --o:security.capabilities=false above are
       # a single indivisible change: without the capabilities, coolforkit cannot
@@ -831,6 +841,8 @@ services:
       # "Initialized jail nodes, dropped caps. Final caps are: =".
       - SYS_ADMIN
       - SYS_CHROOT
+      - CHOWN
+      - FOWNER
     tmpfs:
       # World-writable (mode=1777) so the non-root 'cool' user can create
       # per-session jails here.


### PR DESCRIPTION
Follow-up to #6383, aligning the compose stack with the capability list the deployed manifests need.

## Why

Collabora picks its forkit **at runtime**:

| Node can create a user namespace? | forkit | needs |
|---|---|---|
| yes (Docker Desktop — always) | `coolforkit-ns` | `SYS_ADMIN`, `SYS_CHROOT` |
| no (the k3s dev cluster) | `coolforkit-caps` | + **`CHOWN`, `FOWNER`** |

#6383's two capabilities are genuinely sufficient *here*, because Docker Desktop always has user namespaces. They were not sufficient on k3s, where the fallback path died with `Failed to spawn coolforkit` / `waitpid failed (ECHILD)` / exit 70 and crash-looped the pod — see alkem-io/dev-orchestration#82 for the full root cause and the elimination matrix.

## Why change it here at all

Nothing is broken in the local stack. This is about the compose file not quietly depending on Docker Desktop being more permissive than the clusters: with the same list everywhere, local dev exercises the same configuration that ships, and the next person comparing the two doesn't find an unexplained difference.

Verified both forkit modes export the same document to a **byte-identical 57,375-byte PDF**. `docker compose config` renders `cap_add: [SYS_ADMIN, SYS_CHROOT, CHOWN, FOWNER]` with `cap_drop: [ALL]`.

Still `drop: ALL`, still non-root, and the kit that parses the untrusted document still lands in a jail with zero capabilities (`Initialized jail nodes, dropped caps. Final caps are: =`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both user-namespace and capability-based runtime modes.
  * Expanded required capabilities to improve startup compatibility across different runtime environments.

* **Documentation**
  * Documented runtime-dependent behavior and potential failure modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->