### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -67,6 +67,38 @@ input AccountAuthorizationResetInput {
   accountID: UUID!
 }
 
+"""
+One item blocking a user from deleting their own account — a space, virtual contributor, innovation pack, innovation hub, or an organization the user is the sole owner of.
+"""
+type AccountDeletionBlocker {
+  displayName: String!
+  kind: AccountDeletionBlockerKind!
+  resourceID: UUID!
+  """
+  True when the user can resolve the blocker alone, via the existing account-resources page. False for a sole-owned organization — ownership must be handed over, or support contacted.
+  """
+  selfResolvable: Boolean!
+  """Client-navigable URL of the blocking resource, when one exists."""
+  url: String
+}
+
+"""The kind of resource blocking a user from deleting their own account."""
+enum AccountDeletionBlockerKind {
+  ACCOUNT_INNOVATION_HUB
+  ACCOUNT_INNOVATION_PACK
+  ACCOUNT_SPACE
+  ACCOUNT_VIRTUAL_CONTRIBUTOR
+  SOLE_ORGANIZATION_OWNER
+}
+
+"""
+Accurate per-kind total, independent of whether the itemized blocker list was truncated.
+"""
+type AccountDeletionBlockerTotal {
+  kind: AccountDeletionBlockerKind!
+  total: Int!
+}
+
 type AccountLicensePlan {
   """The number of Innovation Packs allowed."""
   innovationPacks: Int!
@@ -3829,10 +3861,6 @@ type InAppNotificationPayloadPlatformUserMessageRoom implements InAppNotificatio
 type InAppNotificationPayloadPlatformUserProfileRemoved implements InAppNotificationPayload {
   """The payload type."""
   type: NotificationEventPayload!
-  """The display name of the User that was removed."""
-  userDisplayName: String!
-  """The email of the User that was removed."""
-  userEmail: String!
 }
 
 type InAppNotificationPayloadSpace implements InAppNotificationPayload {
@@ -4771,6 +4799,28 @@ enum McpApiKeyStatus {
   REVOKED
 }
 
+"""
+Self-scoped pre-flight read for account deletion: whether the calling user can delete their own account right now, and if not, exactly what blocks them. Computed by the same predicate the deleteUser mutation's self-branch guard uses, so the two can never drift. Not gated on session freshness — see sessionFresh.
+"""
+type MeAccountDeletionStatus {
+  """Itemized blockers, capped at 25."""
+  blockers: [AccountDeletionBlocker!]!
+  """True iff no blockers exist for the self branch."""
+  canDelete: Boolean!
+  """
+  True when the account carries a stored external billing linkage. Surfaced for transparency and captured in the audit record on deletion — never a blocker.
+  """
+  externalSubscriptionLinked: Boolean!
+  """
+  True iff the calling session currently satisfies the privileged freshness window. Advisory for client routing; the deleteUser mutation re-enforces this authoritatively at mutation time.
+  """
+  sessionFresh: Boolean!
+  """Accurate per-kind totals, independent of truncation."""
+  totals: [AccountDeletionBlockerTotal!]!
+  """True when the blocker list above was truncated at the cap."""
+  truncated: Boolean!
+}
+
 type MeConversationsResult {
   """
   All conversations (direct and group) for the current authenticated user. Client handles categorization by room type and member actor types.
@@ -4779,6 +4829,10 @@ type MeConversationsResult {
 }
 
 type MeQueryResults {
+  """
+  Self-scoped pre-flight read for account deletion: whether the calling user can delete their own account right now, and if not, exactly what blocks them.
+  """
+  accountDeletion: MeAccountDeletionStatus!
   """The community applications current authenticated user can act on."""
   communityApplications(
     """The state names you want to filter on"""
@@ -8682,6 +8736,10 @@ input UpdateCalloutContributionDefaultsInput {
   clearWhiteboardContent: Boolean
   """The default title to use for new contributions."""
   defaultDisplayName: String
+  """
+  Replace the default from a server-owned live Whiteboard contribution-default draft. Mutually exclusive with either source field and clearWhiteboardContent.
+  """
+  draftWhiteboardID: UUID
   """The default description to use for new Post contributions."""
   postDescription: Markdown
   """


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 345889 bytes
Snapshot md5: 0acda231ee705b7ce3cac6bf8b547b9a

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account-deletion status checks, including blockers, resolution links, deletion eligibility, and subscription/session information.
  * Added support for specifying a draft whiteboard when updating callout contribution defaults.

* **Changes**
  * Removed display name and email details from user-profile removal notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->