### PR TITLE
fix(visual): make 10:1 the banner default aspect ratio server-side (was 6)

### DIFF
--- a/src/domain/common/visual/visual.constraints.ts
+++ b/src/domain/common/visual/visual.constraints.ts
@@ -26,8 +26,9 @@ export const MEDIA_GALLERY_VIDEO_ALLOWED_TYPES = [
 // `aspectRatio` is the DEFAULT shape for a newly created visual.
 // `minAspectRatio`/`maxAspectRatio` bound what an editor may later change it to
 // via `updateVisual`. For every type except BANNER they equal `aspectRatio`,
-// i.e. the shape is fixed. BANNER is the one adjustable visual: a space admin
-// can pick anything from 6 (the historic shape) to 10 (a slimmer strip).
+// i.e. the shape is fixed. BANNER is the one adjustable visual: its default is
+// 10 (the slim strip — the same design default client-web renders), and a
+// space admin can pick anything from 6 (the historic shape) to 10.
 //
 // IMPORTANT — because the ratio is adjustable, BANNER's height bounds have to
 // span the WHOLE ratio range rather than matching a single shape:
@@ -50,7 +51,7 @@ export const DEFAULT_VISUAL_CONSTRAINTS = {
     maxWidth: 3840,
     minHeight: 120,
     maxHeight: 640,
-    aspectRatio: 6,
+    aspectRatio: 10,
     minAspectRatio: 6,
     maxAspectRatio: 10,
     allowedTypes: VISUAL_ALLOWED_TYPES,

--- a/src/domain/common/visual/visual.service.spec.ts
+++ b/src/domain/common/visual/visual.service.spec.ts
@@ -333,7 +333,8 @@ describe('VisualService', () => {
       // Height bounds span the whole 6-10 aspect-ratio range, not just 6:1.
       expect(result.minHeight).toBe(120);
       expect(result.maxHeight).toBe(640);
-      expect(result.aspectRatio).toBe(6);
+      // The default shape is the 10:1 slim strip; 6-10 stays the admin range.
+      expect(result.aspectRatio).toBe(10);
     });
   });
 

--- a/src/migrations/1788300000000-SetBannerDefaultAspectRatio.ts
+++ b/src/migrations/1788300000000-SetBannerDefaultAspectRatio.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Make 10:1 (the slim strip) the default aspect ratio of a BANNER visual that
+ * has no image yet, aligning the server with client-web's design default.
+ *
+ * `DEFAULT_VISUAL_CONSTRAINTS[BANNER].aspectRatio` is denormalized onto each
+ * `visual` row at creation time. Until an image is uploaded that stored value
+ * is nothing but the creation default — chosen by nobody. The moment an image
+ * IS uploaded, `uploadImageOnVisual` overwrites it with the ratio derived from
+ * the real pixels (width / height, 1 decimal), and a space admin may afterwards
+ * pick any ratio in the 6-10 range via `updateVisual`. So:
+ *
+ *   - rows WITH an image (`uri` non-empty) are NEVER touched: their ratio was
+ *     derived from real pixels or chosen by an admin, and is user data;
+ *   - rows WITHOUT an image still carrying the old creation default 6 are
+ *     re-synced to the new creation default 10, so an existing empty banner
+ *     and a freshly created one agree on what "default" means.
+ *
+ *   aspectRatio   6 -> 10   (only where "uri" is empty AND aspectRatio = 6)
+ *   minWidth / maxWidth / minHeight / maxHeight   unchanged
+ *
+ * The admin range stays 6-10, and the height bounds already span that whole
+ * range (see `1785283200000-WidenSpaceBannerVisualConstraints`), so no other
+ * stored constraint has to move.
+ *
+ * About the `uri` predicate: the column is `character varying(2048) NOT NULL`
+ * with no SQL DEFAULT (baseline migration) and no entity-level default;
+ * `VisualService.createVisual` writes `initialUri ?? ''`, so a banner without
+ * an image is stored as `''`, never NULL. The `IS NULL` branch is kept only as
+ * a belt-and-braces guard and matches no row today.
+ *
+ * Data-only, idempotent, no DDL, no authorization_policy writes, no auth reset.
+ * Existing `uri` values are untouched. Re-running up() is a no-op because the
+ * `"aspectRatio" = 6` predicate no longer matches after the first run.
+ *
+ * Scope note: the `"name" = 'banner'` filter covers EVERY profile that owns a
+ * BANNER-type visual (spaces, callout framings, etc.). That is intended: a
+ * banner with no image has no chosen shape anywhere, so the creation default
+ * is the only meaning its `aspectRatio` can have. `bannerWide` (innovation
+ * hubs) is deliberately NOT touched here.
+ *
+ * Rollback: down() restores 6 on the same set of rows (no image, currently at
+ * the new default 10). A banner that received an image while up() was applied
+ * keeps its pixel-derived ratio and its uri and is not rewritten either way.
+ */
+export class SetBannerDefaultAspectRatio1788300000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "visual" SET
+         "aspectRatio" = 10
+       WHERE "name" = 'banner'
+         AND ("uri" IS NULL OR "uri" = '')
+         AND "aspectRatio" = 6`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "visual" SET
+         "aspectRatio" = 6
+       WHERE "name" = 'banner'
+         AND ("uri" IS NULL OR "uri" = '')
+         AND "aspectRatio" = 10`
+    );
+  }
+}

--- a/src/migrations/__tests__/1788300000000-SetBannerDefaultAspectRatio.spec.ts
+++ b/src/migrations/__tests__/1788300000000-SetBannerDefaultAspectRatio.spec.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { VisualType } from '@common/enums/visual.type';
+import { DEFAULT_VISUAL_CONSTRAINTS } from '@domain/common/visual/visual.constraints';
+import { SetBannerDefaultAspectRatio1788300000000 } from '../1788300000000-SetBannerDefaultAspectRatio';
+
+/**
+ * Static-analysis assertions for the SetBannerDefaultAspectRatio migration.
+ * These run without a database connection by inspecting the migration source,
+ * and pin the migrated value to the constants so the two cannot drift apart.
+ */
+describe('SetBannerDefaultAspectRatio migration (1788300000000)', () => {
+  const migrationSrc = readFileSync(
+    resolve(__dirname, '../1788300000000-SetBannerDefaultAspectRatio.ts'),
+    'utf8'
+  );
+  const banner = DEFAULT_VISUAL_CONSTRAINTS[VisualType.BANNER];
+  const sqlBlocks =
+    migrationSrc.match(/await queryRunner\.query\(\s*`([\s\S]*?)`\s*\)/g) ?? [];
+  const upSrc = migrationSrc.slice(
+    migrationSrc.indexOf('async up('),
+    migrationSrc.indexOf('async down(')
+  );
+
+  it('exports the expected class', () => {
+    const instance = new SetBannerDefaultAspectRatio1788300000000();
+    expect(typeof instance.up).toBe('function');
+    expect(typeof instance.down).toBe('function');
+  });
+
+  it('up() writes the same default as DEFAULT_VISUAL_CONSTRAINTS[BANNER]', () => {
+    expect(upSrc).toMatch(
+      new RegExp(`"aspectRatio"\\s*=\\s*${banner.aspectRatio}\\b`)
+    );
+  });
+
+  it('the default sits within the adjustable [minAspectRatio, maxAspectRatio] range', () => {
+    expect(banner.aspectRatio).toBeGreaterThanOrEqual(banner.minAspectRatio);
+    expect(banner.aspectRatio).toBeLessThanOrEqual(banner.maxAspectRatio);
+  });
+
+  it('only touches image-less banner rows and never rewrites the size bounds or uri', () => {
+    expect(sqlBlocks.length).toBe(2);
+    for (const block of sqlBlocks) {
+      expect(block).toMatch(/WHERE\s+"name"\s*=\s*'banner'/);
+      // Rows WITH an image are user data and must never be rewritten.
+      expect(block).toMatch(/\(\s*"uri"\s+IS\s+NULL\s+OR\s+"uri"\s*=\s*''\s*\)/);
+      // The SET clause only ever writes aspectRatio: the size bounds and the
+      // uri are never rewritten (uri appears in the WHERE predicate only).
+      const setClause = block.slice(
+        block.indexOf('SET'),
+        block.indexOf('WHERE')
+      );
+      expect(setClause).toMatch(/^SET\s+"aspectRatio"\s*=\s*\d+\s*$/);
+      for (const column of [
+        'minWidth',
+        'maxWidth',
+        'minHeight',
+        'maxHeight',
+        'uri',
+      ]) {
+        expect(setClause).not.toMatch(new RegExp(`"${column}"`));
+      }
+      expect(block).not.toMatch(/bannerWide/i);
+    }
+  });
+
+  it('up() and down() are exact inverses over the same predicate', () => {
+    const [upBlock, downBlock] = sqlBlocks;
+    expect(upBlock).toMatch(/"aspectRatio"\s*=\s*10\s+WHERE/);
+    expect(upBlock).toMatch(/AND\s+"aspectRatio"\s*=\s*6\b/);
+    expect(downBlock).toMatch(/"aspectRatio"\s*=\s*6\s+WHERE/);
+    expect(downBlock).toMatch(/AND\s+"aspectRatio"\s*=\s*10\b/);
+  });
+});


### PR DESCRIPTION
Design alignment, not a bug fix today: the server still stamped `aspectRatio: 6` on every BANNER visual row while client-web renders the 10:1 slim strip as its design default, so the two repos disagreed about what "default" means. The default is 10:1 everywhere now. The admin-adjustable range stays 6–10 and the width/height bounds are unchanged.

## Changes

- `visual.constraints.ts`: `DEFAULT_VISUAL_CONSTRAINTS[BANNER].aspectRatio` 6 → 10; header comment updated.
- `visual.service.spec.ts`: the `createVisualBanner` assertion that pinned 6 now pins 10.
- New data-only migration `1788300000000-SetBannerDefaultAspectRatio`: sets `aspectRatio = 10` on banner rows that have **no image** and still carry the creation default 6. Rows with an image are never touched: their ratio was derived from real pixels on upload or chosen by an admin. `bannerWide` untouched. Idempotent, no DDL, no authorization writes. `down()` is the exact inverse over the same predicate. (`uri` is `NOT NULL` with no SQL default and the service writes `''` for a no-image visual; the `IS NULL` branch is belt-and-braces.)
- Static-analysis spec for the migration pins the written value to the constant, requires the default to sit inside `[minAspectRatio, maxAspectRatio]`, and asserts the SQL only touches `aspectRatio` on no-image banner rows.

## Verification

- `tsc --noEmit`, biome (full `src/`), vitest for `src/domain/common/visual` and `src/migrations/__tests__` (92 tests)
- Printed GraphQL schema is byte-identical to `schema.graphql`; no client codegen needed
- Migration not executed against any database

Client counterpart: alkem-io/client-web#10257 mirrors the new default in the create-space fallback constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaL9Nzwu9H2HNo9cHsipuT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Banner visuals now default to a slimmer aspect ratio of 10.
  * The selectable aspect-ratio range remains 6–10.
  * Existing image-less banner visuals are updated to use the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->