### PR TITLE
chore: update schema baseline

### DIFF
--- a/schema-baseline.graphql
+++ b/schema-baseline.graphql
@@ -3671,15 +3671,22 @@ enum ForumDiscussionCategory {
   CHALLENGE_CENTRIC
   COMMUNITY_BUILDING
   HELP
+  NEWSLETTER
   OTHER
   PLATFORM_FUNCTIONALITIES
   RELEASES
+  TIPS_AND_TRICKS
 }
 
 enum ForumDiscussionPrivacy {
   AUTHENTICATED
   AUTHOR
   PUBLIC
+}
+
+input ForumRemoveDiscussionCategoryInput {
+  """The category to remove from the platform Forum active category list."""
+  category: ForumDiscussionCategory!
 }
 
 type Geo {
@@ -5218,6 +5225,10 @@ type Mutation {
   adminCommunicationSyncSpaceHierarchy: Boolean!
   """Allow updating the state flags of a particular rule."""
   adminCommunicationUpdateRoomState(roomStateData: CommunicationAdminUpdateRoomStateInput!): Boolean!
+  """
+  Removes one category from the platform Forum's active discussionCategories list. Refuses while any Discussion still carries the category. Idempotent for an already-absent category. The enum member is never removed. Requires PLATFORM_ADMIN. Audited (PLATFORM_OPERATIONS).
+  """
+  adminForumRemoveDiscussionCategory(removeData: ForumRemoveDiscussionCategoryInput!): Forum!
   """Delete a Kratos identity by ID."""
   adminIdentityDeleteKratosIdentity(kratosIdentityId: UUID!): Boolean!
   """


### PR DESCRIPTION
Automated schema baseline update.
Snapshot size: 348274 bytes
Snapshot md5: 9e2219fbf3ded8da66734d11edd0d421

This PR was generated by the schema-baseline workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added **Newsletter** and **Tips & Tricks** as available forum discussion categories.
  - Platform administrators can remove categories from the forum’s active category list.
  - Category removal is blocked while discussions still use that category and is safely repeatable when the category is already absent.
  - Removal actions require platform administrator access and are recorded for operational auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->