### PR TITLE
fix: replace expired TypeORM preview with durable package

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "replace-special-characters": "^1.2.7",
     "rxjs": "^7.8.1",
     "sharp": "^0.35.3",
-    "typeorm": "https://pkg.pr.new/antst/typeorm@2c8f380",
+    "typeorm": "https://pkg.pr.new/antst/typeorm@f0dc460",
     "uuid": "^13.0.0",
     "web-push": "^3.6.7",
     "winston": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "replace-special-characters": "^1.2.7",
     "rxjs": "^7.8.1",
     "sharp": "^0.35.3",
-    "typeorm": "https://pkg.pr.new/antst/typeorm@f0dc460",
+    "typeorm": "npm:@alkemio/typeorm@0.3.13-cti.1",
     "uuid": "^13.0.0",
     "web-push": "^3.6.7",
     "winston": "^3.13.1",
@@ -252,7 +252,7 @@
       "@swc/core-linux-arm64-musl": "false"
     },
     "patchedDependencies": {
-      "typeorm@0.3.13": "patches/typeorm@0.3.13.patch"
+      "@alkemio/typeorm@0.3.13-cti.1": "patches/typeorm@0.3.13.patch"
     }
   },
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ importers:
         version: 4.1.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
       '@nestjs/typeorm':
         specifier: 10.0.2
-        version: 10.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@https://pkg.pr.new/antst/typeorm@2c8f380(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))
+        version: 10.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))
       '@ory/kratos-client':
         specifier: ^26.2.0
         version: 26.2.0
@@ -307,8 +307,8 @@ importers:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@22.19.2)
       typeorm:
-        specifier: https://pkg.pr.new/antst/typeorm@2c8f380
-        version: https://pkg.pr.new/antst/typeorm@2c8f380(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))
+        specifier: https://pkg.pr.new/antst/typeorm@f0dc460
+        version: https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -6072,8 +6072,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typeorm@https://pkg.pr.new/antst/typeorm@2c8f380:
-    resolution: {tarball: https://pkg.pr.new/antst/typeorm@2c8f380}
+  typeorm@https://pkg.pr.new/antst/typeorm@f0dc460:
+    resolution: {tarball: https://pkg.pr.new/antst/typeorm@f0dc460}
     version: 0.3.13
     engines: {node: '>= 12.9.0'}
     hasBin: true
@@ -8073,13 +8073,13 @@ snapshots:
       '@nestjs/microservices': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(amqp-connection-manager@4.1.15(amqplib@0.10.9))(amqplib@0.10.9)(cache-manager@5.7.6)(ioredis@5.10.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
 
-  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@https://pkg.pr.new/antst/typeorm@2c8f380(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))':
+  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))':
     dependencies:
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@10.4.20)(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
-      typeorm: https://pkg.pr.new/antst/typeorm@2c8f380(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))
+      typeorm: https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))
       uuid: 9.0.1
 
   '@noble/hashes@1.8.0': {}
@@ -12540,7 +12540,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typeorm@https://pkg.pr.new/antst/typeorm@2c8f380(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)):
+  typeorm@https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       app-root-path: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ overrides:
   '@swc/core-linux-arm64-musl': 'false'
 
 patchedDependencies:
-  typeorm@0.3.13:
+  '@alkemio/typeorm@0.3.13-cti.1':
     hash: 900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4
     path: patches/typeorm@0.3.13.patch
 
@@ -119,7 +119,7 @@ importers:
         version: 4.1.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
       '@nestjs/typeorm':
         specifier: 10.0.2
-        version: 10.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))
+        version: 10.0.2(@alkemio/typeorm@0.3.13-cti.1(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@ory/kratos-client':
         specifier: ^26.2.0
         version: 26.2.0
@@ -307,8 +307,8 @@ importers:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@22.19.2)
       typeorm:
-        specifier: https://pkg.pr.new/antst/typeorm@f0dc460
-        version: https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))
+        specifier: npm:@alkemio/typeorm@0.3.13-cti.1
+        version: '@alkemio/typeorm@0.3.13-cti.1(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))'
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -471,6 +471,64 @@ packages:
   '@alkemio/notifications-lib@0.20.0':
     resolution: {integrity: sha512-4OhPH/HH2M4nXRgvq9UJFOdj8/Hh/Pn5rBv1cN1aRuKWThwNPXHQADbYPJHY/vGJtN7MgpEER7Hcf4G9X0i6AQ==}
     engines: {node: '>=20.0.0', npm: '>=8.5.5'}
+
+  '@alkemio/typeorm@0.3.13-cti.1':
+    resolution: {integrity: sha512-ylANam3GD5XYVEQPoOr04SLrjBkOFfE8CH1K2CPeHdyOUF9sBGzVAYUL7gDq/7bO/3F42I63v0/j3diuhnAXHg==}
+    engines: {node: '>= 12.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@google-cloud/spanner': ^5.18.0
+      '@sap/hana-client': ^2.12.25
+      better-sqlite3: ^7.1.2 || ^8.0.0
+      hdb-pool: ^0.1.6
+      ioredis: ^5.0.4
+      mongodb: ^3.6.0
+      mssql: ^9.1.1
+      mysql2: ^2.2.5 || ^3.0.1
+      oracledb: ^5.1.0
+      pg: ^8.5.1
+      pg-native: ^3.0.0
+      pg-query-stream: ^4.0.0
+      redis: ^3.1.1 || ^4.0.0
+      sql.js: ^1.4.0
+      sqlite3: ^5.0.3
+      ts-node: ^10.7.0
+      typeorm-aurora-data-api-driver: ^2.0.0
+    peerDependenciesMeta:
+      '@google-cloud/spanner':
+        optional: true
+      '@sap/hana-client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      hdb-pool:
+        optional: true
+      ioredis:
+        optional: true
+      mongodb:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      oracledb:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      redis:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      ts-node:
+        optional: true
+      typeorm-aurora-data-api-driver:
+        optional: true
 
   '@angular-devkit/core@17.3.11':
     resolution: {integrity: sha512-vTNDYNsLIWpYk2I969LMQFH29GTsLzxNk/0cLw5q56ARF0v5sIWfHYwGTS88jdDqIpuuettcSczbxeA7EuAmqQ==}
@@ -1852,7 +1910,6 @@ packages:
 
   '@nestjs/typeorm@10.0.2':
     resolution: {integrity: sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==}
-    version: 10.0.2
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
       '@nestjs/core': ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -6072,65 +6129,6 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typeorm@https://pkg.pr.new/antst/typeorm@f0dc460:
-    resolution: {tarball: https://pkg.pr.new/antst/typeorm@f0dc460}
-    version: 0.3.13
-    engines: {node: '>= 12.9.0'}
-    hasBin: true
-    peerDependencies:
-      '@google-cloud/spanner': ^5.18.0
-      '@sap/hana-client': ^2.12.25
-      better-sqlite3: ^7.1.2 || ^8.0.0
-      hdb-pool: ^0.1.6
-      ioredis: ^5.0.4
-      mongodb: ^3.6.0
-      mssql: ^9.1.1
-      mysql2: ^2.2.5 || ^3.0.1
-      oracledb: ^5.1.0
-      pg: ^8.5.1
-      pg-native: ^3.0.0
-      pg-query-stream: ^4.0.0
-      redis: ^3.1.1 || ^4.0.0
-      sql.js: ^1.4.0
-      sqlite3: ^5.0.3
-      ts-node: ^10.7.0
-      typeorm-aurora-data-api-driver: ^2.0.0
-    peerDependenciesMeta:
-      '@google-cloud/spanner':
-        optional: true
-      '@sap/hana-client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      hdb-pool:
-        optional: true
-      ioredis:
-        optional: true
-      mongodb:
-        optional: true
-      mssql:
-        optional: true
-      mysql2:
-        optional: true
-      oracledb:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      pg-query-stream:
-        optional: true
-      redis:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
-      ts-node:
-        optional: true
-      typeorm-aurora-data-api-driver:
-        optional: true
-
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
@@ -6658,6 +6656,33 @@ snapshots:
       - '@types/koa'
       - debug
       - encoding
+      - supports-color
+
+  '@alkemio/typeorm@0.3.13-cti.1(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))':
+    dependencies:
+      '@sqltools/formatter': 1.2.5
+      app-root-path: 3.1.0
+      buffer: 6.0.3
+      chalk: 4.1.2
+      cli-highlight: 2.1.11
+      debug: 4.4.3
+      dotenv: 16.4.5
+      glob: 8.1.0
+      js-yaml: 4.3.0
+      mkdirp: 2.1.6
+      reflect-metadata: 0.1.14
+      sha.js: 2.4.12
+      tslib: 2.8.1
+      uuid: 9.0.1
+      xml2js: 0.4.23
+      yargs: 17.7.2
+    optionalDependencies:
+      ioredis: 5.10.1
+      mysql2: 3.15.1
+      pg: 8.16.3
+      redis: 3.1.2
+      ts-node: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)
+    transitivePeerDependencies:
       - supports-color
 
   '@angular-devkit/core@17.3.11(chokidar@3.6.0)':
@@ -8073,13 +8098,13 @@ snapshots:
       '@nestjs/microservices': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(amqp-connection-manager@4.1.15(amqplib@0.10.9))(amqplib@0.10.9)(cache-manager@5.7.6)(ioredis@5.10.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
 
-  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))':
+  '@nestjs/typeorm@10.0.2(@alkemio/typeorm@0.3.13-cti.1(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)))(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@10.4.20)(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
-      typeorm: https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))
+      typeorm: '@alkemio/typeorm@0.3.13-cti.1(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2))'
       uuid: 9.0.1
 
   '@noble/hashes@1.8.0': {}
@@ -12539,33 +12564,6 @@ snapshots:
       is-typed-array: 1.1.15
 
   typedarray@0.0.6: {}
-
-  typeorm@https://pkg.pr.new/antst/typeorm@f0dc460(patch_hash=900fefc861876e5a2e5379bc9477be4434233cdbad5d3043cf8c810b26cc80a4)(ioredis@5.10.1)(mysql2@3.15.1)(pg@8.16.3)(redis@3.1.2)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)):
-    dependencies:
-      '@sqltools/formatter': 1.2.5
-      app-root-path: 3.1.0
-      buffer: 6.0.3
-      chalk: 4.1.2
-      cli-highlight: 2.1.11
-      debug: 4.4.3
-      dotenv: 16.4.5
-      glob: 8.1.0
-      js-yaml: 4.3.0
-      mkdirp: 2.1.6
-      reflect-metadata: 0.1.14
-      sha.js: 2.4.12
-      tslib: 2.8.1
-      uuid: 9.0.1
-      xml2js: 0.4.23
-      yargs: 17.7.2
-    optionalDependencies:
-      ioredis: 5.10.1
-      mysql2: 3.15.1
-      pg: 8.16.3
-      redis: 3.1.2
-      ts-node: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@22.19.2)(@typescript/typescript6@6.0.2)
-    transitivePeerDependencies:
-      - supports-color
 
   typescript@4.9.5: {}
 


### PR DESCRIPTION
## Source

Free-text bug, no board story.

## Root cause

The server pinned TypeORM to the ephemeral preview https://pkg.pr.new/antst/typeorm@2c8f380. That build expired and returned HTTP 404, so uncached pnpm installs failed with ERR_PNPM_FETCH_404. Repinning to https://pkg.pr.new/antst/typeorm@f0dc460 was a temporary recovery stopgap, but pkg.pr.new artifacts remain ephemeral.

The latest develop fresh-install failure was run 34121234458 at 7887711a556dcfc6b49d6a048f599460e9d0dce1. The last verified fresh green build before the failure was run 33846724700 at 857d6e6081a58f466c35a131f0791e666341c199.

## Fix

- Replace the preview URL with the durable npm alias typeorm: npm:@alkemio/typeorm@0.3.13-cti.1.
- Retarget the existing TypeORM patch metadata to the published package version so the security backport remains applied.
- Regenerate pnpm-lock.yaml for the package identity change only.

The pkg.pr.new repin was the stopgap; the registry-published alias is the durable fix.

## Regression evidence

- Cold pnpm install used Node 22.23.2, pnpm 10.17.1, no existing node_modules, and a fresh empty store: pnpm install --frozen-lockfile succeeded after downloading 1,306 packages.
- Installed resolution: typeorm <- @alkemio/typeorm 0.3.13-cti.1; the existing stringifyObjects security patch is present.
- pnpm test:ci:no:coverage: 771 files passed, 6 skipped; 8,894 tests passed, 7 skipped.
- pnpm build: green.
- pnpm lint: green, including native typecheck and Biome over 3,302 files.
- Tracked diff is limited to package.json and pnpm-lock.yaml.

Human merge required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying database package to a newer compatible version.
  * Adjusted related package configuration to support the updated database package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->