### PR TITLE
fix: sanitize missing memo image references

### DIFF
--- a/src/core/bootstrap/collaboration-migration.worker.module.spec.ts
+++ b/src/core/bootstrap/collaboration-migration.worker.module.spec.ts
@@ -1,5 +1,6 @@
 import { GraphqlGuardModule } from '@core/authorization/graphql.guard.module';
 import { StorageBucketModule } from '@domain/storage/storage-bucket/storage.bucket.module';
+import { CollaborationClientModule } from '@services/collaboration-client/collaboration-client.module';
 import { CollaborationMigrationWorkerModule } from './collaboration-migration.worker.module';
 
 /**
@@ -29,5 +30,9 @@ describe('CollaborationMigrationWorkerModule', () => {
 
   it('imports GraphqlGuardModule so GraphqlGuard + ActorContextService resolve in the listener-less worker (regression: the worker MUST bootstrap)', () => {
     expect(imports).toContain(GraphqlGuardModule);
+  });
+
+  it('imports CollaborationClientModule so repairs use the live room persistence path', () => {
+    expect(imports).toContain(CollaborationClientModule);
   });
 });

--- a/src/core/bootstrap/collaboration-migration.worker.module.ts
+++ b/src/core/bootstrap/collaboration-migration.worker.module.ts
@@ -12,17 +12,22 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FileServiceAdapterModule } from '@services/adapters/file-service-adapter/file.service.adapter.module';
-import { CollaborationMigrationService } from '@services/collaboration-integration/migration';
+import { CollaborationClientModule } from '@services/collaboration-client/collaboration-client.module';
+import {
+  CollaborationMigrationService,
+  MemoImageRepairService,
+} from '@services/collaboration-integration/migration';
 import { AlkemioConfig } from '@src/types';
 import { WinstonModule } from 'nest-winston';
 import { join } from 'path';
 
 /**
  * Minimal one-shot operator context for the 006 legacy-content back-fill +
- * verification (Release A). Imports ONLY what `CollaborationMigrationService`
- * needs: config, Winston, the DB (via the shared runtime options helper, which
- * forces `migrationsRun:false` — the operator NEVER applies schema migrations),
- * the Memo/Whiteboard repos, and `FileServiceAdapter`.
+ * verification (Release A), plus the explicit memo image repair. Imports ONLY
+ * what those one-shot services need: config, Winston, the DB (via the shared
+ * runtime options helper, which forces `migrationsRun:false` — the operator NEVER
+ * applies schema migrations), the content repos, `FileServiceAdapter`, and the
+ * live collaboration client used for concurrency-safe memo repair.
  *
  * Deliberately excluded (§12 side-effect trace): `ScheduleModule` (so the
  * collaboration lifecycle publisher is inert because this worker never deletes),
@@ -65,6 +70,7 @@ import { join } from 'path';
     }),
     TypeOrmModule.forFeature([Memo, Whiteboard, CalloutContributionDefaults]),
     FileServiceAdapterModule,
+    CollaborationClientModule,
     // In-memory (no-store) cache purely to satisfy the global `CACHE_MANAGER`
     // token that `StorageBucketService`'s transitive `UrlGeneratorCacheService`
     // injects. The migration never calls the URL generator, so this cache is
@@ -91,6 +97,6 @@ import { join } from 'path';
     // pattern `AuthResetWorkerModule` uses for its isolated worker.
     GraphqlGuardModule,
   ],
-  providers: [CollaborationMigrationService],
+  providers: [CollaborationMigrationService, MemoImageRepairService],
 })
 export class CollaborationMigrationWorkerModule {}

--- a/src/main.collaboration-migration.ts
+++ b/src/main.collaboration-migration.ts
@@ -1,6 +1,10 @@
 import { CollaborationMigrationWorkerModule } from '@core/bootstrap/collaboration-migration.worker.module';
 import { NestFactory } from '@nestjs/core';
-import { CollaborationMigrationService } from '@services/collaboration-integration/migration';
+import {
+  CollaborationMigrationService,
+  MemoImageRepairService,
+} from '@services/collaboration-integration/migration';
+import { parseCollaborationMigrationCommand } from '@services/collaboration-integration/migration/collaboration-migration.cli';
 
 /**
  * One-shot operator entry for the 006 legacy-content back-fill + verification
@@ -9,26 +13,23 @@ import { CollaborationMigrationService } from '@services/collaboration-integrati
  *
  *   node dist/main.collaboration-migration --migrate [--dry-run]
  *   node dist/main.collaboration-migration --verify
+ *   node dist/main.collaboration-migration --repair-memo-images --actor-id <uuid> [--apply] [--memo-id <uuid>]...
  *
  * Prints one machine-readable JSON line and a human-readable summary (no
  * secrets), and exits non-zero on any non-clean outcome (migrate: source-flagged,
  * migrated-with-explicit-visual-loss, or failed rows;
  * verify: any NULL pointer, any pointer that does not resolve in file-service, or
- * any snapshot that fails decode / content-root-schema validation).
+ * any snapshot that fails decode / content-root-schema validation;
+ * memo image repair: any document whose inspection or repair failed).
  * Boots a minimal side-effect-free Nest application context (no scheduler / RMQ /
  * Redis / HTTP) — see `CollaborationMigrationWorkerModule`.
  */
 const USAGE =
-  'usage: main.collaboration-migration (--migrate [--dry-run] | --verify)';
+  'usage: main.collaboration-migration (--migrate [--dry-run] | --verify | --repair-memo-images --actor-id <uuid> [--apply] [--memo-id <uuid>]...)';
 
 const run = async (): Promise<number> => {
-  const args = process.argv.slice(2);
-  const migrate = args.includes('--migrate');
-  const verify = args.includes('--verify');
-  const dryRun = args.includes('--dry-run');
-
-  // Exactly one explicit mode is required — no default mutating action.
-  if (migrate === verify) {
+  const command = parseCollaborationMigrationCommand(process.argv.slice(2));
+  if (!command) {
     process.stderr.write(`${USAGE}\n`);
     return 2;
   }
@@ -38,9 +39,8 @@ const run = async (): Promise<number> => {
     { logger: ['error', 'warn', 'log'] }
   );
   try {
-    const service = app.get(CollaborationMigrationService);
-
-    if (verify) {
+    if (command.mode === 'verify') {
+      const service = app.get(CollaborationMigrationService);
       const summary = await service.verifyAll();
       process.stdout.write(
         `${JSON.stringify({ mode: 'verify', ...summary })}\n`
@@ -51,12 +51,29 @@ const run = async (): Promise<number> => {
       return summary.ok ? 0 : 1;
     }
 
-    const summary = await service.migrateAll({ dryRun });
+    if (command.mode === 'repair-memo-images') {
+      const service = app.get(MemoImageRepairService);
+      const summary = await service.repairMemoImages({
+        actorId: command.actorId,
+        apply: command.apply,
+        memoIds: command.memoIds,
+      });
+      process.stdout.write(
+        `${JSON.stringify({ mode: command.mode, ...summary })}\n`
+      );
+      process.stdout.write(
+        `repair-memo-images${summary.dryRun ? ' (dry-run)' : ''}: total=${summary.total} affected=${summary.affected} proposed=${summary.proposedRemovals} repaired=${summary.repaired} removed=${summary.removedReferences} failed=${summary.failed}\n`
+      );
+      return summary.failed === 0 ? 0 : 1;
+    }
+
+    const service = app.get(CollaborationMigrationService);
+    const summary = await service.migrateAll({ dryRun: command.dryRun });
     process.stdout.write(
       `${JSON.stringify({ mode: 'migrate', ...summary })}\n`
     );
     process.stdout.write(
-      `migrate${dryRun ? ' (dry-run)' : ''}: total=${summary.total} migrated=${summary.migrated} unattached=${summary.unattached} flagged=${summary.flagged} failed=${summary.failed}\n`
+      `migrate${command.dryRun ? ' (dry-run)' : ''}: total=${summary.total} migrated=${summary.migrated} unattached=${summary.unattached} flagged=${summary.flagged} failed=${summary.failed}\n`
     );
     return summary.failed === 0 && summary.flagged === 0 ? 0 : 1;
   } finally {

--- a/src/services/collaboration-integration/migration/collaboration-migration.cli.spec.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.cli.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { parseCollaborationMigrationCommand } from './collaboration-migration.cli';
+
+const actorId = '11111111-1111-4111-8111-111111111111';
+const memoId = '22222222-2222-4222-8222-222222222222';
+
+describe('parseCollaborationMigrationCommand', () => {
+  it('makes memo image repair a read-only dry run unless apply is explicit', () => {
+    expect(
+      parseCollaborationMigrationCommand([
+        '--repair-memo-images',
+        '--actor-id',
+        actorId,
+        '--memo-id',
+        memoId,
+      ])
+    ).toEqual({
+      mode: 'repair-memo-images',
+      actorId,
+      apply: false,
+      memoIds: [memoId],
+    });
+    expect(
+      parseCollaborationMigrationCommand([
+        '--repair-memo-images',
+        `--actor-id=${actorId}`,
+        '--apply',
+      ])
+    ).toEqual({
+      mode: 'repair-memo-images',
+      actorId,
+      apply: true,
+      memoIds: [],
+    });
+  });
+
+  it('rejects ambiguous modes, unknown flags, missing actors, and malformed ids', () => {
+    expect(parseCollaborationMigrationCommand([])).toBeUndefined();
+    expect(
+      parseCollaborationMigrationCommand(['--migrate', '--verify'])
+    ).toBeUndefined();
+    expect(
+      parseCollaborationMigrationCommand(['--repair-memo-images'])
+    ).toBeUndefined();
+    expect(
+      parseCollaborationMigrationCommand([
+        '--repair-memo-images',
+        '--actor-id=not-a-uuid',
+      ])
+    ).toBeUndefined();
+    expect(
+      parseCollaborationMigrationCommand(['--verify', '--apply'])
+    ).toBeUndefined();
+  });
+});

--- a/src/services/collaboration-integration/migration/collaboration-migration.cli.ts
+++ b/src/services/collaboration-integration/migration/collaboration-migration.cli.ts
@@ -1,0 +1,89 @@
+import { isUUID } from 'class-validator';
+
+export type CollaborationMigrationCommand =
+  | { mode: 'migrate'; dryRun: boolean }
+  | { mode: 'verify' }
+  | {
+      mode: 'repair-memo-images';
+      actorId: string;
+      apply: boolean;
+      memoIds: string[];
+    };
+
+const readValue = (
+  args: string[],
+  index: number,
+  name: string
+): { value: string; nextIndex: number } | undefined => {
+  const argument = args[index];
+  const inlinePrefix = `${name}=`;
+  if (argument.startsWith(inlinePrefix)) {
+    return { value: argument.slice(inlinePrefix.length), nextIndex: index };
+  }
+  if (argument !== name || index + 1 >= args.length) {
+    return undefined;
+  }
+  return { value: args[index + 1], nextIndex: index + 1 };
+};
+
+/** Parse the bounded, fail-closed collaboration migration worker command. */
+export const parseCollaborationMigrationCommand = (
+  args: string[]
+): CollaborationMigrationCommand | undefined => {
+  const modes = [
+    args.includes('--migrate'),
+    args.includes('--verify'),
+    args.includes('--repair-memo-images'),
+  ].filter(Boolean).length;
+  if (modes !== 1) {
+    return undefined;
+  }
+
+  if (args.includes('--migrate')) {
+    const allowed = new Set(['--migrate', '--dry-run']);
+    return args.every(argument => allowed.has(argument))
+      ? { mode: 'migrate', dryRun: args.includes('--dry-run') }
+      : undefined;
+  }
+  if (args.includes('--verify')) {
+    return args.length === 1 ? { mode: 'verify' } : undefined;
+  }
+
+  let actorId: string | undefined;
+  const memoIds: string[] = [];
+  let apply = false;
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--repair-memo-images') {
+      continue;
+    }
+    if (argument === '--apply') {
+      apply = true;
+      continue;
+    }
+    const actor = readValue(args, index, '--actor-id');
+    if (actor) {
+      if (actorId !== undefined || !isUUID(actor.value)) {
+        return undefined;
+      }
+      actorId = actor.value;
+      index = actor.nextIndex;
+      continue;
+    }
+    const memo = readValue(args, index, '--memo-id');
+    if (memo) {
+      if (!isUUID(memo.value)) {
+        return undefined;
+      }
+      memoIds.push(memo.value);
+      index = memo.nextIndex;
+      continue;
+    }
+    return undefined;
+  }
+
+  if (!actorId) {
+    return undefined;
+  }
+  return { mode: 'repair-memo-images', actorId, apply, memoIds };
+};

--- a/src/services/collaboration-integration/migration/index.ts
+++ b/src/services/collaboration-integration/migration/index.ts
@@ -2,3 +2,4 @@ export * from './collaboration-migration.module';
 export * from './collaboration-migration.result';
 export * from './collaboration-migration.service';
 export * from './legacy.content.record';
+export * from './memo-image-repair.service';

--- a/src/services/collaboration-integration/migration/memo-image-repair.service.spec.ts
+++ b/src/services/collaboration-integration/migration/memo-image-repair.service.spec.ts
@@ -1,0 +1,373 @@
+import { LogContext } from '@common/enums';
+import { EntityNotFoundException } from '@common/exceptions';
+import { ActorContext } from '@core/actor-context/actor.context';
+import {
+  markdownToYjsV2State,
+  yjsStateToMarkdown,
+} from '@domain/common/memo/conversion';
+import { MemoPdfRenderer } from '@domain/common/memo/memo.pdf.renderer';
+import { FileServiceAdapterException } from '@services/adapters/file-service-adapter/file.service.adapter.exception';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as Y from 'yjs';
+import { MemoImageRepairService } from './memo-image-repair.service';
+
+const BASE = 'https://alkem.io/api/private/rest/storage/document';
+const MISSING_METADATA = '11111111-1111-4111-8111-111111111111';
+const MISSING_CONTENT = '22222222-2222-4222-8222-222222222222';
+const VALID = '33333333-3333-4333-8333-333333333333';
+const TRANSIENT = '44444444-4444-4444-8444-444444444444';
+const MALFORMED = '55555555-5555-4555-8555-555555555555';
+const source = (id: string) => `${BASE}/${id}`;
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z4xkAAAAASUVORK5CYII=',
+  'base64'
+);
+
+const memoDoc = (markdown: string): Y.Doc => {
+  const doc = new Y.Doc();
+  Y.applyUpdateV2(doc, markdownToYjsV2State(markdown));
+  return doc;
+};
+
+const queryBuilder = (rows: { id: string; storageBucketId: string }[]) => {
+  let returned = false;
+  const qb: any = {};
+  for (const method of [
+    'leftJoin',
+    'select',
+    'addSelect',
+    'where',
+    'orderBy',
+    'limit',
+    'andWhere',
+  ]) {
+    qb[method] = vi.fn(() => qb);
+  }
+  qb.getRawMany = vi.fn(async () => {
+    if (returned) return [];
+    returned = true;
+    return rows;
+  });
+  return qb;
+};
+
+describe('MemoImageRepairService', () => {
+  let doc: Y.Doc;
+  let memoRepository: { createQueryBuilder: ReturnType<typeof vi.fn> };
+  let documentService: {
+    isAlkemioDocumentURL: ReturnType<typeof vi.fn>;
+    getDocumentsBaseUrlPath: ReturnType<typeof vi.fn>;
+    getDocumentOrFail: ReturnType<typeof vi.fn>;
+    getDocumentFromURL: ReturnType<typeof vi.fn>;
+  };
+  let fileServiceAdapter: {
+    getDocumentContent: ReturnType<typeof vi.fn>;
+  };
+  let collaborationDocumentService: {
+    read: ReturnType<typeof vi.fn>;
+    mutate: ReturnType<typeof vi.fn>;
+  };
+  let service: MemoImageRepairService;
+
+  beforeEach(() => {
+    doc = memoDoc('plain text');
+    memoRepository = {
+      createQueryBuilder: vi.fn(() =>
+        queryBuilder([{ id: 'memo-1', storageBucketId: 'bucket-1' }])
+      ),
+    };
+    documentService = {
+      isAlkemioDocumentURL: vi.fn((value: string) => value.startsWith(BASE)),
+      getDocumentsBaseUrlPath: vi.fn(() => BASE),
+      getDocumentOrFail: vi.fn(async (id: string) => {
+        if (id === MISSING_METADATA) {
+          throw new EntityNotFoundException(
+            'Document not found',
+            LogContext.STORAGE_BUCKET
+          );
+        }
+        return { id, storageBucket: { id: 'bucket-1' } };
+      }),
+      getDocumentFromURL: vi.fn(async (value: string) => ({
+        id: value.slice(BASE.length + 1),
+        storageBucket: { id: 'bucket-1' },
+        authorization: { id: 'auth-1' },
+      })),
+    };
+    fileServiceAdapter = {
+      getDocumentContent: vi.fn(async (id: string) => {
+        if (id === MISSING_CONTENT) {
+          throw new FileServiceAdapterException(
+            'File service HTTP error',
+            'getDocumentContent',
+            404
+          );
+        }
+        if (id === TRANSIENT) {
+          throw new FileServiceAdapterException(
+            'File service HTTP error',
+            'getDocumentContent',
+            503
+          );
+        }
+        if (id === MALFORMED) {
+          return Buffer.alloc(0);
+        }
+        return PNG;
+      }),
+    };
+    collaborationDocumentService = {
+      read: vi.fn(async (_id, _type, _actor, reader) => reader(doc)),
+      mutate: vi.fn(async (_id, _type, _actor, mutator) => mutator(doc)),
+    };
+    service = new MemoImageRepairService(
+      { warn: vi.fn(), error: vi.fn() } as any,
+      memoRepository as any,
+      documentService as any,
+      fileServiceAdapter as any,
+      collaborationDocumentService as any
+    );
+  });
+
+  it('dry-run reports missing metadata and missing backing bytes, deduplicates repeated lookups, and writes nothing', async () => {
+    doc.destroy();
+    doc = memoDoc(
+      [
+        `before ![missing metadata](${source(MISSING_METADATA)})`,
+        '',
+        `![missing bytes one](${source(MISSING_CONTENT)}) and ![missing bytes two](${source(MISSING_CONTENT)})`,
+        '',
+        `![valid](${source(VALID)}) ![external](https://example.com/image.png)`,
+      ].join('\n')
+    );
+
+    const result = await service.repairMemoImages({ actorId: 'actor-1' });
+
+    expect(result).toMatchObject({
+      total: 1,
+      affected: 1,
+      repaired: 0,
+      proposedRemovals: 3,
+      removedReferences: 0,
+      failed: 0,
+      dryRun: true,
+    });
+    expect(result.affectedDocuments[0].references).toEqual([
+      {
+        source: source(MISSING_METADATA),
+        documentId: MISSING_METADATA,
+        occurrences: 1,
+        reason: 'metadata-missing',
+      },
+      {
+        source: source(MISSING_CONTENT),
+        documentId: MISSING_CONTENT,
+        occurrences: 2,
+        reason: 'content-missing',
+      },
+    ]);
+    expect(documentService.getDocumentOrFail).toHaveBeenCalledTimes(3);
+    expect(fileServiceAdapter.getDocumentContent).toHaveBeenCalledTimes(2);
+    expect(collaborationDocumentService.mutate).not.toHaveBeenCalled();
+  });
+
+  it('apply removes only confirmed-missing repeated image nodes from the fresh live doc, persists through the room, and is harmless on rerun', async () => {
+    doc.destroy();
+    doc = memoDoc(
+      [
+        '# Heading',
+        '',
+        `before **bold** ![lost](${source(MISSING_CONTENT)}) after`,
+        '',
+        `- keep list ![lost again](${source(MISSING_CONTENT)})`,
+        `- keep valid ![valid](${source(VALID)})`,
+      ].join('\n')
+    );
+
+    const result = await service.repairMemoImages({
+      actorId: 'actor-1',
+      apply: true,
+    });
+
+    expect(result).toMatchObject({
+      affected: 1,
+      repaired: 1,
+      proposedRemovals: 2,
+      removedReferences: 2,
+      failed: 0,
+      dryRun: false,
+    });
+    expect(collaborationDocumentService.mutate).toHaveBeenCalledWith(
+      'memo-1',
+      'memo',
+      'actor-1',
+      expect.any(Function)
+    );
+    const repairedMarkdown = yjsStateToMarkdown(
+      Buffer.from(Y.encodeStateAsUpdateV2(doc))
+    );
+    expect(repairedMarkdown).toContain('# Heading');
+    expect(repairedMarkdown).toContain('before **bold**  after');
+    expect(repairedMarkdown).toContain('- keep list');
+    expect(repairedMarkdown).toContain(`![valid](${source(VALID)})`);
+    expect(repairedMarkdown).not.toContain(source(MISSING_CONTENT));
+
+    collaborationDocumentService.mutate.mockClear();
+    memoRepository.createQueryBuilder.mockImplementation(() =>
+      queryBuilder([{ id: 'memo-1', storageBucketId: 'bucket-1' }])
+    );
+    const rerun = await service.repairMemoImages({
+      actorId: 'actor-1',
+      apply: true,
+    });
+    expect(rerun).toMatchObject({ affected: 0, repaired: 0, failed: 0 });
+    expect(collaborationDocumentService.mutate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'transient file-service error',
+      TRANSIENT,
+      'file-service:getDocumentContent:http-503',
+    ],
+    [
+      'malformed empty content response',
+      MALFORMED,
+      'Memo image lookup returned malformed or empty content',
+    ],
+  ])('leaves the entire memo unchanged on %s', async (_label, documentId, expectedReason) => {
+    doc.destroy();
+    doc = memoDoc(
+      `![confirmed missing](${source(MISSING_CONTENT)}) ![inconclusive](${source(documentId)})`
+    );
+    const before = Buffer.from(Y.encodeStateAsUpdateV2(doc));
+
+    const result = await service.repairMemoImages({
+      actorId: 'actor-1',
+      apply: true,
+    });
+
+    expect(result).toMatchObject({ affected: 0, repaired: 0, failed: 1 });
+    expect(result.failedDocuments[0].reason).toBe(expectedReason);
+    expect(collaborationDocumentService.mutate).not.toHaveBeenCalled();
+    expect(Buffer.from(Y.encodeStateAsUpdateV2(doc))).toEqual(before);
+  });
+
+  it.each([
+    [
+      'file-service authorization failure',
+      new FileServiceAdapterException(
+        'File service HTTP error',
+        'getDocumentContent',
+        403
+      ),
+      'file-service:getDocumentContent:http-403',
+    ],
+    [
+      'file-service timeout',
+      FileServiceAdapterException.fromTransportError(
+        'getDocumentContent',
+        new Error('request timed out')
+      ),
+      'file-service:getDocumentContent:transport-failure',
+    ],
+    [
+      'file-service network error',
+      FileServiceAdapterException.fromTransportError(
+        'getDocumentContent',
+        new Error('connection reset')
+      ),
+      'file-service:getDocumentContent:transport-failure',
+    ],
+    [
+      'file-service 5xx response',
+      new FileServiceAdapterException(
+        'File service HTTP error',
+        'getDocumentContent',
+        500
+      ),
+      'file-service:getDocumentContent:http-500',
+    ],
+  ])('does not remove images on %s', async (_label, error, expectedReason) => {
+    doc.destroy();
+    doc = memoDoc(`![inconclusive](${source(VALID)})`);
+    const before = Buffer.from(Y.encodeStateAsUpdateV2(doc));
+    fileServiceAdapter.getDocumentContent.mockRejectedValueOnce(error);
+
+    const result = await service.repairMemoImages({
+      actorId: 'actor-1',
+      apply: true,
+    });
+
+    expect(result).toMatchObject({ affected: 0, repaired: 0, failed: 1 });
+    expect(result.failedDocuments[0].reason).toBe(expectedReason);
+    expect(collaborationDocumentService.mutate).not.toHaveBeenCalled();
+    expect(Buffer.from(Y.encodeStateAsUpdateV2(doc))).toEqual(before);
+  });
+
+  it('does not classify collaboration authorization failure as missing content', async () => {
+    collaborationDocumentService.read.mockRejectedValue(
+      new Error('Read-only room')
+    );
+
+    const result = await service.repairMemoImages({
+      actorId: 'actor-1',
+      apply: true,
+    });
+
+    expect(result).toMatchObject({ affected: 0, repaired: 0, failed: 1 });
+    expect(documentService.getDocumentOrFail).not.toHaveBeenCalled();
+    expect(collaborationDocumentService.mutate).not.toHaveBeenCalled();
+  });
+
+  it('does not report visual loss when the live-room mutation fails before durability', async () => {
+    doc.destroy();
+    doc = memoDoc(`![lost](${source(MISSING_CONTENT)})`);
+    collaborationDocumentService.mutate.mockImplementation(
+      async (_id, _type, _actor, mutator) => {
+        mutator(doc);
+        throw new Error('persist barrier failed');
+      }
+    );
+
+    const result = await service.repairMemoImages({
+      actorId: 'actor-1',
+      apply: true,
+    });
+
+    expect(result).toMatchObject({
+      affected: 1,
+      repaired: 0,
+      removedReferences: 0,
+      failed: 1,
+    });
+    expect(result.affectedDocuments[0].removedReferences).toBe(0);
+  });
+
+  it('the repaired memo projection prepares a PDF without reading the stale image', async () => {
+    doc.destroy();
+    doc = memoDoc(
+      `preserved text ![lost](${source(MISSING_CONTENT)}) and ![valid](${source(VALID)})`
+    );
+    await service.repairMemoImages({ actorId: 'actor-1', apply: true });
+    const markdown = yjsStateToMarkdown(
+      Buffer.from(Y.encodeStateAsUpdateV2(doc))
+    );
+    fileServiceAdapter.getDocumentContent.mockClear();
+    const renderer = new MemoPdfRenderer(
+      documentService as any,
+      { grantAccessOrFail: vi.fn() } as any,
+      fileServiceAdapter as any
+    );
+
+    const pdf = await renderer.render(
+      markdown,
+      'bucket-1',
+      Object.assign(new ActorContext(), { actorID: 'actor-1' })
+    );
+
+    expect(pdf.subarray(0, 5).toString()).toBe('%PDF-');
+    expect(fileServiceAdapter.getDocumentContent).toHaveBeenCalledTimes(1);
+    expect(fileServiceAdapter.getDocumentContent).toHaveBeenCalledWith(VALID);
+  });
+});

--- a/src/services/collaboration-integration/migration/memo-image-repair.service.ts
+++ b/src/services/collaboration-integration/migration/memo-image-repair.service.ts
@@ -1,0 +1,304 @@
+import { LogContext } from '@common/enums';
+import { EntityNotFoundException } from '@common/exceptions';
+import { Memo } from '@domain/common/memo/memo.entity';
+import { DocumentService } from '@domain/storage/document/document.service';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FileServiceAdapter } from '@services/adapters/file-service-adapter/file.service.adapter';
+import { FileServiceAdapterException } from '@services/adapters/file-service-adapter/file.service.adapter.exception';
+import { CollaborationDocumentService } from '@services/collaboration-client/collaboration-document.service';
+import { isUUID } from 'class-validator';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { Repository } from 'typeorm';
+import {
+  collectMemoImageSources,
+  removeMemoImagesBySource,
+} from './memo-image-repair';
+
+const DEFAULT_REPAIR_BATCH_SIZE = 200;
+
+export type MissingMemoImageReason = 'metadata-missing' | 'content-missing';
+
+export interface MissingMemoImageReference {
+  source: string;
+  documentId: string;
+  occurrences: number;
+  reason: MissingMemoImageReason;
+}
+
+export interface MemoImageRepairDocument {
+  id: string;
+  references: MissingMemoImageReference[];
+  removedReferences: number;
+}
+
+export interface MemoImageRepairSummary {
+  total: number;
+  affected: number;
+  repaired: number;
+  proposedRemovals: number;
+  removedReferences: number;
+  failed: number;
+  affectedDocuments: MemoImageRepairDocument[];
+  failedDocuments: { id: string; reason: string }[];
+  dryRun: boolean;
+}
+
+export interface MemoImageRepairOptions {
+  actorId: string;
+  apply?: boolean;
+  batchSize?: number;
+  memoIds?: string[];
+}
+
+interface MemoRepairCandidate {
+  id: string;
+  storageBucketId: string | null;
+}
+
+type ImageContentState =
+  | { missing: false }
+  | { missing: true; reason: MissingMemoImageReason };
+
+const repairErrorReason = (error: unknown): string => {
+  if (error instanceof FileServiceAdapterException) {
+    const outcome =
+      error.httpStatus === undefined
+        ? 'transport-failure'
+        : `http-${error.httpStatus}`;
+    return `file-service:${error.operation}:${outcome}`;
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return 'Unknown memo image repair error';
+};
+
+/**
+ * Explicit operator repair inside the existing collaboration-migration runtime.
+ * Discovery is read-only by default. Apply mode mutates only the live memo room,
+ * so the collaboration service remains the snapshot owner and concurrent edits
+ * are never replaced by a stale file-service snapshot.
+ */
+@Injectable()
+export class MemoImageRepairService {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+    @InjectRepository(Memo)
+    private readonly memoRepository: Repository<Memo>,
+    private readonly documentService: DocumentService,
+    private readonly fileServiceAdapter: FileServiceAdapter,
+    private readonly collaborationDocumentService: CollaborationDocumentService
+  ) {}
+
+  async repairMemoImages(
+    options: MemoImageRepairOptions
+  ): Promise<MemoImageRepairSummary> {
+    const dryRun = options.apply !== true;
+    const summary: MemoImageRepairSummary = {
+      total: 0,
+      affected: 0,
+      repaired: 0,
+      proposedRemovals: 0,
+      removedReferences: 0,
+      failed: 0,
+      affectedDocuments: [],
+      failedDocuments: [],
+      dryRun,
+    };
+
+    for await (const candidate of this.readCandidates(
+      options.batchSize,
+      options.memoIds
+    )) {
+      summary.total++;
+      try {
+        if (!candidate.storageBucketId) {
+          throw new Error('Memo has no storage bucket');
+        }
+        const sourceCounts = await this.collaborationDocumentService.read(
+          candidate.id,
+          'memo',
+          options.actorId,
+          collectMemoImageSources
+        );
+        const references = await this.findMissingReferences(
+          sourceCounts,
+          candidate.storageBucketId
+        );
+        if (references.length === 0) {
+          continue;
+        }
+
+        summary.affected++;
+        summary.proposedRemovals += references.reduce(
+          (total, reference) => total + reference.occurrences,
+          0
+        );
+        const result: MemoImageRepairDocument = {
+          id: candidate.id,
+          references,
+          removedReferences: 0,
+        };
+        summary.affectedDocuments.push(result);
+
+        if (dryRun) {
+          continue;
+        }
+
+        const missingSources = new Set(
+          references.map(reference => reference.source)
+        );
+        let removedReferences = 0;
+        await this.collaborationDocumentService.mutate(
+          candidate.id,
+          'memo',
+          options.actorId,
+          doc => {
+            removedReferences = removeMemoImagesBySource(doc, missingSources);
+          }
+        );
+        result.removedReferences = removedReferences;
+        summary.removedReferences += result.removedReferences;
+        if (result.removedReferences > 0) {
+          summary.repaired++;
+          this.logger.warn?.(
+            {
+              message:
+                'Memo image repair removed confirmed-unrecoverable image references',
+              memoId: candidate.id,
+              removedReferences: result.removedReferences,
+              references,
+            },
+            LogContext.COLLABORATION_INTEGRATION
+          );
+        }
+      } catch (error) {
+        summary.failed++;
+        const reason = repairErrorReason(error);
+        summary.failedDocuments.push({ id: candidate.id, reason });
+        this.logger.error?.(
+          {
+            message:
+              'Memo image repair did not complete; durability was not confirmed',
+            memoId: candidate.id,
+            error: reason,
+          },
+          error instanceof Error ? error.stack : undefined,
+          LogContext.COLLABORATION_INTEGRATION
+        );
+      }
+    }
+
+    return summary;
+  }
+
+  private async findMissingReferences(
+    sourceCounts: Map<string, number>,
+    storageBucketId: string
+  ): Promise<MissingMemoImageReference[]> {
+    const missing: MissingMemoImageReference[] = [];
+    const states = new Map<string, Promise<ImageContentState>>();
+    for (const [source, occurrences] of sourceCounts) {
+      if (!this.documentService.isAlkemioDocumentURL(source)) {
+        continue;
+      }
+      const documentId = this.extractDocumentId(source);
+      let pending = states.get(documentId);
+      if (!pending) {
+        pending = this.readImageContentState(documentId, storageBucketId);
+        states.set(documentId, pending);
+      }
+      const state = await pending;
+      if (state.missing) {
+        missing.push({ source, documentId, occurrences, reason: state.reason });
+      }
+    }
+    return missing;
+  }
+
+  private extractDocumentId(source: string): string {
+    const prefix = `${this.documentService.getDocumentsBaseUrlPath().replace(/\/+$/, '')}/`;
+    const documentId = source.startsWith(prefix)
+      ? source.slice(prefix.length)
+      : '';
+    if (!isUUID(documentId)) {
+      throw new Error('Memo contains a malformed internal image reference');
+    }
+    return documentId;
+  }
+
+  private async readImageContentState(
+    documentId: string,
+    storageBucketId: string
+  ): Promise<ImageContentState> {
+    let document;
+    try {
+      document = await this.documentService.getDocumentOrFail(documentId, {
+        relations: { storageBucket: true },
+      });
+    } catch (error) {
+      if (error instanceof EntityNotFoundException) {
+        return { missing: true, reason: 'metadata-missing' };
+      }
+      throw error;
+    }
+    if (document.storageBucket?.id !== storageBucketId) {
+      throw new Error('Memo image does not belong to the memo storage bucket');
+    }
+
+    let content: Buffer;
+    try {
+      content = await this.fileServiceAdapter.getDocumentContent(documentId);
+    } catch (error) {
+      if (
+        error instanceof FileServiceAdapterException &&
+        error.operation === 'getDocumentContent' &&
+        error.httpStatus === 404
+      ) {
+        return { missing: true, reason: 'content-missing' };
+      }
+      throw error;
+    }
+    if (!Buffer.isBuffer(content) || content.length === 0) {
+      throw new Error('Memo image lookup returned malformed or empty content');
+    }
+    return { missing: false };
+  }
+
+  private async *readCandidates(
+    batchSize = DEFAULT_REPAIR_BATCH_SIZE,
+    memoIds?: string[]
+  ): AsyncGenerator<MemoRepairCandidate> {
+    let lastId: string | undefined;
+    for (;;) {
+      const qb = this.memoRepository
+        .createQueryBuilder('memo')
+        .leftJoin('memo.profile', 'profile')
+        .leftJoin('profile.storageBucket', 'storageBucket')
+        .select('memo.id', 'id')
+        .addSelect('storageBucket.id', 'storageBucketId')
+        .where('memo.contentPointer IS NOT NULL')
+        .orderBy('memo.id', 'ASC')
+        .limit(batchSize);
+      if (memoIds?.length) {
+        qb.andWhere('memo.id IN (:...memoIds)', { memoIds });
+      }
+      if (lastId !== undefined) {
+        qb.andWhere('memo.id > :lastId', { lastId });
+      }
+      const rows = await qb.getRawMany<MemoRepairCandidate>();
+      if (rows.length === 0) {
+        return;
+      }
+      for (const row of rows) {
+        yield row;
+      }
+      lastId = rows[rows.length - 1].id;
+      if (rows.length < batchSize) {
+        return;
+      }
+    }
+  }
+}

--- a/src/services/collaboration-integration/migration/memo-image-repair.spec.ts
+++ b/src/services/collaboration-integration/migration/memo-image-repair.spec.ts
@@ -1,0 +1,106 @@
+import {
+  markdownToYjsV2State,
+  yjsStateToMarkdown,
+} from '@domain/common/memo/conversion';
+import { markdownSchema } from '@domain/common/memo/conversion/markdown.schema';
+import { prosemirrorToYDoc } from '@tiptap/y-tiptap';
+import type { Node as ProseMirrorNode } from 'prosemirror-model';
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import {
+  collectMemoImageSources,
+  removeMemoImagesBySource,
+} from './memo-image-repair';
+
+const memoDoc = (markdown: string): Y.Doc => {
+  const doc = new Y.Doc();
+  Y.applyUpdateV2(doc, markdownToYjsV2State(markdown));
+  return doc;
+};
+
+describe('memo image repair', () => {
+  it('finds repeated image references without losing their occurrence count', () => {
+    const doc = memoDoc(
+      [
+        'before ![first](https://alkem.io/rest/storage/document/missing)',
+        '',
+        '- ![second](https://alkem.io/rest/storage/document/missing)',
+      ].join('\n')
+    );
+
+    expect(collectMemoImageSources(doc)).toEqual(
+      new Map([['https://alkem.io/rest/storage/document/missing', 2]])
+    );
+    doc.destroy();
+  });
+
+  it('removes only matching image nodes and preserves unrelated text, lists, tables, formatting, and valid images', () => {
+    const missing = 'https://alkem.io/rest/storage/document/missing';
+    const valid = 'https://alkem.io/rest/storage/document/valid';
+    const paragraph = (...content: ProseMirrorNode[]) =>
+      markdownSchema.nodes.paragraph.create(null, content);
+    const text = (value: string, bold = false) =>
+      markdownSchema.text(
+        value,
+        bold ? [markdownSchema.marks.bold.create()] : undefined
+      );
+    const image = (source: string, alt: string) =>
+      markdownSchema.nodes.image.create({ src: source, alt });
+    const doc = prosemirrorToYDoc(
+      markdownSchema.nodes.doc.create(null, [
+        markdownSchema.nodes.heading.create({ level: 1 }, text('Heading')),
+        paragraph(
+          text('before '),
+          text('bold', true),
+          text(' '),
+          image(missing, 'lost'),
+          text(' after')
+        ),
+        markdownSchema.nodes.bulletList.create(null, [
+          markdownSchema.nodes.listItem.create(null, [
+            paragraph(text('keep list '), image(missing, 'also lost')),
+          ]),
+          markdownSchema.nodes.listItem.create(null, [
+            paragraph(text('keep valid '), image(valid, 'valid')),
+          ]),
+        ]),
+        markdownSchema.nodes.table.create(null, [
+          markdownSchema.nodes.tableRow.create(null, [
+            markdownSchema.nodes.tableHeader.create(null, paragraph(text('A'))),
+            markdownSchema.nodes.tableHeader.create(null, paragraph(text('B'))),
+          ]),
+          markdownSchema.nodes.tableRow.create(null, [
+            markdownSchema.nodes.tableCell.create(null, paragraph(text('1'))),
+            markdownSchema.nodes.tableCell.create(null, paragraph(text('2'))),
+          ]),
+        ]),
+      ]),
+      'default'
+    );
+
+    const before = yjsStateToMarkdown(
+      Buffer.from(Y.encodeStateAsUpdateV2(doc))
+    );
+    expect(before).toContain(missing);
+    expect(collectMemoImageSources(doc)).toEqual(
+      new Map([
+        [missing, 2],
+        [valid, 1],
+      ])
+    );
+    expect(removeMemoImagesBySource(doc, new Set([missing]))).toBe(2);
+    expect(removeMemoImagesBySource(doc, new Set([missing]))).toBe(0);
+
+    const markdown = yjsStateToMarkdown(
+      Buffer.from(Y.encodeStateAsUpdateV2(doc))
+    );
+    expect(markdown).toContain('# Heading');
+    expect(markdown).toContain('before **bold**  after');
+    expect(markdown).toContain('- keep list');
+    expect(markdown).toContain(`![valid](${valid})`);
+    expect(markdown).toContain('| A | B |');
+    expect(markdown).toContain('| 1 | 2 |');
+    expect(markdown).not.toContain(missing);
+    doc.destroy();
+  });
+});

--- a/src/services/collaboration-integration/migration/memo-image-repair.ts
+++ b/src/services/collaboration-integration/migration/memo-image-repair.ts
@@ -1,0 +1,64 @@
+import * as Y from 'yjs';
+
+const MEMO_ROOT = 'default';
+
+type MemoXmlParent = Y.XmlFragment | Y.XmlElement;
+
+const visitMemoElements = (
+  parent: MemoXmlParent,
+  visitor: (parent: MemoXmlParent, child: Y.XmlElement, index: number) => void,
+  reverse = false
+): void => {
+  const children = parent.toArray();
+  const indexes = children.map((_child, index) => index);
+  if (reverse) {
+    indexes.reverse();
+  }
+  for (const index of indexes) {
+    const child = children[index];
+    if (!(child instanceof Y.XmlElement)) {
+      continue;
+    }
+    visitor(parent, child, index);
+    if (child.parent) {
+      visitMemoElements(child, visitor, reverse);
+    }
+  }
+};
+
+/** Collect image source occurrence counts from the canonical memo root. */
+export const collectMemoImageSources = (doc: Y.Doc): Map<string, number> => {
+  const sources = new Map<string, number>();
+  visitMemoElements(doc.getXmlFragment(MEMO_ROOT), (_parent, child) => {
+    if (child.nodeName !== 'image') {
+      return;
+    }
+    const source = child.getAttribute('src');
+    if (typeof source === 'string' && source.length > 0) {
+      sources.set(source, (sources.get(source) ?? 0) + 1);
+    }
+  });
+  return sources;
+};
+
+/** Remove only image nodes whose exact source was confirmed unrecoverable. */
+export const removeMemoImagesBySource = (
+  doc: Y.Doc,
+  sources: ReadonlySet<string>
+): number => {
+  let removed = 0;
+  visitMemoElements(
+    doc.getXmlFragment(MEMO_ROOT),
+    (parent, child, index) => {
+      if (
+        child.nodeName === 'image' &&
+        sources.has(child.getAttribute('src') as string)
+      ) {
+        parent.delete(index, 1);
+        removed++;
+      }
+    },
+    true
+  );
+  return removed;
+};


### PR DESCRIPTION
Fixes alkem-io/server#6492

## Root cause

Memo signing renders the live Yjs projection and resolves every internal image through document metadata and file-service bytes. Existing memos can still reference a document whose metadata row is absent, or whose metadata exists while the backing bytes return a typed 404. The renderer correctly fails rather than silently changing the signed output, but the existing collaboration migration worker had no memo-image discovery or repair path.

## Fix

- extends the existing one-shot collaboration migration worker with `--repair-memo-images --actor-id <uuid>`; it is a read-only dry run by default, and mutation requires explicit `--apply`
- reads each current memo through the live collaboration room, reports exact missing references and repeated occurrence counts, and only treats typed metadata absence or a typed file-service 404 as confirmed loss
- leaves authorization failures, transport failures/timeouts, 5xx responses, malformed responses, foreign-bucket metadata, and malformed internal locators untouched and reports the memo as failed
- removes only confirmed-missing image nodes from the fresh live Yjs document and persists via the existing correlated durability-barrier path, so concurrent edits are not overwritten by a stale snapshot
- preserves valid/external images and unrelated memo text, formatting, lists, and tables; rerunning a completed repair is a no-op
- reports visual loss explicitly, while the repaired projection is also the projection used by preview/signing

The memo image schema contains no alternate byte source to recover a genuinely absent internal document. Images whose metadata and non-empty file-service bytes are available are preserved.

## Tests

- focused repair/CLI/module suite: 18 passed
- full `pnpm test:ci`: 793 files passed, 8 skipped; 9,247 tests passed, 28 skipped
- `pnpm build`: passed
- `pnpm lint` (TypeScript + Biome): passed
- commit hooks: full no-coverage test suite and typecheck passed

No production or acceptance repair was executed. No memo, file, signing attempt, or external environment was mutated while implementing or testing this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line workflow to detect and repair missing memo images.
  * Supports dry-run reporting, confirmed repairs, actor validation, and optional memo filtering.
  * Repairs preserve unrelated memo content and report categorized results and failures.
  * Added stricter validation for migration, verification, and image-repair commands.

* **Tests**
  * Added coverage for command parsing, image detection and removal, dry runs, repeated execution, failures, authorization, persistence, and document rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->