### PR TITLE
ci(content-signing): run real-service integration on docker-capable runner

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,6 +38,37 @@ jobs:
         timeout-minutes: 10
         run: pnpm run test:ci
 
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: coverage-ci/
+          retention-days: 1
+
+  content-signing-integration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NODE_OPTIONS: "--max-old-space-size=4096"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.22.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Checkout pinned file-service for content-signing integration
         uses: actions/checkout@v7
         with:
@@ -50,12 +81,12 @@ jobs:
           docker build --label org.opencontainers.image.source=https://github.com/alkem-io/file-service --label org.opencontainers.image.revision=0a3995b235ef427c9d7cfd1092e7945e5244c137 --tag aiai2025-file-service-pr1:0a3995 .content-signing-file-service
           CONTENT_SIGNING_FILE_SERVICE_IMAGE=aiai2025-file-service-pr1:0a3995 pnpm run test:content-signing:coverage
 
-      - name: Upload coverage artifact
+      - name: Upload content-signing coverage artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage
-          path: coverage-ci/
+          name: coverage-content-signing
+          path: coverage-ci/content-signing/
           retention-days: 1
 
   sonarqube:


### PR DESCRIPTION
## Source

Free-text bug, no board story.

Failed run: https://github.com/alkem-io/server/actions/runs/34327230474

## Root cause

The main `test` job intentionally uses the trusted `arc-trusted-linux-x64` runner for pushes to `develop`, but that Kubernetes ARC runner has no Docker daemon. The content-signing real-service steps were added inside that job and therefore failed at `docker build` on the merge push. Pull requests use `ubuntu-latest`, so the PR checks exercised a Docker-capable path and masked the push-event mismatch.

## Fix

- Keep the existing event-dependent runner expression for the main test job unchanged.
- Move the pinned file-service checkout, Docker build, and real-service content-signing suite into an independent job whose runner is unconditionally `ubuntu-latest`.
- Upload its scoped JSON coverage as the separate `coverage-content-signing` artifact.
- Keep the unit `coverage` artifact, SonarQube dependency, download, and LCOV input unchanged; integration JSON is retained for inspection and is not presented as Sonar input.

The whole test job was not moved because repository practice deliberately uses the trusted ARC runner for push events. The workflow still fails when either the main suite or the independent real-service job fails, so develop does not skip the integration suite.

## Regression and validation

- RED evidence: the linked push run completed the unit suite on ARC and failed when the same job reached its first Docker command.
- `actionlint .github/workflows/ci-tests.yml`
- Structural assertions: main runner expression unchanged; no Docker step remains in `test`; the integration job has literal `runs-on: ubuntu-latest` and no event guard; Sonar still consumes only the original unit coverage artifact.
- Cold `pnpm install --frozen-lockfile` on Node 22.
- `pnpm test:ci`: 782 files passed, 9,087 tests passed.
- Pinned file-service Docker build plus `pnpm run test:content-signing:coverage`: 18 files passed, 419 tests passed; the existing harness cleaned its isolated containers, volume, and network.
- `pnpm build`
- `pnpm lint`
- Signed commit pre-commit hook: typecheck plus 9,087 tests passed again.

A PR can prove the exact-head Ubuntu job and its Docker execution, and the unconditional literal runner makes the job event-independent. A true `push` or `workflow_dispatch` run on `develop` can only be observed after a human merges this PR; no merge or dispatch was performed here.

## Pinned file-service disposition

`0a3995b235ef427c9d7cfd1092e7945e5244c137` is the merged commit of alkem-io/file-service#82, not a PR-branch-only commit. `aiai2025-file-service-pr1:0a3995` is only the local Docker image tag used by the test, so no follow-up ticket is required.

No product code, contract, feature flag, or SpecKit artifact changes.
