### PR TITLE
feat(signing): map Cleverbase certificate subject

### DIFF
--- a/src/services/infrastructure/kratos/kratos.service.spec.ts
+++ b/src/services/infrastructure/kratos/kratos.service.spec.ts
@@ -6,10 +6,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import type { Identity } from '@ory/kratos-client';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
-import { KratosService } from './kratos.service';
+import {
+  CLEVERBASE_SIGNING_CERTIFICATE_CLAIM,
+  KratosService,
+} from './kratos.service';
 
-const CLEVERBASE_SIGNING_CERTIFICATE_CLAIM =
-  'com.cleverbase.signing_certificate';
 const SYNTHETIC_SIGNING_CERTIFICATE = `-----BEGIN CERTIFICATE-----
 MIIDWjCCAkICAwZ5MjANBgkqhkiG9w0BAQsFADByMQswCQYDVQQGEwJOTDEVMBMG
 A1UECgwMQWxrZW1pbyBUZXN0MR0wGwYDVQQFExRIQi1TWU5USEVUSUMtTUFQUElO
@@ -43,11 +44,13 @@ const createSyntheticIDToken = (claims: Record<string, unknown>): string =>
 describe('KratosService', () => {
   let service: KratosService;
   const warn = MockWinstonProvider.useValue.warn as ReturnType<typeof vi.fn>;
-  const expectRedactedSigningIdentityWarning = () =>
+  const expectRedactedSigningIdentityWarning = () => {
+    expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       'Stored Cleverbase signing identity is unavailable for identity kratos-identity.',
       LogContext.KRATOS
     );
+  };
 
   beforeEach(async () => {
     vi.restoreAllMocks();

--- a/src/services/infrastructure/kratos/kratos.service.spec.ts
+++ b/src/services/infrastructure/kratos/kratos.service.spec.ts
@@ -1,4 +1,5 @@
 import { X509Certificate } from 'node:crypto';
+import { LogContext } from '@common/enums';
 import { AuthenticationType } from '@common/enums/authentication.type';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -41,9 +42,16 @@ const createSyntheticIDToken = (claims: Record<string, unknown>): string =>
 
 describe('KratosService', () => {
   let service: KratosService;
+  const warn = MockWinstonProvider.useValue.warn as ReturnType<typeof vi.fn>;
+  const expectRedactedSigningIdentityWarning = () =>
+    expect(warn).toHaveBeenCalledWith(
+      'Stored Cleverbase signing identity is unavailable for identity kratos-identity.',
+      LogContext.KRATOS
+    );
 
   beforeEach(async () => {
     vi.restoreAllMocks();
+    warn.mockClear();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -608,6 +616,20 @@ describe('KratosService', () => {
     });
 
     it.each([
+      ['empty', ''],
+      ['whitespace-only', '   '],
+    ])('falls back and logs a redacted warning when the initial ID token is %s', async (_label, token) => {
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue(
+        createIdentity(token)
+      );
+
+      await expect(
+        service.getCleverbaseSubject('kratos-identity')
+      ).resolves.toBe('subject-from-provider');
+      expectRedactedSigningIdentityWarning();
+    });
+
+    it.each([
       ['is malformed', 'not-a-jwt'],
       [
         'has a malformed payload',
@@ -641,6 +663,7 @@ describe('KratosService', () => {
       await expect(
         service.getCleverbaseSubject('kratos-identity')
       ).resolves.toBeUndefined();
+      expectRedactedSigningIdentityWarning();
     });
 
     it('does not fall back when the signing certificate has no subject serialNumber', async () => {
@@ -659,6 +682,7 @@ describe('KratosService', () => {
       await expect(
         service.getCleverbaseSubject('kratos-identity')
       ).resolves.toBeUndefined();
+      expectRedactedSigningIdentityWarning();
     });
 
     it('does not use a signing certificate from another OIDC provider', async () => {
@@ -733,6 +757,7 @@ describe('KratosService', () => {
       ).rejects.toBe(unavailable);
     });
   });
+
   describe('getAuthenticatedAt', () => {
     it('should return undefined when sessions is null', async () => {
       vi.spyOn(

--- a/src/services/infrastructure/kratos/kratos.service.spec.ts
+++ b/src/services/infrastructure/kratos/kratos.service.spec.ts
@@ -5,10 +5,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import type { Identity } from '@ory/kratos-client';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
-import { KratosService } from './kratos.service';
-
-const CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY =
-  'com.cleverbase.signing_certificate';
+import {
+  CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY,
+  KratosService,
+} from './kratos.service';
 
 // Returned by Cleverbase's public Identification Driver Stub for the
 // com.cleverbase.signing_certificate scope on 2026-09-09.

--- a/src/services/infrastructure/kratos/kratos.service.spec.ts
+++ b/src/services/infrastructure/kratos/kratos.service.spec.ts
@@ -5,57 +5,39 @@ import { Test, TestingModule } from '@nestjs/testing';
 import type { Identity } from '@ory/kratos-client';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
-import {
-  CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY,
-  KratosService,
-} from './kratos.service';
+import { KratosService } from './kratos.service';
 
-// Returned by Cleverbase's public Identification Driver Stub for the
-// com.cleverbase.signing_certificate scope on 2026-09-09.
-const CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE = `-----BEGIN CERTIFICATE-----
-MIIH1jCCBb6gAwIBAgIQaU/hFVNlOnLQ23XZ8IpjsjANBgkqhkiG9w0BAQsFADB7
-MQswCQYDVQQGEwJOTDEbMBkGA1UECgwSQ2xldmVyYmFzZSBJRCBCLlYuMRcwFQYD
-VQRhDA5OVFJOTC02NzQxOTkyNTE2MDQGA1UEAwwtVEVTVCBDbGV2ZXJiYXNlIElE
-IFBLSW92ZXJoZWlkIEJ1cmdlciBDQSAtIEczMB4XDTI2MDEyOTE1NDEyOVoXDTI4
-MDEyOTE2MDgzMlowgZUxEjAQBgNVBAQMCURFIEJSVUlKTjEaMBgGA1UEKgwRV0lM
-TEVLRSBMSVNFTE9UVEUxCzAJBgNVBAYTAk5MMSQwIgYDVQQDDBtXSUxMRUtFIExJ
-U0VMT1RURSBERSBCUlVJSk4xMDAuBgNVBAUTJ0hCLTVjNjk5ZWFiLTFjNjEtNDFj
-NS05MzE4LTI0NmE5MzZjNGVjNjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBALqGXpjiojBczv6p7i2lP0JUSw0P6nMFFFX0g0vhBNLaEDQciuWolqDo+Y/L
-cJ8OCClkpxeSS/xZvcRJ1o7Sf5kXY9irXa7gPlDtdYvmhXzhkplyIlFxewX76MLk
-pp01cbMcFYawu0ImagbIC5h8d8kY5WWCMbDgudkCFP1AJqE3OEsfK6Z2mGs+zez2
-C5Nwu/zVVlAeQ/XTT/olkbomwkbSrLaf4PTtC4cxDYQ2KRhifQKHHlICFUlTRK0z
-eYb5JxCsD30Diz4n6gk6ESVYUdOraoGdaX5UJv6SiRTqCn4DWSB4r/HXXRBeqAm+
-9bXxItFZ5ZZRsvMAnWtjkYVjVhsCAwEAAaOCAzkwggM1MB8GA1UdIwQYMBaAFOrh
-GtA3NsHo1ZT3j1te/5HtSkzxMB0GA1UdDgQWBBSZfNUAN+w5nu5fBkB2EWgDacoi
-vDAOBgNVHQ8BAf8EBAMCBkAwggESBgNVHSAEggEJMIIBBTCCAQEGCmCEEAGHawEC
-AwIwgfIwMwYIKwYBBQUHAgEWJ2h0dHBzOi8vcGtpLnRlc3QuY2xldmVyYmFzZS5j
-b20vY3BzLnBkZjCBugYIKwYBBQUHAgIwga0MgapSZWxpYW5jZSBvbiB0aGlzIGNl
-cnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhl
-IHJlbGV2YW50IENsZXZlcmJhc2UgQ2VydGlmaWNhdGlvbiBQcmFjdGljZSBTdGF0
-ZW1lbnQgYW5kIG90aGVyIGRvY3VtZW50cyBpbiB0aGUgQ2xldmVyYmFzZSByZXBv
-c2l0b3J5LjBcBgNVHREEVTBToFEGCisGAQQBgjcUAgOgQwxBSEItNWM2OTllYWIt
-MWM2MS00MWM1LTkzMTgtMjQ2YTkzNmM0ZWM2QDIuMTYuNTI4LjEuMTAwMy4xLjMu
-My40LjEwQAYDVR0fBDkwNzA1oDOgMYYvaHR0cDovL3BraS50ZXN0LmNsZXZlcmJh
-c2UuY29tL2NsZXZlcmJhc2UzYy5jcmwwHwYDVR0lBBgwFgYIKwYBBQUHAwQGCisG
-AQQBgjcKAwwwgYYGCCsGAQUFBwEBBHoweDAzBggrBgEFBQcwAYYnaHR0cHM6Ly9w
-a2kudGVzdC5jbGV2ZXJiYXNlLmNvbS9vY3NwLzNjMEEGCCsGAQUFBzAChjVodHRw
-Oi8vcGtpLnRlc3QuY2xldmVyYmFzZS5jb20vQ2xldmVyYmFzZUJ1cmdlckczLmNl
-cjCBggYIKwYBBQUHAQMEdjB0MAgGBgQAjkYBATAIBgYEAI5GAQQwSQYGBACORgEF
-MD8wPRY3aHR0cHM6Ly9wa2kuY2xldmVyYmFzZS5jb20vcGtpLWRpc2Nsb3N1cmUt
-c3RhdGVtZW50LnBkZhMCZW4wEwYGBACORgEGMAkGBwQAjkYBBgEwDQYJKoZIhvcN
-AQELBQADggIBAFnxIy/EsDL6hvL4ei574IL0+9zHAHh1pbqBWDdHFi5RoLGJGPbR
-Ukm1vmlcnap/ssqxdZs1RbNJlOtaGLvtm68CqxwZPQOQheDzp0jvcU0PcyM1M+kO
-mJ35fGtBOd4zCvAR3kLRrN0S1++dRz1H0rKQKdn0FZz0CxAkO6NQCab9OCL9U/GG
-MGeI5IMMw8saAd4uAt+iWHcUcX5pAaDO6NXToO3+3zEShKry/dtCKle10wHxs2Ix
-v+w69Ys1eVFpcvTy6uyVrCp2gbJTevOJqKQH2fcJUg4x8Iv1tUzMQibMKkeweCn2
-GlkH7UCDyf+hP/lp3u1bO3szzQXijHCojYlnRU5xFNgcz1+KHebOk2hNO3OUZtwa
-hXnKrOdysg+nI9LkCH/jOJZ9V9xapUEpJLItWNYOZmTH7dU8Cx09W9meH2BYLrBU
-Tot7OIdf8s1zHywdyWOMxDw56KUl2an7nvFGDhrUNygV+k+eXJFPd1uDUIzPgTAT
-VhorWzRQUOSJE4PrwaIXy2bs+5+6o1k441O50p/pU94nVl94ROxoj6MdbyBbb4U0
-EhWxV4Ep89BDzanjbdzyemjM3g6AKKMCCpiDW8xizVNgbdtkdwQ/iAfj+6mOStdX
-bb+kuJ+Td45tU7cjY5mJ0CntDQ+YtlJzFeDvgiEIWgn0GeoT7p/ftFK7
+const CLEVERBASE_SIGNING_CERTIFICATE_CLAIM =
+  'com.cleverbase.signing_certificate';
+const SYNTHETIC_SIGNING_CERTIFICATE = `-----BEGIN CERTIFICATE-----
+MIIDWjCCAkICAwZ5MjANBgkqhkiG9w0BAQsFADByMQswCQYDVQQGEwJOTDEVMBMG
+A1UECgwMQWxrZW1pbyBUZXN0MR0wGwYDVQQFExRIQi1TWU5USEVUSUMtTUFQUElO
+RzEtMCsGA1UEAwwkQ2xldmVyYmFzZSBTeW50aGV0aWMgU2lnbmluZyBGaXh0dXJl
+MB4XDTI2MDkwOTExMjgyN1oXDTM2MDkwNjExMjgyN1owcjELMAkGA1UEBhMCTkwx
+FTATBgNVBAoMDEFsa2VtaW8gVGVzdDEdMBsGA1UEBRMUSEItU1lOVEhFVElDLU1B
+UFBJTkcxLTArBgNVBAMMJENsZXZlcmJhc2UgU3ludGhldGljIFNpZ25pbmcgRml4
+dHVyZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALNWCz0VvupVRssl
+Ie+gtx1JXPgYoOvjLLDiidfVBg4OmRlsmbUCreIU7I3f2V6aTMZMu+V7zsAiMfhk
+SDbQ1MlYdTOurozOsaDStKXc6U0hyHdmmfgLrHyS7AtUdf1C1X7NkVfx6WcOTxPN
+gJ6ETEAKCgVhI/AVUB2PodYohfgWMzg2Q6WlxlJuppY/BM4Yt4ak6kctWznOlgbY
+TpZ1cOEctwKkjzeHfSFOJ9W9jrXPbjeLNnrpUqqbnTGqdJrS1RFVOBkXKbPN4rec
+GDS5jswIi7sycR2VDuXz5Bc6QOMYUhSO6AJbekbls4894aawiK66PVePv7cLGk/a
+r19IvwECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAIwXspPD6MtwaRydrPNAm4ptp
+OT1JTPI6/gO93V+rINJw0pUNul7bdbrY0V0J3YQeEOdj/NaZmCMFPCoMy2zRJNWa
+jHAmckA8pRxGDLHSxG+r/YnToTCIL/U+23J1mA09+WziJ2gfyjcFgPO54IPxFd9p
+CWxwC+UrF0us1oSwr2bVeSEMVJuCDRVwrTkCxfVxcHH1FvIVYqJ5bIF3ZMDgbsYj
+qiYHn/rrKDOL6ZmZqsNHUXXa1pQMb5c5zdXfeSWhbVFKBljJDMi323tCPkn0i5VJ
+Fl690EDNrENZPXRU2sgWhVsc2L8Pjpu2+9NeTem+pdNrLRt+XGrLwBIjM++3hQ==
 -----END CERTIFICATE-----`;
+
+const createSyntheticIDToken = (claims: Record<string, unknown>): string =>
+  [
+    Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString(
+      'base64url'
+    ),
+    Buffer.from(JSON.stringify(claims)).toString('base64url'),
+    'synthetic-signature',
+  ].join('.');
 
 describe('KratosService', () => {
   let service: KratosService;
@@ -560,38 +542,65 @@ describe('KratosService', () => {
   });
 
   describe('getCleverbaseSubject', () => {
-    it('returns the signing certificate subject serialNumber instead of its certificate serial or provider subject', async () => {
-      const getIdentity = vi
-        .spyOn(service, 'getIdentityById')
-        .mockResolvedValue({
-          credentials: {
-            oidc: {
-              identifiers: [
-                'linkedin:elsewhere',
-                'cleverbase:subject-from-provider',
+    const createIdentity = (initialIDToken?: unknown) =>
+      ({
+        credentials: {
+          oidc: {
+            identifiers: [
+              'linkedin:elsewhere',
+              'cleverbase:subject-from-provider',
+            ],
+            config: {
+              providers: [
+                {
+                  provider: 'linkedin',
+                  subject: 'elsewhere',
+                  initial_id_token: createSyntheticIDToken({
+                    [CLEVERBASE_SIGNING_CERTIFICATE_CLAIM]:
+                      SYNTHETIC_SIGNING_CERTIFICATE,
+                  }),
+                },
+                {
+                  provider: 'cleverbase',
+                  subject: 'subject-from-provider',
+                  ...(initialIDToken === undefined
+                    ? {}
+                    : { initial_id_token: initialIDToken }),
+                },
               ],
             },
           },
-          metadata_admin: {
-            [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]:
-              CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE,
-          },
-        } as any);
+        },
+      }) as any;
+
+    it('returns the signing certificate subject serialNumber instead of its certificate serial or provider subject', async () => {
+      const getIdentity = vi
+        .spyOn(service, 'getIdentityById')
+        .mockResolvedValue(
+          createIdentity(
+            createSyntheticIDToken({
+              [CLEVERBASE_SIGNING_CERTIFICATE_CLAIM]:
+                SYNTHETIC_SIGNING_CERTIFICATE,
+            })
+          )
+        );
 
       await expect(
         service.getCleverbaseSubject('kratos-identity')
-      ).resolves.toBe('HB-5c699eab-1c61-41c5-9318-246a936c4ec6');
+      ).resolves.toBe('HB-SYNTHETIC-MAPPING');
       expect(getIdentity).toHaveBeenCalledWith('kratos-identity', ['oidc']);
     });
 
-    it('falls back to the provider subject when the signing certificate claim is absent', async () => {
-      vi.spyOn(service, 'getIdentityById').mockResolvedValue({
-        credentials: {
-          oidc: {
-            identifiers: ['cleverbase:subject-from-provider'],
-          },
-        },
-      } as any);
+    it.each([
+      ['the Cleverbase provider has no initial ID token', undefined],
+      [
+        'the initial ID token has no signing certificate claim',
+        createSyntheticIDToken({ sub: 'subject-from-provider' }),
+      ],
+    ])('falls back to the provider subject when %s', async (_label, token) => {
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue(
+        createIdentity(token)
+      );
 
       await expect(
         service.getCleverbaseSubject('kratos-identity')
@@ -599,19 +608,35 @@ describe('KratosService', () => {
     });
 
     it.each([
-      ['not a string', 123],
-      ['malformed', 'not-a-certificate'],
-    ])('does not fall back to the provider subject when the signing certificate claim is %s', async (_label, signingCertificate) => {
-      vi.spyOn(service, 'getIdentityById').mockResolvedValue({
-        credentials: {
-          oidc: {
-            identifiers: ['cleverbase:subject-from-provider'],
-          },
-        },
-        metadata_admin: {
-          [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]: signingCertificate,
-        },
-      } as any);
+      ['is malformed', 'not-a-jwt'],
+      [
+        'has a malformed payload',
+        ['synthetic-header', 'not-base64url!', 'synthetic-signature'].join('.'),
+      ],
+      [
+        'has a non-JSON payload',
+        [
+          'synthetic-header',
+          Buffer.from('not-json').toString('base64url'),
+          'synthetic-signature',
+        ].join('.'),
+      ],
+      [
+        'has a non-string signing certificate claim',
+        createSyntheticIDToken({
+          [CLEVERBASE_SIGNING_CERTIFICATE_CLAIM]: 123,
+        }),
+      ],
+      [
+        'has a malformed signing certificate claim',
+        createSyntheticIDToken({
+          [CLEVERBASE_SIGNING_CERTIFICATE_CLAIM]: 'not-a-certificate',
+        }),
+      ],
+    ])('does not fall back when the initial ID token %s', async (_label, token) => {
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue(
+        createIdentity(token)
+      );
 
       await expect(
         service.getCleverbaseSubject('kratos-identity')
@@ -620,35 +645,50 @@ describe('KratosService', () => {
 
     it('does not fall back when the signing certificate has no subject serialNumber', async () => {
       vi.spyOn(X509Certificate.prototype, 'toLegacyObject').mockReturnValue({
-        subject: { CN: 'Cleverbase fixture without subject serialNumber' },
+        subject: { CN: 'Synthetic fixture without subject serialNumber' },
       } as any);
-      vi.spyOn(service, 'getIdentityById').mockResolvedValue({
-        credentials: {
-          oidc: {
-            identifiers: ['cleverbase:subject-from-provider'],
-          },
-        },
-        metadata_admin: {
-          [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]:
-            CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE,
-        },
-      } as any);
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue(
+        createIdentity(
+          createSyntheticIDToken({
+            [CLEVERBASE_SIGNING_CERTIFICATE_CLAIM]:
+              SYNTHETIC_SIGNING_CERTIFICATE,
+          })
+        )
+      );
 
       await expect(
         service.getCleverbaseSubject('kratos-identity')
       ).resolves.toBeUndefined();
     });
 
-    it('requires the linked Cleverbase provider even when certificate metadata is present', async () => {
+    it('does not use a signing certificate from another OIDC provider', async () => {
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue(
+        createIdentity(undefined)
+      );
+
+      await expect(
+        service.getCleverbaseSubject('kratos-identity')
+      ).resolves.toBe('subject-from-provider');
+    });
+
+    it('requires the linked Cleverbase provider even when an OIDC token contains the signing certificate', async () => {
       vi.spyOn(service, 'getIdentityById').mockResolvedValue({
         credentials: {
           oidc: {
             identifiers: ['github:subject'],
+            config: {
+              providers: [
+                {
+                  provider: 'github',
+                  subject: 'subject',
+                  initial_id_token: createSyntheticIDToken({
+                    [CLEVERBASE_SIGNING_CERTIFICATE_CLAIM]:
+                      SYNTHETIC_SIGNING_CERTIFICATE,
+                  }),
+                },
+              ],
+            },
           },
-        },
-        metadata_admin: {
-          [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]:
-            CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE,
         },
       } as any);
 
@@ -693,7 +733,6 @@ describe('KratosService', () => {
       ).rejects.toBe(unavailable);
     });
   });
-
   describe('getAuthenticatedAt', () => {
     it('should return undefined when sessions is null', async () => {
       vi.spyOn(

--- a/src/services/infrastructure/kratos/kratos.service.spec.ts
+++ b/src/services/infrastructure/kratos/kratos.service.spec.ts
@@ -1,3 +1,4 @@
+import { X509Certificate } from 'node:crypto';
 import { AuthenticationType } from '@common/enums/authentication.type';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -5,6 +6,56 @@ import type { Identity } from '@ory/kratos-client';
 import { MockWinstonProvider } from '@test/mocks/winston.provider.mock';
 import { defaultMockerFactory } from '@test/utils/default.mocker.factory';
 import { KratosService } from './kratos.service';
+
+const CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY =
+  'com.cleverbase.signing_certificate';
+
+// Returned by Cleverbase's public Identification Driver Stub for the
+// com.cleverbase.signing_certificate scope on 2026-09-09.
+const CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE = `-----BEGIN CERTIFICATE-----
+MIIH1jCCBb6gAwIBAgIQaU/hFVNlOnLQ23XZ8IpjsjANBgkqhkiG9w0BAQsFADB7
+MQswCQYDVQQGEwJOTDEbMBkGA1UECgwSQ2xldmVyYmFzZSBJRCBCLlYuMRcwFQYD
+VQRhDA5OVFJOTC02NzQxOTkyNTE2MDQGA1UEAwwtVEVTVCBDbGV2ZXJiYXNlIElE
+IFBLSW92ZXJoZWlkIEJ1cmdlciBDQSAtIEczMB4XDTI2MDEyOTE1NDEyOVoXDTI4
+MDEyOTE2MDgzMlowgZUxEjAQBgNVBAQMCURFIEJSVUlKTjEaMBgGA1UEKgwRV0lM
+TEVLRSBMSVNFTE9UVEUxCzAJBgNVBAYTAk5MMSQwIgYDVQQDDBtXSUxMRUtFIExJ
+U0VMT1RURSBERSBCUlVJSk4xMDAuBgNVBAUTJ0hCLTVjNjk5ZWFiLTFjNjEtNDFj
+NS05MzE4LTI0NmE5MzZjNGVjNjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBALqGXpjiojBczv6p7i2lP0JUSw0P6nMFFFX0g0vhBNLaEDQciuWolqDo+Y/L
+cJ8OCClkpxeSS/xZvcRJ1o7Sf5kXY9irXa7gPlDtdYvmhXzhkplyIlFxewX76MLk
+pp01cbMcFYawu0ImagbIC5h8d8kY5WWCMbDgudkCFP1AJqE3OEsfK6Z2mGs+zez2
+C5Nwu/zVVlAeQ/XTT/olkbomwkbSrLaf4PTtC4cxDYQ2KRhifQKHHlICFUlTRK0z
+eYb5JxCsD30Diz4n6gk6ESVYUdOraoGdaX5UJv6SiRTqCn4DWSB4r/HXXRBeqAm+
+9bXxItFZ5ZZRsvMAnWtjkYVjVhsCAwEAAaOCAzkwggM1MB8GA1UdIwQYMBaAFOrh
+GtA3NsHo1ZT3j1te/5HtSkzxMB0GA1UdDgQWBBSZfNUAN+w5nu5fBkB2EWgDacoi
+vDAOBgNVHQ8BAf8EBAMCBkAwggESBgNVHSAEggEJMIIBBTCCAQEGCmCEEAGHawEC
+AwIwgfIwMwYIKwYBBQUHAgEWJ2h0dHBzOi8vcGtpLnRlc3QuY2xldmVyYmFzZS5j
+b20vY3BzLnBkZjCBugYIKwYBBQUHAgIwga0MgapSZWxpYW5jZSBvbiB0aGlzIGNl
+cnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhl
+IHJlbGV2YW50IENsZXZlcmJhc2UgQ2VydGlmaWNhdGlvbiBQcmFjdGljZSBTdGF0
+ZW1lbnQgYW5kIG90aGVyIGRvY3VtZW50cyBpbiB0aGUgQ2xldmVyYmFzZSByZXBv
+c2l0b3J5LjBcBgNVHREEVTBToFEGCisGAQQBgjcUAgOgQwxBSEItNWM2OTllYWIt
+MWM2MS00MWM1LTkzMTgtMjQ2YTkzNmM0ZWM2QDIuMTYuNTI4LjEuMTAwMy4xLjMu
+My40LjEwQAYDVR0fBDkwNzA1oDOgMYYvaHR0cDovL3BraS50ZXN0LmNsZXZlcmJh
+c2UuY29tL2NsZXZlcmJhc2UzYy5jcmwwHwYDVR0lBBgwFgYIKwYBBQUHAwQGCisG
+AQQBgjcKAwwwgYYGCCsGAQUFBwEBBHoweDAzBggrBgEFBQcwAYYnaHR0cHM6Ly9w
+a2kudGVzdC5jbGV2ZXJiYXNlLmNvbS9vY3NwLzNjMEEGCCsGAQUFBzAChjVodHRw
+Oi8vcGtpLnRlc3QuY2xldmVyYmFzZS5jb20vQ2xldmVyYmFzZUJ1cmdlckczLmNl
+cjCBggYIKwYBBQUHAQMEdjB0MAgGBgQAjkYBATAIBgYEAI5GAQQwSQYGBACORgEF
+MD8wPRY3aHR0cHM6Ly9wa2kuY2xldmVyYmFzZS5jb20vcGtpLWRpc2Nsb3N1cmUt
+c3RhdGVtZW50LnBkZhMCZW4wEwYGBACORgEGMAkGBwQAjkYBBgEwDQYJKoZIhvcN
+AQELBQADggIBAFnxIy/EsDL6hvL4ei574IL0+9zHAHh1pbqBWDdHFi5RoLGJGPbR
+Ukm1vmlcnap/ssqxdZs1RbNJlOtaGLvtm68CqxwZPQOQheDzp0jvcU0PcyM1M+kO
+mJ35fGtBOd4zCvAR3kLRrN0S1++dRz1H0rKQKdn0FZz0CxAkO6NQCab9OCL9U/GG
+MGeI5IMMw8saAd4uAt+iWHcUcX5pAaDO6NXToO3+3zEShKry/dtCKle10wHxs2Ix
+v+w69Ys1eVFpcvTy6uyVrCp2gbJTevOJqKQH2fcJUg4x8Iv1tUzMQibMKkeweCn2
+GlkH7UCDyf+hP/lp3u1bO3szzQXijHCojYlnRU5xFNgcz1+KHebOk2hNO3OUZtwa
+hXnKrOdysg+nI9LkCH/jOJZ9V9xapUEpJLItWNYOZmTH7dU8Cx09W9meH2BYLrBU
+Tot7OIdf8s1zHywdyWOMxDw56KUl2an7nvFGDhrUNygV+k+eXJFPd1uDUIzPgTAT
+VhorWzRQUOSJE4PrwaIXy2bs+5+6o1k441O50p/pU94nVl94ROxoj6MdbyBbb4U0
+EhWxV4Ep89BDzanjbdzyemjM3g6AKKMCCpiDW8xizVNgbdtkdwQ/iAfj+6mOStdX
+bb+kuJ+Td45tU7cjY5mJ0CntDQ+YtlJzFeDvgiEIWgn0GeoT7p/ftFK7
+-----END CERTIFICATE-----`;
 
 describe('KratosService', () => {
   let service: KratosService;
@@ -509,7 +560,7 @@ describe('KratosService', () => {
   });
 
   describe('getCleverbaseSubject', () => {
-    it('reads OIDC credentials and returns only the provider subject', async () => {
+    it('returns the signing certificate subject serialNumber instead of its certificate serial or provider subject', async () => {
       const getIdentity = vi
         .spyOn(service, 'getIdentityById')
         .mockResolvedValue({
@@ -521,13 +572,89 @@ describe('KratosService', () => {
               ],
             },
           },
-          traits: { serialNumber: 'NOT-THE-SUBJECT' },
+          metadata_admin: {
+            [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]:
+              CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE,
+          },
         } as any);
 
       await expect(
         service.getCleverbaseSubject('kratos-identity')
-      ).resolves.toBe('subject-from-provider');
+      ).resolves.toBe('HB-5c699eab-1c61-41c5-9318-246a936c4ec6');
       expect(getIdentity).toHaveBeenCalledWith('kratos-identity', ['oidc']);
+    });
+
+    it('falls back to the provider subject when the signing certificate claim is absent', async () => {
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue({
+        credentials: {
+          oidc: {
+            identifiers: ['cleverbase:subject-from-provider'],
+          },
+        },
+      } as any);
+
+      await expect(
+        service.getCleverbaseSubject('kratos-identity')
+      ).resolves.toBe('subject-from-provider');
+    });
+
+    it.each([
+      ['not a string', 123],
+      ['malformed', 'not-a-certificate'],
+    ])('does not fall back to the provider subject when the signing certificate claim is %s', async (_label, signingCertificate) => {
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue({
+        credentials: {
+          oidc: {
+            identifiers: ['cleverbase:subject-from-provider'],
+          },
+        },
+        metadata_admin: {
+          [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]: signingCertificate,
+        },
+      } as any);
+
+      await expect(
+        service.getCleverbaseSubject('kratos-identity')
+      ).resolves.toBeUndefined();
+    });
+
+    it('does not fall back when the signing certificate has no subject serialNumber', async () => {
+      vi.spyOn(X509Certificate.prototype, 'toLegacyObject').mockReturnValue({
+        subject: { CN: 'Cleverbase fixture without subject serialNumber' },
+      } as any);
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue({
+        credentials: {
+          oidc: {
+            identifiers: ['cleverbase:subject-from-provider'],
+          },
+        },
+        metadata_admin: {
+          [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]:
+            CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE,
+        },
+      } as any);
+
+      await expect(
+        service.getCleverbaseSubject('kratos-identity')
+      ).resolves.toBeUndefined();
+    });
+
+    it('requires the linked Cleverbase provider even when certificate metadata is present', async () => {
+      vi.spyOn(service, 'getIdentityById').mockResolvedValue({
+        credentials: {
+          oidc: {
+            identifiers: ['github:subject'],
+          },
+        },
+        metadata_admin: {
+          [CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY]:
+            CLEVERBASE_IDF_STUB_SIGNING_CERTIFICATE,
+        },
+      } as any);
+
+      await expect(
+        service.getCleverbaseSubject('kratos-identity')
+      ).resolves.toBeUndefined();
     });
 
     it.each([

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -1,3 +1,4 @@
+import { X509Certificate } from 'node:crypto';
 import { LogContext } from '@common/enums';
 import { AuthenticationType } from '@common/enums/authentication.type';
 import {
@@ -18,6 +19,9 @@ import {
 import { AlkemioConfig } from '@src/types';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { OryDefaultIdentitySchema } from './types/ory.default.identity.schema';
+
+export const CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY =
+  'com.cleverbase.signing_certificate';
 
 /**
  * The `KratosService` class provides methods to interact with the Ory Kratos identity management system:
@@ -421,7 +425,33 @@ export class KratosService {
     const identifier = identity?.credentials?.oidc?.identifiers?.find(value =>
       value.startsWith(prefix)
     );
-    return identifier?.slice(prefix.length) || undefined;
+    const providerSubject = identifier?.slice(prefix.length) || undefined;
+    if (!providerSubject) {
+      return undefined;
+    }
+
+    const metadata = identity?.metadata_admin as
+      | Record<string, unknown>
+      | undefined;
+    const signingCertificate =
+      metadata?.[CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY];
+    if (signingCertificate === undefined) {
+      return providerSubject;
+    }
+    if (typeof signingCertificate !== 'string') {
+      return undefined;
+    }
+
+    try {
+      const subject = new X509Certificate(signingCertificate).toLegacyObject()
+        .subject as unknown as Record<string, unknown>;
+      const serialNumber = subject.serialNumber;
+      return typeof serialNumber === 'string' && serialNumber.length > 0
+        ? serialNumber
+        : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /**

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -15,13 +15,11 @@ import {
   type GetIdentityIncludeCredentialEnum,
   Identity,
   IdentityApi,
+  type IdentityCredentialsOidc,
 } from '@ory/kratos-client';
 import { AlkemioConfig } from '@src/types';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { OryDefaultIdentitySchema } from './types/ory.default.identity.schema';
-
-export const CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY =
-  'com.cleverbase.signing_certificate';
 
 /**
  * The `KratosService` class provides methods to interact with the Ory Kratos identity management system:
@@ -430,19 +428,41 @@ export class KratosService {
       return undefined;
     }
 
-    const metadata = identity?.metadata_admin as
-      | Record<string, unknown>
+    const oidcConfig = identity?.credentials?.oidc?.config as
+      | IdentityCredentialsOidc
       | undefined;
-    const signingCertificate =
-      metadata?.[CLEVERBASE_SIGNING_CERTIFICATE_METADATA_KEY];
-    if (signingCertificate === undefined) {
+    const initialIDToken = oidcConfig?.providers?.find(
+      provider => provider.provider === AuthenticationType.CLEVERBASE
+    )?.initial_id_token;
+    if (initialIDToken === undefined) {
       return providerSubject;
-    }
-    if (typeof signingCertificate !== 'string') {
-      return undefined;
     }
 
     try {
+      const segments = initialIDToken.split('.');
+      const encodedPayload = segments[1];
+      if (
+        segments.length !== 3 ||
+        !encodedPayload ||
+        !/^[A-Za-z0-9_-]+$/.test(encodedPayload)
+      ) {
+        return undefined;
+      }
+      const payload = JSON.parse(
+        Buffer.from(encodedPayload, 'base64url').toString('utf8')
+      ) as unknown;
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return undefined;
+      }
+      const signingCertificate = (payload as Record<string, unknown>)[
+        'com.cleverbase.signing_certificate'
+      ];
+      if (signingCertificate === undefined) {
+        return providerSubject;
+      }
+      if (typeof signingCertificate !== 'string') {
+        return undefined;
+      }
       const subject = new X509Certificate(signingCertificate).toLegacyObject()
         .subject as unknown as Record<string, unknown>;
       const serialNumber = subject.serialNumber;

--- a/src/services/infrastructure/kratos/kratos.service.ts
+++ b/src/services/infrastructure/kratos/kratos.service.ts
@@ -18,8 +18,12 @@ import {
   type IdentityCredentialsOidc,
 } from '@ory/kratos-client';
 import { AlkemioConfig } from '@src/types';
+import { decodeJwt } from 'jose';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { OryDefaultIdentitySchema } from './types/ory.default.identity.schema';
+
+export const CLEVERBASE_SIGNING_CERTIFICATE_CLAIM =
+  'com.cleverbase.signing_certificate';
 
 /**
  * The `KratosService` class provides methods to interact with the Ory Kratos identity management system:
@@ -437,41 +441,49 @@ export class KratosService {
     if (initialIDToken === undefined) {
       return providerSubject;
     }
+    if (initialIDToken.trim().length === 0) {
+      this.warnUnavailableCleverbaseSigningIdentity(identityId);
+      return providerSubject;
+    }
+
+    let payload: ReturnType<typeof decodeJwt>;
+    try {
+      payload = decodeJwt(initialIDToken);
+    } catch {
+      this.warnUnavailableCleverbaseSigningIdentity(identityId);
+      return undefined;
+    }
+
+    const signingCertificate = payload[CLEVERBASE_SIGNING_CERTIFICATE_CLAIM];
+    if (signingCertificate === undefined) {
+      return providerSubject;
+    }
+    if (typeof signingCertificate !== 'string') {
+      this.warnUnavailableCleverbaseSigningIdentity(identityId);
+      return undefined;
+    }
 
     try {
-      const segments = initialIDToken.split('.');
-      const encodedPayload = segments[1];
-      if (
-        segments.length !== 3 ||
-        !encodedPayload ||
-        !/^[A-Za-z0-9_-]+$/.test(encodedPayload)
-      ) {
-        return undefined;
-      }
-      const payload = JSON.parse(
-        Buffer.from(encodedPayload, 'base64url').toString('utf8')
-      ) as unknown;
-      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-        return undefined;
-      }
-      const signingCertificate = (payload as Record<string, unknown>)[
-        'com.cleverbase.signing_certificate'
-      ];
-      if (signingCertificate === undefined) {
-        return providerSubject;
-      }
-      if (typeof signingCertificate !== 'string') {
-        return undefined;
-      }
       const subject = new X509Certificate(signingCertificate).toLegacyObject()
         .subject as unknown as Record<string, unknown>;
       const serialNumber = subject.serialNumber;
-      return typeof serialNumber === 'string' && serialNumber.length > 0
-        ? serialNumber
-        : undefined;
+      if (typeof serialNumber === 'string' && serialNumber.length > 0) {
+        return serialNumber;
+      }
     } catch {
+      this.warnUnavailableCleverbaseSigningIdentity(identityId);
       return undefined;
     }
+
+    this.warnUnavailableCleverbaseSigningIdentity(identityId);
+    return undefined;
+  }
+
+  private warnUnavailableCleverbaseSigningIdentity(identityId: string): void {
+    this.logger.warn(
+      `Stored Cleverbase signing identity is unavailable for identity ${identityId}.`,
+      LogContext.KRATOS
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

- request the linked Cleverbase OIDC credential in the existing Kratos admin identity read
- decode its persisted initial ID token with the existing `jose@5.10` dependency and extract `com.cleverbase.signing_certificate`
- derive the signing identity from the certificate subject `serialNumber` RDN with Node `X509Certificate`
- retain provider-subject fallback only when the token or claim is absent; malformed present data fails closed
- emit one fixed, redacted warning containing only the Kratos identity ID when stored token material is empty or unusable

Relates to alkem-io/alkemio#2025.

## Source contract

Kratos v26.2.0 validates the OIDC ID token, encrypts and persists it as the provider `initial_id_token` when a provider is linked through settings, and declassifies it when `GET /admin/identities/{id}?include_credential=oidc` is requested. The server uses that exact privileged response, so this adds no second Kratos call or cache.

The official Identification Driver Stub was exercised on 2026-09-09 with the signing-certificate scope. The returned `id_token` itself contained `com.cleverbase.signing_certificate` as a PEM string. The observed certificate subject `serialNumber` RDN differed from its own X.509 serial, proving which value the signing contract needs. No token, certificate, or credential value is retained in this PR.

The JWT signature is not revalidated here: Kratos validated the token before persisting it, and this code reads only Kratos-protected OIDC credentials from its admin API. No token, claim, certificate, parse error, message, stack, configuration, or URL is logged.

A linked Cleverbase identifier remains required. A missing initial ID token or missing certificate claim uses the legacy provider subject. An empty/whitespace token also falls back because Kratos returns an empty token when credential decryption is unavailable, while recording the fixed redacted warning. A present malformed token, non-string claim, malformed certificate, or certificate without a subject `serialNumber` logs the same redacted warning and returns no signing subject.

No schema, migration, new dependency, configuration, metadata mapper, or framework change is included.

## RED / GREEN chronology

The initial branch implementation read `metadata_admin`. Source verification established that Kratos settings-link does not run the Jsonnet mapper. The PR was made draft while the token path was verified, and the metadata approach was superseded before merge.

- `1a2df25aac4440cd8e23c540c7c1b7293aca8ee0`: token-reader RED; seven expected failures, with absence fallbacks green
- `147a9343a64c582b1fb19e47c0e45e8b9c349cac`: token-reader GREEN
- `3a17d0ba5410e5d5dcc4d94580d0d1da8ff2c29e`: diagnostic/fallback RED; 8 expected failures and 51 passes
- `d37c83846b5ae8eb5ba5f9e9317af681a5a55829`: corrected GREEN

Tests use a synthetic JWT and synthetic self-signed PEM matching the official stub payload shape; no live identity material is committed.

## Verification

- focused Kratos service suite: 59/59 passed
- required signed-commit hook: lint-staged, native typecheck, and full unit suite passed
- full unit suite: 784 files passed, 8 skipped; 9,109 tests passed, 28 skipped
- `git diff --check`: passed

Local verification used Node 26; supported Node 22 CI is authoritative. Please squash the RED/GREEN implementation history when merging.
