### PR TITLE
fix(callouts): honour the destination's changed innovation flow on callout transfer

### DIFF
--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.spec.ts
@@ -539,6 +539,78 @@ describe('InnovationFlowService', () => {
   });
 
   describe('createStateOnInnovationFlow', () => {
+    beforeEach(() => {
+      // Adding a state rewrites the flow-state vocabulary, which re-loads the
+      // flow together with its template.
+      vi.mocked(repository.findOne).mockResolvedValue({
+        id: 'flow-1',
+        flowStatesTagsetTemplate: { id: 'tt-1', tagsets: [] },
+      } as any);
+    });
+
+    it('rewrites the vocabulary with the new state in flow order and keeps the current default', async () => {
+      const flow = {
+        id: 'flow-1',
+        currentStateID: 's-1',
+        states: [
+          { id: 's-1', displayName: 'A', sortOrder: 1 },
+          { id: 's-2', displayName: 'B', sortOrder: 2 },
+        ],
+        settings: { maximumNumberOfStates: 8, minimumNumberOfStates: 1 },
+      } as any;
+      const created = { id: 's-3', displayName: 'C', sortOrder: 3 } as any;
+      vi.mocked(
+        innovationFlowStateService.createInnovationFlowState
+      ).mockResolvedValue(created);
+      vi.mocked(innovationFlowStateService.save).mockResolvedValue(created);
+
+      await service.createStateOnInnovationFlow(flow, {
+        displayName: 'C',
+        sortOrder: 3,
+      } as any);
+
+      expect(
+        tagsetTemplateService.updateTagsetTemplateDefinition
+      ).toHaveBeenCalledWith(expect.objectContaining({ id: 'tt-1' }), {
+        allowedValues: ['A', 'B', 'C'],
+        defaultSelectedValue: 'A',
+      });
+      expect(tagsetService.updateTagsetsSelectedValue).toHaveBeenCalledWith(
+        expect.anything(),
+        ['A', 'B', 'C'],
+        'A'
+      );
+    });
+
+    it('orders the vocabulary by sort order when the new state is inserted first', async () => {
+      const flow = {
+        id: 'flow-1',
+        currentStateID: 's-1',
+        states: [
+          { id: 's-1', displayName: 'A', sortOrder: 1 },
+          { id: 's-2', displayName: 'B', sortOrder: 2 },
+        ],
+        settings: { maximumNumberOfStates: 8, minimumNumberOfStates: 1 },
+      } as any;
+      const created = { id: 's-3', displayName: 'C', sortOrder: 0 } as any;
+      vi.mocked(
+        innovationFlowStateService.createInnovationFlowState
+      ).mockResolvedValue(created);
+      vi.mocked(innovationFlowStateService.save).mockResolvedValue(created);
+
+      await service.createStateOnInnovationFlow(flow, {
+        displayName: 'C',
+        sortOrder: 0,
+      } as any);
+
+      expect(
+        tagsetTemplateService.updateTagsetTemplateDefinition
+      ).toHaveBeenCalledWith(expect.objectContaining({ id: 'tt-1' }), {
+        allowedValues: ['C', 'A', 'B'],
+        defaultSelectedValue: 'A',
+      });
+    });
+
     it('should create a new state on the innovation flow', async () => {
       const flow = {
         id: 'flow-1',
@@ -653,6 +725,67 @@ describe('InnovationFlowService', () => {
   });
 
   describe('deleteStateOnInnovationFlow', () => {
+    const deleteFrom = async (deletedID: string) => {
+      const flow = {
+        id: 'flow-1',
+        currentStateID: 's-1',
+        states: [
+          { id: 's-1', displayName: 'A', sortOrder: 1 },
+          { id: 's-2', displayName: 'B', sortOrder: 2 },
+          { id: 's-3', displayName: 'C', sortOrder: 3 },
+        ],
+        settings: { maximumNumberOfStates: 8, minimumNumberOfStates: 1 },
+      } as any;
+      (repository as any).manager = {
+        getRepository: vi.fn().mockReturnValue({
+          findOne: vi
+            .fn()
+            .mockResolvedValue({ id: 'collab-1', calloutsSet: { id: 'cs-1' } }),
+        }),
+      };
+      vi.mocked(_calloutsSetService.getCalloutsSetOrFail).mockResolvedValue({
+        id: 'cs-1',
+        callouts: [],
+      } as any);
+      const deleted = flow.states.find((s: any) => s.id === deletedID);
+      vi.mocked(
+        innovationFlowStateService.getInnovationFlowStateOrFail
+      ).mockResolvedValue(deleted);
+      vi.mocked(innovationFlowStateService.delete).mockResolvedValue({
+        ...deleted,
+      });
+      vi.mocked(repository.findOne).mockResolvedValue({
+        id: 'flow-1',
+        flowStatesTagsetTemplate: { id: 'tt-1', tagsets: [] },
+      } as any);
+
+      return service.deleteStateOnInnovationFlow(flow, {
+        ID: deletedID,
+      } as any);
+    };
+
+    it('drops the deleted name from the vocabulary and keeps the current default', async () => {
+      await deleteFrom('s-2');
+
+      expect(
+        tagsetTemplateService.updateTagsetTemplateDefinition
+      ).toHaveBeenCalledWith(expect.objectContaining({ id: 'tt-1' }), {
+        allowedValues: ['A', 'C'],
+        defaultSelectedValue: 'A',
+      });
+    });
+
+    it('moves the default to the first remaining state when the current state is deleted', async () => {
+      await deleteFrom('s-1');
+
+      expect(
+        tagsetTemplateService.updateTagsetTemplateDefinition
+      ).toHaveBeenCalledWith(expect.objectContaining({ id: 'tt-1' }), {
+        allowedValues: ['B', 'C'],
+        defaultSelectedValue: 'B',
+      });
+    });
+
     it('should throw RelationshipNotFoundException when states are not loaded', async () => {
       const flow = {
         id: 'flow-1',
@@ -919,6 +1052,78 @@ describe('InnovationFlowService', () => {
       expect(tagsetService.updateTagsetsSelectedValue).toHaveBeenCalled();
     });
 
+    describe('vocabulary default after a replacement', () => {
+      const replaceStates = async (
+        previousCurrentName: string,
+        newNames: string[]
+      ) => {
+        const flow = {
+          id: 'flow-1',
+          states: [
+            { id: 's-old-1', displayName: previousCurrentName, sortOrder: 10 },
+          ],
+          currentStateID: 's-old-1',
+        } as any;
+        vi.mocked(
+          innovationFlowStateService.getInnovationFlowStateOrFail
+        ).mockResolvedValue({
+          id: 's-old-1',
+          displayName: previousCurrentName,
+        } as any);
+        vi.mocked(innovationFlowStateService.delete).mockResolvedValue(
+          {} as any
+        );
+        const created = newNames.map((displayName, index) => ({
+          id: `s-new-${index}`,
+          displayName,
+          sortOrder: index + 1,
+        }));
+        const createMock = vi.mocked(
+          innovationFlowStateService.createInnovationFlowState
+        );
+        for (const state of created) {
+          createMock.mockResolvedValueOnce(state as any);
+        }
+        vi.mocked(repository.save).mockImplementation(
+          async (entity: any) => entity
+        );
+        vi.mocked(repository.findOne).mockResolvedValue({
+          id: 'flow-1',
+          flowStatesTagsetTemplate: { id: 'tst-1', tagsets: [] },
+        } as any);
+
+        await service.updateInnovationFlowStates(
+          flow,
+          newNames.map((displayName, index) => ({
+            displayName,
+            sortOrder: index + 1,
+          })) as any
+        );
+      };
+
+      it('keeps the previously current state as default when its name survives', async () => {
+        await replaceStates('Keep', ['First', 'Keep', 'Last']);
+
+        expect(
+          tagsetTemplateService.updateTagsetTemplateDefinition
+        ).toHaveBeenCalledWith(expect.objectContaining({ id: 'tst-1' }), {
+          allowedValues: ['First', 'Keep', 'Last'],
+          defaultSelectedValue: 'Keep',
+        });
+      });
+
+      it('falls back to the first new state when the previous current name is gone', async () => {
+        await replaceStates('Gone', ['First', 'Second']);
+
+        expect(
+          tagsetTemplateService.updateTagsetTemplateDefinition
+        ).toHaveBeenCalledWith(expect.objectContaining({ id: 'tst-1' }), {
+          allowedValues: ['First', 'Second'],
+          defaultSelectedValue: 'First',
+        });
+      });
+    });
+
     it('should throw ValidationException when a new state name contains a comma', async () => {
       const flow = {
         id: 'flow-1',
@@ -965,6 +1170,11 @@ describe('InnovationFlowService', () => {
         innovationFlowStateService.createInnovationFlowState
       ).mockResolvedValue(newState);
       vi.mocked(innovationFlowStateService.save).mockResolvedValue(newState);
+      // Adding a state rewrites the flow-state vocabulary, which re-loads the flow.
+      vi.mocked(repository.findOne).mockResolvedValue({
+        id: 'flow-l0',
+        flowStatesTagsetTemplate: { id: 'tt-l0', tagsets: [] },
+      } as any);
 
       const stateData = { displayName: 'Fifth' } as any;
       const result = await service.createStateOnInnovationFlow(flow, stateData);

--- a/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
+++ b/src/domain/collaboration/innovation-flow/innovation.flow.service.ts
@@ -225,10 +225,10 @@ export class InnovationFlowService {
     // Generate the new tagset template definition
     if (renamedState && innovationFlow.flowStatesTagsetTemplate) {
       const allowedValues = states.map(state => state.displayName);
-      const defaultSelectedValue =
-        states.find(state => state.id === currentStateID)?.displayName ??
-        states[0]?.displayName ??
-        '';
+      const defaultSelectedValue = this.resolveDefaultFlowStateName(
+        states,
+        currentStateID
+      );
 
       await this.tagsetTemplateService.updateTagsetTemplateDefinition(
         innovationFlow.flowStatesTagsetTemplate,
@@ -425,18 +425,45 @@ export class InnovationFlowService {
 
     innovationFlow = await this.save(innovationFlow);
 
-    const tagsetAllowedValues = [...newStates]
-      .sort(sortBySortOrder)
-      .map(state => state.displayName);
-
-    const tagsetDefaultSelectedValue = currentState.displayName;
     await this.updateFlowStatesTagsetTemplate(
       innovationFlow.id,
-      tagsetAllowedValues,
-      tagsetDefaultSelectedValue
+      this.orderedStateNames(innovationFlow.states),
+      this.resolveDefaultFlowStateName(
+        innovationFlow.states,
+        innovationFlow.currentStateID
+      )
     );
 
     return innovationFlow;
+  }
+
+  /**
+   * The flow-state tagset template is the vocabulary that callout creation and
+   * callout transfer validate against, so every operation that changes the set
+   * of states must rewrite it. These two helpers are the single definition of
+   * what that vocabulary looks like: the state names in flow order, and a
+   * default that follows the flow's current state while it exists and otherwise
+   * falls back to the first state.
+   */
+  private orderedStateNames(states: IInnovationFlowState[]): string[] {
+    return [...states].sort(sortBySortOrder).map(state => state.displayName);
+  }
+
+  private resolveDefaultFlowStateName(
+    states: IInnovationFlowState[],
+    currentStateID?: string
+  ): string {
+    const ordered = [...states].sort(sortBySortOrder);
+    if (ordered.length === 0) {
+      throw new ValidationException(
+        'Cannot resolve a default flow state without any states',
+        LogContext.INNOVATION_FLOW
+      );
+    }
+    return (
+      ordered.find(state => state.id === currentStateID)?.displayName ??
+      ordered[0].displayName
+    );
   }
 
   private async updateFlowStatesTagsetTemplate(
@@ -522,7 +549,18 @@ export class InnovationFlowService {
         stateData
       );
     state.innovationFlow = innovationFlow;
-    return await this.innovationFlowStateService.save(state);
+    const savedState = await this.innovationFlowStateService.save(state);
+
+    // Mirror the new state list into the flow-state vocabulary; otherwise a
+    // callout transferred in with this state's name would not be recognised.
+    const states = [...innovationFlow.states, savedState];
+    await this.updateFlowStatesTagsetTemplate(
+      innovationFlow.id,
+      this.orderedStateNames(states),
+      this.resolveDefaultFlowStateName(states, innovationFlow.currentStateID)
+    );
+
+    return savedState;
   }
 
   public async deleteStateOnInnovationFlow(
@@ -633,6 +671,21 @@ export class InnovationFlowService {
 
     const deletedInnovationFlowState =
       await this.innovationFlowStateService.delete(state);
+
+    // Drop the deleted name from the flow-state vocabulary; a callout carrying
+    // that name would otherwise be accepted on transfer and sit on no tab. The
+    // minimum-states guard above guarantees at least one state remains.
+    const remainingStates = innovationFlow.states.filter(
+      s => s.id !== stateData.ID
+    );
+    await this.updateFlowStatesTagsetTemplate(
+      innovationFlow.id,
+      this.orderedStateNames(remainingStates),
+      this.resolveDefaultFlowStateName(
+        remainingStates,
+        innovationFlow.currentStateID
+      )
+    );
 
     deletedInnovationFlowState.id = stateData.ID;
     return deletedInnovationFlowState;

--- a/src/domain/common/tagset/tagset.service.spec.ts
+++ b/src/domain/common/tagset/tagset.service.spec.ts
@@ -674,6 +674,8 @@ describe('TagsetService', () => {
         { id: 'ts-1', tags: ['oldName'] },
       ] as unknown as ITagset[];
 
+      tagsetRepository.save!.mockResolvedValue({});
+
       await service.updateTagsetsSelectedValue(
         tagsets,
         ['newName', 'default'],
@@ -682,6 +684,9 @@ describe('TagsetService', () => {
       );
 
       expect(tagsets[0].tags).toEqual(['newName']);
+      // The template does not cascade to its tagsets, so the re-tag must be
+      // persisted here or the renamed phase loses its callouts on reload.
+      expect(tagsetRepository.save).toHaveBeenCalledWith(tagsets[0]);
     });
 
     it('should set to newDefaultValue when selected value is not allowed and not renamed', async () => {

--- a/src/domain/common/tagset/tagset.service.ts
+++ b/src/domain/common/tagset/tagset.service.ts
@@ -227,7 +227,11 @@ export class TagsetService {
         continue;
       }
       if (valueRenamed && tagsetSelectedValue === valueRenamed.old) {
+        // The tagset template does not cascade to the tagsets that use it, so
+        // the re-tag has to be persisted here or the renamed value would only
+        // exist in memory and every callout in that phase would vanish on reload.
         tagset.tags = [valueRenamed.new];
+        await this.tagsetRepository.save(tagset);
         continue;
       }
       tagset.tags = [newDefaultValue];

--- a/src/domain/template/template-applier/template.applier.service.spec.ts
+++ b/src/domain/template/template-applier/template.applier.service.spec.ts
@@ -480,4 +480,139 @@ describe('TemplateApplierService', () => {
       expect(targetCollab.calloutsSet.callouts).toEqual([existingCallout]);
     });
   });
+  describe('flow-state vocabulary after a template apply', () => {
+    const flowStateTemplateOf = (collab: any) =>
+      collab.calloutsSet.tagsetTemplateSet.tagsetTemplates.find(
+        (template: any) => template.name === 'flow-state'
+      );
+
+    const buildFixture = () => {
+      const sourceStates = [
+        { displayName: 'New A', sortOrder: 1 },
+        { displayName: 'New B', sortOrder: 2 },
+      ];
+      templateService.getTemplateOrFail.mockResolvedValue({
+        id: 'tpl-1',
+        contentSpace: {
+          id: 'tcs-1',
+          collaboration: {
+            innovationFlow: { states: sourceStates },
+            calloutsSet: { callouts: [] },
+          },
+        },
+      } as any);
+
+      // The collaboration graph as the resolver loads it: the callouts set carries
+      // its own copy of the flow-state template, read before the flow is updated.
+      const targetCollab = {
+        id: 'collab-1',
+        innovationFlow: {
+          id: 'flow-1',
+          states: [{ displayName: 'Old A' }, { displayName: 'Old B' }],
+        },
+        calloutsSet: {
+          id: 'cs-1',
+          tagsetTemplateSet: {
+            id: 'tts-1',
+            tagsetTemplates: [
+              {
+                id: 'tt-flow',
+                name: 'flow-state',
+                allowedValues: ['Old A', 'Old B'],
+                defaultSelectedValue: 'Old A',
+              },
+            ],
+          },
+          callouts: [],
+        },
+      } as any;
+
+      inputCreatorService.buildCreateInnovationFlowStateInputFromInnovationFlowState.mockReturnValue(
+        sourceStates as any
+      );
+      innovationFlowService.updateInnovationFlowStatesFromTemplate.mockResolvedValue(
+        { id: 'flow-1', states: sourceStates } as any
+      );
+      // What the database holds once the flow update has run.
+      calloutsSetService.getTagsetTemplatesSet.mockResolvedValue({
+        id: 'tts-1',
+        tagsetTemplates: [
+          {
+            id: 'tt-flow',
+            name: 'flow-state',
+            allowedValues: ['New A', 'New B'],
+            defaultSelectedValue: 'New A',
+          },
+        ],
+      } as any);
+      storageAggregatorResolverService.getStorageAggregatorForCollaboration.mockResolvedValue(
+        {} as any
+      );
+      templateService.ensureCalloutsInValidGroupsAndStates.mockReturnValue(
+        undefined as any
+      );
+      collaborationService.save.mockImplementation(
+        async (collab: any) => collab
+      );
+      return targetCollab;
+    };
+
+    it('re-reads the vocabulary after the flow update so the cascade save carries the new state names', async () => {
+      const targetCollab = buildFixture();
+
+      await service.updateCollaborationFromSpaceTemplate(
+        {
+          collaborationID: 'collab-1',
+          spaceTemplateID: 'tpl-1',
+          addCallouts: false,
+          deleteExistingCallouts: false,
+        },
+        targetCollab,
+        actorContextData.actorContext
+      );
+
+      expect(calloutsSetService.getTagsetTemplatesSet).toHaveBeenCalledWith(
+        'cs-1'
+      );
+      const reloadOrder =
+        calloutsSetService.getTagsetTemplatesSet.mock.invocationCallOrder[0];
+      const flowUpdateOrder =
+        innovationFlowService.updateInnovationFlowStatesFromTemplate.mock
+          .invocationCallOrder[0];
+      expect(reloadOrder).toBeGreaterThan(flowUpdateOrder);
+
+      const saved = collaborationService.save.mock.calls[0][0];
+      expect(flowStateTemplateOf(saved).allowedValues).toEqual([
+        'New A',
+        'New B',
+      ]);
+      expect(flowStateTemplateOf(saved).defaultSelectedValue).toBe('New A');
+    });
+
+    it('classifies callouts added from the template against the updated vocabulary', async () => {
+      const targetCollab = buildFixture();
+      inputCreatorService.buildCreateCalloutInputsFromCallouts.mockResolvedValue(
+        [] as any
+      );
+      calloutsSetService.addCallouts.mockResolvedValue([]);
+
+      await service.updateCollaborationFromSpaceTemplate(
+        {
+          collaborationID: 'collab-1',
+          spaceTemplateID: 'tpl-1',
+          addCallouts: true,
+          deleteExistingCallouts: false,
+        },
+        targetCollab,
+        actorContextData.actorContext
+      );
+
+      const calloutsSetPassed = calloutsSetService.addCallouts.mock.calls[0][0];
+      expect(
+        calloutsSetPassed.tagsetTemplateSet?.tagsetTemplates.find(
+          (template: any) => template.name === 'flow-state'
+        )?.allowedValues
+      ).toEqual(['New A', 'New B']);
+    });
+  });
 });

--- a/src/domain/template/template-applier/template.applier.service.ts
+++ b/src/domain/template/template-applier/template.applier.service.ts
@@ -137,6 +137,18 @@ export class TemplateApplierService {
         newStatesInput
       );
 
+    // The collaboration graph was loaded before the flow states were replaced,
+    // so the callouts set still carries a stale copy of the flow-state tagset
+    // template (the vocabulary callout creation and transfer validate against).
+    // That copy sits on a cascading relation: saving the collaboration below
+    // would write the old allowed values back over the row the flow update just
+    // corrected. Re-read it so the cascade persists the current vocabulary and
+    // callouts added from the template are classified against it.
+    targetCollaboration.calloutsSet.tagsetTemplateSet =
+      await this.calloutsSetService.getTagsetTemplatesSet(
+        targetCollaboration.calloutsSet.id
+      );
+
     // Delete existing callouts if requested (only after the flow-state update
     // succeeds, so an overflow rejection above leaves callouts untouched).
     if (deleteExistingCallouts && targetCollaboration.calloutsSet?.callouts) {

--- a/src/migrations/1789000000000-ResyncFlowStateTagsetTemplates.ts
+++ b/src/migrations/1789000000000-ResyncFlowStateTagsetTemplates.ts
@@ -1,0 +1,127 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Re-synchronises every innovation flow's flow-state tagset template with the
+ * flow's actual states.
+ *
+ * The flow-state tagset template is the vocabulary that callout creation and
+ * callout transfer validate a callout's flow-state tag against. It is meant to
+ * mirror the flow's states exactly: `allowedValues` lists the state display
+ * names in `sortOrder`, and `defaultSelectedValue` names the current state (or
+ * the first state when no current state is set). In practice the two drifted
+ * apart: applying an innovation-flow template wrote the template correctly and
+ * then re-persisted a stale copy through a cascading save, and adding or
+ * deleting a single state never touched the template at all. The result was a
+ * vocabulary that still listed states which no longer existed, which made
+ * transfers reject valid callouts and left callouts tagged with names no
+ * longer present in their flow.
+ *
+ * The repair is three set-based updates, each driven by the same
+ * `flow_states` aggregate over `innovation_flow` joined to
+ * `innovation_flow_state`. Only flows that reference a template and have at
+ * least one state are selected — the inner join guarantees both — so
+ * stateless or template-less flows are skipped rather than corrupted.
+ *
+ *  1. `tagset_template.allowedValues` converges to the comma-joined state
+ *     display names ordered by `sortOrder`. Guarded by `IS DISTINCT FROM` so an
+ *     already-correct template is not rewritten.
+ *  2. `tagset_template.defaultSelectedValue` converges to the current state's
+ *     display name when `currentStateID` names one of the flow's states, and to
+ *     the first state's display name otherwise. Guarded so a default that is
+ *     already one of the state names is left untouched.
+ *  3. Every callout `tagset` of name `flow-state` attached to the template whose
+ *     tag no longer matches any state name (case-insensitively) is moved to the
+ *     repaired default from step 2. Tags that already match a state are left as
+ *     they are.
+ *
+ * Statement order matters: step 3 reads the default that step 2 has already
+ * repaired. On an already-converged database every step updates zero rows, so
+ * re-running the migration is a no-op.
+ */
+export class ResyncFlowStateTagsetTemplates1789000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Step 1: allowedValues := state display names in sortOrder.
+    await queryRunner.query(`
+      WITH flow_states AS (
+        SELECT
+          f.id AS flow_id,
+          f."flowStatesTagsetTemplateId" AS template_id,
+          f."currentStateID",
+          string_agg(s."displayName", ',' ORDER BY s."sortOrder") AS names,
+          array_agg(s."displayName" ORDER BY s."sortOrder") AS name_array,
+          (array_agg(s."displayName" ORDER BY s."sortOrder"))[1] AS first_name,
+          max(s."displayName") FILTER (WHERE s.id::text = f."currentStateID"::text) AS current_name
+        FROM innovation_flow f
+        JOIN innovation_flow_state s ON s."innovationFlowId" = f.id
+        WHERE f."flowStatesTagsetTemplateId" IS NOT NULL
+        GROUP BY f.id
+      )
+      UPDATE tagset_template tt
+      SET "allowedValues" = fs.names
+      FROM flow_states fs
+      WHERE tt.id = fs.template_id
+        AND tt."allowedValues" IS DISTINCT FROM fs.names
+    `);
+
+    // Step 2: defaultSelectedValue := current state's name, else first state's name.
+    await queryRunner.query(`
+      WITH flow_states AS (
+        SELECT
+          f.id AS flow_id,
+          f."flowStatesTagsetTemplateId" AS template_id,
+          f."currentStateID",
+          string_agg(s."displayName", ',' ORDER BY s."sortOrder") AS names,
+          array_agg(s."displayName" ORDER BY s."sortOrder") AS name_array,
+          (array_agg(s."displayName" ORDER BY s."sortOrder"))[1] AS first_name,
+          max(s."displayName") FILTER (WHERE s.id::text = f."currentStateID"::text) AS current_name
+        FROM innovation_flow f
+        JOIN innovation_flow_state s ON s."innovationFlowId" = f.id
+        WHERE f."flowStatesTagsetTemplateId" IS NOT NULL
+        GROUP BY f.id
+      )
+      UPDATE tagset_template tt
+      SET "defaultSelectedValue" = COALESCE(fs.current_name, fs.first_name)
+      FROM flow_states fs
+      WHERE tt.id = fs.template_id
+        AND (
+          tt."defaultSelectedValue" IS NULL
+          OR tt."defaultSelectedValue" <> ALL(fs.name_array)
+        )
+    `);
+
+    // Step 3: stranded callout flow-state tags := the repaired default.
+    await queryRunner.query(`
+      WITH flow_states AS (
+        SELECT
+          f.id AS flow_id,
+          f."flowStatesTagsetTemplateId" AS template_id,
+          f."currentStateID",
+          string_agg(s."displayName", ',' ORDER BY s."sortOrder") AS names,
+          array_agg(s."displayName" ORDER BY s."sortOrder") AS name_array,
+          (array_agg(s."displayName" ORDER BY s."sortOrder"))[1] AS first_name,
+          max(s."displayName") FILTER (WHERE s.id::text = f."currentStateID"::text) AS current_name
+        FROM innovation_flow f
+        JOIN innovation_flow_state s ON s."innovationFlowId" = f.id
+        WHERE f."flowStatesTagsetTemplateId" IS NOT NULL
+        GROUP BY f.id
+      )
+      UPDATE tagset t
+      SET tags = tt."defaultSelectedValue"
+      FROM tagset_template tt
+      JOIN flow_states fs ON fs.template_id = tt.id
+      WHERE t."tagsetTemplateId" = tt.id
+        AND t.name = 'flow-state'
+        AND lower(t.tags) <> ALL(SELECT lower(unnest(fs.name_array)))
+    `);
+  }
+
+  /**
+   * Intentionally a no-op. The values this migration overwrote were
+   * inconsistent data — a vocabulary that disagreed with its own flow's states
+   * — not a schema state worth restoring. Reinstating them would only
+   * reintroduce the drift.
+   */
+  public async down(_queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/migrations/__tests__/1789000000000-ResyncFlowStateTagsetTemplates.spec.ts
+++ b/src/migrations/__tests__/1789000000000-ResyncFlowStateTagsetTemplates.spec.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { ResyncFlowStateTagsetTemplates1789000000000 } from '../1789000000000-ResyncFlowStateTagsetTemplates';
+
+/**
+ * Static-analysis plus mocked-QueryRunner assertions for the flow-state
+ * vocabulary repair migration — no database connection needed, mirroring the
+ * other migration specs in this directory.
+ *
+ * The migration must be a pure data repair: exactly three guarded UPDATE
+ * statements, issued in dependency order (allowed values, then the default,
+ * then the stranded callout tags that read the repaired default), with no
+ * DDL and no row creation or deletion. `down()` is a documented no-op.
+ * The real-database before/after evidence (drift converges, re-run touches
+ * zero rows) is gathered against the dev stack and recorded in the PR body.
+ */
+describe('ResyncFlowStateTagsetTemplates migration', () => {
+  const migrationSrc = readFileSync(
+    resolve(__dirname, '../1789000000000-ResyncFlowStateTagsetTemplates.ts'),
+    'utf8'
+  );
+  const upSection = migrationSrc.slice(
+    migrationSrc.indexOf('public async up'),
+    migrationSrc.indexOf('public async down')
+  );
+
+  const runUp = async () => {
+    const queryRunner = { query: vi.fn().mockResolvedValue(undefined) };
+    const migration = new ResyncFlowStateTagsetTemplates1789000000000();
+    await migration.up(queryRunner as any);
+    return queryRunner.query.mock.calls.map(call => call[0] as string);
+  };
+
+  it('exports the expected class with up()/down()', () => {
+    expect(ResyncFlowStateTagsetTemplates1789000000000).toBeDefined();
+    const instance = new ResyncFlowStateTagsetTemplates1789000000000();
+    expect(typeof instance.up).toBe('function');
+    expect(typeof instance.down).toBe('function');
+  });
+
+  it('up() issues exactly three UPDATE statements: allowedValues, then defaultSelectedValue, then tags', async () => {
+    const statements = await runUp();
+
+    expect(statements).toHaveLength(3);
+    for (const sql of statements) {
+      expect(sql).toMatch(/WITH flow_states AS/);
+      expect(sql).toMatch(/\bUPDATE\b/);
+    }
+    expect(statements[0]).toMatch(/UPDATE tagset_template tt/);
+    expect(statements[0]).toMatch(/SET "allowedValues"/);
+    expect(statements[1]).toMatch(/UPDATE tagset_template tt/);
+    expect(statements[1]).toMatch(/SET "defaultSelectedValue"/);
+    expect(statements[2]).toMatch(/UPDATE tagset t\b/);
+    expect(statements[2]).toMatch(/SET tags =/);
+  });
+
+  it('allowedValues statement aggregates state names ordered by sortOrder and is guarded by IS DISTINCT FROM', async () => {
+    const [allowedValuesSql] = await runUp();
+
+    expect(allowedValuesSql).toMatch(
+      /string_agg\(s\."displayName", ',' ORDER BY s\."sortOrder"\)/
+    );
+    expect(allowedValuesSql).toMatch(/"allowedValues" IS DISTINCT FROM/);
+  });
+
+  it('defaultSelectedValue statement is guarded by IS NULL OR not-in-state-names (<> ALL)', async () => {
+    const [, defaultSql] = await runUp();
+
+    expect(defaultSql).toMatch(/COALESCE\(fs\.current_name, fs\.first_name\)/);
+    expect(defaultSql).toMatch(/"defaultSelectedValue" IS NULL\s+OR/);
+    expect(defaultSql).toMatch(/"defaultSelectedValue" <> ALL\(/);
+  });
+
+  it('tagset statement targets flow-state tagsets only and compares case-insensitively on both sides', async () => {
+    const [, , tagsSql] = await runUp();
+
+    expect(tagsSql).toMatch(/t\.name = 'flow-state'/);
+    expect(tagsSql).toMatch(/t\."tagsetTemplateId" = tt\.id/);
+    expect(tagsSql).toMatch(/lower\(t\.tags\) <> ALL\(SELECT lower\(unnest\(/);
+    expect(tagsSql).toMatch(/SET tags = tt\."defaultSelectedValue"/);
+  });
+
+  it('up() is a pure data repair: no DDL, no INSERT, no DELETE', () => {
+    expect(upSection).not.toMatch(/\bCREATE\b/i);
+    expect(upSection).not.toMatch(/\bALTER\b/i);
+    expect(upSection).not.toMatch(/\bDROP\b/i);
+    expect(upSection).not.toMatch(/\bINSERT\b/i);
+    expect(upSection).not.toMatch(/\bDELETE\b/i);
+  });
+
+  it('down() issues no query (intentionally irreversible)', async () => {
+    const queryRunner = { query: vi.fn().mockResolvedValue(undefined) };
+    const migration = new ResyncFlowStateTagsetTemplates1789000000000();
+
+    await migration.down(queryRunner as any);
+
+    expect(queryRunner.query).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #6021

Related (remain open until manually closed): alkem-io/server#4970, alkem-io/client-web#9353.

Workspace spec: `workspace#063-callout-transfer-flow-state` — https://github.com/alkem-io/agents-hq/tree/feat/063-callout-transfer-flow-state/specs/063-callout-transfer-flow-state/

## What was still broken after #6339

QA re-tested #6021 after #6339 merged and acceptance criterion 3 ("same logic applies when the destination's innovation flow was changed via template", the alkem-io/client-web#9353 sequence) still failed: the transferred callout is tagged with one of the destination's **old** state names and shows on no flow tab.

## Root cause (proven at code level)

The transfer logic from #6339 is correct but validates against the destination's flow-state `TagsetTemplate` (`allowedValues` / `defaultSelectedValue`), and that template drifts from the `InnovationFlow`'s actual states through three writers:

1. **Template apply** — `updateCollaborationFromSpaceTemplate` loads the target collaboration with `calloutsSet.tagsetTemplateSet` (eager `tagsetTemplates`, `cascade: true` on every hop). `updateInnovationFlowStates` updates a *separately loaded* copy of the template and saves it; the applier's final `collaborationService.save(targetCollaboration)` then cascades the **stale** in-memory template back over the row, reverting `allowedValues`/`defaultSelectedValue` to the pre-template names. The destination's own callouts stay visible (they are re-homed by state *name*), which is why only transfers exposed it.
2. **Add / delete a single state** — neither `createStateOnInnovationFlow` nor `deleteStateOnInnovationFlow` ever rewrote the template.
3. **Rename** — `TagsetService.updateTagsetsSelectedValue` re-tagged callouts in memory on the rename branch and `continue`d without `save`; nothing cascades to those tagsets, so callouts in a renamed phase kept the old name on reload.

## Fix (behaviour-only; no DDL, no GraphQL change)

- `TemplateApplierService`: re-read the callouts set's `TagsetTemplateSet` after the flow-state update, so the cascade save persists the current vocabulary and template-added callouts are classified against it.
- `InnovationFlowService`: add/delete state rewrite the flow-state template; one shared default rule (`resolveDefaultFlowStateName`: current state while it exists, else first) now backs template apply, rename, add and delete.
- `TagsetService`: persist the re-tag on the rename branch.
- Migration `1789000000000-ResyncFlowStateTagsetTemplates` (data-only, idempotent, no-op `down`): re-derives `allowedValues` from the flow's states in flow order, repairs a missing/unknown default, and moves callout flow-state tags that match no state (case-insensitively) to that default. Existing drifted spaces (acceptance, where QA reproduced this) are healed on deploy.

## Regression tests (each RED on `develop`, GREEN here)

- `template.applier.service.spec.ts` — the #9353 sequence: the graph handed to the cascade save carries the template's new state names; template-added callouts see the updated vocabulary.
- `innovation.flow.service.spec.ts` — add-state (incl. sort-order insertion) and delete-state (incl. deleting the current state) rewrite the vocabulary with the shared default rule; two pins for the default rule on the template path.
- `tagset.service.spec.ts` — rename branch saves the re-tagged tagset.
- `src/migrations/__tests__/1789000000000-ResyncFlowStateTagsetTemplates.spec.ts` — structural pins (three ordered UPDATEs, idempotence guards, case-insensitive re-tag, no DDL, no-op down).
- #6339's transfer pins (`classification.service.spec.ts`, `callout.transfer.service.spec.ts`) unchanged and green.

## Migration evidence (dev DB, seeded drift, run inside a rolled-back transaction)

| phase | allowedValues | defaultSelectedValue | stranded flow-state tags |
|---|---|---|---|
| before | `Stale A,Stale B` | `Stale A` | 7 |
| after first run | `Home` (= the flow's states) | `Home` | 0 |
| second run | `UPDATE 0` / `UPDATE 0` / `UPDATE 0` | | |

## Gates (one uninterrupted run)

- `pnpm test:ci:no:coverage` — 796 files / 9409 tests passed
- `pnpm build` — ok
- `pnpm lint` (tsc + biome) — clean
- `pnpm run schema:print && pnpm run schema:sort && git diff --exit-code -- schema.graphql` — no schema change

SDD loop counts: clarify 2 iterations, analyze 2 iterations. New/changed code comments carry no spec/issue references (per the workspace `docs/conventions/code-comments.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2LxqC8L2mULFdse2JHi9m