### PR TITLE
fix(memo): preserve block structure in signing PDFs

### DIFF
--- a/src/domain/common/memo/conversion/const.ts
+++ b/src/domain/common/memo/conversion/const.ts
@@ -1,1 +1,2 @@
-export const newLineReplacement = '\n\n\u00A0\n\n';
+export const blankLineReplacement = '\u00A0';
+export const newLineReplacement = `\n\n${blankLineReplacement}\n\n`;

--- a/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
+++ b/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
@@ -3,9 +3,8 @@ import Highlight from '@tiptap/extension-highlight';
 import StarterKit from '@tiptap/starter-kit';
 import { renderToMarkdown } from '@tiptap/static-renderer';
 import { yXmlFragmentToProseMirrorRootNode } from '@tiptap/y-tiptap';
-import { Fragment, Node as ProseMirrorNode } from 'prosemirror-model';
+import { Node as ProseMirrorNode } from 'prosemirror-model';
 import * as Y from 'yjs';
-import { newLineReplacement } from './const';
 import { Iframe } from './Iframe';
 import { ImageExtension } from './image.extension';
 
@@ -32,30 +31,12 @@ export const yjsStateToMarkdown = (state: Buffer) => {
   } finally {
     doc.destroy();
   }
-  // Build a new array of child nodes, replacing empty paragraphs with paragraphs containing a non-breaking space
-  // This ensures that empty paragraphs are preserved in the markdown output
-  // (ProseMirror and TipTap tend to ignore completely empty paragraphs)
-  const newContent: ProseMirrorNode[] = [];
-  // use the built-in forEach method of the ProseMirror Fragment
-  pmDoc.content.forEach(child => {
-    // we only target paragraphs without content
-    if (child.type.name !== 'paragraph') {
-      newContent.push(child);
-      return;
-    }
-
-    if (child.content.size > 0) {
-      newContent.push(child);
-      return;
-    }
-    // Overwrite this paragraph with a new one, containing a non-breaking space
-    const newNode = markdownSchema.nodes.paragraph.create(
-      null,
-      markdownSchema.text(newLineReplacement)
-    );
-    newContent.push(newNode);
-  });
-  const newDoc = pmDoc.copy(Fragment.fromArray(newContent));
+  if (
+    pmDoc.childCount === 1 &&
+    pmDoc.firstChild?.type.name === 'paragraph' &&
+    pmDoc.firstChild.content.size === 0
+  )
+    return '';
 
   // Manually serialize with proper indentation by traversing the tree
   const serializeNode = (
@@ -70,16 +51,15 @@ export const yjsStateToMarkdown = (state: Buffer) => {
     switch (node.type.name) {
       case 'bulletList':
       case 'orderedList': {
-        let listOutput = '';
+        const items: string[] = [];
         node.content.forEach(child => {
-          listOutput += serializeNode(child, depth, node.type.name);
+          items.push(serializeNode(child, depth, node.type.name));
         });
-        return listOutput;
+        return items.join('\n');
       }
 
       case 'listItem': {
-        let itemText = '';
-        let nestedLists = '';
+        const blocks: { nested: boolean; value: string }[] = [];
 
         node.content.forEach(child => {
           if (child.type.name === 'paragraph') {
@@ -87,27 +67,44 @@ export const yjsStateToMarkdown = (state: Buffer) => {
               extensions: [StarterKit, ImageExtension, Highlight, Iframe],
               content: child,
             }).trim();
-            itemText += paragraphMarkdown;
+            blocks.push({
+              nested: false,
+              value: paragraphMarkdown || '&nbsp;',
+            });
           } else if (
             child.type.name === 'bulletList' ||
             child.type.name === 'orderedList'
           ) {
-            nestedLists += serializeNode(child, depth + 1, child.type.name);
+            blocks.push({
+              nested: true,
+              value: serializeNode(child, depth + 1, child.type.name),
+            });
           } else {
             // Handle other node types (images, code blocks, etc.) using renderToMarkdown
             const otherContent = renderToMarkdown({
               extensions: [StarterKit, ImageExtension, Highlight, Iframe],
               content: child,
             }).trim();
-            itemText += otherContent;
+            blocks.push({ nested: false, value: otherContent });
           }
         });
 
         const bullet = parentType === 'orderedList' ? '1.' : '-';
-        const mainLine = itemText
-          ? `${indent}${bullet} ${itemText}\n`
-          : `${indent}${bullet}\n`;
-        return mainLine + nestedLists;
+        const continuationIndent = `${indent}${' '.repeat(bullet.length + 1)}`;
+        const indentContinuation = (value: string) =>
+          value
+            .split('\n')
+            .map(line => `${continuationIndent}${line}`)
+            .join('\n');
+        const [firstBlock, ...remainingBlocks] = blocks;
+        let itemOutput = `${indent}${bullet}`;
+        if (firstBlock)
+          itemOutput += firstBlock.nested
+            ? `\n${firstBlock.value}`
+            : ` ${firstBlock.value.replaceAll('\n', `\n${continuationIndent}`)}`;
+        for (const block of remainingBlocks)
+          itemOutput += `\n\n${block.nested ? block.value : indentContinuation(block.value)}`;
+        return itemOutput;
       }
 
       case 'table': {
@@ -164,10 +161,12 @@ export const yjsStateToMarkdown = (state: Buffer) => {
           }
         });
 
-        return tableOutput + '\n';
+        return tableOutput.trimEnd();
       }
 
       case 'paragraph': {
+        if (node.content.size === 0) return '&nbsp;';
+
         // Check if paragraph only contains literal "<br>" text (empty line placeholder)
         const isLiteralBrPlaceholder =
           node.content.childCount === 1 &&
@@ -175,8 +174,7 @@ export const yjsStateToMarkdown = (state: Buffer) => {
           node.content.firstChild?.text === '<br>';
 
         if (isLiteralBrPlaceholder) {
-          // Convert to an empty line in markdown
-          return '\n';
+          return '&nbsp;';
         }
 
         // Use TipTap's default for regular paragraphs
@@ -195,10 +193,10 @@ export const yjsStateToMarkdown = (state: Buffer) => {
     }
   };
 
-  let result = '';
-  newDoc.content.forEach(child => {
-    result += serializeNode(child);
+  const blocks: string[] = [];
+  pmDoc.content.forEach(child => {
+    blocks.push(serializeNode(child));
   });
 
-  return result.trim();
+  return blocks.join('\n\n').trim();
 };

--- a/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
+++ b/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
@@ -42,24 +42,22 @@ export const yjsStateToMarkdown = (state: Buffer) => {
   // Manually serialize with proper indentation by traversing the tree
   const serializeNode = (
     node: ProseMirrorNode,
-    depth = 0,
+    indent = '',
     parentType = ''
   ): string => {
-    // Ordered lists need 4 spaces per level, bullet lists need 2
-    const indentSize = parentType === 'orderedList' ? 4 : 2;
-    const indent = ' '.repeat(depth * indentSize);
-
     switch (node.type.name) {
       case 'bulletList':
       case 'orderedList': {
         const items: string[] = [];
         node.content.forEach(child => {
-          items.push(serializeNode(child, depth, node.type.name));
+          items.push(serializeNode(child, indent, node.type.name));
         });
         return items.join('\n');
       }
 
       case 'listItem': {
+        const bullet = parentType === 'orderedList' ? '1.' : '-';
+        const continuationIndent = `${indent}${' '.repeat(bullet.length + 1)}`;
         const blocks: { nested: boolean; value: string }[] = [];
 
         node.content.forEach(child => {
@@ -78,7 +76,7 @@ export const yjsStateToMarkdown = (state: Buffer) => {
           ) {
             blocks.push({
               nested: true,
-              value: serializeNode(child, depth + 1, child.type.name),
+              value: serializeNode(child, continuationIndent, child.type.name),
             });
           } else {
             // Handle other node types (images, code blocks, etc.) using renderToMarkdown
@@ -90,8 +88,6 @@ export const yjsStateToMarkdown = (state: Buffer) => {
           }
         });
 
-        const bullet = parentType === 'orderedList' ? '1.' : '-';
-        const continuationIndent = `${indent}${' '.repeat(bullet.length + 1)}`;
         const indentContinuation = (value: string) =>
           value
             .split('\n')

--- a/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
+++ b/src/domain/common/memo/conversion/yjs.state.to.markdown.ts
@@ -5,6 +5,7 @@ import { renderToMarkdown } from '@tiptap/static-renderer';
 import { yXmlFragmentToProseMirrorRootNode } from '@tiptap/y-tiptap';
 import { Node as ProseMirrorNode } from 'prosemirror-model';
 import * as Y from 'yjs';
+import { blankLineReplacement } from './const';
 import { Iframe } from './Iframe';
 import { ImageExtension } from './image.extension';
 
@@ -69,7 +70,7 @@ export const yjsStateToMarkdown = (state: Buffer) => {
             }).trim();
             blocks.push({
               nested: false,
-              value: paragraphMarkdown || '&nbsp;',
+              value: paragraphMarkdown || blankLineReplacement,
             });
           } else if (
             child.type.name === 'bulletList' ||
@@ -165,7 +166,7 @@ export const yjsStateToMarkdown = (state: Buffer) => {
       }
 
       case 'paragraph': {
-        if (node.content.size === 0) return '&nbsp;';
+        if (node.content.size === 0) return blankLineReplacement;
 
         // Check if paragraph only contains literal "<br>" text (empty line placeholder)
         const isLiteralBrPlaceholder =
@@ -174,7 +175,7 @@ export const yjsStateToMarkdown = (state: Buffer) => {
           node.content.firstChild?.text === '<br>';
 
         if (isLiteralBrPlaceholder) {
-          return '&nbsp;';
+          return blankLineReplacement;
         }
 
         // Use TipTap's default for regular paragraphs

--- a/src/domain/common/memo/memo.pdf.renderer.spec.ts
+++ b/src/domain/common/memo/memo.pdf.renderer.spec.ts
@@ -109,6 +109,47 @@ const structuredMemoState = (): Buffer => {
   }
 };
 
+const mixedNestedListsState = (): Buffer => {
+  const paragraph = (text: string) =>
+    markdownSchema.nodes.paragraph.create(null, markdownSchema.text(text));
+  const listItem = (...content: ProseMirrorNode[]) =>
+    markdownSchema.nodes.listItem.create(null, content);
+  const bulletList = (...items: ProseMirrorNode[]) =>
+    markdownSchema.nodes.bulletList.create(null, items);
+  const orderedList = (...items: ProseMirrorNode[]) =>
+    markdownSchema.nodes.orderedList.create(null, items);
+  const document = markdownSchema.nodes.doc.create(null, [
+    bulletList(
+      listItem(
+        paragraph('Bullet top'),
+        orderedList(
+          listItem(
+            paragraph('Ordered child'),
+            bulletList(listItem(paragraph('Bullet grandchild')))
+          )
+        )
+      )
+    ),
+    orderedList(
+      listItem(
+        paragraph('Ordered top'),
+        bulletList(
+          listItem(
+            paragraph('Bullet child'),
+            orderedList(listItem(paragraph('Ordered grandchild')))
+          )
+        )
+      )
+    ),
+  ]) as ProseMirrorNode;
+  const ydoc = prosemirrorToYDoc(document, 'default');
+  try {
+    return Buffer.from(Y.encodeStateAsUpdateV2(ydoc));
+  } finally {
+    ydoc.destroy();
+  }
+};
+
 const extractText = async (pdf: Buffer): Promise<string> => {
   const document = await parseOffice(pdf, { fileType: 'pdf', ocr: false });
   return document.toText();
@@ -274,6 +315,56 @@ describe('MemoPdfRenderer', () => {
           )
         )
         .toHaveLength(1);
+    } finally {
+      convertHtml.mockRestore();
+    }
+  });
+
+  it('preserves accumulated indentation through mixed nested list types', async () => {
+    const projectedMarkdown = yjsStateToMarkdown(mixedNestedListsState());
+    const convertHtml = vi.spyOn(renderer as any, 'convertHtml');
+
+    try {
+      await renderer.render(projectedMarkdown, 'bucket-1', actor);
+      const definition = convertHtml.mock.results[0].value as PdfMakeNode[];
+      const topLevelLists = definition.filter(
+        node => node.nodeName === 'UL' || node.nodeName === 'OL'
+      );
+      const [bulletRoot, orderedRoot] = topLevelLists;
+      const bulletTopItem = (bulletRoot?.ul as PdfMakeNode[] | undefined)?.[0];
+      const orderedChildList = (
+        bulletTopItem?.stack as PdfMakeNode[] | undefined
+      )?.find(node => node.nodeName === 'OL');
+      const orderedChildItem = (
+        orderedChildList?.ol as PdfMakeNode[] | undefined
+      )?.[0];
+      const bulletGrandchildList = (
+        orderedChildItem?.stack as PdfMakeNode[] | undefined
+      )?.find(node => node.nodeName === 'UL');
+      const orderedTopItem = (
+        orderedRoot?.ol as PdfMakeNode[] | undefined
+      )?.[0];
+      const bulletChildList = (
+        orderedTopItem?.stack as PdfMakeNode[] | undefined
+      )?.find(node => node.nodeName === 'UL');
+      const bulletChildItem = (
+        bulletChildList?.ul as PdfMakeNode[] | undefined
+      )?.[0];
+      const orderedGrandchildList = (
+        bulletChildItem?.stack as PdfMakeNode[] | undefined
+      )?.find(node => node.nodeName === 'OL');
+
+      expect.soft(topLevelLists).toHaveLength(2);
+      expect.soft(orderedChildList?.nodeName).toBe('OL');
+      expect.soft(bulletGrandchildList?.nodeName).toBe('UL');
+      expect
+        .soft((bulletGrandchildList?.ul as PdfMakeNode[] | undefined)?.[0])
+        .toMatchObject({ nodeName: 'LI', text: 'Bullet grandchild' });
+      expect.soft(bulletChildList?.nodeName).toBe('UL');
+      expect.soft(orderedGrandchildList?.nodeName).toBe('OL');
+      expect
+        .soft((orderedGrandchildList?.ol as PdfMakeNode[] | undefined)?.[0])
+        .toMatchObject({ nodeName: 'LI', text: 'Ordered grandchild' });
     } finally {
       convertHtml.mockRestore();
     }

--- a/src/domain/common/memo/memo.pdf.renderer.spec.ts
+++ b/src/domain/common/memo/memo.pdf.renderer.spec.ts
@@ -213,6 +213,8 @@ describe('MemoPdfRenderer', () => {
         .soft(projectedMarkdown)
         .toContain('\n\n| Column 1 | Column 2 | Column 3 |');
       expect.soft(projectedMarkdown).toContain('\n\n## Heading after table');
+      expect.soft(projectedMarkdown).toContain('\n\n\u00a0\n\n');
+      expect.soft(projectedMarkdown).not.toContain('&nbsp;');
       expect.soft(converterHtml).toContain('<table>');
 
       const listItems = collectPdfMakeNodes(

--- a/src/domain/common/memo/memo.pdf.renderer.spec.ts
+++ b/src/domain/common/memo/memo.pdf.renderer.spec.ts
@@ -4,12 +4,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AuthorizationPrivilege } from '@common/enums/authorization.privilege';
 import { ActorContext } from '@core/actor-context/actor.context';
+import { prosemirrorToYDoc } from '@tiptap/y-tiptap';
 import { JSDOM } from 'jsdom';
 import MarkdownIt from 'markdown-it';
 import { parseOffice } from 'officeparser';
 import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';
+import type { Node as ProseMirrorNode } from 'prosemirror-model';
 import sharp from 'sharp';
+import * as Y from 'yjs';
 import { markdownToYjsV2State, yjsStateToMarkdown } from './conversion';
+import { markdownSchema } from './conversion/markdown.schema';
 import { MemoPdfRenderer } from './memo.pdf.renderer';
 
 const pdfjsRequire = createRequire(require.resolve('pdfjs-dist/package.json'));
@@ -27,6 +31,82 @@ const pdfMake = require('pdfmake') as {
 };
 const fonts = require('pdfmake/fonts/Roboto') as {
   Roboto: Record<string, string>;
+};
+
+type PdfMakeNode = Record<string, unknown>;
+
+const collectPdfMakeNodes = (
+  value: unknown,
+  predicate: (node: PdfMakeNode) => boolean
+): PdfMakeNode[] => {
+  if (!value || typeof value !== 'object') return [];
+  const node = value as PdfMakeNode;
+  const matches = predicate(node) ? [node] : [];
+  return [
+    ...matches,
+    ...Object.values(node).flatMap(child =>
+      collectPdfMakeNodes(child, predicate)
+    ),
+  ];
+};
+
+const structuredMemoState = (): Buffer => {
+  const paragraph = (text = '') =>
+    markdownSchema.nodes.paragraph.create(
+      null,
+      text ? markdownSchema.text(text) : undefined
+    );
+  const listItem = markdownSchema.nodes.listItem.create(null, [
+    paragraph('First paragraph inside item.'),
+    paragraph('Second paragraph inside same item.'),
+    paragraph('Third paragraph inside same item.'),
+    markdownSchema.nodes.bulletList.create(null, [
+      markdownSchema.nodes.listItem.create(null, [
+        paragraph('Nested child'),
+        markdownSchema.nodes.bulletList.create(null, [
+          markdownSchema.nodes.listItem.create(null, [paragraph('Grandchild')]),
+        ]),
+      ]),
+    ]),
+  ]);
+  const tableRows = Array.from({ length: 8 }, (_, rowIndex) => {
+    const cellType =
+      rowIndex === 0
+        ? markdownSchema.nodes.tableHeader
+        : markdownSchema.nodes.tableCell;
+    return markdownSchema.nodes.tableRow.create(
+      null,
+      Array.from({ length: 3 }, (_, columnIndex) =>
+        cellType.create(
+          null,
+          paragraph(
+            rowIndex === 0
+              ? `Column ${columnIndex + 1}`
+              : `${rowIndex}${columnIndex + 1}`
+          )
+        )
+      )
+    );
+  });
+  const document = markdownSchema.nodes.doc.create(null, [
+    markdownSchema.nodes.heading.create(
+      { level: 1 },
+      paragraph('Structure probe').content
+    ),
+    paragraph(),
+    markdownSchema.nodes.bulletList.create(null, [listItem]),
+    markdownSchema.nodes.table.create(null, tableRows),
+    markdownSchema.nodes.heading.create(
+      { level: 2 },
+      paragraph('Heading after table').content
+    ),
+  ]) as ProseMirrorNode;
+  const ydoc = prosemirrorToYDoc(document, 'default');
+  try {
+    return Buffer.from(Y.encodeStateAsUpdateV2(ydoc));
+  } finally {
+    ydoc.destroy();
+  }
 };
 
 const extractText = async (pdf: Buffer): Promise<string> => {
@@ -113,6 +193,88 @@ describe('MemoPdfRenderer', () => {
     expect(text).toContain('A');
     expect(text).toContain('quoted');
     expect(text).toContain('Γειά σου');
+  });
+
+  it('preserves editor block structure through the current Yjs projection', async () => {
+    const projectedMarkdown = yjsStateToMarkdown(structuredMemoState());
+    const convertHtml = vi.spyOn(renderer as any, 'convertHtml');
+
+    try {
+      await renderer.render(projectedMarkdown, 'bucket-1', actor);
+      const converterHtml = convertHtml.mock.calls[0][0] as string;
+      const definition = convertHtml.mock.results[0].value;
+
+      expect
+        .soft(projectedMarkdown)
+        .toContain(
+          '- First paragraph inside item.\n\n  Second paragraph inside same item.\n\n  Third paragraph inside same item.'
+        );
+      expect
+        .soft(projectedMarkdown)
+        .toContain('\n\n| Column 1 | Column 2 | Column 3 |');
+      expect.soft(projectedMarkdown).toContain('\n\n## Heading after table');
+      expect.soft(converterHtml).toContain('<table>');
+
+      const listItems = collectPdfMakeNodes(
+        definition,
+        node => node.nodeName === 'LI'
+      );
+      const topListItem = listItems.find(node => {
+        const stack = node.stack;
+        return (
+          Array.isArray(stack) &&
+          stack.some(
+            child =>
+              typeof child === 'object' &&
+              child !== null &&
+              (child as PdfMakeNode).text === 'First paragraph inside item.'
+          )
+        );
+      });
+      expect.soft(topListItem).toBeDefined();
+      expect
+        .soft(
+          (topListItem?.stack as PdfMakeNode[] | undefined)
+            ?.filter(node => node.nodeName === 'P')
+            .map(node => node.text)
+        )
+        .toEqual([
+          'First paragraph inside item.',
+          'Second paragraph inside same item.',
+          'Third paragraph inside same item.',
+        ]);
+      expect
+        .soft(collectPdfMakeNodes(topListItem, node => node.nodeName === 'UL'))
+        .toHaveLength(2);
+
+      const tables = collectPdfMakeNodes(
+        definition,
+        node => node.nodeName === 'TABLE'
+      );
+      expect.soft(tables).toHaveLength(1);
+      const body = (tables[0]?.table as { body?: unknown[][] } | undefined)
+        ?.body;
+      expect.soft(body).toHaveLength(8);
+      expect.soft(body?.every(row => row.length === 3)).toBe(true);
+      expect
+        .soft(
+          collectPdfMakeNodes(
+            definition,
+            node => node.nodeName === 'H1' || node.nodeName === 'H2'
+          ).map(node => node.text)
+        )
+        .toEqual(['Structure probe', 'Heading after table']);
+      expect
+        .soft(
+          collectPdfMakeNodes(
+            definition,
+            node => node.nodeName === 'P' && node.text === '\u00a0'
+          )
+        )
+        .toHaveLength(1);
+    } finally {
+      convertHtml.mockRestore();
+    }
   });
 
   it('renders European platform languages and a visible box for an unsupported symbol', async () => {

--- a/src/domain/common/memo/memo.pdf.renderer.ts
+++ b/src/domain/common/memo/memo.pdf.renderer.ts
@@ -9,6 +9,7 @@ import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file
 import { JSDOM } from 'jsdom';
 import MarkdownIt from 'markdown-it';
 import sharp from 'sharp';
+import { blankLineReplacement } from './conversion/const';
 
 // pdfmake and html-to-pdfmake publish CommonJS without TypeScript declarations.
 const htmlToPdfMake = require('html-to-pdfmake') as (
@@ -184,6 +185,10 @@ export class MemoPdfRenderer {
         replaceWithLink(image, `Image: ${image.alt || source}`, source);
       }
     }
+
+    document.querySelectorAll('p:empty').forEach(paragraph => {
+      paragraph.textContent = blankLineReplacement;
+    });
 
     const content = this.convertHtml(document.body.innerHTML, {
       window: dom.window as unknown as Window,


### PR DESCRIPTION
## What changed

- Preserve CommonMark block boundaries when projecting Yjs memo state to Markdown.
- Keep multiple paragraphs inside a list item as separate, correctly indented blocks.
- Carry each list item's accumulated continuation indentation through mixed bullet/ordered nesting.
- Separate adjacent block nodes so a table or heading after a list is not parsed as list-item text.
- Preserve intentional blank paragraphs using the existing U+00A0 representation; normalize MarkdownIt's genuine empty `<p>` at the PDF HTML boundary so `html-to-pdfmake` retains the blank block.

## Root cause

Memo signing reads the live Yjs document and converts it through `yjsStateToMarkdown` before rendering the PDF. The serializer trimmed each paragraph in a list item and concatenated the results without a separator, ended a list with only one newline, and concatenated subsequent top-level blocks without a CommonMark block boundary. As a result, MarkdownIt received the table rows as lazy continuation text inside the list item; the sanitizer and `html-to-pdfmake` never saw a `<table>` node.

List nesting also derived indentation from `depth * indentSize`, where `indentSize` described only the immediate list type. Mixed bullet/ordered descendants therefore lost their ancestors' marker widths and reparsed as siblings or top-level lists.

The structural fix is in the shared Yjs-to-Markdown projection: it emits blank lines between block-level nodes, indents continuation paragraphs relative to the current marker, and carries that accumulated prefix into nested lists. The renderer does not widen sanitization; it only restores a U+00A0 text node for a genuinely empty `<p></p>` immediately before `html-to-pdfmake`, because MarkdownIt removes the U+00A0 text while retaining the paragraph element.

## Regression proof

- RED commit: `83583bfef6a93acea6a99e5c0bdaf19a0246da8c`
- Synthetic Yjs fixture covers a three-paragraph bullet item, nested lists, a 3x8 table, headings, and an intentional blank paragraph.
- Initial RED: 18 passed / 1 failed, with 10 expected soft assertion failures for collapsed list paragraphs/boundaries, absent HTML/PDF table, absent nested-list structure, and lost blank paragraph.
- Review RED on the prior head: 19 passed / 1 failed, with six hierarchy failures for bullet→ordered→bullet and ordered→bullet→ordered; output had three top-level lists instead of two and both grandchild list types were detached.
- GREEN targeted renderer/converter suite: 43/43.
- GREEN caller-impact suite: 301/301, including collaboration migration validation 124/124.
- Full server suite on the final head: 790 files passed, 9,231 tests passed / 28 skipped.
- `pnpm build`: PASS.
- Pre-commit native typecheck + Biome: PASS.
- `git diff --check`: PASS.

## Shared caller impact

- Memo signing renderer: receives structurally correct Markdown, so list paragraphs, mixed nested lists, and tables reach MarkdownIt, the sanitizer, and `html-to-pdfmake` as real block nodes.
- Memo content loader and MemoService: client-visible Markdown gains the same correct block boundaries while intentional blank lines keep the existing U+00A0 byte representation.
- Input creator/export projection: only block whitespace/boundaries change; authored content is unchanged.
- Search ingest: only whitespace/block boundaries change; indexed words are unchanged, and the existing U+00A0 blank-line byte is preserved rather than replaced with a literal HTML entity.
- Collaboration migration validation: existing conversion/round-trip suite remains green (124/124).

No schema, API, client, or SDK change.

Source: free-text production defect; no board story.
