### PR TITLE
chore(content-signing): bump quickstart trust-gateway to v0.2.2

### DIFF
--- a/docs/local-content-signing.md
+++ b/docs/local-content-signing.md
@@ -7,8 +7,9 @@ publish only on loopback, but sibling containers share `alkemio_dev_net`.
 
 ## Start the fixture
 
-The Compose file pins trust-gateway v0.2.0 and the Cleverbase reference mock by digest. Start the
-normal quickstart with fresh storage, then run the server and client on their usual host ports.
+The Compose file pins the released trust-gateway v0.2.2 tag and the Cleverbase reference mock by
+digest. Start the normal quickstart with fresh storage, then run the server and client on their usual
+host ports.
 Docker, pnpm and `jq` are prerequisites. `COMPOSE_PROJECT_NAME` names only this task-owned fresh
 stack; never run the volume-removal command against a default or developer project.
 
@@ -63,7 +64,7 @@ curl -fsS "$KRATOS_ADMIN/identities/$identity_id?include_credential=oidc" |
 `PNONL-123` is the provider subject from the
 [SDK mock-signer contract](https://github.com/alkem-io/cleverbase-sdk/blob/develop/examples/reference-integration/mock-upstream/README.md),
 not the X.509 certificate serial. The complete environment recipe is owned by the
-[gateway v0.2.0 local-stack documentation](https://github.com/alkem-io/trust-gateway/blob/v0.2.0/README.md#local-alkemio-stack-mock-and-public-stub).
+[gateway v0.2.2 local-stack documentation](https://github.com/alkem-io/trust-gateway/blob/v0.2.2/README.md#local-alkemio-stack-mock-and-public-stub).
 
 ## Verify the journey
 

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -44,7 +44,7 @@ services:
         target: /etc/traefik/
 
   trust-gateway:
-    image: alkemio/trust-gateway@sha256:a1759065252c946c970cb1dd8d98ecde37af0f0ddad4355d7f9b78a93a988265
+    image: alkemio/trust-gateway:v0.2.2
     depends_on:
       - cleverbase-refmock
     environment:

--- a/quickstart-services.yml
+++ b/quickstart-services.yml
@@ -44,7 +44,7 @@ services:
         target: /etc/traefik/
 
   trust-gateway:
-    image: alkemio/trust-gateway@sha256:68035416db3fdb89aeaf2cc2f9e93a8906415cca0093edaa5dacf5d910382a39
+    image: alkemio/trust-gateway@sha256:a1759065252c946c970cb1dd8d98ecde37af0f0ddad4355d7f9b78a93a988265
     depends_on:
       - cleverbase-refmock
     environment:

--- a/test/integration/content-signing/quickstart.config.spec.ts
+++ b/test/integration/content-signing/quickstart.config.spec.ts
@@ -19,7 +19,7 @@ describe('content-signing local quickstart', () => {
     const mock = compose.services['cleverbase-refmock'];
 
     expect(gateway.image).toBe(
-      'alkemio/trust-gateway@sha256:68035416db3fdb89aeaf2cc2f9e93a8906415cca0093edaa5dacf5d910382a39'
+      'alkemio/trust-gateway@sha256:a1759065252c946c970cb1dd8d98ecde37af0f0ddad4355d7f9b78a93a988265'
     );
     expect(gateway.ports).toEqual(['127.0.0.1:8080:8080']);
     expect(mock.image).toBe(

--- a/test/integration/content-signing/quickstart.config.spec.ts
+++ b/test/integration/content-signing/quickstart.config.spec.ts
@@ -18,9 +18,7 @@ describe('content-signing local quickstart', () => {
     const gateway = compose.services['trust-gateway'];
     const mock = compose.services['cleverbase-refmock'];
 
-    expect(gateway.image).toBe(
-      'alkemio/trust-gateway@sha256:a1759065252c946c970cb1dd8d98ecde37af0f0ddad4355d7f9b78a93a988265'
-    );
+    expect(gateway.image).toBe('alkemio/trust-gateway:v0.2.2');
     expect(gateway.ports).toEqual(['127.0.0.1:8080:8080']);
     expect(mock.image).toBe(
       'ghcr.io/alkem-io/cleverbase-refmock@sha256:271f70ee82e8114c0fc03f45788512d5d8f54a9a4fb3c3d7b33057781233fee2'


### PR DESCRIPTION
## Source

Free-text bug, no board story.

## Root cause

The server quickstart still referenced trust-gateway v0.2.1 after v0.2.2 was released and deployed. The original memo-signing change also introduced a digest-form trust-gateway pin, while neighboring released services in `quickstart-services.yml` use release version tags, for example `alkemio/notifications:v0.38.0`, `alkemio/matrix-adapter:v0.8.17`, and `alkemio/file-service:v0.2.6`.

## Fix

Pin the quickstart trust-gateway to the released `alkemio/trust-gateway:v0.2.2` tag, update the existing exact-pin contract test, and align the local signing guide and its versioned gateway documentation link. No service settings, dependencies, source code, workflows, or other quickstart services change.

## Regression evidence

- Focused quickstart contract: 5/5 passed.
- Docker Compose config validation passed.
- Full test suite: 9,229 passed, 28 skipped.
- `pnpm build` passed.
- `pnpm lint` passed.
- `git diff --check` passed.

## CodeRabbit triage

- Inline threads: 1 accepted and fixed (stale local signing guide version/link).
- Outside-diff findings: 0 independent findings.
- Review-body findings: the stale-documentation risk duplicates the fixed inline finding; the Biome nested-root notice is tool-only and the repository lint gate passes.
- No reply was posted on the code/docs-fixed thread; CodeRabbit can close it automatically on the successor.

Release: https://github.com/alkem-io/trust-gateway/releases/tag/v0.2.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Trust Gateway image used by quickstart deployments and content-signing integration checks to version `v0.2.2`.
  - Quickstart validation now checks the updated Trust Gateway image reference.

- **Documentation**
  - Updated local content-signing setup instructions to use Trust Gateway `v0.2.2`.
  - Added a link to the corresponding `v0.2.2` local-stack documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->